### PR TITLE
G38: bundle facts model, multibuild pairing, signature-evidence gate, and stabilization phases

### DIFF
--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -80,12 +80,19 @@ from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
     ConsumerEntry as ConsumerEntry,
     ProviderEntry as ProviderEntry,
     ResolutionGraph as ResolutionGraph,
+    basename_to_bundle_key,
 )
 from .bundle_resolution_reachability import (
     reachable_intra_libraries as _reachable_intra_libraries,
 )
 from .bundle_soname import hard_link_alias_basenames, soname_matches_providers
-from .checker_policy import ChangeKind, Verdict, compute_verdict
+from .checker_policy import (
+    ChangeKind,
+    Verdict,
+    compute_verdict,
+    effective_category,
+    policy_kind_sets,
+)
 from .checker_types import DiffResult
 from .elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, parse_elf_metadata
 
@@ -794,15 +801,17 @@ def compare_bundle(
     sys_libs = set(DEFAULT_SYSTEM_PROVIDERS) | explicit_providers
     findings: list[BundleFinding] = []
 
-    # Index per-library diff results by canonical basename. This is the
-    # same key the resolution graph uses for libraries (see
-    # build_bundle_snapshot's `libraries` dict), so look-ups in the
-    # detectors agree. We canonicalise once instead of double-indexing —
-    # double-indexing caused detectors to iterate the same DiffResult
+    # Index per-library diff results by the resolution graph's own
+    # bundle-canonical key, not the raw (possibly SONAME-versioned)
+    # on-disk basename -- see `basename_to_bundle_key`'s own docstring
+    # (G38 plan doc Phase 5). Canonicalise once instead of double-indexing
+    # — double-indexing caused detectors to iterate the same DiffResult
     # twice when DiffResult.library happened to differ from its basename.
+    basename_to_key = basename_to_bundle_key(new)
     diff_by_library: dict[str, DiffResult] = {}
     for result in per_library_results:
-        canonical = Path(result.library).name
+        basename = Path(result.library).name
+        canonical = basename_to_key.get(basename, basename)
         diff_by_library.setdefault(canonical, result)
 
     # 1. bundle_library_removed / bundle_library_added (structural)
@@ -811,10 +820,9 @@ def compare_bundle(
     # 2. bundle_intra_dep_removed: an import in the new bundle has no provider.
     findings.extend(_detect_intra_dep_removed(old, new, sys_libs, explicit_providers))
 
-    # 3. bundle_intra_dep_signature_changed: provider's per-library diff
-    #    flagged func_params_changed / func_return_changed / var_type_changed
-    #    on a symbol some sibling imports.
-    findings.extend(_detect_intra_dep_signature_changed(new, diff_by_library))
+    # 3. bundle_intra_dep_signature_changed: a promotable confirmed change
+    #    on a symbol some sibling imports (see that function's docstring).
+    findings.extend(_detect_intra_dep_signature_changed(new, diff_by_library, policy))
 
     # 4. bundle_intra_type_changed: a type_*_changed touches a type that
     #    appears in a public symbol of a sibling library.
@@ -1153,41 +1161,38 @@ def _detect_unresolved_intra_dependency(
 def _detect_intra_dep_signature_changed(
     new: BundleSnapshot,
     diff_by_library: dict[str, DiffResult],
+    policy: str = "strict_abi",
 ) -> list[BundleFinding]:
     """Promote provider-side signature changes to consumer-side findings.
 
     For each per-library confirmed, *promotable* C-boundary signature break
-    (see :data:`abicheck.bundle_models.
-    PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS` — params/return/variable
-    type, variadicness, calling convention; deliberately narrower than
-    :data:`abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS`,
-    which also covers noexcept/exception-spec/ref-qualifier/virtual-ness
-    for a *weaker* claim elsewhere — see that constant's own docstring),
-    look up which siblings import that symbol in the new bundle and emit
-    one finding per (consumer, symbol) pair. Multiple change kinds against
-    the same symbol collapse into one finding to avoid double-counting,
-    e.g. params+return changing together.
+    (:data:`abicheck.bundle_models.PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_
+    KINDS` — a strict, verdict-checked subset of
+    :data:`~abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
+    KINDS`; see that constant's own docstring for why the two sets must
+    stay distinct, G38 plan doc Phase 5 for the incident), look up which
+    siblings import that symbol in the new bundle and emit one finding per
+    (consumer, symbol) pair. Multiple change kinds against the same symbol
+    collapse into one finding to avoid double-counting, e.g. params+return
+    changing together.
 
-    G38 stabilization: this used to share the *broad* set with
-    :mod:`abicheck.bundle_signature_evidence`'s own suppression check for
-    ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` — reviewed and reverted
-    (Codex review, fresh evidence): the broad set includes
-    ``FUNC_NOEXCEPT_ADDED`` (``default_verdict=COMPATIBLE`` in
-    ``change_registry.py``) and ``FUNC_NOEXCEPT_REMOVED``/
-    ``FUNC_EXCEPTION_SPEC_CHANGED`` (``COMPATIBLE_WITH_RISK``, explicitly
-    "not a binary break"), so sharing it here would have promoted a
-    same-or-lower-severity per-library change into a fabricated BREAKING
-    cross-library finding. The narrow set is a strict subset of the broad
-    one (asserted in `bundle_models.py`), so the two still cannot
-    independently drift on which of *these* kinds counts as a confirmed
-    boundary break — they simply answer two different questions now.
+    *policy* (G38 plan doc Phase 5, Codex review): a promoted kind's own
+    registry entry can carry a ``policy_overrides`` demotion —
+    ``CALLING_CONVENTION_CHANGED`` is ``COMPATIBLE`` under ``plugin_abi``.
+    A change whose effective category under this policy is not
+    ``BREAKING`` is skipped, so promotion can't defeat an override
+    ``compute_verdict(policy=...)`` already honors for the originating
+    per-library finding.
     """
     findings: list[BundleFinding] = []
     seen: set[tuple[str, str, str]] = set()
     relevant_kinds = PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+    policy_sets = policy_kind_sets(policy)
     for provider_lib, diff in diff_by_library.items():
         for change in diff.changes:
             if change.kind not in relevant_kinds:
+                continue
+            if effective_category(change, *policy_sets) != Verdict.BREAKING:
                 continue
             consumers = new.resolution.consumers_of(change.symbol)
             consumer_libs = sorted(

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -72,8 +72,8 @@ from .bundle_manifest import (  # noqa: F401  (re-exported for back-compat)
     load_manifest as load_manifest,
 )
 from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
-    CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
     DEFAULT_SYSTEM_PROVIDERS as DEFAULT_SYSTEM_PROVIDERS,
+    PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
     BundleDiffResult as BundleDiffResult,
     BundleFinding as BundleFinding,
     BundleSnapshot as BundleSnapshot,
@@ -1156,24 +1156,35 @@ def _detect_intra_dep_signature_changed(
 ) -> list[BundleFinding]:
     """Promote provider-side signature changes to consumer-side findings.
 
-    For each per-library confirmed C-boundary signature break (see
-    :data:`abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS`
-    — params/return/variable type, variadicness, calling convention,
-    noexcept, exception spec, ref-qualifier, virtual-ness), look up which
-    siblings import that symbol in the new bundle and emit one finding per
-    (consumer, symbol) pair. Multiple change kinds against the same symbol
-    collapse into one finding to avoid double-counting, e.g. params+return
-    changing together.
+    For each per-library confirmed, *promotable* C-boundary signature break
+    (see :data:`abicheck.bundle_models.
+    PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS` — params/return/variable
+    type, variadicness, calling convention; deliberately narrower than
+    :data:`abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS`,
+    which also covers noexcept/exception-spec/ref-qualifier/virtual-ness
+    for a *weaker* claim elsewhere — see that constant's own docstring),
+    look up which siblings import that symbol in the new bundle and emit
+    one finding per (consumer, symbol) pair. Multiple change kinds against
+    the same symbol collapse into one finding to avoid double-counting,
+    e.g. params+return changing together.
 
-    This set is shared with :mod:`abicheck.bundle_signature_evidence`'s own
-    suppression check for ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` — the
-    two must never independently disagree on "which confirmed changes prove
-    the C boundary broke" (G38 stabilization; see the shared constant's own
-    docstring for the incident this closes).
+    G38 stabilization: this used to share the *broad* set with
+    :mod:`abicheck.bundle_signature_evidence`'s own suppression check for
+    ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` — reviewed and reverted
+    (Codex review, fresh evidence): the broad set includes
+    ``FUNC_NOEXCEPT_ADDED`` (``default_verdict=COMPATIBLE`` in
+    ``change_registry.py``) and ``FUNC_NOEXCEPT_REMOVED``/
+    ``FUNC_EXCEPTION_SPEC_CHANGED`` (``COMPATIBLE_WITH_RISK``, explicitly
+    "not a binary break"), so sharing it here would have promoted a
+    same-or-lower-severity per-library change into a fabricated BREAKING
+    cross-library finding. The narrow set is a strict subset of the broad
+    one (asserted in `bundle_models.py`), so the two still cannot
+    independently drift on which of *these* kinds counts as a confirmed
+    boundary break — they simply answer two different questions now.
     """
     findings: list[BundleFinding] = []
     seen: set[tuple[str, str, str]] = set()
-    relevant_kinds = CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+    relevant_kinds = PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS
     for provider_lib, diff in diff_by_library.items():
         for change in diff.changes:
             if change.kind not in relevant_kinds:

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -800,10 +800,14 @@ def compare_bundle(
     # Index per-library diff results by the resolution graph's own
     # bundle-canonical key, not the raw (possibly SONAME-versioned)
     # on-disk basename -- see `basename_to_bundle_key`'s own docstring
-    # (G38 plan doc Phase 5). Canonicalise once instead of double-indexing
-    # — double-indexing caused detectors to iterate the same DiffResult
-    # twice when DiffResult.library happened to differ from its basename.
-    basename_to_key = basename_to_bundle_key(new)
+    # (G38 plan doc Phase 5). Canonicalise once instead of double-indexing.
+    #
+    # Merge OLD+NEW maps (Codex review): `checker.compare()` sets
+    # `DiffResult.library = old.library`, so a versioned basename that
+    # changed between old and new (`libcore.so.1.2` -> `.1.3`) only
+    # resolves through `old`'s own map. New wins a collision -- it's what
+    # the resolution graph these keys feed into was built from.
+    basename_to_key = {**basename_to_bundle_key(old), **basename_to_bundle_key(new)}
     diff_by_library: dict[str, DiffResult] = {}
     for result in per_library_results:
         basename = Path(result.library).name
@@ -1166,12 +1170,9 @@ def _detect_intra_dep_signature_changed(
     KINDS`, a strict subset of ``CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
     KINDS`` -- G38 plan doc Phase 5), find siblings that import the symbol
     *and actually resolve it against this provider*
-    (:func:`_consumer_resolves_via_provider`), and emit one finding per
-    (consumer, symbol) pair (multiple kinds against one symbol collapse
-    into one finding).
-
-    *policy*: both a named-policy demotion and a ``--policy-file``
-    override on the originating diff are honored, via
+    (:func:`_consumer_resolves_via_provider`), emitting one finding per
+    (consumer, symbol) pair. *policy*: both a named-policy demotion and a
+    ``--policy-file`` override on the diff are honored, via
     :func:`_diff_change_is_breaking`.
     """
     findings: list[BundleFinding] = []

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -85,6 +85,7 @@ from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
     diff_change_is_breaking as _diff_change_is_breaking,
 )
 from .bundle_resolution_reachability import (
+    cached_reachable_intra_libraries as _cached_reachable_intra_libraries,
     reachable_intra_libraries as _reachable_intra_libraries,
 )
 from .bundle_soname import hard_link_alias_basenames, soname_matches_providers
@@ -1168,12 +1169,11 @@ def _detect_intra_dep_signature_changed(
     For each confirmed *promotable* C-boundary signature break
     (:data:`~abicheck.bundle_models.PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_
     KINDS`, a strict subset of ``CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
-    KINDS`` -- G38 plan doc Phase 5), find siblings that import the symbol
-    *and actually resolve it against this provider*
-    (:func:`_consumer_resolves_via_provider`), emitting one finding per
-    (consumer, symbol) pair. *policy*: both a named-policy demotion and a
-    ``--policy-file`` override on the diff are honored, via
-    :func:`_diff_change_is_breaking`.
+    KINDS``), find siblings importing the symbol that *actually resolve it
+    against this provider* (:func:`_consumer_resolves_via_provider`),
+    emitting one finding per (consumer, symbol) pair. *policy*: a
+    named-policy demotion and a ``--policy-file`` override on the diff are
+    both honored, via :func:`_diff_change_is_breaking`.
     """
     findings: list[BundleFinding] = []
     seen: set[tuple[str, str, str]] = set()
@@ -1182,7 +1182,7 @@ def _detect_intra_dep_signature_changed(
     reachable_cache: dict[str, set[str]] = {}
 
     def _reachable(lib: str) -> set[str]:
-        return reachable_cache.setdefault(lib, _reachable_intra_libraries(new, lib))
+        return _cached_reachable_intra_libraries(new, reachable_cache, lib)
 
     for provider_lib, diff in diff_by_library.items():
         for change in diff.changes:

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -72,6 +72,7 @@ from .bundle_manifest import (  # noqa: F401  (re-exported for back-compat)
     load_manifest as load_manifest,
 )
 from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
+    CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
     DEFAULT_SYSTEM_PROVIDERS as DEFAULT_SYSTEM_PROVIDERS,
     BundleDiffResult as BundleDiffResult,
     BundleFinding as BundleFinding,
@@ -1155,19 +1156,24 @@ def _detect_intra_dep_signature_changed(
 ) -> list[BundleFinding]:
     """Promote provider-side signature changes to consumer-side findings.
 
-    For each per-library ``func_params_changed`` / ``func_return_changed``
-    / ``var_type_changed``, look up which siblings import that symbol in
-    the new bundle and emit one finding per (consumer, symbol) pair.
-    Multiple change kinds against the same symbol collapse into one
-    finding to avoid double-counting params+return changes.
+    For each per-library confirmed C-boundary signature break (see
+    :data:`abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS`
+    — params/return/variable type, variadicness, calling convention,
+    noexcept, exception spec, ref-qualifier, virtual-ness), look up which
+    siblings import that symbol in the new bundle and emit one finding per
+    (consumer, symbol) pair. Multiple change kinds against the same symbol
+    collapse into one finding to avoid double-counting, e.g. params+return
+    changing together.
+
+    This set is shared with :mod:`abicheck.bundle_signature_evidence`'s own
+    suppression check for ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` — the
+    two must never independently disagree on "which confirmed changes prove
+    the C boundary broke" (G38 stabilization; see the shared constant's own
+    docstring for the incident this closes).
     """
     findings: list[BundleFinding] = []
     seen: set[tuple[str, str, str]] = set()
-    relevant_kinds = {
-        ChangeKind.FUNC_PARAMS_CHANGED,
-        ChangeKind.FUNC_RETURN_CHANGED,
-        ChangeKind.VAR_TYPE_CHANGED,
-    }
+    relevant_kinds = CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
     for provider_lib, diff in diff_by_library.items():
         for change in diff.changes:
             if change.kind not in relevant_kinds:

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -81,18 +81,14 @@ from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
     ProviderEntry as ProviderEntry,
     ResolutionGraph as ResolutionGraph,
     basename_to_bundle_key,
+    consumer_resolves_via_provider as _consumer_resolves_via_provider,
+    diff_change_is_breaking as _diff_change_is_breaking,
 )
 from .bundle_resolution_reachability import (
     reachable_intra_libraries as _reachable_intra_libraries,
 )
 from .bundle_soname import hard_link_alias_basenames, soname_matches_providers
-from .checker_policy import (
-    ChangeKind,
-    Verdict,
-    compute_verdict,
-    effective_category,
-    policy_kind_sets,
-)
+from .checker_policy import ChangeKind, Verdict, compute_verdict, policy_kind_sets
 from .checker_types import DiffResult
 from .elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, parse_elf_metadata
 
@@ -1165,38 +1161,44 @@ def _detect_intra_dep_signature_changed(
 ) -> list[BundleFinding]:
     """Promote provider-side signature changes to consumer-side findings.
 
-    For each per-library confirmed, *promotable* C-boundary signature break
-    (:data:`abicheck.bundle_models.PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_
-    KINDS` — a strict, verdict-checked subset of
-    :data:`~abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
-    KINDS`; see that constant's own docstring for why the two sets must
-    stay distinct, G38 plan doc Phase 5 for the incident), look up which
-    siblings import that symbol in the new bundle and emit one finding per
-    (consumer, symbol) pair. Multiple change kinds against the same symbol
-    collapse into one finding to avoid double-counting, e.g. params+return
-    changing together.
+    For each confirmed *promotable* C-boundary signature break
+    (:data:`~abicheck.bundle_models.PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_
+    KINDS`, a strict subset of ``CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
+    KINDS`` -- G38 plan doc Phase 5), find siblings that import the symbol
+    *and actually resolve it against this provider*
+    (:func:`_consumer_resolves_via_provider`), and emit one finding per
+    (consumer, symbol) pair (multiple kinds against one symbol collapse
+    into one finding).
 
-    *policy* (G38 plan doc Phase 5, Codex review): a promoted kind's own
-    registry entry can carry a ``policy_overrides`` demotion —
-    ``CALLING_CONVENTION_CHANGED`` is ``COMPATIBLE`` under ``plugin_abi``.
-    A change whose effective category under this policy is not
-    ``BREAKING`` is skipped, so promotion can't defeat an override
-    ``compute_verdict(policy=...)`` already honors for the originating
-    per-library finding.
+    *policy*: both a named-policy demotion and a ``--policy-file``
+    override on the originating diff are honored, via
+    :func:`_diff_change_is_breaking`.
     """
     findings: list[BundleFinding] = []
     seen: set[tuple[str, str, str]] = set()
     relevant_kinds = PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS
     policy_sets = policy_kind_sets(policy)
+    reachable_cache: dict[str, set[str]] = {}
+
+    def _reachable(lib: str) -> set[str]:
+        return reachable_cache.setdefault(lib, _reachable_intra_libraries(new, lib))
+
     for provider_lib, diff in diff_by_library.items():
         for change in diff.changes:
             if change.kind not in relevant_kinds:
                 continue
-            if effective_category(change, *policy_sets) != Verdict.BREAKING:
+            if not _diff_change_is_breaking(diff, change, policy_sets):
                 continue
             consumers = new.resolution.consumers_of(change.symbol)
             consumer_libs = sorted(
-                {c.library for c in consumers if c.library != provider_lib}
+                {
+                    c.library
+                    for c in consumers
+                    if c.library != provider_lib
+                    and _consumer_resolves_via_provider(
+                        new, c, provider_lib, change.symbol, _reachable(c.library)
+                    )
+                }
             )
             if not consumer_libs:
                 continue

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -62,6 +62,62 @@ DEFAULT_SYSTEM_PROVIDERS: frozenset[str] = frozenset(
     }
 )
 
+#: G38 stabilization (post-Phase-4): the single source of truth for "which
+#: confirmed per-symbol ``ChangeKind``s prove a sibling library's direct C
+#: calling-boundary contract changed." Two independent consumers must agree
+#: on this set, and previously did not:
+#:
+#: - :func:`abicheck.bundle._detect_intra_dep_signature_changed` — promotes
+#:   a confirmed change of one of these kinds on a provider's own export to
+#:   a consumer-attributed ``BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`` finding.
+#: - :mod:`abicheck.bundle_signature_evidence` — treats a confirmed change
+#:   of one of these kinds as proof that *something* concrete is known
+#:   about the symbol, and therefore suppresses its own
+#:   ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` "couldn't tell either way"
+#:   finding for it.
+#:
+#: Before this constant existed, `bundle.py` promoted only three kinds
+#: (``FUNC_PARAMS_CHANGED``/``FUNC_RETURN_CHANGED``/``VAR_TYPE_CHANGED``)
+#: while `bundle_signature_evidence.py` independently suppressed on twelve
+#: — so a confirmed ``CALLING_CONVENTION_CHANGED`` (say) correctly
+#: suppressed the "unverified" finding but was silently *not* promoted to
+#: a consumer-attributed break, losing the cross-library causality the
+#: bundle report exists to surface. Living here (not in either consumer
+#: module) matches this module's own leaf-module contract: `bundle.py`
+#: imports it directly, and `bundle_signature_evidence.py` — which must
+#: not import `bundle.py` (see that module's own docstring on why it stays
+#: leaf-only) — already imports this module for `BundleFinding`/
+#: `BundleSnapshot`/`ConsumerEntry`/`ProviderEntry`, so this adds no new
+#: import edge either direction.
+#:
+#: Deliberately excludes ``CTOR_EXPLICIT_ADDED``/``CTOR_EXPLICIT_REMOVED``:
+#: an ``explicit`` specifier transition is a purely source-level fact that
+#: never alters the mangled name (see `checker_policy.py`'s own
+#: `ChangeKind` comment for these two kinds) and therefore proves nothing
+#: about whether the binary calling signature — params, return type,
+#: variadicness, calling convention, ... — this set exists to police still
+#: agrees. Also excludes ``FUNC_LANGUAGE_LINKAGE_CHANGED`` (an
+#: ``extern "C"`` transition changes the mangled name itself, so old/new
+#: can't share the symbol key either consumer matches on) and the
+#: vtable-slot/inline-transition kinds (about virtual-dispatch layout and
+#: definition placement, not calling-signature agreement).
+CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS: frozenset[ChangeKind] = frozenset(
+    {
+        ChangeKind.FUNC_PARAMS_CHANGED,
+        ChangeKind.FUNC_RETURN_CHANGED,
+        ChangeKind.VAR_TYPE_CHANGED,
+        ChangeKind.FUNC_VARIADIC_ADDED,
+        ChangeKind.FUNC_VARIADIC_REMOVED,
+        ChangeKind.CALLING_CONVENTION_CHANGED,
+        ChangeKind.FUNC_NOEXCEPT_ADDED,
+        ChangeKind.FUNC_NOEXCEPT_REMOVED,
+        ChangeKind.FUNC_EXCEPTION_SPEC_CHANGED,
+        ChangeKind.FUNC_REF_QUAL_CHANGED,
+        ChangeKind.FUNC_VIRTUAL_ADDED,
+        ChangeKind.FUNC_VIRTUAL_REMOVED,
+    }
+)
+
 
 @dataclass(frozen=True)
 class ProviderEntry:

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -371,6 +371,7 @@ def consumer_resolves_via_provider(
     """
     if provider_lib not in reachable:
         return False
+    all_entries = new.resolution.providers_for(symbol)
     # A single provider library can legitimately export several *versioned*
     # definitions of the same bare symbol name (e.g. compat-symbol pattern
     # `foo@V1` alongside `foo@@V2`) -- check every one of this provider's
@@ -378,20 +379,39 @@ def consumer_resolves_via_provider(
     # own matching), not just the first one found (Codex review): picking
     # only the first could test a non-matching V1 entry while the real
     # match is a later V2 one from the same provider.
-    candidates = [
-        p for p in new.resolution.providers_for(symbol) if p.library == provider_lib
-    ]
+    candidates = [p for p in all_entries if p.library == provider_lib]
     if not candidates:
         return False
-    if not consumer.version:
-        # An unversioned reference can only be satisfied by an unversioned
-        # or default-version ("@@default") provider definition.
-        return any(c.is_default for c in candidates)
-    if consumer.version_soname:
+
+    if consumer.version and consumer.version_soname:
+        # The per-symbol verneed provider pins resolution to one specific
+        # library by construction (GNU symbol versioning) -- no
+        # interposition ambiguity applies to this branch.
         target_lib = new.resolution.soname_to_name.get(consumer.version_soname)
         if target_lib != provider_lib:
             return False
-    return any(c.version == consumer.version for c in candidates)
+        return any(c.version == consumer.version for c in candidates)
+
+    # No per-symbol version pin (an unversioned reference, or a versioned
+    # one whose verneed soname wasn't captured): two reachable bundle
+    # siblings can each independently define a matching entry for this
+    # bare symbol, and this model has no notion of real ELF symbol-search
+    # order (DT_NEEDED / global-scope precedence) to say which one a
+    # consumer's unversioned reference actually binds to (Codex review,
+    # G38 stabilization -- fresh evidence beyond the reachability fix
+    # above). Attributing to any one of several equally-plausible
+    # providers would be a guess, so decline (ambiguous) rather than
+    # fabricate an attribution -- a missed promotion is the safe
+    # direction here, not a false one.
+    def _matches(p: ProviderEntry) -> bool:
+        if p.library not in reachable:
+            return False
+        if not consumer.version:
+            return p.is_default
+        return p.version == consumer.version
+
+    matching_libs = {p.library for p in all_entries if _matches(p)}
+    return matching_libs == {provider_lib}
 
 
 def diff_change_is_breaking(

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -474,6 +474,21 @@ class BundleDiffResult:
     #: parameter). Defaults to ``strict_abi`` — every caller that predates
     #: this field behaves exactly as before.
     policy: str = "strict_abi"
+    #: G38 stabilization Phase 11: structured record of a partial-analysis
+    #: degradation (``compare_bundle`` itself raising, or
+    #: ``find_unverified_signature_findings`` raising) that
+    #: `cli_compare_release_helpers._run_bundle_analysis` previously only
+    #: ever reported as a stderr warning -- an empty list here is a real,
+    #: positive claim that analysis completed cleanly, not merely "nothing
+    #: to say"; a report consumer (CI, a downstream tool) can now
+    #: distinguish "bundle_findings is empty because nothing broke" from
+    #: "bundle_findings is empty because analysis degraded partway
+    #: through" by checking this field instead of grepping the run's own
+    #: stderr. Deliberately plain strings, not a richer per-error type --
+    #: see this phase's own plan-doc entry for what a fuller structured
+    #: coverage ledger (mirroring `contract_coverage_ledger.py`) would add
+    #: beyond this.
+    analysis_errors: list[str] = field(default_factory=list)
 
     @property
     def bundle_verdict(self) -> Verdict:

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -26,12 +26,14 @@ types here are re-exported from :mod:`abicheck.bundle` so the historical
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .checker_policy import ChangeKind, Verdict, compute_verdict
 from .checker_types import Change, DiffResult
 from .elf_metadata import ElfMetadata
+from .model import AbiSnapshot, Function, Variable
 
 # Symbols imported by virtually every C/C++ shared library that are
 # provided by the system loader, not by the bundle. Resolution against the
@@ -342,6 +344,60 @@ def basename_to_bundle_key(snapshot: BundleSnapshot) -> dict[str, str]:
     caller degrades to comparing the raw basename, rather than raising.
     """
     return {path.name: key for key, path in snapshot.libraries.items()}
+
+
+@dataclass(frozen=True)
+class BundleSignatureEvidence:
+    """Compact, per-library stand-in for an :class:`~abicheck.model.
+    AbiSnapshot`, carrying only what
+    :func:`abicheck.bundle_signature_evidence.find_unverified_signature_
+    findings` actually reads from one (G38 stabilization Phase 9, memory
+    regression fix).
+
+    Wiring Phase 4 into the live ``compare --release`` path made every
+    directory/package comparison retain each library's full old+new
+    ``AbiSnapshot`` (functions, types, layouts, source graph, build-source
+    evidence -- everything) until the whole release finished and bundle
+    analysis ran, even when neither JUnit nor ``--bundle-facts-out`` needed
+    it. Confirmed by reading every attribute
+    ``find_unverified_signature_findings``'s own helpers touch on a
+    snapshot: exactly ``function_map``, ``variable_map``, and
+    ``elf_only_mode`` -- never a type, a record, the source graph, or any
+    other field. This type exposes only those three, built once right
+    after a per-library comparison completes
+    (:meth:`from_snapshot`), so the caller can drop its reference to the
+    full ``AbiSnapshot`` and let the rest of it (the part that actually
+    dominates memory for a template-heavy C++ library) be garbage
+    collected instead of retained for the whole release.
+
+    Deliberately duck-type compatible with ``AbiSnapshot`` for this one
+    consumer's purposes rather than a narrower ``Protocol`` -- both this
+    type and ``AbiSnapshot`` are accepted anywhere
+    ``find_unverified_signature_findings`` takes an
+    ``old_snapshots``/``new_snapshots`` mapping, so a caller that *does*
+    need the full snapshot for another reason (JUnit, ``--bundle-facts-
+    out``) can keep passing the real thing with no special-casing on the
+    receiving end.
+    """
+
+    function_map: Mapping[str, Function]
+    variable_map: Mapping[str, Variable]
+    elf_only_mode: bool
+
+    @classmethod
+    def from_snapshot(cls, snapshot: AbiSnapshot) -> BundleSignatureEvidence:
+        """Project *snapshot* down to its bundle-signature-evidence-relevant
+        fields. Holds references to the same ``Function``/``Variable``
+        objects (no deep copy) -- correct because those are exactly what
+        the caller wants to keep alive; everything else *not* referenced
+        from here becomes eligible for garbage collection once the caller
+        drops its own reference to ``snapshot``.
+        """
+        return cls(
+            function_map=snapshot.function_map,
+            variable_map=snapshot.variable_map,
+            elf_only_mode=snapshot.elf_only_mode,
+        )
 
 
 @dataclass

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -62,45 +62,74 @@ DEFAULT_SYSTEM_PROVIDERS: frozenset[str] = frozenset(
     }
 )
 
-#: G38 stabilization (post-Phase-4): the single source of truth for "which
-#: confirmed per-symbol ``ChangeKind``s prove a sibling library's direct C
-#: calling-boundary contract changed." Two independent consumers must agree
-#: on this set, and previously did not:
+#: G38 stabilization (post-Phase-4, revised after a Codex review round on
+#: PR #845): "confirmed, so don't claim total ignorance about this symbol"
+#: (suppression) and "confirmed severely enough to promote a per-library
+#: change to a consumer-attributed BREAKING bundle finding" (promotion) are
+#: two different bars, not one. An earlier revision of this constant tried
+#: to serve both with a single 12-kind set shared by `bundle.py`'s
+#: promotion path and `bundle_signature_evidence.py`'s suppression path —
+#: which was wrong in a concrete, checkable way: `FUNC_NOEXCEPT_ADDED`'s
+#: own registry entry (`change_registry.py`) has `default_verdict=
+#: COMPATIBLE`, and `FUNC_NOEXCEPT_REMOVED`/`FUNC_EXCEPTION_SPEC_CHANGED`
+#: are `COMPATIBLE_WITH_RISK` with an explicit "not a binary break"
+#: rationale — promoting either to a BREAKING
+#: `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` would have fabricated a
+#: release-blocking cross-library break out of a change the tool's own
+#: policy layer says is not one. `FUNC_VIRTUAL_ADDED`/`FUNC_VIRTUAL_REMOVED`
+#: are genuinely `BREAKING`, but about vtable-slot layout, not a direct
+#: mismatched call boundary — a different failure mode than what
+#: `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`'s own description ("Calling
+#: convention is now mismatched") claims. This module therefore keeps two
+#: sets, one a strict subset of the other (see the test asserting that
+#: relationship in `tests/test_bundle.py`):
 #:
-#: - :func:`abicheck.bundle._detect_intra_dep_signature_changed` — promotes
-#:   a confirmed change of one of these kinds on a provider's own export to
-#:   a consumer-attributed ``BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`` finding.
-#: - :mod:`abicheck.bundle_signature_evidence` — treats a confirmed change
-#:   of one of these kinds as proof that *something* concrete is known
-#:   about the symbol, and therefore suppresses its own
-#:   ``BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED`` "couldn't tell either way"
-#:   finding for it.
+#: - :data:`CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` (broad) — used only
+#:   by :mod:`abicheck.bundle_signature_evidence` for suppression: any one
+#:   of these being confirmed means *something* concrete is known about the
+#:   symbol, which is enough to withhold the "couldn't tell either way"
+#:   `BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` finding, without that
+#:   confirmed fact itself needing to be a proven binary break.
+#: - :data:`PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS` (narrow) — used
+#:   only by :func:`abicheck.bundle._detect_intra_dep_signature_changed`
+#:   for promotion: a confirmed change of one of *these* kinds on a
+#:   provider's own export is promoted to a consumer-attributed
+#:   `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` finding. Every member is both
+#:   `default_verdict=BREAKING` on its own and describes a genuine,
+#:   direct call-boundary mismatch (parameter/return/variable type,
+#:   variadicness, calling convention) rather than a vtable-layout or
+#:   policy-adjustable source-level concern.
 #:
-#: Before this constant existed, `bundle.py` promoted only three kinds
-#: (``FUNC_PARAMS_CHANGED``/``FUNC_RETURN_CHANGED``/``VAR_TYPE_CHANGED``)
-#: while `bundle_signature_evidence.py` independently suppressed on twelve
-#: — so a confirmed ``CALLING_CONVENTION_CHANGED`` (say) correctly
-#: suppressed the "unverified" finding but was silently *not* promoted to
-#: a consumer-attributed break, losing the cross-library causality the
-#: bundle report exists to surface. Living here (not in either consumer
-#: module) matches this module's own leaf-module contract: `bundle.py`
-#: imports it directly, and `bundle_signature_evidence.py` — which must
-#: not import `bundle.py` (see that module's own docstring on why it stays
-#: leaf-only) — already imports this module for `BundleFinding`/
-#: `BundleSnapshot`/`ConsumerEntry`/`ProviderEntry`, so this adds no new
-#: import edge either direction.
+#: Before the broad set existed, `bundle.py` promoted only three kinds
+#: (`FUNC_PARAMS_CHANGED`/`FUNC_RETURN_CHANGED`/`VAR_TYPE_CHANGED`) while
+#: `bundle_signature_evidence.py` independently suppressed on twelve — a
+#: confirmed `CALLING_CONVENTION_CHANGED` correctly suppressed the
+#: "unverified" finding but was never promoted, losing cross-library
+#: causality. The narrow set closes exactly that gap (adding
+#: `FUNC_VARIADIC_ADDED`/`FUNC_VARIADIC_REMOVED`/`CALLING_CONVENTION_
+#: CHANGED` to the original three) without also promoting the nine kinds
+#: that are correctly suppression-only evidence.
 #:
-#: Deliberately excludes ``CTOR_EXPLICIT_ADDED``/``CTOR_EXPLICIT_REMOVED``:
-#: an ``explicit`` specifier transition is a purely source-level fact that
-#: never alters the mangled name (see `checker_policy.py`'s own
-#: `ChangeKind` comment for these two kinds) and therefore proves nothing
-#: about whether the binary calling signature — params, return type,
-#: variadicness, calling convention, ... — this set exists to police still
-#: agrees. Also excludes ``FUNC_LANGUAGE_LINKAGE_CHANGED`` (an
-#: ``extern "C"`` transition changes the mangled name itself, so old/new
-#: can't share the symbol key either consumer matches on) and the
-#: vtable-slot/inline-transition kinds (about virtual-dispatch layout and
-#: definition placement, not calling-signature agreement).
+#: Living here (not in either consumer module) matches this module's own
+#: leaf-module contract: `bundle.py` imports it directly, and
+#: `bundle_signature_evidence.py` — which must not import `bundle.py` (see
+#: that module's own docstring on why it stays leaf-only) — already
+#: imports this module for `BundleFinding`/`BundleSnapshot`/
+#: `ConsumerEntry`/`ProviderEntry`, so this adds no new import edge either
+#: direction.
+#:
+#: `CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` deliberately excludes
+#: `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED`: an `explicit` specifier
+#: transition is a purely source-level fact that never alters the mangled
+#: name (see `checker_policy.py`'s own `ChangeKind` comment for these two
+#: kinds) and therefore proves nothing about whether the binary calling
+#: signature — params, return type, variadicness, calling convention, ...
+#: — this set exists to police still agrees. Also excludes
+#: `FUNC_LANGUAGE_LINKAGE_CHANGED` (an `extern "C"` transition changes the
+#: mangled name itself, so old/new can't share the symbol key either
+#: consumer matches on) and the vtable-slot/inline-transition kinds (about
+#: virtual-dispatch layout and definition placement, not calling-signature
+#: agreement).
 CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS: frozenset[ChangeKind] = frozenset(
     {
         ChangeKind.FUNC_PARAMS_CHANGED,
@@ -117,6 +146,34 @@ CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS: frozenset[ChangeKind] = frozenset(
         ChangeKind.FUNC_VIRTUAL_REMOVED,
     }
 )
+
+#: The narrow, promotion-only subset of the set above — see that constant's
+#: own docstring for the full reasoning. Every member has
+#: `default_verdict=BREAKING` in `change_registry.py` *and* describes a
+#: direct call-boundary mismatch, not a vtable-layout or policy-adjustable
+#: source-level concern. `FUNC_NOEXCEPT_ADDED`/`FUNC_NOEXCEPT_REMOVED`/
+#: `FUNC_EXCEPTION_SPEC_CHANGED` (COMPATIBLE/RISK, explicitly "not a binary
+#: break" per their own registry comments) and `FUNC_VIRTUAL_ADDED`/
+#: `FUNC_VIRTUAL_REMOVED`/`FUNC_REF_QUAL_CHANGED` (BREAKING, but about
+#: vtable-slot layout or overload-resolution mangling rather than a plain
+#: mismatched calling boundary on an otherwise-identical symbol) are
+#: deliberately excluded — promoting any of them would fabricate a
+#: release-blocking cross-library finding from a change that is not one,
+#: or not one of *this* shape.
+PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS: frozenset[ChangeKind] = frozenset(
+    {
+        ChangeKind.FUNC_PARAMS_CHANGED,
+        ChangeKind.FUNC_RETURN_CHANGED,
+        ChangeKind.VAR_TYPE_CHANGED,
+        ChangeKind.FUNC_VARIADIC_ADDED,
+        ChangeKind.FUNC_VARIADIC_REMOVED,
+        ChangeKind.CALLING_CONVENTION_CHANGED,
+    }
+)
+
+assert PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS.issubset(
+    CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+), "every promotable kind must also count as confirmed evidence for suppression"
 
 
 @dataclass(frozen=True)

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from .checker_policy import ChangeKind, Verdict, compute_verdict, effective_category
 from .checker_types import Change, DiffResult
+from .contract_gating import is_evaluated
 from .elf_metadata import ElfMetadata
 from .model import AbiSnapshot, Function, Variable
 
@@ -437,7 +438,16 @@ def diff_change_is_breaking(
     the same one that already scored the per-library finding -- so a
     policy-file override can't be defeated by promotion the way the
     named-policy override already couldn't be.
+
+    Also checks ADR-049 contract-relevance status first (Codex review):
+    a ``NOT_EVALUATED`` (out-of-contract-scope) finding stays in
+    ``diff.changes`` but is excluded from the per-library verdict/exit
+    code, so promoting it here would contradict that already-scored
+    result -- ``is_evaluated`` defaults ``True`` for an unstamped finding,
+    so a run with no ``--contract`` is unaffected.
     """
+    if not is_evaluated(change):
+        return False
     if diff.policy_file is not None:
         return diff.policy_file.compute_verdict([change]) == Verdict.BREAKING
     return effective_category(change, *policy_sets) == Verdict.BREAKING

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -30,7 +30,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .checker_policy import ChangeKind, Verdict, compute_verdict
+from .checker_policy import ChangeKind, Verdict, compute_verdict, effective_category
 from .checker_types import Change, DiffResult
 from .elf_metadata import ElfMetadata
 from .model import AbiSnapshot, Function, Variable
@@ -344,6 +344,77 @@ def basename_to_bundle_key(snapshot: BundleSnapshot) -> dict[str, str]:
     caller degrades to comparing the raw basename, rather than raising.
     """
     return {path.name: key for key, path in snapshot.libraries.items()}
+
+
+def consumer_resolves_via_provider(
+    new: BundleSnapshot,
+    consumer: ConsumerEntry,
+    provider_lib: str,
+    symbol: str,
+    reachable: set[str],
+) -> bool:
+    """Whether *consumer*'s import of *symbol* actually resolves against
+    *provider_lib* specifically, not merely "some library in the bundle
+    happens to export a same-named symbol."
+
+    Mirrors ``bundle._detect_unresolved_intra_dependency``'s version-aware,
+    reachability-constrained provider matching (see that function's own
+    docstring for the full contract, including the unversioned
+    ``is_default`` subtlety) -- narrowed here to check one specific
+    candidate provider rather than "does this consumer resolve *anywhere*."
+    Two same-named exports across unrelated bundle siblings is a real, if
+    unusual, shape (CodeRabbit review, G38 stabilization): without this
+    check, a promoted signature-change finding could attribute a consumer
+    to a provider it never actually links against. Lives here rather than
+    in ``bundle.py`` purely to keep that module under its AI-readiness
+    file-size cap -- no other reason for the split.
+    """
+    if provider_lib not in reachable:
+        return False
+    candidate = next(
+        (p for p in new.resolution.providers_for(symbol) if p.library == provider_lib),
+        None,
+    )
+    if candidate is None:
+        return False
+    if not consumer.version:
+        # An unversioned reference can only be satisfied by an unversioned
+        # or default-version ("@@default") provider definition.
+        return candidate.is_default
+    if consumer.version_soname:
+        target_lib = new.resolution.soname_to_name.get(consumer.version_soname)
+        if target_lib != provider_lib:
+            return False
+    return candidate.version == consumer.version
+
+
+def diff_change_is_breaking(
+    diff: DiffResult,
+    change: Change,
+    policy_sets: tuple[
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+    ],
+) -> bool:
+    """Whether *change* classifies as ``BREAKING`` under the policy that
+    actually scored *diff* (Codex review, G38 stabilization).
+
+    ``policy_kind_sets(policy)`` alone only knows a *named* base policy
+    (``strict_abi``/``plugin_abi``/...) -- a ``--policy-file`` demotion is
+    resolved through a completely separate path
+    (``PolicyFile.compute_verdict``) that does **not** populate
+    ``Change.effective_verdict``, so ``checker_policy.effective_category``
+    alone cannot see it. When the originating diff carries a resolved
+    ``PolicyFile``, defer to its own per-change classification instead --
+    the same one that already scored the per-library finding -- so a
+    policy-file override can't be defeated by promotion the way the
+    named-policy override already couldn't be.
+    """
+    if diff.policy_file is not None:
+        return diff.policy_file.compute_verdict([change]) == Verdict.BREAKING
+    return effective_category(change, *policy_sets) == Verdict.BREAKING
 
 
 @dataclass(frozen=True)

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -308,6 +308,42 @@ class BundleSnapshot:
         return None
 
 
+def basename_to_bundle_key(snapshot: BundleSnapshot) -> dict[str, str]:
+    """Map each library's real on-disk file basename to its bundle-canonical
+    key (``snapshot.libraries``' own keys -- the same version-stripped key
+    :func:`~abicheck.binary_utils._canonical_library_key` produces, e.g.
+    ``libfoo.so`` for a real ``libfoo.so.1.2.3``).
+
+    G38 stabilization (Codex/CodeRabbit review on PR #845, fresh evidence,
+    with a concrete repro traced through the wired ``compare --release``
+    path): :class:`~abicheck.checker_types.DiffResult.library` is always set
+    from ``path.name`` (`abicheck/service.py`/`abicheck/dumper.py`, every
+    ELF/PE/Mach-O dump site) -- the literal on-disk filename, not the
+    bundle's canonical key -- so for any normally-versioned SONAME the two
+    differ. `bundle_signature_evidence.py`'s own `_confirmed_provider_
+    symbols` needed this exact fix once already (see that module's git
+    history); `bundle.py`'s `diff_by_library` construction had the
+    identical bug independently, confirmed via `cli_compare_release.py`'s
+    own `_bundle_key`/`DiffResult.library` split: the release fan-out
+    stores the canonical key separately and leaves `DiffResult.library` as
+    the real, possibly-versioned filename, so `compare_bundle()`'s
+    `_detect_intra_dep_signature_changed`/`_detect_intra_type_changed`/
+    `_detect_provider_changed` could attribute a promoted finding to
+    ``provider_library="libcore.so.1.2.3"`` while `BundleSnapshot.
+    resolution` keys the same provider as ``"libcore.so"`` -- silently
+    breaking the ``consumer.library != provider_lib``/lookup comparisons
+    those detectors depend on. Living here (not duplicated in each
+    consumer module) is exactly what this module's own leaf-module
+    contract exists for -- see :data:`CONFIRMED_C_BOUNDARY_SIGNATURE_
+    BREAK_KINDS`'s docstring for the identical reasoning applied to a
+    shared constant instead of a shared function.
+
+    A basename with no matching bundle entry is left unmapped -- the
+    caller degrades to comparing the raw basename, rather than raising.
+    """
+    return {path.name: key for key, path in snapshot.libraries.items()}
+
+
 @dataclass
 class BundleFinding:
     """A single bundle-level finding.

--- a/abicheck/bundle_models.py
+++ b/abicheck/bundle_models.py
@@ -371,21 +371,27 @@ def consumer_resolves_via_provider(
     """
     if provider_lib not in reachable:
         return False
-    candidate = next(
-        (p for p in new.resolution.providers_for(symbol) if p.library == provider_lib),
-        None,
-    )
-    if candidate is None:
+    # A single provider library can legitimately export several *versioned*
+    # definitions of the same bare symbol name (e.g. compat-symbol pattern
+    # `foo@V1` alongside `foo@@V2`) -- check every one of this provider's
+    # own entries (`any`, mirroring `_detect_unresolved_intra_dependency`'s
+    # own matching), not just the first one found (Codex review): picking
+    # only the first could test a non-matching V1 entry while the real
+    # match is a later V2 one from the same provider.
+    candidates = [
+        p for p in new.resolution.providers_for(symbol) if p.library == provider_lib
+    ]
+    if not candidates:
         return False
     if not consumer.version:
         # An unversioned reference can only be satisfied by an unversioned
         # or default-version ("@@default") provider definition.
-        return candidate.is_default
+        return any(c.is_default for c in candidates)
     if consumer.version_soname:
         target_lib = new.resolution.soname_to_name.get(consumer.version_soname)
         if target_lib != provider_lib:
             return False
-    return candidate.version == consumer.version
+    return any(c.version == consumer.version for c in candidates)
 
 
 def diff_change_is_breaking(

--- a/abicheck/bundle_resolution_reachability.py
+++ b/abicheck/bundle_resolution_reachability.py
@@ -61,3 +61,20 @@ def reachable_intra_libraries(snapshot: BundleSnapshot, root: str) -> set[str]:
             seen.add(target)
             queue.append(target)
     return seen
+
+
+def cached_reachable_intra_libraries(
+    snapshot: BundleSnapshot, cache: dict[str, set[str]], root: str
+) -> set[str]:
+    """Memoized :func:`reachable_intra_libraries`, using *cache* as the
+    memo table (one BFS per distinct *root* across repeated calls).
+
+    Deliberately **not** ``cache.setdefault(root, reachable_intra_libraries(...))``
+    (Codex review, fresh evidence): a `dict.setdefault` call's default-value
+    argument is evaluated unconditionally by Python, before the key
+    membership check -- that would run the full BFS on every call
+    regardless of cache hit, defeating the memoization entirely.
+    """
+    if root not in cache:
+        cache[root] = reachable_intra_libraries(snapshot, root)
+    return cache[root]

--- a/abicheck/bundle_signature_evidence.py
+++ b/abicheck/bundle_signature_evidence.py
@@ -105,84 +105,43 @@ import re
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 
-from .bundle_models import BundleFinding, BundleSnapshot, ConsumerEntry, ProviderEntry
+from .bundle_models import (
+    CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
+    BundleFinding,
+    BundleSnapshot,
+    ConsumerEntry,
+    ProviderEntry,
+)
 from .bundle_resolution_reachability import reachable_intra_libraries
 from .checker_policy import ChangeKind
 from .checker_types import DiffResult
 from .model import AbiSnapshot, Visibility
 
-#: Every per-symbol diff kind this module's own evidence-sufficiency check
-#: (`_symbol_evidence_sufficient`) can itself detect the *positive* side
-#: of. The first three (`FUNC_PARAMS_CHANGED`/`FUNC_RETURN_CHANGED`/
-#: `VAR_TYPE_CHANGED`) are the same three `bundle._detect_intra_dep_
-#: signature_changed` promotes to `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`;
-#: duplicated here (rather than imported from `bundle.py`) since that
-#: module must not import this leaf-module's own detector (see this
-#: module's own docstring on why it stays leaf-only) and a shared
-#: constant would need a home neither module owns. `FUNC_VARIADIC_ADDED`/
-#: `FUNC_VARIADIC_REMOVED`/`CALLING_CONVENTION_CHANGED` were added
-#: alongside this module's own `is_variadic`/`contract_attributes`
-#: sufficiency checks (Codex review, fresh evidence): without them, a
-#: symbol that diff_symbols already confirmed changed on one of *those*
-#: two axes, but which also happens to carry an unrelated unresolved
-#: field (an unresolved parameter type, say), would still produce a
-#: redundant, contradictory "cannot be confirmed or denied" finding
-#: alongside the already-proven break. A confirmed change for a symbol
-#: always takes precedence over the unverified kind this module emits --
-#: real evidence of a break is strictly more informative than "couldn't
-#: tell either way". `bundle._detect_intra_dep_signature_changed`'s own
-#: `relevant_kinds` set does not (yet) include these two -- a
-#: pre-existing, narrower gap in that sibling function, not something
-#: this module's own precedence check needs to wait on.
-#:
-#: The next six kinds (Codex review, fresh evidence, filed after the three
-#: above already went in) close the same coexistence gap for every *other*
-#: `Function`-level fact `diff_symbols.py` can independently confirm or deny
-#: with certainty, none of which `_symbol_evidence_sufficient` itself
-#: inspects (it only ever reads `return_type`/`params`/`is_variadic`/
-#: `contract_attributes`): `is_noexcept`/`is_virtual`/`ref_qualifier` are
-#: plain (non-tri-state) `Function` fields, always confidently comparable
-#: regardless of any other field's resolution state; `exception_spec` is a
-#: tri-state field whose own `diff_symbols._check_exception_spec_change`
-#: already skips on `None` the identical way `_check_variadic_change`/
-#: `_check_contract_attributes_change` do. Any one of these being genuinely
-#: confirmed for a symbol is exactly as informative as a confirmed
-#: params/return/variadic/calling-convention change -- "we know something
-#: concrete changed (or didn't) here," not "we couldn't tell" -- so it must
-#: suppress this module's own risk finding the same way.
-#:
-#: Deliberately excluded: `FUNC_LANGUAGE_LINKAGE_CHANGED` (an `extern "C"`
-#: transition changes the mangled name itself, so old/new can't share the
-#: `symbol` key this module matches on in the first place); the
-#: vtable-slot/inline-transition kinds (about virtual-dispatch layout and
-#: definition placement, not the calling-signature-agreement question this
-#: module exists to answer); and `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_
-#: REMOVED` (Codex review, fresh evidence -- tried once, reverted). Unlike
-#: every kind actually included above, an `explicit` specifier transition
-#: is a purely source-level fact: `checker_policy.py`'s own `ChangeKind`
-#: comment for these two kinds states plainly "neither change alters the
-#: mangled name," meaning it proves nothing about whether the *binary*
-#: calling signature this module exists to verify (params/return/
-#: variadic/calling-convention/...) actually still agrees. Including it in
-#: this set let a confirmed, unrelated source-level fact silently suppress
-#: a real, still-unresolved binary-signature-agreement question for the
-#: same symbol.
-_CONFIRMED_SIGNATURE_CHANGE_KINDS = frozenset(
-    {
-        ChangeKind.FUNC_PARAMS_CHANGED,
-        ChangeKind.FUNC_RETURN_CHANGED,
-        ChangeKind.VAR_TYPE_CHANGED,
-        ChangeKind.FUNC_VARIADIC_ADDED,
-        ChangeKind.FUNC_VARIADIC_REMOVED,
-        ChangeKind.CALLING_CONVENTION_CHANGED,
-        ChangeKind.FUNC_NOEXCEPT_ADDED,
-        ChangeKind.FUNC_NOEXCEPT_REMOVED,
-        ChangeKind.FUNC_EXCEPTION_SPEC_CHANGED,
-        ChangeKind.FUNC_REF_QUAL_CHANGED,
-        ChangeKind.FUNC_VIRTUAL_ADDED,
-        ChangeKind.FUNC_VIRTUAL_REMOVED,
-    }
-)
+#: G38 stabilization: this used to be a locally-duplicated frozenset
+#: (comment preserved below for the history of why each kind is or isn't
+#: included), independently maintained from `bundle._detect_intra_dep_
+#: signature_changed`'s own `relevant_kinds` set -- and the two drifted:
+#: `bundle.py` promoted only three kinds
+#: (`FUNC_PARAMS_CHANGED`/`FUNC_RETURN_CHANGED`/`VAR_TYPE_CHANGED`) to a
+#: consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` finding while
+#: this module already suppressed its own "unverified" finding on nine
+#: more. A confirmed `CALLING_CONVENTION_CHANGED` (say) correctly
+#: suppressed this module's uncertainty finding but was silently never
+#: promoted to a cross-library break -- losing exactly the causality the
+#: bundle report exists to surface. Both consumers now import the same
+#: :data:`abicheck.bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS`
+#: rather than keeping two lists that can disagree again; see that
+#: constant's own docstring for the per-kind inclusion/exclusion reasoning
+#: (`FUNC_VARIADIC_ADDED`/`FUNC_VARIADIC_REMOVED`/`CALLING_CONVENTION_
+#: CHANGED`, then `is_noexcept`/`is_virtual`/`ref_qualifier`/
+#: `exception_spec`, all added across several Codex review rounds for the
+#: identical "a confirmed change on one axis must not coexist with a
+#: contradictory 'couldn't tell' finding on the whole symbol" reason;
+#: `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED` deliberately excluded,
+#: tried once and reverted, since an `explicit` transition never changes
+#: the mangled name and proves nothing about the binary calling signature
+#: this module verifies).
+_CONFIRMED_SIGNATURE_CHANGE_KINDS = CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
 
 #: The sentinel `dumper_elf_fallback.py` (and any other L0-only extraction
 #: path) writes into `Function.return_type`/`Param.type`/`Variable.type`

--- a/abicheck/bundle_signature_evidence.py
+++ b/abicheck/bundle_signature_evidence.py
@@ -108,6 +108,7 @@ from pathlib import Path
 from .bundle_models import (
     CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
     BundleFinding,
+    BundleSignatureEvidence,
     BundleSnapshot,
     ConsumerEntry,
     ProviderEntry,
@@ -246,7 +247,9 @@ def _type_spelling_is_unresolved(spelling: str) -> bool:
     )
 
 
-def _symbol_evidence_sufficient(symbol: str, snapshot: AbiSnapshot) -> bool:
+def _symbol_evidence_sufficient(
+    symbol: str, snapshot: AbiSnapshot | BundleSignatureEvidence
+) -> bool:
     """Does *snapshot* carry real DWARF/header-derived type evidence for
     *symbol*, as opposed to only a bare ELF export with no corroborating
     declaration?
@@ -328,7 +331,9 @@ def _symbol_evidence_sufficient(symbol: str, snapshot: AbiSnapshot) -> bool:
     return False
 
 
-def _symbol_was_exported(symbol: str, snapshot: AbiSnapshot) -> bool:
+def _symbol_was_exported(
+    symbol: str, snapshot: AbiSnapshot | BundleSignatureEvidence
+) -> bool:
     """Did *snapshot*'s own `Function`/`Variable` entry for *symbol* actually
     reach the binary's *dynamic* export table (`.dynsym`) -- as opposed to
     merely being *some* declaration, public or private, that `AbiSnapshot`
@@ -547,8 +552,8 @@ def find_unverified_signature_findings(
     old: BundleSnapshot,
     new: BundleSnapshot,
     per_library_results: Iterable[DiffResult],
-    old_snapshots: Mapping[str, AbiSnapshot],
-    new_snapshots: Mapping[str, AbiSnapshot],
+    old_snapshots: Mapping[str, AbiSnapshot | BundleSignatureEvidence],
+    new_snapshots: Mapping[str, AbiSnapshot | BundleSignatureEvidence],
 ) -> list[BundleFinding]:
     """`BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` findings: a sibling library's
     undefined import resolves by name to a provider's export in *new* (the
@@ -572,8 +577,12 @@ def find_unverified_signature_findings(
 
     *old_snapshots*/*new_snapshots* map bundle-relative library name (the
     same canonical key `BundleSnapshot.libraries` uses) to that library's
-    own `AbiSnapshot` -- the one input `compare_bundle` itself never
-    receives. A provider absent from either mapping, or whose symbol was
+    own `AbiSnapshot` -- or, since G38 stabilization Phase 9, the
+    cheaper `BundleSignatureEvidence` projection of one (see that type's
+    own docstring); both are accepted since this function reads only the
+    three fields the projection carries. Either way this is the one input
+    `compare_bundle` itself never receives. A provider absent from either
+    mapping, or whose symbol was
     not actually part of the *old* side's export surface (`_symbol_was_
     exported`), is skipped for that symbol -- this covers both a genuine
     addition (no declaration on the old side at all) and a symbol that

--- a/abicheck/bundle_signature_evidence.py
+++ b/abicheck/bundle_signature_evidence.py
@@ -111,6 +111,7 @@ from .bundle_models import (
     BundleSnapshot,
     ConsumerEntry,
     ProviderEntry,
+    basename_to_bundle_key,
 )
 from .bundle_resolution_reachability import reachable_intra_libraries
 from .checker_policy import ChangeKind
@@ -367,26 +368,13 @@ def _symbol_was_exported(symbol: str, snapshot: AbiSnapshot) -> bool:
     return False
 
 
-def _basename_to_bundle_key(old: BundleSnapshot) -> dict[str, str]:
-    """Map each library's real on-disk file basename to its bundle-canonical
-    key (``old.libraries``' own keys -- the same version-stripped key
-    :func:`~abicheck.binary_utils._canonical_library_key` produces, e.g.
-    ``libfoo.so`` for a real ``libfoo.so.1.2.3``).
-
-    :class:`~abicheck.checker_types.DiffResult.library` is always set from
-    ``path.name`` (`abicheck/service.py`/`abicheck/dumper.py`, every ELF/PE/
-    Mach-O dump site) -- the literal on-disk filename, not the bundle's
-    canonical key -- so for any normally-versioned SONAME the two differ
-    (Codex review, fresh evidence: `_confirmed_provider_symbols` previously
-    compared a `DiffResult`'s raw basename directly against
-    `BundleSnapshot.resolution`'s canonical keys, which never match for a
-    realistically-versioned library, silently defeating the "a confirmed
-    change outranks unverified" precedence for the overwhelmingly common
-    case). A basename with no matching bundle entry is left unmapped --
-    the caller degrades to comparing the raw basename, same as before this
-    fix, rather than raising.
-    """
-    return {path.name: key for key, path in old.libraries.items()}
+#: G38 stabilization: this used to be a locally-duplicated function
+#: (`_basename_to_bundle_key`, original docstring's own history preserved
+#: in `bundle_models.basename_to_bundle_key` now) -- `bundle.py`'s own
+#: `diff_by_library` construction had the identical bug independently
+#: (Codex/CodeRabbit review on PR #845), so the fix moved to the one
+#: shared leaf module both already import from.
+_basename_to_bundle_key = basename_to_bundle_key
 
 
 def _confirmed_provider_symbols(

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -33,6 +33,7 @@ import click
 
 from .api_types import CompareResult
 from .bundle import BundleDiffResult
+from .bundle_models import BundleSignatureEvidence
 from .checker import Change, DiffResult
 from .cli import (
     _build_match_map,
@@ -224,6 +225,7 @@ _CompareReleaseCommonArgs = tuple[
     "SeverityConfig | None",
     "PackApplication | None",
     bool,
+    bool,
     "CompileContext | None",
 ]
 
@@ -270,34 +272,24 @@ def _compare_one_library(
     severity_config: SeverityConfig | None = None,
     pack_application: PackApplication | None = None,
     collect_diff_results: bool = False,
+    need_full_snapshots: bool = False,
     compile_context: CompileContext | None = None,
 ) -> dict[str, object]:
-    """Compare one library pair — suitable for parallel dispatch.
+    """Compare one library pair — suitable for parallel dispatch. Any
+    exception yields an ERROR entry rather than aborting the release.
 
-    The entire per-library flow (debug info resolution, comparison, output
-    writing) is wrapped so that *any* exception yields an ERROR entry
-    instead of aborting the whole release comparison.
+    The full :class:`DiffResult` is stashed under ``"_diff_result"``;
+    callers needing it (bundle layer, JUnit) pop it before JSON-serialising.
+    *collect_diff_results* additionally stashes ``"_bundle_key"`` plus
+    either ``"_old_snapshot"``/``"_new_snapshot"`` (when
+    *need_full_snapshots* -- JUnit/``--bundle-facts-out``) or the much
+    smaller ``"_old_bundle_evidence"``/``"_new_bundle_evidence"`` (G38
+    Phase 9's memory fix; see :class:`~abicheck.bundle_models.
+    BundleSignatureEvidence`).
 
-    The full :class:`DiffResult` is stashed in the returned dict under
-    the ``"_diff_result"`` key. Callers that need the full diff (the
-    bundle layer, JUnit aggregation) pop it from the entry before
-    JSON-serialising — keeps the per-library compare a single-pass.
-
-    *collect_diff_results* additionally stashes old+new
-    :class:`AbiSnapshot`\\ s and this library's bundle-canonical key under
-    ``"_old_snapshot"``/``"_new_snapshot"``/``"_bundle_key"`` -- gated
-    (Codex review) since an `AbiSnapshot` is large. Feeds
-    `find_unverified_signature_findings` from ``_collect_bundle_result``
-    (G38 Phase 4 -- see its plan doc's "Update (2026-08-24)" note).
-
-    *severity_config* is forwarded to the per-library ``--output-dir`` JSON
-    write below (Codex review, fresh evidence): without it, that write
-    always used the legacy exit-code scheme's ``ExitDecision`` regardless of
-    whether the release itself resolved and gates on a severity
-    configuration — so a severity-aware release (``severity.addition:
-    error``, say) could exit non-zero at the release level while every
-    per-library report it wrote said ``exit.code: 0``, ``reasons:
-    ["clean"]``, disagreeing with the release's own real exit.
+    *severity_config* is forwarded to the ``--output-dir`` JSON write below
+    (Codex review): without it, that write always used the legacy
+    exit-code scheme regardless of the release's own severity config.
     """
     old_path = old_map[key]
     new_path = new_map[key]
@@ -346,20 +338,19 @@ def _compare_one_library(
             "_diff_result": result,
         }
         if collect_diff_results:
-            # CodeRabbit review, PR #798: stashed alongside `_diff_result`
-            # so a secondary JUnit render (`--write junit=...`/`--format
-            # junit`) can build its (DiffResult, old_snapshot) pairs
-            # straight from this single primary pass, the same way
-            # annotations already do -- instead of
-            # `_collect_release_extras`'s old independent re-run, whose own
-            # failure path silently *dropped* a pair from the secondary
-            # report on a rerun error even though the primary pass had
-            # already succeeded for it (a truncated JUnit report next to a
-            # complete primary one). Gated on the flag (Codex review,
-            # fresh evidence) -- see this function's own docstring for why.
-            entry["_old_snapshot"] = compare_result.old_snapshot
-            entry["_new_snapshot"] = compare_result.new_snapshot
+            # See this function's own docstring (CodeRabbit review #798;
+            # full- vs. compact-evidence split, G38 Phase 9).
             entry["_bundle_key"] = key
+            if need_full_snapshots:
+                entry["_old_snapshot"] = compare_result.old_snapshot
+                entry["_new_snapshot"] = compare_result.new_snapshot
+            else:
+                entry["_old_bundle_evidence"] = BundleSignatureEvidence.from_snapshot(
+                    compare_result.old_snapshot
+                )
+                entry["_new_bundle_evidence"] = BundleSignatureEvidence.from_snapshot(
+                    compare_result.new_snapshot
+                )
         if contract_evaluation:
             # ADR-049 Phase 7's orthogonal contract-coverage floor (0/1),
             # read off this library's own persisted contract context --
@@ -516,6 +507,7 @@ def _compare_release_libraries(
     output_dir: Path | None,
     collect_diff_results: bool = False,
     *,
+    need_full_snapshots: bool = False,
     jobs: int = 1,
     scope_to_public_surface: bool = True,
     include_dependencies: bool = True,
@@ -527,9 +519,9 @@ def _compare_release_libraries(
 ) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
     """Compare each matched library pair and collect results.
 
-    When *collect_diff_results* is True, ``(DiffResult, old_snapshot)``
-    pairs are collected and returned as the third element of the tuple
-    (used by the JUnit output format).
+    When *collect_diff_results* and *need_full_snapshots* are both True,
+    ``(DiffResult, old_snapshot)`` pairs are collected and returned as the
+    third element of the tuple (used by the JUnit output format).
 
     When *jobs* > 1, comparisons are dispatched in parallel via
     :func:`_compare_one_library` using a :class:`ThreadPoolExecutor` -- not
@@ -568,6 +560,7 @@ def _compare_release_libraries(
         severity_config,
         pack_application,
         collect_diff_results,
+        need_full_snapshots,
         compile_context,
     )
 
@@ -1100,10 +1093,9 @@ def _strip_diff_results_and_adjust_verdict(
     a library gated by a promoted addition/quality-issue category (not one of
     the legacy breaking/api_break/risk buckets) still gets a matching
     finding, not an empty list next to a nonzero ``severity.exit_code``.
-    Stripping ``_diff_result`` itself keeps the summary formatter free of any
-    Python-only objects. Additionally, if any library was *removed* from the
-    release and the verdict has not already been escalated, the verdict is
-    bumped to at least ``COMPATIBLE_WITH_RISK``.
+    Stripping the private keys (``_diff_result`` and friends) keeps the
+    summary formatter free of Python-only objects. If any library was
+    *removed*, the verdict is bumped to at least ``COMPATIBLE_WITH_RISK``.
 
     *needs_annotations* gates whether the uncapped ``annotations`` array
     (unlike ``findings`` above, deliberately unbounded -- see its own
@@ -1111,11 +1103,8 @@ def _strip_diff_results_and_adjust_verdict(
     render (primary ``--format json`` or a secondary ``--write
     json=...``) ever reads it, but every entry in ``library_results`` is
     held until the whole release finishes, so building it unconditionally
-    grew a large release's peak memory by the combined size of every
-    library's full finding set even for the common markdown/JUnit-only
-    case that never reads it -- the same class of gap the sibling
-    ``_old_snapshot``/``collect_diff_results`` gate already closed for
-    JUnit specifically.
+    grew peak memory by every library's full finding set even for a
+    markdown/JUnit-only render that never reads it.
 
     Returns the (possibly updated) *worst_verdict* string.
     """
@@ -1154,6 +1143,8 @@ def _strip_diff_results_and_adjust_verdict(
         entry.pop("_diff_result", None)
         entry.pop("_old_snapshot", None)
         entry.pop("_new_snapshot", None)
+        entry.pop("_old_bundle_evidence", None)
+        entry.pop("_new_bundle_evidence", None)
         entry.pop("_bundle_key", None)
     if removed_keys and _RELEASE_VERDICT_ORDER.get(
         worst_verdict, 0
@@ -1650,8 +1641,15 @@ def compare_release_cmd(
                 collect_diff_results=(
                     fmt == "junit"
                     or secondary_fmt == "junit"
+                    or bundle_facts_out is not None
                     # G38 Phase 4 (_compare_one_library's docstring):
                     or not no_bundle_analysis
+                ),
+                # Phase 9: only JUnit/--bundle-facts-out need AbiSnapshot.
+                need_full_snapshots=(
+                    fmt == "junit"
+                    or secondary_fmt == "junit"
+                    or bundle_facts_out is not None
                 ),
                 jobs=jobs,
                 scope_to_public_surface=scope_public_headers,

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -815,8 +815,18 @@ def _fold_release_global_severity(
     worst = base_code
     if bundle_result is not None and bundle_result.bundle_findings:
         # Bundle findings carry canonical (partitioned) ChangeKinds.
+        # G38 stabilization Phase 10 (Codex review, fresh evidence): this
+        # omitted `policy=` entirely, unlike the matrix_result branch right
+        # below it -- so a policy that reclassifies a bundle kind (e.g.
+        # `plugin_abi` demoting `calling_convention_changed`, which
+        # `BundleDiffResult.bundle_verdict` already honors via its own
+        # `.policy` field) never reached the severity-aware exit code,
+        # letting the displayed verdict and the process exit disagree.
         bundle_changes = [f.to_change() for f in bundle_result.bundle_findings]
-        worst = max(worst, compute_exit_code(bundle_changes, config))
+        worst = max(
+            worst,
+            compute_exit_code(bundle_changes, config, policy=bundle_result.policy),
+        )
     if matrix_result is not None and matrix_result.changes:
         worst = max(
             worst,

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 import click
 
 from .bundle import BundleDiffResult, render_bundle_findings_markdown
+from .bundle_models import BundleSignatureEvidence
 from .checker import DiffResult
 from .model import AbiSnapshot
 
@@ -157,8 +158,8 @@ def _run_bundle_analysis(
     bundle_system_providers: str,
     bundle_cohorts: tuple[str, ...] = (),
     policy: str = "strict_abi",
-    old_snapshots: dict[str, AbiSnapshot] | None = None,
-    new_snapshots: dict[str, AbiSnapshot] | None = None,
+    old_snapshots: dict[str, AbiSnapshot | BundleSignatureEvidence] | None = None,
+    new_snapshots: dict[str, AbiSnapshot | BundleSignatureEvidence] | None = None,
 ) -> BundleDiffResult | None:
     """Run bundle-level (ADR-023) analysis on a compare-release run.
 
@@ -549,10 +550,22 @@ def _collect_bundle_result(
     bundle_cohorts: tuple[str, ...] = (),
     policy: str = "strict_abi",
 ) -> tuple[BundleDiffResult | None, str]:
-    """Extract stashed DiffResults, run bundle analysis, update worst verdict."""
+    """Extract stashed DiffResults, run bundle analysis, update worst verdict.
+
+    Each entry carries *either* the full ``_old_snapshot``/``_new_snapshot``
+    (JUnit/``--bundle-facts-out`` in effect) *or* the much smaller
+    ``_old_bundle_evidence``/``_new_bundle_evidence`` (G38 stabilization
+    Phase 9's memory fix — see :class:`~abicheck.bundle_models.
+    BundleSignatureEvidence`) — never both, per
+    ``cli_compare_release._compare_one_library``'s own stash logic. Either
+    is duck-type compatible with what
+    :func:`~abicheck.bundle_signature_evidence.find_unverified_signature_
+    findings` reads, so both are folded into the same ``old_snapshots``/
+    ``new_snapshots`` mapping this function has always built.
+    """
     stashed_diffs: list[DiffResult] = []
-    old_snapshots: dict[str, AbiSnapshot] = {}
-    new_snapshots: dict[str, AbiSnapshot] = {}
+    old_snapshots: dict[str, AbiSnapshot | BundleSignatureEvidence] = {}
+    new_snapshots: dict[str, AbiSnapshot | BundleSignatureEvidence] = {}
     for entry in library_results:
         if not isinstance(entry, dict):
             continue
@@ -560,12 +573,12 @@ def _collect_bundle_result(
         if isinstance(diff, DiffResult):
             stashed_diffs.append(diff)
         bundle_key = entry.get("_bundle_key")
-        old_snap = entry.get("_old_snapshot")
-        new_snap = entry.get("_new_snapshot")
+        old_snap = entry.get("_old_snapshot") or entry.get("_old_bundle_evidence")
+        new_snap = entry.get("_new_snapshot") or entry.get("_new_bundle_evidence")
         if (
             isinstance(bundle_key, str)
-            and isinstance(old_snap, AbiSnapshot)
-            and isinstance(new_snap, AbiSnapshot)
+            and isinstance(old_snap, (AbiSnapshot, BundleSignatureEvidence))
+            and isinstance(new_snap, (AbiSnapshot, BundleSignatureEvidence))
         ):
             old_snapshots[bundle_key] = old_snap
             new_snapshots[bundle_key] = new_snap

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -167,8 +167,16 @@ def _run_bundle_analysis(
     :func:`_compare_release_libraries` — no second per-pair compare pass.
 
     Returns None when there is nothing to analyze (e.g. all libraries
-    failed to dump). Errors during analysis are caught and reported as a
-    warning rather than aborting; bundle analysis is additive.
+    failed to dump, or the bundle snapshot itself could not be built --
+    the two cases a caller has no meaningful ``BundleDiffResult`` to
+    inspect regardless). Errors during analysis are caught and reported
+    as a warning rather than aborting; bundle analysis is additive. A
+    failure in ``compare_bundle()`` itself or in the Phase 4
+    signature-evidence check is additionally recorded structurally, in
+    the returned result's own ``analysis_errors`` (G38 stabilization
+    Phase 11 / P0-D), so a JSON/Markdown report consumer can tell
+    "bundle analysis ran clean" apart from "ran, but degraded" without
+    grepping stderr.
 
     *old_snapshots*/*new_snapshots* (G38 Phase 4), when both given and
     non-empty, additionally run
@@ -229,10 +237,16 @@ def _run_bundle_analysis(
         )
     except Exception as exc:
         # Analysis-engine bugs should not block the per-library report;
-        # surface as a warning. Future work: surface as a coverage_warning
-        # in the JSON output so downstream CI can detect degradation.
+        # surface as a warning *and* structurally, in the returned result's
+        # own `analysis_errors` (G38 stabilization Phase 11), so a JSON
+        # report consumer isn't limited to grepping stderr to tell "clean"
+        # apart from "degraded".
         click.echo(f"Warning: bundle analysis raised: {exc}", err=True)
-        return BundleDiffResult(old_root=old_snap.root, new_root=new_snap.root)
+        return BundleDiffResult(
+            old_root=old_snap.root,
+            new_root=new_snap.root,
+            analysis_errors=[f"bundle analysis raised: {exc}"],
+        )
 
     if old_snapshots and new_snapshots:
         # G38 Phase 4: run separately from compare_bundle() itself (a
@@ -255,6 +269,9 @@ def _run_bundle_analysis(
             click.echo(
                 f"Warning: bundle signature-evidence check raised: {exc}",
                 err=True,
+            )
+            result.analysis_errors.append(
+                f"bundle signature-evidence check raised: {exc}"
             )
 
     return result
@@ -1110,6 +1127,16 @@ def _format_release_json(
             }
             for f in bundle_result.bundle_findings
         ]
+        # G38 P0-D: surface a bundle-analysis-step failure structurally
+        # instead of only as a stderr `click.echo`, so a JSON-consuming
+        # caller (CI gate, PR-comment renderer) can tell "bundle analysis
+        # ran clean" apart from "bundle analysis partially failed, treat
+        # bundle_verdict/bundle_findings as a possibly-incomplete view" --
+        # present only when non-empty, matching this file's established
+        # "present only when active" convention for the other optional
+        # summary keys above.
+        if bundle_result.analysis_errors:
+            summary["bundle_analysis_errors"] = list(bundle_result.analysis_errors)
     if matrix_result is not None:
         # Release-global build-configuration findings (G2: probe matrix).
         # `.changes` is post-suppression, so suppressed findings are
@@ -1272,15 +1299,26 @@ def _release_md_changed_libraries(
 
 
 def _release_md_bundle_findings(bundle_result: BundleDiffResult | None) -> list[str]:
-    """Markdown section for cross-library (bundle) findings."""
+    """Markdown section for cross-library (bundle) findings.
+
+    G38 P0-D: a partial ``analysis_errors`` warning is rendered even when
+    ``bundle_findings`` is empty -- an empty finding list after a raised
+    exception means "nothing was checked", not "nothing was found", and a
+    reader must not conflate the two.
+    """
+    lines: list[str] = []
+    if bundle_result is not None and bundle_result.analysis_errors:
+        lines += ["", "## ⚠️ Bundle Analysis Warnings", ""]
+        lines += [f"- {msg}" for msg in bundle_result.analysis_errors]
     if bundle_result is None or not bundle_result.bundle_findings:
-        return []
-    return [
+        return lines
+    lines += [
         "",
         "## 🔗 Bundle (Cross-Library) Findings",
         "",
         *render_bundle_findings_markdown(bundle_result.bundle_findings),
     ]
+    return lines
 
 
 def _release_md_matrix_findings(matrix_result: DiffResult | None) -> list[str]:

--- a/changelog.d/20260824_010000_claude_g38_phase5_shared_confirmed_boundary_kinds.md
+++ b/changelog.d/20260824_010000_claude_g38_phase5_shared_confirmed_boundary_kinds.md
@@ -4,20 +4,27 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
 
 ### Fixed
 
-- **G38 bundle analysis: the confirmed-signature-change kind set used to
-  promote a cross-library break and the kind set used to suppress
-  `BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` no longer disagree.**
-  `bundle._detect_intra_dep_signature_changed` previously promoted only
-  `func_params_changed`/`func_return_changed`/`var_type_changed` to a
-  consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` finding, while
-  `bundle_signature_evidence.find_unverified_signature_findings`
-  independently suppressed its own "unverified" finding on nine more kinds
-  (`func_variadic_added`/`removed`, `calling_convention_changed`,
-  `func_noexcept_added`/`removed`, `func_exception_spec_changed`,
-  `func_ref_qual_changed`, `func_virtual_added`/`removed`). A confirmed
-  `calling_convention_changed` on a provider's export therefore correctly
-  suppressed the "couldn't tell either way" finding but was never itself
+- **G38 bundle analysis: `calling_convention_changed`/`func_variadic_added`/
+  `func_variadic_removed` on a bundled provider's export now correctly
+  promote to a consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`
+  bundle finding, without also fabricating one for `noexcept`/exception-spec/
+  virtual-ness changes.** `bundle._detect_intra_dep_signature_changed`
+  previously promoted only `func_params_changed`/`func_return_changed`/
+  `var_type_changed` — so a confirmed `calling_convention_changed` on a
+  provider's export correctly suppressed
+  `bundle_signature_evidence`'s "couldn't tell either way"
+  `BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` finding but was never itself
   promoted to a cross-library break, silently losing the consumer-attributed
-  causality bundle reports exist to surface. Both detectors now import one
-  shared `bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` frozenset
-  instead of maintaining two independent lists.
+  causality bundle reports exist to surface. Fixed by widening the
+  promotion set to also cover `func_variadic_added`/`removed` and
+  `calling_convention_changed` — every one a genuine, `BREAKING`, direct
+  call-boundary mismatch. `func_noexcept_added`/`removed`,
+  `func_exception_spec_changed`, `func_ref_qual_changed`, and
+  `func_virtual_added`/`removed` remain deliberately excluded from
+  promotion (though they still correctly suppress the "unverified"
+  finding, a separate and weaker bar): `func_noexcept_added` has
+  `default_verdict=COMPATIBLE` and the other three are either
+  `COMPATIBLE_WITH_RISK` (explicitly "not a binary break") or describe
+  vtable-slot layout rather than a mismatched calling boundary, so
+  promoting any of them would fabricate a release-blocking bundle finding
+  out of a change that is not one.

--- a/changelog.d/20260824_010000_claude_g38_phase5_shared_confirmed_boundary_kinds.md
+++ b/changelog.d/20260824_010000_claude_g38_phase5_shared_confirmed_boundary_kinds.md
@@ -1,0 +1,23 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: the confirmed-signature-change kind set used to
+  promote a cross-library break and the kind set used to suppress
+  `BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` no longer disagree.**
+  `bundle._detect_intra_dep_signature_changed` previously promoted only
+  `func_params_changed`/`func_return_changed`/`var_type_changed` to a
+  consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` finding, while
+  `bundle_signature_evidence.find_unverified_signature_findings`
+  independently suppressed its own "unverified" finding on nine more kinds
+  (`func_variadic_added`/`removed`, `calling_convention_changed`,
+  `func_noexcept_added`/`removed`, `func_exception_spec_changed`,
+  `func_ref_qual_changed`, `func_virtual_added`/`removed`). A confirmed
+  `calling_convention_changed` on a provider's export therefore correctly
+  suppressed the "couldn't tell either way" finding but was never itself
+  promoted to a cross-library break, silently losing the consumer-attributed
+  causality bundle reports exist to surface. Both detectors now import one
+  shared `bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` frozenset
+  instead of maintaining two independent lists.

--- a/changelog.d/20260824_020000_claude_g38_phase5_provider_key_and_plugin_abi.md
+++ b/changelog.d/20260824_020000_claude_g38_phase5_provider_key_and_plugin_abi.md
@@ -1,0 +1,27 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: two more correctness gaps in the confirmed-boundary-
+  break promotion path, found by review after the fix above.**
+  1. `bundle._detect_intra_dep_signature_changed`'s `diff_by_library` lookup
+     previously keyed on `DiffResult.library`'s raw, possibly SONAME-versioned
+     on-disk basename (e.g. `libcore.so.1.2.3`), while
+     `BundleSnapshot.resolution` keys every provider/consumer by the
+     version-stripped bundle-canonical name (`libcore.so`) — so a promoted
+     finding could silently never fire, or attribute
+     `provider_library="libcore.so.1.2.3"` instead of the canonical name, for
+     any normally-versioned library. Fixed by sharing one
+     `bundle_models.basename_to_bundle_key()` function between `bundle.py`
+     and `bundle_signature_evidence.py` (which already had the identical fix
+     for its own, separate lookup).
+  2. Widening promotion to cover `calling_convention_changed` reached a kind
+     with a real `plugin_abi` policy demotion (`COMPATIBLE`, for a plugin and
+     its host rebuilt together from the same toolchain) — but the promoted
+     `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` bundle finding had no policy
+     sensitivity, always `BREAKING` regardless of the caller's selected
+     policy. `_detect_intra_dep_signature_changed` now takes the same
+     `policy` string `compare_bundle()` already receives and skips promoting
+     a change whose effective category under that policy isn't `BREAKING`.

--- a/changelog.d/20260824_030000_claude_g38_phase9_compact_bundle_evidence.md
+++ b/changelog.d/20260824_030000_claude_g38_phase9_compact_bundle_evidence.md
@@ -1,0 +1,24 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: `compare --release` no longer retains every
+  library's full `AbiSnapshot` for the whole release when only the bundle
+  layer's signature-evidence gate needs it.** Wiring G38 Phase 4 into the
+  live `compare --release` path made `collect_diff_results=True` the
+  default for every directory/package comparison (not only when
+  `--bundle-facts-out`/JUnit was requested), so every completed library's
+  full old+new `AbiSnapshot` (functions, types, layouts, source graph,
+  build-source evidence, everything) was retained until the whole release
+  finished and bundle analysis ran — a real memory regression relative to
+  the pre-Phase-4 default. Fixed with a new, frozen
+  `bundle_models.BundleSignatureEvidence` projection carrying only the
+  three fields `find_unverified_signature_findings` actually reads
+  (`function_map`, `variable_map`, `elf_only_mode`); a default
+  `compare --release` (bundle analysis on, no JUnit/`--bundle-facts-out`)
+  now stashes this compact projection instead of the full snapshot, so the
+  rest of each snapshot becomes eligible for garbage collection once the
+  per-library comparison returns. JUnit and `--bundle-facts-out`, which do
+  need the real `AbiSnapshot`, are unaffected.

--- a/changelog.d/20260824_040000_claude_g38_phase10_bundle_severity_policy.md
+++ b/changelog.d/20260824_040000_claude_g38_phase10_bundle_severity_policy.md
@@ -1,0 +1,19 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: the severity-aware exit code now honors the same
+  policy `BundleDiffResult.bundle_verdict` (the displayed verdict) already
+  does.** `_fold_release_global_severity`'s bundle-findings branch called
+  `compute_exit_code()` with no `policy=` at all, unlike the sibling
+  `matrix_result` branch right next to it — so a built-in policy profile
+  that demotes a bundle-promoted kind (e.g. `plugin_abi` demoting
+  `calling_convention_changed` to `COMPATIBLE`) already read correctly in
+  the displayed verdict but still forced a nonzero severity-aware exit
+  code. Fixed by passing `policy=bundle_result.policy`, the same resolved
+  policy name `bundle_verdict` reads. A custom `--policy-file`, a
+  `kind: policy` pack override, and direct suppression of a `bundle_*`
+  kind still don't reach bundle findings at all (`BundleDiffResult` has no
+  fields for them yet) — tracked as a larger, separately-scoped follow-up.

--- a/changelog.d/20260824_050000_claude_g38_phase11_bundle_analysis_errors.md
+++ b/changelog.d/20260824_050000_claude_g38_phase11_bundle_analysis_errors.md
@@ -1,0 +1,19 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: a `compare_bundle()` or Phase 4 signature-evidence
+  failure is now recorded structurally, not only echoed to stderr.**
+  `BundleDiffResult` gained `analysis_errors: list[str]`; a `compare
+  --release` run whose bundle-analysis step raised previously returned an
+  empty `bundle_findings` list with the failure visible only in the CLI's
+  own stderr, indistinguishable in the JSON/Markdown report from "bundle
+  analysis ran cleanly and found nothing." The JSON summary now carries
+  `bundle_analysis_errors` (present only when non-empty) and the Markdown
+  report gains a "⚠️ Bundle Analysis Warnings" section, rendered even when
+  there are no bundle findings to show. A snapshot-construction failure
+  (before any `BundleDiffResult` exists) still degrades to a bare `None`
+  return with only a stderr warning — tracked as a follow-up in the G38
+  plan doc's Phase 11 section.

--- a/changelog.d/20260824_060000_claude_g38_bundle_signature_promotion_reachability_and_policy_file.md
+++ b/changelog.d/20260824_060000_claude_g38_bundle_signature_promotion_reachability_and_policy_file.md
@@ -1,0 +1,25 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: signature-change promotion no longer attributes a
+  consumer to the wrong provider, and now honors a `--policy-file`
+  override, not just a named base policy.** `_detect_intra_dep_signature_
+  changed` previously treated *any* sibling importing a changed symbol's
+  name as affected by the change — if two unrelated libraries in the same
+  bundle happen to export a same-named symbol, a consumer that only needs
+  the *unchanged* one could still receive a fabricated
+  `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` finding attributed to the changed
+  one. Fixed by requiring the consumer to actually resolve the symbol
+  against that specific provider (reachability, symbol versioning, and
+  default-definition matching — mirroring the same checks
+  `_detect_unresolved_intra_dependency` already applies for its own
+  provider-matching). Separately, a `PolicyFile` override demoting a
+  promotable kind (e.g. via `--policy-file`) is resolved through a
+  different path than a named base policy (`policy_file.compute_verdict`,
+  which does not populate `Change.effective_verdict`), so the promotion
+  check previously couldn't see it — promotion now defers to the
+  originating diff's own `policy_file` when one is present, the same way
+  it already couldn't defeat a named-policy demotion like `plugin_abi`.

--- a/changelog.d/20260824_070000_claude_g38_bundle_canonical_key_old_and_new.md
+++ b/changelog.d/20260824_070000_claude_g38_bundle_canonical_key_old_and_new.md
@@ -1,0 +1,18 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: a per-library diff's canonical provider key is now
+  resolved against both bundle sides, not only the new one.**
+  `compare_bundle()`'s `diff_by_library` canonicalized `DiffResult.library`
+  (a real, possibly SONAME-versioned on-disk basename) against only the
+  new-side bundle snapshot's own basename map. `checker.compare()` sets
+  `DiffResult.library` from the *old* side, so a provider whose versioned
+  filename changed between old and new (e.g. `libcore.so.1.2` →
+  `libcore.so.1.3`) had a basename the new-side map could never resolve —
+  the promotion/type-change/provider-change detectors silently never fired
+  for that provider. Fixed by merging both sides' basename maps (new-side
+  wins a collision, since it's what the resolution graph these keys feed
+  into was actually built from).

--- a/changelog.d/20260824_080000_claude_g38_bundle_versioned_provider_entries.md
+++ b/changelog.d/20260824_080000_claude_g38_bundle_versioned_provider_entries.md
@@ -1,0 +1,18 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: signature-change promotion now checks every
+  versioned definition a provider exports for a symbol, not just the
+  first one found.** `consumer_resolves_via_provider` used `next()` to
+  pick a single `ProviderEntry` for the candidate provider — but a
+  library can legitimately export multiple versioned definitions of one
+  bare symbol (the compat-symbol pattern `foo@V1` alongside `foo@@V2`).
+  Picking only the first entry (e.g. a non-default `V1`) could test it
+  against a consumer explicitly requiring `V2` and wrongly conclude no
+  match, silently dropping a promoted finding even though the same
+  provider's `V2` entry does match. Fixed by checking `any()` over every
+  entry from that provider, mirroring `_detect_unresolved_intra_
+  dependency`'s own matching.

--- a/changelog.d/20260824_090000_claude_g38_bundle_ambiguous_provider_decline.md
+++ b/changelog.d/20260824_090000_claude_g38_bundle_ambiguous_provider_decline.md
@@ -1,0 +1,23 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: signature-change promotion now declines to
+  attribute a consumer when more than one bundle sibling could plausibly
+  be the resolved provider.** `consumer_resolves_via_provider` checked
+  each candidate provider independently, so when a consumer directly
+  needs *two* DSOs that both export a matching (unversioned/default, or
+  same-labeled) definition of the same bare symbol, the check returned
+  `True` for both — the bundle model has no notion of real ELF
+  symbol-search order (`DT_NEEDED`/global-scope precedence) to say which
+  one actually wins, so a signature change on *either* sibling could be
+  attributed to a consumer that may bind to the other one entirely. Fixed
+  by requiring the reachable+matching provider set for the symbol to be
+  exactly one library before promoting — an ambiguous case now declines
+  (a missed promotion) rather than fabricating an attribution (a false
+  one), matching this codebase's established preference for that
+  direction of error. A per-symbol GNU version pin (`version_soname`) is
+  unaffected, since GNU symbol versioning already ties that reference to
+  one specific provider by construction.

--- a/changelog.d/20260824_100000_claude_g38_bundle_contract_evaluation_and_cache_fix.md
+++ b/changelog.d/20260824_100000_claude_g38_bundle_contract_evaluation_and_cache_fix.md
@@ -1,0 +1,25 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 bundle analysis: signature-change promotion now honors ADR-049
+  contract-evaluation status, and a real caching bug is fixed.**
+  `diff_change_is_breaking` previously reclassified a change's raw kind
+  regardless of whether compatibility policy actually scored it — under
+  `compare --contract ...`, a finding outside the selected contract's
+  scope is stamped `compatibility_evaluation_status=NOT_EVALUATED` and
+  stays in `diff.changes`, but is excluded from the per-library
+  verdict/exit code. Promoting such a finding to a bundle-level BREAKING
+  finding contradicted that already-scored result. Fixed by checking
+  `contract_gating.is_evaluated(change)` first (defaults `True` for an
+  unstamped finding, so a run with no `--contract` is unaffected).
+  Separately, `_detect_intra_dep_signature_changed`'s reachability cache
+  used `reachable_cache.setdefault(lib, _reachable_intra_libraries(...))`,
+  which evaluates the default-value argument unconditionally regardless
+  of cache hit — running the full `DT_NEEDED` BFS on every call and
+  defeating the point of caching for a bundle with many changed symbols
+  against the same consumer. Fixed via a new shared
+  `bundle_resolution_reachability.cached_reachable_intra_libraries`
+  helper with an explicit membership check.

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1330,6 +1330,171 @@ scan scheduling), not additional G38 phase surface.
 
 ---
 
+## Real-world validation and further phases (napetrov/abicheck-bazel-lab, real oneDAL)
+
+An external contributor ran a full real-oneDAL validation pass (`daal`,
+`oneapi::dal`, and `dpc` scans; three `dump` baselines) against a pin bump
+from `7cf8adf83` to `c370aed07a` (101 commits). This is the first evidence
+in this plan sourced from a real, at-scale binary rather than a synthetic
+fixture, and it both confirms Phase 4 works correctly in production and
+surfaces real gaps this section turns into phases. Headline results:
+
+- **Cost-neutral pin bump.** All three scans and three dumps landed within
+  noise of the old pin (22m40s → 22m44s total scan time across the three
+  libraries; snapshot sizes unchanged). All three scans exit 0,
+  `COMPATIBLE_WITH_RISK`, with identical risk scores (78/27/47) to the old
+  pin — the bump changed correctness, not behavior, for this codebase.
+- **A real dumper correctness fix, already shipped, with an operational
+  lesson for this plan.** The bump also picked up a fix for an enumerator-
+  initializer value getting lost when folded on an intermediate clang AST
+  wrapper node (a positional auto-increment silently replaced the real
+  value — e.g. `csrArray = 1 << 4` recorded as `3` instead of `16`). This is
+  a general dumper bug, not specific to bundle analysis, and is not part of
+  G38 — but re-running the *same* source tree against stale, pre-fix
+  baselines produced 280 false `enum_member_value_changed` `BREAKING`
+  findings (155 `daal` + 125 `dpc`) with `schema_version=25` on both sides
+  and *nothing in the report naming which baseline caused it*. Re-dumping
+  the baselines at the new pin took all 280 to zero. The operational
+  lesson — "`schema_version` unchanged does not imply a baseline is still
+  valid across a core pin bump; any pin bump needs baselines re-dispatched"
+  — belongs in the repo's release/CI process documentation, not this plan,
+  but is recorded here since it was found by exercising this plan's own
+  Phase 2 stored-facts model at scale. A structured coverage block (Phase 8)
+  naming *which* baseline a mismatch traces to would have made this
+  diagnosable without a bisection.
+- **Phase 4 confirmed correct at production scale.** The cheap, headerless
+  bundle path (34s / 240MB for the full oneDAL bundle) correctly produced
+  `bundle_verdict=COMPATIBLE_WITH_RISK` with 156 advisory
+  `bundle_intra_dep_signature_unverified` findings — not spurious
+  `BREAKING` findings — validating both the C-boundary signature-evidence
+  gate's design and (retroactively) the Phase 5 promotion/suppression
+  split above: a headerless scan has essentially no DWARF/header evidence
+  for its stripped internal C symbols, so every one of the 156 correctly
+  landed as the advisory "unverified" finding rather than a fabricated
+  break.
+- **Bundle blockers: three of four now understood, two already fixed.**
+  Independently confirms `#831`'s two landed fixes (header analysis in
+  directory-scoped bundle compare; SONAME-stem matching eliminating 379
+  false `bundle_intra_dep_removed` findings on external providers, → 0) and
+  identifies two more, detailed as Phases 11–13 below.
+
+### Phase 11 — Headerless-bundle public-surface scoping
+
+**Finding:** a headerless directory/package bundle compare has no header
+evidence to scope by, so `FilterNonPublicSurface` (or its bundle-analysis
+equivalent) has nothing to restrict findings to the library's actual public
+API — every ELF-visible symbol, including ones with no public header at
+all, is treated as in-scope. Measured on real oneDAL libraries: 1414/237/272
+unscoped `BREAKING` findings across the three headerless scans, an order of
+magnitude more than a header-scoped compare of the same libraries would
+report. An earlier upstream attempt to scope this from ELF visibility alone
+(no headers) was reverted — ELF visibility (`GLOBAL`/hidden) answers "is
+this symbol exported," not "is this symbol part of the documented public
+API," and the two diverge for exactly the internal-but-exported C symbols
+this whole initiative's own oneDAL repro (ADR-023's own origin story) is
+built around.
+
+**Not yet designed.** A correct fix needs a public-surface signal that
+does not depend on parsing headers — candidates worth evaluating rather
+than assuming one is right: (a) a version-script/export-map-derived
+allowlist, when the library's build already produces one (oneDAL's own
+CMake does, for several of its libraries); (b) `--public-header-dir`/an
+explicit `-H`/include-scoping flag threaded through the headerless bundle
+path specifically so a *cheap* partial header set (just the public
+umbrella headers, not the full transitive include graph a header-scoped
+compare pays for) can scope without paying Phase 13's full cost; (c) a
+documented, opt-in "no public-surface scoping available" flag on the
+finding set itself (mirroring Phase 8's structured coverage idea) so a
+headerless bundle report is honest about running unscoped rather than
+silently over-reporting. Given the ELF-visibility attempt's own revert,
+whichever design is chosen needs validation against the same real oneDAL
+corpus before landing, not just synthetic fixtures.
+
+### Phase 12 — Audit-mode (`scan --artifact-set`) system-provider coverage and friction
+
+**Finding, part 1 (additive, low-risk):** `scan --artifact-set`'s cheap
+audit path (10.8s / 383MB for the full six-library oneDAL set, no baseline
+required) is blocked in practice by `bundle_models.DEFAULT_SYSTEM_PROVIDERS`
+having no entries for the Intel oneAPI/TBB/MKL runtime libraries oneDAL
+links against — 862 audit findings collapsed to 58 once the missing
+sonames were supplied via the existing `--bundle-system-providers` escape
+hatch. **Not fixed in this pass**: the exact SONAMEs (`libtbbmalloc.so.2`,
+`libiomp5.so`, the MKL runtime family, the oneAPI Level Zero/Unified
+Runtime loaders, ...) were not independently re-verified against a real
+Intel oneAPI install in this environment, and this codebase's own
+"known gaps over risky reactive patches" convention argues against
+committing unverified SONAME strings to a shared, curated default list —
+a wrong entry here silently under-reports, which is worse than the
+current, honest "you must name it yourself" default. The actionable next
+step is for whoever ran this validation to supply the exact SONAME list
+(from `ldd`/`readelf` output against the real libraries) so it can be
+added to `DEFAULT_SYSTEM_PROVIDERS` with real provenance, mirroring how the
+existing entries (`libtbb.so.12`, `libsycl.so`, ...) already cover the
+same product family.
+
+**Finding, part 2 (a documented design tradeoff, re-examined, not
+reversed):** even after naming every system provider, 58 residual audit
+findings remained, traced to `_detect_unresolved_intra_dependency`'s own
+docstring — it deliberately has **no** `_looks_system_symbol` name-shape
+fallback, unlike its diff-driven sibling `_detect_intra_dep_removed`,
+specifically so a legitimate, non-system-shaped custom export (the
+docstring's own example: `vendor_init`) is never silently swallowed by a
+shape heuristic. That design choice is sound in the abstract and is not
+reversed here — but real usage shows it creates real friction: a fully-
+correct `--bundle-system-providers` list still needs to separately name
+every Intel-runtime-internal mangled symbol the loader resolves, since
+`DEFAULT_SYSTEM_SYMBOLS`/`_looks_system_symbol` are consulted only by the
+diff-driven detector, not the audit one. Worth a scoped follow-up (not
+attempted here, since it needs the same real Intel runtime evidence Part 1
+does): let `--bundle-system-providers` optionally accept a symbol-name
+*pattern*, not only a SONAME, so a real distinguishing signal for exactly
+the Intel-runtime-internal symbols this audit path can't otherwise resolve
+is available without reopening the `vendor_init` false-negative risk the
+original design decision correctly avoided.
+
+### Phase 13 — Cross-pair header/source-context cache for the bundle layer
+
+**Finding:** the fourth, most expensive blocker — a header-scoped
+directory/package bundle compare independently re-parses the shared header
+tree for every library pair, rather than once per unique compile context —
+measured at 2.5+ hours / 38.3GB peak RSS for a 12-union-header-parse oneDAL
+bundle compare (6 libraries × old+new), a cost that makes the header-scoped
+path effectively unusable for a bundle this size in CI. This is the same
+"original multi-binary performance problem" this plan's own Phases 6–10
+section already declares out of scope for G38 proper — this finding does
+not change that scoping decision, it sharpens it with a real, measured
+number rather than a hypothetical one, and confirms (independently of this
+plan) that the streaming JSON pruner AGENTS.md documents as a negative
+result (~1.2% peak-RSS reduction, ~13% slower) is not a viable point fix
+for this cost. The real fix — a shared, content-addressed header/AST cache
+keyed by compile context rather than by library — remains its own,
+separately-scoped initiative per the existing "Out of scope" text above,
+not additional G38 phase surface; this entry exists so that initiative
+inherits a concrete, real-world acceptance target (12 union header parses
+→ however many *unique* compile contexts the bundle actually has, which
+for a single-source-tree product like oneDAL should be closer to 1–2 than
+12) instead of starting from nothing.
+
+### Deferred CLI/API surface asks (not yet filed as phases)
+
+Three smaller, concrete asks came out of the same validation pass that
+don't yet have a phase of their own, each blocking a specific workflow
+rather than correctness:
+
+- **`dump --public-header-dir`** and **per-library header roots on the
+  CLI** — both needed for Phase 11's option (b) above (a cheap, partial
+  header set for headerless-bundle scoping) and for a cleaner Phase 10
+  stored-baseline producer invocation against a multi-library release
+  whose libraries don't all share one umbrella header directory.
+- **`--bundle-facts-out`'s consumer half** — already tracked as Phase 10
+  above; this validation pass is independent confirmation that it's the
+  single highest-value remaining ask, since it's the one gap keeping
+  `scan --artifact-set`'s otherwise-working 10.8s/383MB cheap audit path
+  from producing a real baseline-comparable exit code instead of an
+  audit-only one.
+
+---
+
 ## Out of scope
 
 Restated from the originating review, explicitly deferred rather than

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1096,6 +1096,172 @@ table asks for.
 
 ---
 
+## Stabilization phases (post-Phase-4 external review)
+
+An external review of the state after Phase 4 landed (PR #842/#844, main at
+`c370aed`/`42da2d2`) found Phases 1–4 to be good foundational work that is
+*not yet* a complete, safe-by-default product feature: Phase 2's stored
+facts have no CLI consumer, Phase 3's pairing primitive has no production
+caller, and Phase 4 — now wired into the live `compare --release` path —
+carries a real correctness bug, a policy/severity inconsistency, a
+stored-baseline parity gap, and a memory regression. That review is the
+origin of the phases below; each restates one of its numbered findings as
+a scoped, independently-landable change rather than one large PR. Numbering
+continues from Phase 4 rather than restarting, since these are direct
+continuations of the same initiative, not a new one.
+
+### Phase 5 — Shared confirmed-boundary-break kind set (shipped)
+
+**Finding:** `bundle._detect_intra_dep_signature_changed`'s promoted-kinds
+set (3 kinds: params/return/var-type) and
+`bundle_signature_evidence`'s suppression set (12 kinds) were two
+independently maintained lists that had already drifted apart — a confirmed
+`CALLING_CONVENTION_CHANGED` (and eight other kinds) correctly suppressed
+`BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` but was never promoted to a
+consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`, silently losing
+cross-library causality for exactly the kinds Phase 4 added confirmed-change
+detection for.
+
+**Fix (shipped):** one shared
+`bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` frozenset,
+imported by both `bundle.py` and `bundle_signature_evidence.py` — living in
+`bundle_models.py` (a leaf module both already import) rather than either
+consumer module, matching this codebase's "one shared leaf-owned set, not
+two independently drifting lists" convention (see `AGENTS.md`'s discussion
+of the identical CTOR_EXPLICIT finding this set also fixed, in an earlier
+commit on this same branch). Regression coverage:
+`tests/test_bundle.py::TestIntraDepSignatureChanged::
+test_promotion_set_matches_shared_confirmed_boundary_kinds` (pins the two
+modules' sets to be the same object) and
+`test_promotes_calling_convention_change_to_consumer` (an end-to-end case
+that reproduces and closes the exact `CALLING_CONVENTION_CHANGED` gap named
+above).
+
+### Phase 6 — Compact per-library signature evidence (memory regression fix)
+
+**Finding:** wiring Phase 4 into the live `compare --release`/bundle-
+analysis path (the "Phase 4" changelog entry above) made
+`collect_diff_results=True` the default for *every* directory/package
+comparison, not only when `--bundle-facts-out`/JUnit was requested — so
+every completed library's full old+new `AbiSnapshot` (functions, types,
+layouts, source graph, build-source evidence, everything) is now retained
+until the whole release finishes and bundle analysis runs.
+`_collect_bundle_result()` then builds complete old/new snapshot maps from
+those retained objects. For an N-library release, peak memory approaches
+the sum of every completed library's full snapshot pair plus whatever
+active parallel workers are still extracting — a real regression relative
+to the pre-Phase-4 default, where only JUnit/`--bundle-facts-out` paid that
+cost.
+
+**Planned fix:** a new, frozen `BundleSignatureEvidence` projection
+(`library_key`, `exported_symbols`, per-symbol function/variable signature
+evidence, confirmed-boundary-change keys) built immediately after each
+per-library comparison finishes and immune to the source `AbiSnapshot`'s own
+size — the full snapshot is then released unless something *else* still
+needs it (JUnit rendering, `--bundle-facts-out`). Three independent
+retention reasons currently collapse into one `collect_diff_results` flag;
+they need to become three (JUnit, `--bundle-facts-out`, compact evidence),
+so "bundle analysis is enabled" stops implying "retain every full
+snapshot." Acceptance criterion: a default `compare --release` over N
+libraries retains zero full old/new `AbiSnapshot` objects once each
+library's own comparison completes, verified by asserting retained-object
+counts (not just wall time) in a dedicated regression test. **Not yet
+implemented** — filed here as the top-priority next phase rather than
+attempted in the same change as Phase 5, since it touches the release
+fan-out's own memory-lifetime contract and needs its own careful,
+independently-verified design (per this repo's "known gaps over risky
+reactive patches" convention in the root `AGENTS.md`).
+
+### Phase 7 — Bundle-finding policy/severity/exit-code consistency
+
+**Finding:** `BundleDiffResult.bundle_verdict` is computed from a bare
+policy-profile string (`checker_policy.compute_verdict`), so a built-in
+profile name (`strict_abi`/`sdk_vendor`/`plugin_abi`) reaches bundle
+findings but a custom `--policy-file`, a `kind: policy` pack override, or
+direct suppression of a `bundle_*` kind does not — and the severity
+exit-code fold converts bundle findings to `Change`s and calls
+`compute_exit_code()` without threading the resolved policy/severity
+config through at all. The displayed verdict and the process exit code can
+therefore disagree for any non-default policy/severity combination.
+
+**Planned fix:** resolve bundle policy once into a typed
+`ResolvedBundlePolicy` (profile, `PolicyFile | None`, per-kind pack
+overrides, suppression, severity config) and thread that single object
+through bundle-finding classification, the aggregate bundle verdict,
+JSON/Markdown rendering, and both the severity-aware and legacy exit-code
+paths — so a custom policy demoting `bundle_intra_dep_signature_unverified`
+changes the report and the exit code together, never just one. **Not yet
+implemented.**
+
+### Phase 8 — Structured bundle-analysis coverage/degradation
+
+**Finding:** bundle snapshot construction failures, `find_unverified_
+signature_findings` exceptions, and a provider missing from either
+snapshot map are all caught and reported as stderr warnings only — a
+report's `"bundle_findings": []` cannot be distinguished from "analysis
+ran cleanly and found nothing" versus "analysis partially failed."
+
+**Planned fix:** a structured `bundle_analysis` coverage block in the JSON
+report (mirroring the existing `contract_coverage_ledger`/`analysis_
+assurance` pattern already used for the contract-evaluation axis), naming
+per-sub-analysis status (`complete`/`partial`/`not_requested`) and any
+missing libraries/errors, with a strict policy able to escalate incomplete
+bundle coverage to `NOT_COMPARABLE` rather than silently accepting a clean
+result built on partial evidence. **Not yet implemented.**
+
+### Phase 9 — Live/stored Phase-4 parity (one bundle-analysis orchestrator)
+
+**Finding:** `compare_bundle_from_facts()` (the stored-baseline path)
+delegates only to `compare_bundle()`; `find_unverified_signature_findings()`
+is a separate companion the live `compare --release` CLI path calls
+directly (Phase 4's own wiring). A stored-facts comparison therefore never
+runs the C-boundary signature-evidence gate at all, so "live vs. live" and
+"stored old vs. live new" bundle analysis can disagree on findings for the
+identical underlying evidence — the parity Phase 2's own design section
+promised does not (yet) extend to Phase 4.
+
+**Planned fix:** one `analyze_bundle()` orchestrator both the live release
+path and `compare_bundle_from_facts()` call, taking optional per-library
+signature-evidence maps (Phase 6's compact projection) so a stored side
+with no retained `AbiSnapshot` can still participate. `compare_bundle()`
+stays the core graph-native/diff-derived detector implementation; it is no
+longer presented as the complete bundle-analysis surface. **Not yet
+implemented** — depends on Phase 6's compact evidence existing first, since
+a stored `BundleFacts` side has no full `AbiSnapshot` to build one from
+otherwise.
+
+### Phase 10 — Stored-facts CLI consumer and multibuild wiring
+
+**Finding:** Phase 2's `BundleFacts` are producible (`--bundle-facts-out`)
+but not consumable — there is no `compare old.bundlefacts.json new-release/`
+CLI path, only a documented programmatic API. Phase 3's `pair_variants()`
+has no CLI/config caller and no producer populates a real (non-`"default"`)
+variant fingerprint, so two same-side captures collide as identical
+identity today.
+
+**Planned fix:** a `BundleSideInput` abstraction (`LiveBundleInput` |
+`StoredBundleFactsInput`) resolving into one `ResolvedBundleSide`, so live/
+live, stored/live, and stored/stored share one comparison pipeline instead
+of a second hand-written loop; a declarative `bundle_variants:` config
+block naming each variant's identity coordinates explicitly (target,
+compiler family, feature toggles) rather than inferring it; and a
+`required: true/false` distinction so a missing required variant can gate
+a release rather than only demoting to `COMPATIBLE_WITH_RISK`. **Not yet
+implemented** — deliberately sequenced after Phases 6–9, since a stored-
+baseline CLI surface that skips Phase 4 (Phase 9) or retains full snapshots
+for every variant (Phase 6) would ship the same gaps this stabilization
+sequence exists to close, just on a wider surface.
+
+The original multi-binary performance problem (repeated header/AST
+extraction across sibling DSOs sharing one source tree) is explicitly out
+of scope for all of Phases 6–10 above — Phase 6 stops a *new* regression
+Phase 4's wiring introduced, it does not address the pre-existing
+per-binary extraction cost. That remains its own, separately-scoped
+initiative (shared/content-addressed evidence storage, memory-aware
+scan scheduling), not additional G38 phase surface.
+
+---
+
 ## Out of scope
 
 Restated from the originating review, explicitly deferred rather than

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1475,14 +1475,35 @@ exit-code fold converts bundle findings to `Change`s and calls
 config through at all. The displayed verdict and the process exit code can
 therefore disagree for any non-default policy/severity combination.
 
-**Planned fix:** resolve bundle policy once into a typed
-`ResolvedBundlePolicy` (profile, `PolicyFile | None`, per-kind pack
-overrides, suppression, severity config) and thread that single object
-through bundle-finding classification, the aggregate bundle verdict,
-JSON/Markdown rendering, and both the severity-aware and legacy exit-code
-paths — so a custom policy demoting `bundle_intra_dep_signature_unverified`
-changes the report and the exit code together, never just one. **Not yet
-implemented.**
+**Fix, partial (shipped):** the severity exit-code fold
+(`_fold_release_global_severity`) omitted `policy=` entirely when scoring
+bundle findings — unlike the sibling `matrix_result` branch two lines
+below it, which already threads `policy`/`kind_sets`/`policy_file`
+through correctly. Confirmed the exact disagreement this caused: a
+`plugin_abi`-demoted `CALLING_CONVENTION_CHANGED`-derived bundle finding
+already read `COMPATIBLE` in `bundle_verdict` (the displayed verdict,
+which does read `BundleDiffResult.policy`) but still forced a nonzero
+severity-aware exit code, since the fold scored it under an implicit
+`policy=None`. Fixed by passing `policy=bundle_result.policy` — the same
+resolved policy name `bundle_verdict` already uses — so the two agree for
+every **built-in policy profile name** (`strict_abi`/`sdk_vendor`/
+`plugin_abi`). Regression:
+`tests/test_config_review.py::TestReleaseSeverityPolicyAndGlobal::
+test_fold_bundle_honors_the_bundle_result_own_policy` (the identical
+bundle finding scores exit 4 under `strict_abi`, exit 0 under
+`plugin_abi`).
+
+**Still open, deliberately not attempted in the same fix:** `BundleDiffResult`
+has no `policy_file`/pack-override/suppression fields at all today (only the
+bare `policy: str`), so a custom `--policy-file`, a `kind: policy` pack
+override, or direct suppression of a `bundle_*` kind still don't reach
+bundle findings anywhere — not the verdict, not the exit code, not
+rendering. Closing that needs the full `ResolvedBundlePolicy` design this
+phase originally proposed (profile, `PolicyFile | None`, per-kind pack
+overrides, suppression, severity config, threaded through classification/
+verdict/rendering/exit-code uniformly) — a real, separately-scoped
+feature addition to `BundleDiffResult`'s own data model, not a follow-up
+to the one-line `policy=` fix above.
 
 ### Phase 11 — Structured bundle-analysis coverage/degradation
 

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1346,6 +1346,18 @@ added to `DEFAULT_SYSTEM_PROVIDERS` with real provenance, mirroring how the
 existing entries (`libtbb.so.12`, `libsycl.so`, ...) already cover the
 same product family.
 
+**Re-confirmed, still not fixed (2026-08-24, pin `c370aed07a5` re-scan):**
+a follow-up validation pass against a bumped abicheck pin (see this
+section's own scan-cost table below) reproduced the identical 862 → 58
+split for the same six-library oneDAL set at effectively zero added cost
+(`scan --artifact-set` still 10.8s/383MB), and re-identified the missing
+family in the same shape as before — TBB malloc, MKL, and the Intel
+runtime loaders — without supplying the literal SONAME strings this
+section's "actionable next step" still asks for. The corpus and the
+family are consistent across two independent runs; only the exact,
+`ldd`/`readelf`-sourced spellings remain the missing input to actually
+land the `DEFAULT_SYSTEM_PROVIDERS` entries.
+
 **Finding, part 2 (a documented design tradeoff, re-examined, not
 reversed):** even after naming every system provider, 58 residual audit
 findings remained, traced to `_detect_unresolved_intra_dependency`'s own

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1513,13 +1513,43 @@ snapshot map are all caught and reported as stderr warnings only — a
 report's `"bundle_findings": []` cannot be distinguished from "analysis
 ran cleanly and found nothing" versus "analysis partially failed."
 
-**Planned fix:** a structured `bundle_analysis` coverage block in the JSON
-report (mirroring the existing `contract_coverage_ledger`/`analysis_
-assurance` pattern already used for the contract-evaluation axis), naming
-per-sub-analysis status (`complete`/`partial`/`not_requested`) and any
-missing libraries/errors, with a strict policy able to escalate incomplete
-bundle coverage to `NOT_COMPARABLE` rather than silently accepting a clean
-result built on partial evidence. **Not yet implemented.**
+**Fix, partial (shipped, P0-D).** `BundleDiffResult` gained
+`analysis_errors: list[str]`. Two of the three degradation points named
+above now record into it instead of only echoing to stderr:
+
+- `compare_bundle()` raising inside `_run_bundle_analysis` — the returned
+  stub `BundleDiffResult` now carries
+  `analysis_errors=["bundle analysis raised: <exc>"]` instead of losing the
+  detail (previously only the per-library report survived; `bundle_findings`
+  degraded silently to empty).
+- `find_unverified_signature_findings()` raising — appended to the
+  already-populated result's `analysis_errors` the same way, additive to
+  whatever `compare_bundle()` already found.
+
+`analysis_errors` is surfaced to both report formats: `_format_release_
+json`'s `summary["bundle_analysis_errors"]` (present only when non-empty,
+matching this file's established "present only when active" convention for
+optional summary keys), and a new "⚠️ Bundle Analysis Warnings" Markdown
+section, rendered even when `bundle_findings` is empty — an empty finding
+list after a raised exception means "nothing was checked," not "nothing was
+found," and a reader must not conflate the two.
+
+**Still open:** the third degradation point — `build_bundle_snapshot()`
+raising inside `_run_bundle_analysis`, before any `BundleDiffResult` exists
+to attach errors to — still returns bare `None` with only a stderr echo, so
+a caller distinguishing "bundle analysis was never attempted" from "bundle
+analysis ran and found nothing" still can't do so from the JSON/Markdown
+report alone for that one failure mode. Closing it needs
+`_run_bundle_analysis`'s return type to widen (e.g. always return a
+`BundleDiffResult`, with a dedicated "snapshot construction failed" status
+rather than `None`), which changes every caller's `is not None` check — a
+real, if narrow, follow-up, not bundled into this fix to keep it additive
+and low-risk. The richer, `contract_coverage_ledger`-style structured
+coverage block (per-sub-analysis `complete`/`partial`/`not_requested`
+status, a strict policy able to escalate incomplete bundle coverage to
+`NOT_COMPARABLE`) also remains **not implemented** — `analysis_errors` is a
+flat, additive error list, not a coverage ledger with its own gating
+semantics.
 
 ### Phase 12 — Live/stored Phase-4 parity (one bundle-analysis orchestrator)
 

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1407,40 +1407,61 @@ rather than correctness:
   from producing a real baseline-comparable exit code instead of an
   audit-only one.
 
-### Phase 9 — Compact per-library signature evidence (memory regression fix)
+### Phase 9 — Compact per-library signature evidence (memory regression fix, shipped)
 
 **Finding:** wiring Phase 4 into the live `compare --release`/bundle-
 analysis path (the "Phase 4" changelog entry above) made
 `collect_diff_results=True` the default for *every* directory/package
 comparison, not only when `--bundle-facts-out`/JUnit was requested — so
 every completed library's full old+new `AbiSnapshot` (functions, types,
-layouts, source graph, build-source evidence, everything) is now retained
-until the whole release finishes and bundle analysis runs.
-`_collect_bundle_result()` then builds complete old/new snapshot maps from
-those retained objects. For an N-library release, peak memory approaches
+layouts, source graph, build-source evidence, everything) was retained
+until the whole release finished and bundle analysis ran.
+`_collect_bundle_result()` then built complete old/new snapshot maps from
+those retained objects. For an N-library release, peak memory approached
 the sum of every completed library's full snapshot pair plus whatever
-active parallel workers are still extracting — a real regression relative
+active parallel workers were still extracting — a real regression relative
 to the pre-Phase-4 default, where only JUnit/`--bundle-facts-out` paid that
 cost.
 
-**Planned fix:** a new, frozen `BundleSignatureEvidence` projection
-(`library_key`, `exported_symbols`, per-symbol function/variable signature
-evidence, confirmed-boundary-change keys) built immediately after each
-per-library comparison finishes and immune to the source `AbiSnapshot`'s own
-size — the full snapshot is then released unless something *else* still
-needs it (JUnit rendering, `--bundle-facts-out`). Three independent
-retention reasons currently collapse into one `collect_diff_results` flag;
-they need to become three (JUnit, `--bundle-facts-out`, compact evidence),
-so "bundle analysis is enabled" stops implying "retain every full
-snapshot." Acceptance criterion: a default `compare --release` over N
-libraries retains zero full old/new `AbiSnapshot` objects once each
-library's own comparison completes, verified by asserting retained-object
-counts (not just wall time) in a dedicated regression test. **Not yet
-implemented** — filed here as the top-priority next phase rather than
-attempted in the same change as Phase 5, since it touches the release
-fan-out's own memory-lifetime contract and needs its own careful,
-independently-verified design (per this repo's "known gaps over risky
-reactive patches" convention in the root `AGENTS.md`).
+**Fix (shipped):** a new, frozen `bundle_models.BundleSignatureEvidence`
+projection carrying only the three fields
+`find_unverified_signature_findings` actually reads
+(`function_map`/`variable_map`/`elf_only_mode` — confirmed by reading
+every attribute access that function's own helpers make on a snapshot),
+built immediately in `_compare_one_library` right after each per-library
+comparison finishes, holding references to the *same* `Function`/
+`Variable` objects rather than deep-copying — the rest of the snapshot
+(types, source graph, build-source evidence, everything not referenced
+from the compact projection) becomes eligible for garbage collection the
+moment the caller drops its own reference to the full `AbiSnapshot`,
+rather than staying alive until `_collect_bundle_result` runs. The single
+`collect_diff_results` flag split into two: `collect_diff_results` (stash
+*something* for the bundle layer) and a new `need_full_snapshots`
+(JUnit/`--bundle-facts-out` — the two reasons that genuinely need the
+real `AbiSnapshot`), so a default `compare --release` with bundle
+analysis on but neither of those stashes only the compact projection
+under `"_old_bundle_evidence"`/`"_new_bundle_evidence"` instead of
+`"_old_snapshot"`/`"_new_snapshot"`. `_collect_bundle_result`/
+`_run_bundle_analysis` and `find_unverified_signature_findings` itself
+accept either type interchangeably (duck-type compatible — both expose
+the same three fields), so neither JUnit/`--bundle-facts-out`'s full-
+snapshot path nor the detector's own logic needed to change.
+
+Regression coverage: `tests/test_compare_release_contract_coverage.py::
+test_compare_one_library_stashes_old_snapshot_only_when_requested`
+(pins that `collect_diff_results=True` alone stashes the compact
+projection referencing the *same* `function_map`/`variable_map` objects,
+never a full `AbiSnapshot`, and that `need_full_snapshots=True` restores
+the old full-snapshot behavior) and
+`tests/test_cli_compare_release_bundle_signature_wiring.py::
+TestCollectBundleResultAcceptsCompactBundleEvidence` (the compact and
+full-snapshot paths reach `find_unverified_signature_findings` and
+produce identical finding kinds end to end). The acceptance criterion
+this phase was filed against — "a default `compare --release` retains
+zero full `AbiSnapshot` objects once each library's own comparison
+completes" — now holds by construction: nothing downstream of
+`_compare_one_library` in the default (no-JUnit, no-`--bundle-facts-out`)
+path ever receives a full `AbiSnapshot` reference at all.
 
 ### Phase 10 — Bundle-finding policy/severity/exit-code consistency
 

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1169,13 +1169,52 @@ this phase closes).
 the same underlying fact, so they should share one constant" is not
 sufficient justification on its own — check whether the two consumers are
 actually answering the *same question* at the *same confidence bar* before
-unifying. Phase 7 (bundle policy/severity threading) will face a structurally
+unifying. Phase 10 (bundle policy/severity threading) will face a structurally
 similar temptation (one policy object feeding multiple decision points) and
 should verify each consumer's bar independently rather than assuming a
 single resolved object is automatically correct for all of them.
 
-**Known residual gap, not fixed in this phase (Codex/CodeRabbit review,
-fresh evidence, filed rather than rushed):**
+**Two more findings from the same review round, both fixed (shipped):**
+
+1. **Provider-key normalization.** `diff_by_library`'s keys were built from
+   `Path(result.library).name` — the real, possibly SONAME-versioned
+   on-disk filename (`DiffResult.library` is always set this way at every
+   ELF/PE/Mach-O dump site) — while `BundleSnapshot.resolution` keys every
+   provider/consumer by the version-stripped bundle-canonical name.
+   CodeRabbit traced a concrete repro through `cli_compare_release.py`'s
+   own `_bundle_key`/`DiffResult.library` split: the wired
+   `compare --release` path already stores the canonical key separately
+   and leaves `DiffResult.library` as the real filename, so a promoted
+   finding could carry `provider_library="libcore.so.1.2.3"` while the
+   resolution graph knows the same provider as `"libcore.so"` — silently
+   defeating the `consumer.library != provider_lib` comparisons the
+   detector depends on.
+   `bundle_signature_evidence.py`'s own `_confirmed_provider_symbols` had
+   needed and shipped the identical fix once already (a prior, independent
+   Codex review). Both consumers now share one
+   `bundle_models.basename_to_bundle_key()` function instead of one
+   already having the fix and the other not — the same "one shared
+   leaf-owned primitive, not two independently drifting copies" pattern as
+   the boundary-break kind sets above. Regression:
+   `test_promotes_using_canonical_provider_key_for_a_versioned_basename`.
+2. **`plugin_abi` policy preservation during promotion.** Widening the
+   promotable set to include `CALLING_CONVENTION_CHANGED` (this phase's own
+   fix) reached a kind with a real `policy_overrides` demotion —
+   `change_registry.py` classifies it `COMPATIBLE` under `plugin_abi` (a
+   plugin and its host rebuilt together from the same toolchain) — but the
+   promoted `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` bundle finding had no
+   policy sensitivity at all, always `BREAKING` regardless of the caller's
+   selected policy. `_detect_intra_dep_signature_changed` now takes the
+   same `policy` string `compare_bundle()` already receives and skips
+   promoting a change whose effective category under that policy (via the
+   same `policy_kind_sets`/`effective_category` primitives
+   `compute_verdict` itself uses) is not `BREAKING`. Regression:
+   `test_plugin_abi_policy_suppresses_calling_convention_promotion`
+   (paired with a `strict_abi` control confirming this isn't a blanket
+   regression of the fix above).
+
+**Known residual gap, not fixed in this phase (Codex review, fresh
+evidence, filed rather than rushed):**
 `_detect_intra_dep_signature_changed`'s consumer lookup
 (`new.resolution.consumers_of(change.symbol)`) is a bare, name-only match
 with no reachability or version/default-binding filtering — unlike
@@ -1185,152 +1224,27 @@ be able to load the provider through a real `DT_NEEDED` path) and
 `_consumer_matches_provider()` (a GNU symbol-version match, not just a bare
 name match) before attributing a finding. This predates Phase 5 — widening
 `relevant_kinds` from 3 to 6 kinds increases how often the pre-existing
-imprecision is reached, but does not introduce the imprecision itself. A
-related concern raised in the same review round: `diff_by_library`'s keys
-(`Path(result.library).name`, a "canonical basename" per that code's own
-comment) are asserted, not verified, to always agree with the resolution
-graph's own library-naming convention for every caller of
-`compare_bundle()` — plausible for the wired `compare --release` path
-(both derive from one directory-discovery pass) but not independently
-confirmed for every caller. Not fixed here: `bundle.py` is at the
-AI-readiness 2000-line hard cap (1992/2000 after Phase 5's own docstring
-additions), so borrowing `bundle_signature_evidence.py`'s reachability/
-version-matching logic needs either a shared leaf-module extraction (the
-two private helpers would need to become public, tested primitives with
-their own home) or an equal-or-greater removal elsewhere in `bundle.py` —
-a real, separately-scoped change, not a follow-up edit to the same
-function under review pressure. Until then, a `compare --release` bundle
-report can attribute a promoted finding to a provider a consumer cannot
-actually reach, or across a version mismatch, for the six promotable kinds
-— the same class of imprecision the pre-existing three kinds already
-carried, now reachable by twice as many kinds.
+imprecision is reached, but does not introduce the imprecision itself. Not
+fixed here: `bundle.py` is at the AI-readiness 2000-line hard cap (1997/2000
+after this phase's own fixes), so borrowing `bundle_signature_evidence.py`'s
+reachability/version-matching logic needs either a shared leaf-module
+extraction (the two private helpers would need to become public, tested
+primitives with their own home) or an equal-or-greater removal elsewhere in
+`bundle.py` first — a real, separately-scoped change, not a follow-up edit
+to the same function under review pressure. Until then, a
+`compare --release` bundle report can attribute a promoted finding to a
+provider a consumer cannot actually reach, or across a version mismatch,
+for the six promotable kinds — the same class of imprecision the
+pre-existing three kinds already carried, now reachable by twice as many
+kinds.
 
-### Phase 6 — Compact per-library signature evidence (memory regression fix)
+### Real-world validation: napetrov/abicheck-bazel-lab, real oneDAL
 
-**Finding:** wiring Phase 4 into the live `compare --release`/bundle-
-analysis path (the "Phase 4" changelog entry above) made
-`collect_diff_results=True` the default for *every* directory/package
-comparison, not only when `--bundle-facts-out`/JUnit was requested — so
-every completed library's full old+new `AbiSnapshot` (functions, types,
-layouts, source graph, build-source evidence, everything) is now retained
-until the whole release finishes and bundle analysis runs.
-`_collect_bundle_result()` then builds complete old/new snapshot maps from
-those retained objects. For an N-library release, peak memory approaches
-the sum of every completed library's full snapshot pair plus whatever
-active parallel workers are still extracting — a real regression relative
-to the pre-Phase-4 default, where only JUnit/`--bundle-facts-out` paid that
-cost.
-
-**Planned fix:** a new, frozen `BundleSignatureEvidence` projection
-(`library_key`, `exported_symbols`, per-symbol function/variable signature
-evidence, confirmed-boundary-change keys) built immediately after each
-per-library comparison finishes and immune to the source `AbiSnapshot`'s own
-size — the full snapshot is then released unless something *else* still
-needs it (JUnit rendering, `--bundle-facts-out`). Three independent
-retention reasons currently collapse into one `collect_diff_results` flag;
-they need to become three (JUnit, `--bundle-facts-out`, compact evidence),
-so "bundle analysis is enabled" stops implying "retain every full
-snapshot." Acceptance criterion: a default `compare --release` over N
-libraries retains zero full old/new `AbiSnapshot` objects once each
-library's own comparison completes, verified by asserting retained-object
-counts (not just wall time) in a dedicated regression test. **Not yet
-implemented** — filed here as the top-priority next phase rather than
-attempted in the same change as Phase 5, since it touches the release
-fan-out's own memory-lifetime contract and needs its own careful,
-independently-verified design (per this repo's "known gaps over risky
-reactive patches" convention in the root `AGENTS.md`).
-
-### Phase 7 — Bundle-finding policy/severity/exit-code consistency
-
-**Finding:** `BundleDiffResult.bundle_verdict` is computed from a bare
-policy-profile string (`checker_policy.compute_verdict`), so a built-in
-profile name (`strict_abi`/`sdk_vendor`/`plugin_abi`) reaches bundle
-findings but a custom `--policy-file`, a `kind: policy` pack override, or
-direct suppression of a `bundle_*` kind does not — and the severity
-exit-code fold converts bundle findings to `Change`s and calls
-`compute_exit_code()` without threading the resolved policy/severity
-config through at all. The displayed verdict and the process exit code can
-therefore disagree for any non-default policy/severity combination.
-
-**Planned fix:** resolve bundle policy once into a typed
-`ResolvedBundlePolicy` (profile, `PolicyFile | None`, per-kind pack
-overrides, suppression, severity config) and thread that single object
-through bundle-finding classification, the aggregate bundle verdict,
-JSON/Markdown rendering, and both the severity-aware and legacy exit-code
-paths — so a custom policy demoting `bundle_intra_dep_signature_unverified`
-changes the report and the exit code together, never just one. **Not yet
-implemented.**
-
-### Phase 8 — Structured bundle-analysis coverage/degradation
-
-**Finding:** bundle snapshot construction failures, `find_unverified_
-signature_findings` exceptions, and a provider missing from either
-snapshot map are all caught and reported as stderr warnings only — a
-report's `"bundle_findings": []` cannot be distinguished from "analysis
-ran cleanly and found nothing" versus "analysis partially failed."
-
-**Planned fix:** a structured `bundle_analysis` coverage block in the JSON
-report (mirroring the existing `contract_coverage_ledger`/`analysis_
-assurance` pattern already used for the contract-evaluation axis), naming
-per-sub-analysis status (`complete`/`partial`/`not_requested`) and any
-missing libraries/errors, with a strict policy able to escalate incomplete
-bundle coverage to `NOT_COMPARABLE` rather than silently accepting a clean
-result built on partial evidence. **Not yet implemented.**
-
-### Phase 9 — Live/stored Phase-4 parity (one bundle-analysis orchestrator)
-
-**Finding:** `compare_bundle_from_facts()` (the stored-baseline path)
-delegates only to `compare_bundle()`; `find_unverified_signature_findings()`
-is a separate companion the live `compare --release` CLI path calls
-directly (Phase 4's own wiring). A stored-facts comparison therefore never
-runs the C-boundary signature-evidence gate at all, so "live vs. live" and
-"stored old vs. live new" bundle analysis can disagree on findings for the
-identical underlying evidence — the parity Phase 2's own design section
-promised does not (yet) extend to Phase 4.
-
-**Planned fix:** one `analyze_bundle()` orchestrator both the live release
-path and `compare_bundle_from_facts()` call, taking optional per-library
-signature-evidence maps (Phase 6's compact projection) so a stored side
-with no retained `AbiSnapshot` can still participate. `compare_bundle()`
-stays the core graph-native/diff-derived detector implementation; it is no
-longer presented as the complete bundle-analysis surface. **Not yet
-implemented** — depends on Phase 6's compact evidence existing first, since
-a stored `BundleFacts` side has no full `AbiSnapshot` to build one from
-otherwise.
-
-### Phase 10 — Stored-facts CLI consumer and multibuild wiring
-
-**Finding:** Phase 2's `BundleFacts` are producible (`--bundle-facts-out`)
-but not consumable — there is no `compare old.bundlefacts.json new-release/`
-CLI path, only a documented programmatic API. Phase 3's `pair_variants()`
-has no CLI/config caller and no producer populates a real (non-`"default"`)
-variant fingerprint, so two same-side captures collide as identical
-identity today.
-
-**Planned fix:** a `BundleSideInput` abstraction (`LiveBundleInput` |
-`StoredBundleFactsInput`) resolving into one `ResolvedBundleSide`, so live/
-live, stored/live, and stored/stored share one comparison pipeline instead
-of a second hand-written loop; a declarative `bundle_variants:` config
-block naming each variant's identity coordinates explicitly (target,
-compiler family, feature toggles) rather than inferring it; and a
-`required: true/false` distinction so a missing required variant can gate
-a release rather than only demoting to `COMPATIBLE_WITH_RISK`. **Not yet
-implemented** — deliberately sequenced after Phases 6–9, since a stored-
-baseline CLI surface that skips Phase 4 (Phase 9) or retains full snapshots
-for every variant (Phase 6) would ship the same gaps this stabilization
-sequence exists to close, just on a wider surface.
-
-The original multi-binary performance problem (repeated header/AST
-extraction across sibling DSOs sharing one source tree) is explicitly out
-of scope for all of Phases 6–10 above — Phase 6 stops a *new* regression
-Phase 4's wiring introduced, it does not address the pre-existing
-per-binary extraction cost. That remains its own, separately-scoped
-initiative (shared/content-addressed evidence storage, memory-aware
-scan scheduling), not additional G38 phase surface.
-
----
-
-## Real-world validation and further phases (napetrov/abicheck-bazel-lab, real oneDAL)
+Sequenced immediately after Phase 5, ahead of Phases 9–13 below: this
+validation pass is real, at-scale evidence rather than a synthetic
+fixture, and Phases 6–8 it produced are concrete, already-measured gaps —
+prioritized ahead of the more speculative (if still real) Phases 9–13
+that follow.
 
 An external contributor ran a full real-oneDAL validation pass (`daal`,
 `oneapi::dal`, and `dpc` scans; three `dump` baselines) against a pin bump
@@ -1359,7 +1273,7 @@ surfaces real gaps this section turns into phases. Headline results:
   valid across a core pin bump; any pin bump needs baselines re-dispatched"
   — belongs in the repo's release/CI process documentation, not this plan,
   but is recorded here since it was found by exercising this plan's own
-  Phase 2 stored-facts model at scale. A structured coverage block (Phase 8)
+  Phase 2 stored-facts model at scale. A structured coverage block (Phase 11)
   naming *which* baseline a mismatch traces to would have made this
   diagnosable without a bisection.
 - **Phase 4 confirmed correct at production scale.** The cheap, headerless
@@ -1376,9 +1290,9 @@ surfaces real gaps this section turns into phases. Headline results:
   Independently confirms `#831`'s two landed fixes (header analysis in
   directory-scoped bundle compare; SONAME-stem matching eliminating 379
   false `bundle_intra_dep_removed` findings on external providers, → 0) and
-  identifies two more, detailed as Phases 11–13 below.
+  identifies two more, detailed as Phases 6–8 below.
 
-### Phase 11 — Headerless-bundle public-surface scoping
+### Phase 6 — Headerless-bundle public-surface scoping
 
 **Finding:** a headerless directory/package bundle compare has no header
 evidence to scope by, so `FilterNonPublicSurface` (or its bundle-analysis
@@ -1402,15 +1316,15 @@ CMake does, for several of its libraries); (b) `--public-header-dir`/an
 explicit `-H`/include-scoping flag threaded through the headerless bundle
 path specifically so a *cheap* partial header set (just the public
 umbrella headers, not the full transitive include graph a header-scoped
-compare pays for) can scope without paying Phase 13's full cost; (c) a
+compare pays for) can scope without paying Phase 8's full cost; (c) a
 documented, opt-in "no public-surface scoping available" flag on the
-finding set itself (mirroring Phase 8's structured coverage idea) so a
+finding set itself (mirroring Phase 11's structured coverage idea) so a
 headerless bundle report is honest about running unscoped rather than
 silently over-reporting. Given the ELF-visibility attempt's own revert,
 whichever design is chosen needs validation against the same real oneDAL
 corpus before landing, not just synthetic fixtures.
 
-### Phase 12 — Audit-mode (`scan --artifact-set`) system-provider coverage and friction
+### Phase 7 — Audit-mode (`scan --artifact-set`) system-provider coverage and friction
 
 **Finding, part 1 (additive, low-risk):** `scan --artifact-set`'s cheap
 audit path (10.8s / 383MB for the full six-library oneDAL set, no baseline
@@ -1452,7 +1366,7 @@ the Intel-runtime-internal symbols this audit path can't otherwise resolve
 is available without reopening the `vendor_init` false-negative risk the
 original design decision correctly avoided.
 
-### Phase 13 — Cross-pair header/source-context cache for the bundle layer
+### Phase 8 — Cross-pair header/source-context cache for the bundle layer
 
 **Finding:** the fourth, most expensive blocker — a header-scoped
 directory/package bundle compare independently re-parses the shared header
@@ -1460,7 +1374,7 @@ tree for every library pair, rather than once per unique compile context —
 measured at 2.5+ hours / 38.3GB peak RSS for a 12-union-header-parse oneDAL
 bundle compare (6 libraries × old+new), a cost that makes the header-scoped
 path effectively unusable for a bundle this size in CI. This is the same
-"original multi-binary performance problem" this plan's own Phases 6–10
+"original multi-binary performance problem" this plan's own Phases 9–13
 section already declares out of scope for G38 proper — this finding does
 not change that scoping decision, it sharpens it with a real, measured
 number rather than a hypothetical one, and confirms (independently of this
@@ -1482,16 +1396,139 @@ don't yet have a phase of their own, each blocking a specific workflow
 rather than correctness:
 
 - **`dump --public-header-dir`** and **per-library header roots on the
-  CLI** — both needed for Phase 11's option (b) above (a cheap, partial
-  header set for headerless-bundle scoping) and for a cleaner Phase 10
+  CLI** — both needed for Phase 6's option (b) above (a cheap, partial
+  header set for headerless-bundle scoping) and for a cleaner Phase 13
   stored-baseline producer invocation against a multi-library release
   whose libraries don't all share one umbrella header directory.
-- **`--bundle-facts-out`'s consumer half** — already tracked as Phase 10
+- **`--bundle-facts-out`'s consumer half** — already tracked as Phase 13
   above; this validation pass is independent confirmation that it's the
   single highest-value remaining ask, since it's the one gap keeping
   `scan --artifact-set`'s otherwise-working 10.8s/383MB cheap audit path
   from producing a real baseline-comparable exit code instead of an
   audit-only one.
+
+### Phase 9 — Compact per-library signature evidence (memory regression fix)
+
+**Finding:** wiring Phase 4 into the live `compare --release`/bundle-
+analysis path (the "Phase 4" changelog entry above) made
+`collect_diff_results=True` the default for *every* directory/package
+comparison, not only when `--bundle-facts-out`/JUnit was requested — so
+every completed library's full old+new `AbiSnapshot` (functions, types,
+layouts, source graph, build-source evidence, everything) is now retained
+until the whole release finishes and bundle analysis runs.
+`_collect_bundle_result()` then builds complete old/new snapshot maps from
+those retained objects. For an N-library release, peak memory approaches
+the sum of every completed library's full snapshot pair plus whatever
+active parallel workers are still extracting — a real regression relative
+to the pre-Phase-4 default, where only JUnit/`--bundle-facts-out` paid that
+cost.
+
+**Planned fix:** a new, frozen `BundleSignatureEvidence` projection
+(`library_key`, `exported_symbols`, per-symbol function/variable signature
+evidence, confirmed-boundary-change keys) built immediately after each
+per-library comparison finishes and immune to the source `AbiSnapshot`'s own
+size — the full snapshot is then released unless something *else* still
+needs it (JUnit rendering, `--bundle-facts-out`). Three independent
+retention reasons currently collapse into one `collect_diff_results` flag;
+they need to become three (JUnit, `--bundle-facts-out`, compact evidence),
+so "bundle analysis is enabled" stops implying "retain every full
+snapshot." Acceptance criterion: a default `compare --release` over N
+libraries retains zero full old/new `AbiSnapshot` objects once each
+library's own comparison completes, verified by asserting retained-object
+counts (not just wall time) in a dedicated regression test. **Not yet
+implemented** — filed here as the top-priority next phase rather than
+attempted in the same change as Phase 5, since it touches the release
+fan-out's own memory-lifetime contract and needs its own careful,
+independently-verified design (per this repo's "known gaps over risky
+reactive patches" convention in the root `AGENTS.md`).
+
+### Phase 10 — Bundle-finding policy/severity/exit-code consistency
+
+**Finding:** `BundleDiffResult.bundle_verdict` is computed from a bare
+policy-profile string (`checker_policy.compute_verdict`), so a built-in
+profile name (`strict_abi`/`sdk_vendor`/`plugin_abi`) reaches bundle
+findings but a custom `--policy-file`, a `kind: policy` pack override, or
+direct suppression of a `bundle_*` kind does not — and the severity
+exit-code fold converts bundle findings to `Change`s and calls
+`compute_exit_code()` without threading the resolved policy/severity
+config through at all. The displayed verdict and the process exit code can
+therefore disagree for any non-default policy/severity combination.
+
+**Planned fix:** resolve bundle policy once into a typed
+`ResolvedBundlePolicy` (profile, `PolicyFile | None`, per-kind pack
+overrides, suppression, severity config) and thread that single object
+through bundle-finding classification, the aggregate bundle verdict,
+JSON/Markdown rendering, and both the severity-aware and legacy exit-code
+paths — so a custom policy demoting `bundle_intra_dep_signature_unverified`
+changes the report and the exit code together, never just one. **Not yet
+implemented.**
+
+### Phase 11 — Structured bundle-analysis coverage/degradation
+
+**Finding:** bundle snapshot construction failures, `find_unverified_
+signature_findings` exceptions, and a provider missing from either
+snapshot map are all caught and reported as stderr warnings only — a
+report's `"bundle_findings": []` cannot be distinguished from "analysis
+ran cleanly and found nothing" versus "analysis partially failed."
+
+**Planned fix:** a structured `bundle_analysis` coverage block in the JSON
+report (mirroring the existing `contract_coverage_ledger`/`analysis_
+assurance` pattern already used for the contract-evaluation axis), naming
+per-sub-analysis status (`complete`/`partial`/`not_requested`) and any
+missing libraries/errors, with a strict policy able to escalate incomplete
+bundle coverage to `NOT_COMPARABLE` rather than silently accepting a clean
+result built on partial evidence. **Not yet implemented.**
+
+### Phase 12 — Live/stored Phase-4 parity (one bundle-analysis orchestrator)
+
+**Finding:** `compare_bundle_from_facts()` (the stored-baseline path)
+delegates only to `compare_bundle()`; `find_unverified_signature_findings()`
+is a separate companion the live `compare --release` CLI path calls
+directly (Phase 4's own wiring). A stored-facts comparison therefore never
+runs the C-boundary signature-evidence gate at all, so "live vs. live" and
+"stored old vs. live new" bundle analysis can disagree on findings for the
+identical underlying evidence — the parity Phase 2's own design section
+promised does not (yet) extend to Phase 4.
+
+**Planned fix:** one `analyze_bundle()` orchestrator both the live release
+path and `compare_bundle_from_facts()` call, taking optional per-library
+signature-evidence maps (Phase 9's compact projection) so a stored side
+with no retained `AbiSnapshot` can still participate. `compare_bundle()`
+stays the core graph-native/diff-derived detector implementation; it is no
+longer presented as the complete bundle-analysis surface. **Not yet
+implemented** — depends on Phase 9's compact evidence existing first, since
+a stored `BundleFacts` side has no full `AbiSnapshot` to build one from
+otherwise.
+
+### Phase 13 — Stored-facts CLI consumer and multibuild wiring
+
+**Finding:** Phase 2's `BundleFacts` are producible (`--bundle-facts-out`)
+but not consumable — there is no `compare old.bundlefacts.json new-release/`
+CLI path, only a documented programmatic API. Phase 3's `pair_variants()`
+has no CLI/config caller and no producer populates a real (non-`"default"`)
+variant fingerprint, so two same-side captures collide as identical
+identity today.
+
+**Planned fix:** a `BundleSideInput` abstraction (`LiveBundleInput` |
+`StoredBundleFactsInput`) resolving into one `ResolvedBundleSide`, so live/
+live, stored/live, and stored/stored share one comparison pipeline instead
+of a second hand-written loop; a declarative `bundle_variants:` config
+block naming each variant's identity coordinates explicitly (target,
+compiler family, feature toggles) rather than inferring it; and a
+`required: true/false` distinction so a missing required variant can gate
+a release rather than only demoting to `COMPATIBLE_WITH_RISK`. **Not yet
+implemented** — deliberately sequenced after Phases 9–12, since a stored-
+baseline CLI surface that skips Phase 4 (Phase 12) or retains full snapshots
+for every variant (Phase 9) would ship the same gaps this stabilization
+sequence exists to close, just on a wider surface.
+
+The original multi-binary performance problem (repeated header/AST
+extraction across sibling DSOs sharing one source tree) is explicitly out
+of scope for all of Phases 9–13 above — Phase 9 stops a *new* regression
+Phase 4's wiring introduced, it does not address the pre-existing
+per-binary extraction cost. That remains its own, separately-scoped
+initiative (shared/content-addressed evidence storage, memory-aware
+scan scheduling), not additional G38 phase surface.
 
 ---
 

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1110,7 +1110,7 @@ a scoped, independently-landable change rather than one large PR. Numbering
 continues from Phase 4 rather than restarting, since these are direct
 continuations of the same initiative, not a new one.
 
-### Phase 5 — Shared confirmed-boundary-break kind set (shipped)
+### Phase 5 — Confirmed vs. promotable boundary-break kind sets (shipped)
 
 **Finding:** `bundle._detect_intra_dep_signature_changed`'s promoted-kinds
 set (3 kinds: params/return/var-type) and
@@ -1122,20 +1122,88 @@ consumer-attributed `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`, silently losing
 cross-library causality for exactly the kinds Phase 4 added confirmed-change
 detection for.
 
-**Fix (shipped):** one shared
-`bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` frozenset,
-imported by both `bundle.py` and `bundle_signature_evidence.py` — living in
-`bundle_models.py` (a leaf module both already import) rather than either
-consumer module, matching this codebase's "one shared leaf-owned set, not
-two independently drifting lists" convention (see `AGENTS.md`'s discussion
-of the identical CTOR_EXPLICIT finding this set also fixed, in an earlier
-commit on this same branch). Regression coverage:
+**First fix attempt, reverted the same PR after a Codex review round (fresh
+evidence): sharing one 12-entry set for both purposes is itself wrong.**
+"Confirmed, so don't claim total ignorance about this symbol" (suppression)
+and "confirmed severely enough to fabricate a consumer-attributed BREAKING
+bundle finding" (promotion) are two different bars — `change_registry.py`'s
+own entries prove it: `FUNC_NOEXCEPT_ADDED` has `default_verdict=COMPATIBLE`,
+and `FUNC_NOEXCEPT_REMOVED`/`FUNC_EXCEPTION_SPEC_CHANGED` are
+`COMPATIBLE_WITH_RISK` with an explicit "not a binary break" rationale in
+their own registry comments. A single shared 12-entry set would have made
+`_detect_intra_dep_signature_changed` promote any of those three to a
+BREAKING `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` — fabricating a
+release-blocking cross-library finding out of a change the tool's own policy
+layer says is not a binary break at all. `FUNC_VIRTUAL_ADDED`/
+`FUNC_VIRTUAL_REMOVED` are genuinely `BREAKING` but describe vtable-slot
+layout, not a direct calling-boundary mismatch — a different failure mode
+than `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED`'s own "calling convention is now
+mismatched" description.
+
+**Fix (shipped):** two sets in `bundle_models.py`, one a strict subset of
+the other (asserted at import time and pinned by
 `tests/test_bundle.py::TestIntraDepSignatureChanged::
-test_promotion_set_matches_shared_confirmed_boundary_kinds` (pins the two
-modules' sets to be the same object) and
-`test_promotes_calling_convention_change_to_consumer` (an end-to-end case
-that reproduces and closes the exact `CALLING_CONVENTION_CHANGED` gap named
-above).
+test_promotable_kinds_are_a_strict_subset_of_confirmed_kinds`, which also
+asserts every promotable kind's own `default_verdict` is `BREAKING` via
+`change_registry.REGISTRY`):
+
+- `CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS` (broad, 12 kinds) — used only
+  by `bundle_signature_evidence.py` for suppression, unchanged from the
+  first attempt.
+- `PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS` (narrow, 6 kinds: the
+  original params/return/var-type plus `FUNC_VARIADIC_ADDED`/
+  `FUNC_VARIADIC_REMOVED`/`CALLING_CONVENTION_CHANGED`) — used only by
+  `bundle._detect_intra_dep_signature_changed` for promotion. This is the
+  actual fix for the finding above: it closes the real gap
+  (`CALLING_CONVENTION_CHANGED` and the two variadic kinds now promote)
+  without also promoting the six kinds that are correctly suppression-only
+  evidence.
+
+Regression coverage: the subset/verdict test above, plus
+`test_does_not_promote_noexcept_added_to_a_breaking_finding` (an end-to-end
+case pinning the exact fabrication the first attempt would have shipped)
+and `test_promotes_calling_convention_change_to_consumer` (the genuine gap
+this phase closes).
+
+**Lesson for future phases in this sequence:** "these two consumers read
+the same underlying fact, so they should share one constant" is not
+sufficient justification on its own — check whether the two consumers are
+actually answering the *same question* at the *same confidence bar* before
+unifying. Phase 7 (bundle policy/severity threading) will face a structurally
+similar temptation (one policy object feeding multiple decision points) and
+should verify each consumer's bar independently rather than assuming a
+single resolved object is automatically correct for all of them.
+
+**Known residual gap, not fixed in this phase (Codex/CodeRabbit review,
+fresh evidence, filed rather than rushed):**
+`_detect_intra_dep_signature_changed`'s consumer lookup
+(`new.resolution.consumers_of(change.symbol)`) is a bare, name-only match
+with no reachability or version/default-binding filtering — unlike
+`bundle_signature_evidence.find_unverified_signature_findings`, which
+already gates on `reachable_intra_libraries()` (the consumer must actually
+be able to load the provider through a real `DT_NEEDED` path) and
+`_consumer_matches_provider()` (a GNU symbol-version match, not just a bare
+name match) before attributing a finding. This predates Phase 5 — widening
+`relevant_kinds` from 3 to 6 kinds increases how often the pre-existing
+imprecision is reached, but does not introduce the imprecision itself. A
+related concern raised in the same review round: `diff_by_library`'s keys
+(`Path(result.library).name`, a "canonical basename" per that code's own
+comment) are asserted, not verified, to always agree with the resolution
+graph's own library-naming convention for every caller of
+`compare_bundle()` — plausible for the wired `compare --release` path
+(both derive from one directory-discovery pass) but not independently
+confirmed for every caller. Not fixed here: `bundle.py` is at the
+AI-readiness 2000-line hard cap (1992/2000 after Phase 5's own docstring
+additions), so borrowing `bundle_signature_evidence.py`'s reachability/
+version-matching logic needs either a shared leaf-module extraction (the
+two private helpers would need to become public, tested primitives with
+their own home) or an equal-or-greater removal elsewhere in `bundle.py` —
+a real, separately-scoped change, not a follow-up edit to the same
+function under review pressure. Until then, a `compare --release` bundle
+report can attribute a promoted finding to a provider a consumer cannot
+actually reach, or across a version mismatch, for the six promotable kinds
+— the same class of imprecision the pre-existing three kinds already
+carried, now reachable by twice as many kinds.
 
 ### Phase 6 — Compact per-library signature evidence (memory regression fix)
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1168,6 +1168,121 @@ class TestIntraDepSignatureChanged:
             for f in result_strict.bundle_findings
         )
 
+    def test_does_not_promote_when_consumer_reaches_a_different_provider(self) -> None:
+        # G38 stabilization (CodeRabbit review, fresh evidence): libcore.so
+        # and libalt.so both export core_add; libalgo.so needs only
+        # libcore.so (never libalt.so). libalt.so's own signature change
+        # must not attribute a promoted finding to libalgo.so -- that
+        # consumer never actually resolves core_add against libalt.so.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalt.so": _meta(soname="libalt.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        diff_libalt = _diff(
+            "libalt.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libalt])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+
+    def test_promotes_only_to_the_consumer_reaching_the_changed_provider(
+        self,
+    ) -> None:
+        # Sibling of the negative case above: when a consumer genuinely
+        # NEEDs the provider whose signature changed, promotion still
+        # fires for that consumer, even with an unrelated same-named
+        # export sitting elsewhere in the bundle.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalt.so": _meta(soname="libalt.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        findings = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+        ]
+        assert len(findings) == 1
+        assert findings[0].consumer_library == "libalgo.so"
+        assert findings[0].provider_library == "libcore.so"
+
+    def test_honors_policy_file_override_before_promotion(self) -> None:
+        # G38 stabilization (Codex review, fresh evidence): a custom
+        # PolicyFile override demoting a promotable kind is resolved
+        # through a separate path from a named base policy
+        # (PolicyFile.compute_verdict, not Change.effective_verdict), so
+        # policy_kind_sets(policy) alone can't see it -- promotion must
+        # consult the originating diff's own policy_file too.
+        from abicheck.policy_file import PolicyFile
+
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        policy_file = PolicyFile(
+            overrides={ChangeKind.FUNC_VARIADIC_ADDED: Verdict.COMPATIBLE}
+        )
+        change = Change(
+            kind=ChangeKind.FUNC_VARIADIC_ADDED,
+            symbol="core_add",
+            description="gained ...",
+        )
+        diff_libcore = DiffResult(
+            old_version="old",
+            new_version="new",
+            library="libcore.so",
+            changes=[change],
+            verdict=Verdict.COMPATIBLE,
+            policy_file=policy_file,
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+        # Without the override, the same kind promotes under strict_abi.
+        diff_libcore_no_override = DiffResult(
+            old_version="old",
+            new_version="new",
+            library="libcore.so",
+            changes=[change],
+            verdict=Verdict.BREAKING,
+        )
+        result_no_override = compare_bundle(new, new, [diff_libcore_no_override])
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result_no_override.bundle_findings
+        )
+
 
 # ---------------------------------------------------------------------------
 # bundle_provider_changed

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -538,8 +538,7 @@ class TestIntraDepRemoved:
         # so this must still be reported regardless of the migration guard.
         result = compare_bundle(old, new, per_library_results=[])
         assert any(
-            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
-            and f.symbol == "vendor_op"
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED and f.symbol == "vendor_op"
             for f in result.bundle_findings
         )
 
@@ -582,7 +581,8 @@ class TestIntraDepRemoved:
         # the built-in DEFAULT_SYSTEM_PROVIDERS allow-list alone.
         result = compare_bundle(old, new, per_library_results=[])
         assert not any(
-            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED and f.consumer_library == "libb.so"
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            and f.consumer_library == "libb.so"
             for f in result.bundle_findings
         )
 
@@ -599,7 +599,9 @@ class TestIntraDepRemoved:
         import must not be vetoed by a provider that was never compatible."""
         old_core = _meta(soname="libcore.so.1")
         old_core.symbols.append(
-            ElfSymbol(name="vendor_op", visibility="default", version="V1", is_default=False)
+            ElfSymbol(
+                name="vendor_op", visibility="default", version="V1", is_default=False
+            )
         )
         old = _snapshot(
             {
@@ -965,6 +967,67 @@ class TestIntraDepSignatureChanged:
             f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
             for f in result.bundle_findings
         )
+
+    def test_promotion_set_matches_shared_confirmed_boundary_kinds(self) -> None:
+        # G38 stabilization: `_detect_intra_dep_signature_changed`'s own
+        # promoted-kinds set and `bundle_signature_evidence`'s suppression
+        # set must be the *same* object, not two independently maintained
+        # lists — see `bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
+        # KINDS`'s own docstring for the incident this pins against
+        # regressing (CALLING_CONVENTION_CHANGED and eight others used to
+        # suppress the "unverified" finding without ever promoting a
+        # consumer-attributed break).
+        from abicheck.bundle_models import CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        from abicheck.bundle_signature_evidence import (
+            _CONFIRMED_SIGNATURE_CHANGE_KINDS,
+        )
+
+        assert (
+            CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+            == _CONFIRMED_SIGNATURE_CHANGE_KINDS
+        )
+        # And every kind not in this set must never have been silently
+        # forgotten — ctor-explicit stays excluded on purpose.
+        assert (
+            ChangeKind.CTOR_EXPLICIT_ADDED
+            not in CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
+        assert (
+            ChangeKind.CTOR_EXPLICIT_REMOVED
+            not in CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
+
+    def test_promotes_calling_convention_change_to_consumer(self) -> None:
+        # Previously `relevant_kinds` only covered params/return/var-type,
+        # so a confirmed CALLING_CONVENTION_CHANGED suppressed
+        # bundle_signature_evidence's "unverified" finding but was never
+        # itself promoted to a consumer-attributed bundle break. Fixed by
+        # sharing one kind set between the two consumers.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        findings = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+        ]
+        assert len(findings) == 1
+        assert findings[0].consumer_library == "libalgo.so"
+        assert findings[0].provider_library == "libcore.so"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1088,6 +1088,86 @@ class TestIntraDepSignatureChanged:
         assert findings[0].consumer_library == "libalgo.so"
         assert findings[0].provider_library == "libcore.so"
 
+    def test_promotes_using_canonical_provider_key_for_a_versioned_basename(
+        self,
+    ) -> None:
+        # G38 stabilization (CodeRabbit review, fresh evidence, concrete
+        # repro traced through cli_compare_release.py's own _bundle_key/
+        # DiffResult.library split): DiffResult.library is always the real,
+        # possibly SONAME-versioned on-disk filename, not the bundle's
+        # canonical key -- so a promoted finding's own diff_by_library
+        # lookup must canonicalize it the same way BundleSnapshot.resolution
+        # does, or the promotion silently never fires (the versioned key
+        # never matches any provider the resolution graph actually knows).
+        libraries = {
+            "libcore.so": Path("/fake/libcore.so.1.2.3"),
+            "libalgo.so": Path("/fake/libalgo.so.1"),
+        }
+        metadata = {
+            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+            "libalgo.so": _meta(
+                soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+            ),
+        }
+        graph = _compute_resolution_graph(libraries, metadata)
+        new = BundleSnapshot(
+            root=Path("/fake"), libraries=libraries, metadata=metadata, resolution=graph
+        )
+        diff_libcore = _diff(
+            "libcore.so.1.2.3",  # the real, versioned on-disk basename
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        findings = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+        ]
+        assert len(findings) == 1
+        assert findings[0].consumer_library == "libalgo.so"
+        assert findings[0].provider_library == "libcore.so"  # canonical, not versioned
+
+    def test_plugin_abi_policy_suppresses_calling_convention_promotion(self) -> None:
+        # G38 stabilization (Codex review, fresh evidence): CALLING_
+        # CONVENTION_CHANGED is COMPATIBLE under the plugin_abi policy
+        # (change_registry.py's own policy_overrides), but the original
+        # fix promoted it to an unconditionally-BREAKING
+        # BUNDLE_INTRA_DEP_SIGNATURE_CHANGED regardless of policy --
+        # defeating the exact override compute_verdict(policy="plugin_abi")
+        # already honors for the originating per-library finding.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore], policy="plugin_abi")
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+        # The default (strict_abi) policy still promotes -- this isn't a
+        # blanket regression of the Phase 5 fix, just policy-sensitive.
+        result_strict = compare_bundle(new, new, [diff_libcore])
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result_strict.bundle_findings
+        )
+
 
 # ---------------------------------------------------------------------------
 # bundle_provider_changed

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1275,6 +1275,119 @@ class TestIntraDepSignatureChanged:
             for f in result.bundle_findings
         )
 
+    def test_does_not_promote_a_not_evaluated_finding(self) -> None:
+        # G38 stabilization (Codex review, fresh evidence): under
+        # `compare --contract ...`, a finding outside the selected
+        # contract's scope is stamped `compatibility_evaluation_status=
+        # NOT_EVALUATED` and stays in `diff.changes`, but is excluded from
+        # the per-library verdict/exit code (ADR-049). Promoting it to a
+        # bundle-level BREAKING finding would contradict that already-
+        # scored result.
+        from abicheck.contract_relevance_types import CompatibilityEvaluationStatus
+
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        change = Change(
+            kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+            symbol="core_add",
+            description="cdecl->fastcall",
+            compatibility_evaluation_status=CompatibilityEvaluationStatus.NOT_EVALUATED,
+        )
+        diff_libcore = DiffResult(
+            old_version="old",
+            new_version="new",
+            library="libcore.so",
+            changes=[change],
+            verdict=Verdict.NO_CHANGE,
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+        # An unstamped finding (no --contract in effect) is unaffected.
+        diff_libcore_unstamped = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result_unstamped = compare_bundle(new, new, [diff_libcore_unstamped])
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result_unstamped.bundle_findings
+        )
+
+    def test_reachable_cache_is_not_recomputed_on_a_hit(self, monkeypatch) -> None:
+        # G38 stabilization (Codex review, fresh evidence): the earlier
+        # `reachable_cache.setdefault(lib, _reachable_intra_libraries(...))`
+        # form evaluates the BFS unconditionally regardless of cache hit
+        # (Python evaluates setdefault's default-value argument eagerly),
+        # defeating the point of caching. Two changes against the same
+        # provider, both reaching the same consumer, must trigger the BFS
+        # at most once per distinct library.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1", exports=["core_add", "core_sub"]
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["core_add", "core_sub"],
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_sub",
+                description="cdecl->fastcall",
+            ),
+        )
+
+        import abicheck.bundle_resolution_reachability as reachability_mod
+
+        call_count = 0
+        real_reachable = reachability_mod.reachable_intra_libraries
+
+        def _counting_reachable(snapshot, root):
+            nonlocal call_count
+            call_count += 1
+            return real_reachable(snapshot, root)
+
+        monkeypatch.setattr(
+            reachability_mod, "reachable_intra_libraries", _counting_reachable
+        )
+
+        result = compare_bundle(new, new, [diff_libcore])
+        assert (
+            len(
+                [
+                    f
+                    for f in result.bundle_findings
+                    if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+                ]
+            )
+            == 2
+        )
+        # One BFS per distinct library, not per (change, consumer) pair.
+        assert call_count == 1
+
     def test_plugin_abi_policy_suppresses_calling_convention_promotion(self) -> None:
         # G38 stabilization (Codex review, fresh evidence): CALLING_
         # CONVENTION_CHANGED is COMPATIBLE under the plugin_abi policy

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1186,6 +1186,59 @@ class TestIntraDepSignatureChanged:
         assert findings[0].consumer_library == "libalgo.so"
         assert findings[0].provider_library == "libcore.so"
 
+    def test_checks_every_versioned_definition_from_the_same_provider(self) -> None:
+        # G38 stabilization (Codex review, fresh evidence): a single
+        # provider can legitimately export multiple versioned definitions
+        # of one bare symbol (the compat-symbol pattern core_add@V1
+        # alongside core_add@@V2) -- consumer_resolves_via_provider must
+        # check every one of that provider's own entries, not just the
+        # first providers_for() happens to return. Picking only the first
+        # (a non-default V1 entry) would test it against a consumer
+        # explicitly requiring V2 and wrongly conclude no match, even
+        # though the same provider's V2 entry does match.
+        libcore_meta = ElfMetadata(
+            soname="libcore.so.1",
+            needed=[],
+            symbols=[
+                ElfSymbol(
+                    name="core_add",
+                    visibility="default",
+                    version="V1",
+                    is_default=False,
+                ),
+                ElfSymbol(
+                    name="core_add",
+                    visibility="default",
+                    version="V2",
+                    is_default=True,
+                ),
+            ],
+            imports=[],
+        )
+        libalgo_meta = _meta(
+            soname="libalgo.so.1",
+            needed=["libcore.so.1"],
+            imports=["core_add"],
+            import_versions={"core_add": "V2"},
+        )
+        new = _snapshot({"libcore.so": libcore_meta, "libalgo.so": libalgo_meta})
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        findings = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+        ]
+        assert len(findings) == 1
+        assert findings[0].consumer_library == "libalgo.so"
+
     def test_plugin_abi_policy_suppresses_calling_convention_promotion(self) -> None:
         # G38 stabilization (Codex review, fresh evidence): CALLING_
         # CONVENTION_CHANGED is COMPATIBLE under the plugin_abi policy

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1131,6 +1131,61 @@ class TestIntraDepSignatureChanged:
         assert findings[0].consumer_library == "libalgo.so"
         assert findings[0].provider_library == "libcore.so"  # canonical, not versioned
 
+    def test_promotes_when_the_versioned_basename_changed_between_old_and_new(
+        self,
+    ) -> None:
+        # G38 stabilization (Codex review, fresh evidence): checker.compare()
+        # sets DiffResult.library from the OLD side, so a provider whose
+        # versioned on-disk basename changed between old and new
+        # (libcore.so.1.2 -> libcore.so.1.3) has a DiffResult.library that
+        # only the OLD bundle's own basename map can resolve -- looking it
+        # up only against the NEW map (as the single-snapshot test above
+        # can't distinguish from a same-snapshot-both-sides lookup) left it
+        # unresolved and the promotion silently never fired.
+        old_libraries = {
+            "libcore.so": Path("/fake/libcore.so.1.2"),
+            "libalgo.so": Path("/fake/libalgo.so.1"),
+        }
+        new_libraries = {
+            "libcore.so": Path("/fake/libcore.so.1.3"),
+            "libalgo.so": Path("/fake/libalgo.so.1"),
+        }
+        metadata = {
+            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+            "libalgo.so": _meta(
+                soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+            ),
+        }
+        old = BundleSnapshot(
+            root=Path("/fake"),
+            libraries=old_libraries,
+            metadata=metadata,
+            resolution=_compute_resolution_graph(old_libraries, metadata),
+        )
+        new = BundleSnapshot(
+            root=Path("/fake"),
+            libraries=new_libraries,
+            metadata=metadata,
+            resolution=_compute_resolution_graph(new_libraries, metadata),
+        )
+        diff_libcore = _diff(
+            "libcore.so.1.2",  # the OLD side's real, versioned basename
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(old, new, [diff_libcore])
+        findings = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+        ]
+        assert len(findings) == 1
+        assert findings[0].consumer_library == "libalgo.so"
+        assert findings[0].provider_library == "libcore.so"
+
     def test_plugin_abi_policy_suppresses_calling_convention_promotion(self) -> None:
         # G38 stabilization (Codex review, fresh evidence): CALLING_
         # CONVENTION_CHANGED is COMPATIBLE under the plugin_abi policy

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -968,26 +968,58 @@ class TestIntraDepSignatureChanged:
             for f in result.bundle_findings
         )
 
-    def test_promotion_set_matches_shared_confirmed_boundary_kinds(self) -> None:
-        # G38 stabilization: `_detect_intra_dep_signature_changed`'s own
-        # promoted-kinds set and `bundle_signature_evidence`'s suppression
-        # set must be the *same* object, not two independently maintained
-        # lists — see `bundle_models.CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_
-        # KINDS`'s own docstring for the incident this pins against
-        # regressing (CALLING_CONVENTION_CHANGED and eight others used to
-        # suppress the "unverified" finding without ever promoting a
-        # consumer-attributed break).
-        from abicheck.bundle_models import CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+    def test_promotable_kinds_are_a_strict_subset_of_confirmed_kinds(self) -> None:
+        # G38 stabilization, revised after a Codex review round: promotion
+        # ("confirmed severely enough to fabricate a consumer-attributed
+        # BREAKING bundle finding") and suppression ("confirmed enough to
+        # withhold the 'couldn't tell either way' finding") are two
+        # different bars, not one -- an earlier revision of this test
+        # asserted the two sets were *equal*, which was itself the bug:
+        # it would have required promoting FUNC_NOEXCEPT_ADDED
+        # (default_verdict=COMPATIBLE) and FUNC_NOEXCEPT_REMOVED/
+        # FUNC_EXCEPTION_SPEC_CHANGED (COMPATIBLE_WITH_RISK) to a fabricated
+        # BREAKING bundle finding. The promotable set must be a strict,
+        # proper subset of the confirmed set (bundle_signature_evidence's
+        # own suppression set), and every kind promoted to BREAKING must
+        # itself carry default_verdict=BREAKING in change_registry.py.
+        from abicheck.bundle_models import (
+            CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
+            PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS,
+        )
         from abicheck.bundle_signature_evidence import (
             _CONFIRMED_SIGNATURE_CHANGE_KINDS,
         )
+        from abicheck.change_registry import REGISTRY
+        from abicheck.checker_policy import Verdict
 
+        assert PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS < (
+            CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
         assert (
             CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
             == _CONFIRMED_SIGNATURE_CHANGE_KINDS
         )
-        # And every kind not in this set must never have been silently
-        # forgotten — ctor-explicit stays excluded on purpose.
+        for kind in PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS:
+            meta = REGISTRY.get(kind.value)
+            assert meta is not None and meta.default_verdict == Verdict.BREAKING, (
+                f"{kind} is promotable to a BREAKING bundle finding but its "
+                f"own default_verdict is not BREAKING"
+            )
+        # The specific fabrication this test guards against: noexcept
+        # changes must never be promotable, regardless of their presence
+        # in the (correctly broader) suppression-only confirmed set.
+        assert (
+            ChangeKind.FUNC_NOEXCEPT_ADDED
+            not in PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
+        assert (
+            ChangeKind.FUNC_NOEXCEPT_REMOVED
+            not in PROMOTABLE_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
+        assert (
+            ChangeKind.FUNC_NOEXCEPT_ADDED in CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
+        )
+        # ctor-explicit stays excluded on purpose from both sets.
         assert (
             ChangeKind.CTOR_EXPLICIT_ADDED
             not in CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
@@ -997,12 +1029,39 @@ class TestIntraDepSignatureChanged:
             not in CONFIRMED_C_BOUNDARY_SIGNATURE_BREAK_KINDS
         )
 
+    def test_does_not_promote_noexcept_added_to_a_breaking_finding(self) -> None:
+        # Regression for the fabrication above: FUNC_NOEXCEPT_ADDED is
+        # confirmed (suppresses bundle_signature_evidence's "unverified"
+        # finding) but must never itself promote to
+        # BUNDLE_INTRA_DEP_SIGNATURE_CHANGED -- that would turn a
+        # default_verdict=COMPATIBLE per-library change into a fabricated
+        # BREAKING cross-library one.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.FUNC_NOEXCEPT_ADDED,
+                symbol="core_add",
+                description="gained noexcept",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+
     def test_promotes_calling_convention_change_to_consumer(self) -> None:
-        # Previously `relevant_kinds` only covered params/return/var-type,
-        # so a confirmed CALLING_CONVENTION_CHANGED suppressed
-        # bundle_signature_evidence's "unverified" finding but was never
-        # itself promoted to a consumer-attributed bundle break. Fixed by
-        # sharing one kind set between the two consumers.
+        # CALLING_CONVENTION_CHANGED is in both the confirmed (suppression)
+        # and promotable sets -- it's a genuine, BREAKING, direct
+        # call-boundary mismatch, unlike noexcept/exception-spec above.
         new = _snapshot(
             {
                 "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1239,6 +1239,42 @@ class TestIntraDepSignatureChanged:
         assert len(findings) == 1
         assert findings[0].consumer_library == "libalgo.so"
 
+    def test_declines_to_promote_when_the_provider_is_ambiguous(self) -> None:
+        # G38 stabilization (Codex review, fresh evidence, beyond the
+        # reachability fix above): when a consumer directly NEEDs TWO
+        # DSOs that both export a matching (unversioned/default)
+        # definition of the same bare symbol, this model has no notion of
+        # real ELF symbol-search order (DT_NEEDED / global-scope
+        # precedence) to say which one the consumer's unversioned
+        # reference actually binds to -- attributing a signature change on
+        # either one to that consumer would be a guess. Both candidates
+        # must decline (ambiguous), not just avoid attributing to the
+        # unreachable-sibling case the earlier fix covers.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalt.so": _meta(soname="libalt.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1", "libalt.so.1"],
+                    imports=["core_add"],
+                ),
+            }
+        )
+        diff_libcore = _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+                symbol="core_add",
+                description="cdecl->fastcall",
+            ),
+        )
+        result = compare_bundle(new, new, [diff_libcore])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
+            for f in result.bundle_findings
+        )
+
     def test_plugin_abi_policy_suppresses_calling_convention_promotion(self) -> None:
         # G38 stabilization (Codex review, fresh evidence): CALLING_
         # CONVENTION_CHANGED is COMPATIBLE under the plugin_abi policy

--- a/tests/test_cli_compare_release_bundle_signature_wiring.py
+++ b/tests/test_cli_compare_release_bundle_signature_wiring.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import abicheck.bundle as bundle_mod
-from abicheck.bundle_models import BundleSnapshot
+from abicheck.bundle_models import BundleSignatureEvidence, BundleSnapshot
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.checker_types import DiffResult
 from abicheck.cli_compare_release_helpers import (
@@ -229,3 +229,93 @@ class TestCollectBundleResultBuildsSnapshotMapsFromBundleKey:
         # Entries carrying no _bundle_key (the second library above) must
         # not raise or contribute a spurious mapping entry.
         assert isinstance(worst_verdict, str)
+
+
+class TestCollectBundleResultAcceptsCompactBundleEvidence:
+    """G38 stabilization Phase 9 (memory regression fix): a default
+    ``compare --release`` (bundle analysis on, no JUnit/
+    ``--bundle-facts-out``) stashes ``_old_bundle_evidence``/
+    ``_new_bundle_evidence`` (:class:`~abicheck.bundle_models.
+    BundleSignatureEvidence`) instead of the full ``_old_snapshot``/
+    ``_new_snapshot`` -- ``_collect_bundle_result`` must read either and
+    reach the identical detector output, and no `AbiSnapshot` may leak
+    into the returned entries either way."""
+
+    def test_compact_evidence_reaches_the_detector_identically(
+        self, monkeypatch
+    ) -> None:
+        def _fake_snapshot(libs: dict[str, Path]) -> BundleSnapshot:
+            return _snapshot(
+                {
+                    "libcore.so": _meta(exports=["core_fn"]),
+                    "libconsumer.so": _meta(imports=["core_fn"], needed=["libcore.so"]),
+                }
+            )
+
+        monkeypatch.setattr(bundle_mod, "build_bundle_snapshot", _fake_snapshot)
+
+        old_map = {
+            "libcore.so": Path("libcore.so"),
+            "libconsumer.so": Path("libconsumer.so"),
+        }
+        new_map = dict(old_map)
+
+        old_snap = _snap(
+            "libcore.so", functions=[_elf_only_fn("core_fn")], elf_only_mode=True
+        )
+        new_snap = _snap(
+            "libcore.so", functions=[_elf_only_fn("core_fn")], elf_only_mode=True
+        )
+
+        def _entries(
+            old_evidence: object, new_evidence: object
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "library": "libcore.so",
+                    "verdict": "NO_CHANGE",
+                    "_diff_result": _diff("libcore.so"),
+                    "_old_bundle_evidence": old_evidence,
+                    "_new_bundle_evidence": new_evidence,
+                    "_bundle_key": "libcore.so",
+                },
+                {
+                    "library": "libconsumer.so",
+                    "verdict": "NO_CHANGE",
+                    "_diff_result": _diff("libconsumer.so"),
+                },
+            ]
+
+        compact_old = BundleSignatureEvidence.from_snapshot(old_snap)
+        compact_new = BundleSignatureEvidence.from_snapshot(new_snap)
+
+        compact_result, _ = _collect_bundle_result(
+            _entries(compact_old, compact_new),
+            old_map,
+            new_map,
+            "NO_CHANGE",
+            manifest_path=None,
+            bundle_system_providers="",
+        )
+        full_result, _ = _collect_bundle_result(
+            _entries(old_snap, new_snap),
+            old_map,
+            new_map,
+            "NO_CHANGE",
+            manifest_path=None,
+            bundle_system_providers="",
+        )
+
+        assert compact_result is not None and full_result is not None
+        compact_kinds = sorted(f.kind.value for f in compact_result.bundle_findings)
+        full_kinds = sorted(f.kind.value for f in full_result.bundle_findings)
+        assert compact_kinds == full_kinds
+        assert ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED.value in compact_kinds
+
+        # No AbiSnapshot -- full or otherwise -- leaks through the compact
+        # path's own entries into the result of a later JSON-serialising
+        # step (this is what the CLI-level strip already guards; this pins
+        # the underlying object graph directly).
+        for entry in _entries(compact_old, compact_new):
+            assert not isinstance(entry.get("_old_bundle_evidence"), AbiSnapshot)
+            assert not isinstance(entry.get("_new_bundle_evidence"), AbiSnapshot)

--- a/tests/test_cli_compare_release_bundle_signature_wiring.py
+++ b/tests/test_cli_compare_release_bundle_signature_wiring.py
@@ -29,6 +29,7 @@ detector's own logic -- fails here.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import abicheck.bundle as bundle_mod
@@ -37,6 +38,8 @@ from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.checker_types import DiffResult
 from abicheck.cli_compare_release_helpers import (
     _collect_bundle_result,
+    _format_release_json,
+    _release_md_bundle_findings,
     _run_bundle_analysis,
 )
 from abicheck.elf_metadata import ElfImport, ElfMetadata, ElfSymbol
@@ -319,3 +322,164 @@ class TestCollectBundleResultAcceptsCompactBundleEvidence:
         for entry in _entries(compact_old, compact_new):
             assert not isinstance(entry.get("_old_bundle_evidence"), AbiSnapshot)
             assert not isinstance(entry.get("_new_bundle_evidence"), AbiSnapshot)
+
+
+class TestBundleAnalysisErrorsAreStructural:
+    """G38 stabilization Phase 11 / P0-D: a failure inside bundle analysis
+    (``compare_bundle()`` itself, or the Phase 4 signature-evidence check)
+    must be recorded in ``BundleDiffResult.analysis_errors``, not only
+    echoed to stderr -- so a JSON/Markdown report consumer can tell "ran
+    clean" apart from "ran, but degraded" without grepping logs."""
+
+    def _fake_snapshot(self, libs: dict[str, Path]) -> BundleSnapshot:
+        return _snapshot(
+            {
+                "libcore.so": _meta(exports=["core_fn"]),
+                "libconsumer.so": _meta(imports=["core_fn"], needed=["libcore.so"]),
+            }
+        )
+
+    def test_compare_bundle_failure_is_recorded_in_analysis_errors(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(bundle_mod, "build_bundle_snapshot", self._fake_snapshot)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("synthetic compare_bundle failure")
+
+        monkeypatch.setattr(bundle_mod, "compare_bundle", _boom)
+
+        old_map = {
+            "libcore.so": Path("libcore.so"),
+            "libconsumer.so": Path("libconsumer.so"),
+        }
+        new_map = dict(old_map)
+
+        result = _run_bundle_analysis(
+            old_map,
+            new_map,
+            [_diff("libcore.so"), _diff("libconsumer.so")],
+            manifest_path=None,
+            bundle_system_providers="",
+        )
+
+        assert result is not None
+        assert result.bundle_findings == []
+        assert len(result.analysis_errors) == 1
+        assert "synthetic compare_bundle failure" in result.analysis_errors[0]
+
+    def test_signature_evidence_failure_is_appended_to_analysis_errors(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(bundle_mod, "build_bundle_snapshot", self._fake_snapshot)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("synthetic signature-evidence failure")
+
+        # The real call site does `from .bundle_signature_evidence import
+        # find_unverified_signature_findings` *inside* the function body,
+        # so the patch target is the source module's own attribute, not a
+        # name re-exported by `cli_compare_release_helpers`.
+        import abicheck.bundle_signature_evidence as sig_mod
+
+        monkeypatch.setattr(sig_mod, "find_unverified_signature_findings", _boom)
+
+        old_map = {
+            "libcore.so": Path("libcore.so"),
+            "libconsumer.so": Path("libconsumer.so"),
+        }
+        new_map = dict(old_map)
+        old_snapshots = {
+            "libcore.so": _snap(
+                "libcore.so", functions=[_elf_only_fn("core_fn")], elf_only_mode=True
+            )
+        }
+        new_snapshots = {
+            "libcore.so": _snap(
+                "libcore.so", functions=[_elf_only_fn("core_fn")], elf_only_mode=True
+            )
+        }
+
+        result = _run_bundle_analysis(
+            old_map,
+            new_map,
+            [_diff("libcore.so"), _diff("libconsumer.so")],
+            manifest_path=None,
+            bundle_system_providers="",
+            old_snapshots=old_snapshots,
+            new_snapshots=new_snapshots,
+        )
+
+        assert result is not None
+        assert len(result.analysis_errors) == 1
+        assert "synthetic signature-evidence failure" in result.analysis_errors[0]
+
+    def test_analysis_errors_surface_in_json_summary(self, monkeypatch) -> None:
+        monkeypatch.setattr(bundle_mod, "build_bundle_snapshot", self._fake_snapshot)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("synthetic failure")
+
+        monkeypatch.setattr(bundle_mod, "compare_bundle", _boom)
+
+        old_map = {"libcore.so": Path("libcore.so")}
+        new_map = dict(old_map)
+        result = _run_bundle_analysis(
+            old_map,
+            new_map,
+            [_diff("libcore.so")],
+            manifest_path=None,
+            bundle_system_providers="",
+        )
+        assert result is not None
+
+        doc = _format_release_json(
+            "COMPATIBLE",
+            Path("/old"),
+            Path("/new"),
+            [],
+            [],
+            [],
+            {},
+            {},
+            [],
+            bundle_result=result,
+            matrix_result=None,
+        )
+        payload = json.loads(doc)
+        assert payload["bundle_analysis_errors"] == [
+            "bundle analysis raised: synthetic failure"
+        ]
+
+    def test_no_analysis_errors_key_when_bundle_analysis_is_clean(self) -> None:
+        from abicheck.bundle import BundleDiffResult
+
+        clean_result = BundleDiffResult(old_root=Path("/old"), new_root=Path("/new"))
+        doc = _format_release_json(
+            "COMPATIBLE",
+            Path("/old"),
+            Path("/new"),
+            [],
+            [],
+            [],
+            {},
+            {},
+            [],
+            bundle_result=clean_result,
+            matrix_result=None,
+        )
+        payload = json.loads(doc)
+        assert "bundle_analysis_errors" not in payload
+
+    def test_analysis_errors_surface_in_markdown_even_with_no_findings(self) -> None:
+        from abicheck.bundle import BundleDiffResult
+
+        degraded_result = BundleDiffResult(
+            old_root=Path("/old"),
+            new_root=Path("/new"),
+            analysis_errors=["synthetic failure"],
+        )
+        lines = _release_md_bundle_findings(degraded_result)
+        text = "\n".join(lines)
+        assert "Bundle Analysis Warnings" in text
+        assert "synthetic failure" in text

--- a/tests/test_compare_release_contract_coverage.py
+++ b/tests/test_compare_release_contract_coverage.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 import pytest
 
+from abicheck.bundle_models import BundleSignatureEvidence
 from abicheck.cli_compare_release import (
     _compare_one_library,
     _finalize_release_output,
@@ -156,7 +157,8 @@ def test_compare_one_library_stamps_contract_coverage_failure_count(
 
 
 def test_compare_one_library_stashes_old_snapshot_only_when_requested(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Codex review, fresh evidence: `_old_snapshot` (added for a secondary
     JUnit render to read straight off the primary pass, see
@@ -167,6 +169,14 @@ def test_compare_one_library_stashes_old_snapshot_only_when_requested(
     library's old snapshot even for the common markdown/JSON-only case
     that never reads it. Gated on `collect_diff_results`, the same flag
     that already gates whether `_compare_release_libraries` reads it back.
+
+    G38 stabilization Phase 9 (memory-regression fix): `collect_diff_
+    results=True` alone now stashes only the much smaller
+    `BundleSignatureEvidence` projection under `_old_bundle_evidence`/
+    `_new_bundle_evidence` -- the full `AbiSnapshot` is stashed under
+    `_old_snapshot`/`_new_snapshot` only when `need_full_snapshots=True`
+    too (JUnit/`--bundle-facts-out`), since bundle analysis on its own
+    never needed the full snapshot.
     """
     from abicheck.api_types import CompareResult
     from abicheck.checker import DiffResult, Verdict
@@ -178,8 +188,11 @@ def test_compare_one_library_stashes_old_snapshot_only_when_requested(
 
     def _fake_run_compare_pair(*_args: object, **_kwargs: object) -> CompareResult:
         result = DiffResult(
-            old_version="1.0", new_version="1.0", library="libfoo.so",
-            changes=[], verdict=Verdict.COMPATIBLE,
+            old_version="1.0",
+            new_version="1.0",
+            library="libfoo.so",
+            changes=[],
+            verdict=Verdict.COMPATIBLE,
         )
         return CompareResult(diff=result, old_snapshot=old_snap, new_snapshot=new_snap)
 
@@ -187,17 +200,47 @@ def test_compare_one_library_stashes_old_snapshot_only_when_requested(
         "abicheck.cli_compare_release._run_compare_pair", _fake_run_compare_pair
     )
     common = (
-        {"libfoo.so": old_path}, {"libfoo.so": new_path}, None, None,
-        lambda _old, _dbg: None, [], [], [], [], "1.0", "1.0", "c",
-        None, "strict_abi", None, None,
+        {"libfoo.so": old_path},
+        {"libfoo.so": new_path},
+        None,
+        None,
+        lambda _old, _dbg: None,
+        [],
+        [],
+        [],
+        [],
+        "1.0",
+        "1.0",
+        "c",
+        None,
+        "strict_abi",
+        None,
+        None,
     )
     default_entry = _compare_one_library("libfoo.so", *common)
     assert "_old_snapshot" not in default_entry
+    assert "_old_bundle_evidence" not in default_entry
+
+    bundle_entry = _compare_one_library(
+        "libfoo.so",
+        *common,
+        collect_diff_results=True,
+    )
+    assert "_old_snapshot" not in bundle_entry
+    evidence = bundle_entry["_old_bundle_evidence"]
+    assert isinstance(evidence, BundleSignatureEvidence)
+    assert evidence.function_map is old_snap.function_map
+    assert evidence.variable_map is old_snap.variable_map
+    assert evidence.elf_only_mode == old_snap.elf_only_mode
 
     junit_entry = _compare_one_library(
-        "libfoo.so", *common, collect_diff_results=True,
+        "libfoo.so",
+        *common,
+        collect_diff_results=True,
+        need_full_snapshots=True,
     )
     assert junit_entry["_old_snapshot"] is old_snap
+    assert "_old_bundle_evidence" not in junit_entry
 
 
 def test_strip_diff_results_builds_annotations_only_when_requested() -> None:

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -9,6 +9,7 @@
 - appcompat: --scope-public-headers wiring, -H/-I ignored-mode warning,
   severity options
 """
+
 from __future__ import annotations
 
 import json
@@ -28,9 +29,16 @@ def _write_removed_cpp_symbol(tmp_path: Path) -> tuple[Path, Path]:
     # Use the mangled symbol as the rendered name so the human-format output
     # carries a raw "_Z..." token that demangling can rewrite to "foo()".
     old = AbiSnapshot(
-        library="libtest.so", version="1.0",
-        functions=[Function(name="_Z3foov", mangled="_Z3foov", return_type="int",
-                             visibility=Visibility.PUBLIC)],
+        library="libtest.so",
+        version="1.0",
+        functions=[
+            Function(
+                name="_Z3foov",
+                mangled="_Z3foov",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+            )
+        ],
     )
     new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
     old_p = tmp_path / "old.json"
@@ -42,9 +50,16 @@ def _write_removed_cpp_symbol(tmp_path: Path) -> tuple[Path, Path]:
 
 def _write_identical(tmp_path: Path) -> tuple[Path, Path]:
     snap = AbiSnapshot(
-        library="libtest.so", version="1.0",
-        functions=[Function(name="foo", mangled="_Z3foov", return_type="int",
-                             visibility=Visibility.PUBLIC)],
+        library="libtest.so",
+        version="1.0",
+        functions=[
+            Function(
+                name="foo",
+                mangled="_Z3foov",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+            )
+        ],
     )
     old_p = tmp_path / "old.json"
     new_p = tmp_path / "new.json"
@@ -65,8 +80,10 @@ class TestDemangleTriState:
         module attribute is sufficient. This verifies the *wiring* (which formats
         request demangling), not the platform demangler itself."""
         import abicheck.demangle as _dem
+
         monkeypatch.setattr(
-            _dem, "demangle_text",
+            _dem,
+            "demangle_text",
             lambda text: text.replace("_Z3foov", "foo()"),
         )
 
@@ -74,7 +91,8 @@ class TestDemangleTriState:
         self._patch_demangler(monkeypatch)
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--format", "markdown"],
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "markdown"],
         )
         # markdown requests demangling by default -> stub rewrites the symbol.
         assert "foo()" in result.output
@@ -83,14 +101,16 @@ class TestDemangleTriState:
     def test_json_keeps_mangled_by_default(self, tmp_path):
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--format", "json"],
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "json"],
         )
         assert "_Z3foov" in result.output
 
     def test_sarif_keeps_mangled_by_default(self, tmp_path):
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--format", "sarif"],
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "sarif"],
         )
         assert "_Z3foov" in result.output
 
@@ -101,7 +121,8 @@ class TestDemangleTriState:
         self._patch_demangler(monkeypatch)
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--format", "html"],
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "html"],
         )
         assert "_Z3foov" in result.output
         assert "foo()" not in result.output
@@ -111,7 +132,14 @@ class TestDemangleTriState:
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p), "--format", "markdown", "--no-demangle"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--format",
+                "markdown",
+                "--no-demangle",
+            ],
         )
         # --no-demangle suppresses demangling even on markdown -> stub not run.
         assert "_Z3foov" in result.output
@@ -143,7 +171,8 @@ class TestExitSchemeAnnouncement:
     def test_severity_scheme_announced(self, tmp_path):
         old_p, new_p = _write_identical(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--severity-preset", "default"],
+            main,
+            ["compare", str(old_p), str(new_p), "--severity-preset", "default"],
         )
         assert "Exit-code scheme: severity-aware" in result.stderr
         assert "Exit-code scheme" not in result.stdout
@@ -175,7 +204,8 @@ class TestDebugFormatSelector:
         old_p, new_p = _write_identical(tmp_path)
         # Hidden does not mean removed: --dwarf must remain functional.
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--dwarf"],
+            main,
+            ["compare", str(old_p), str(new_p), "--dwarf"],
         )
         assert result.exit_code == 0
 
@@ -189,7 +219,8 @@ class TestDebugFormatSelector:
     def test_debug_format_auto_accepted(self, tmp_path):
         old_p, new_p = _write_identical(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--debug-format", "auto"],
+            main,
+            ["compare", str(old_p), str(new_p), "--debug-format", "auto"],
         )
         assert result.exit_code == 0
 
@@ -201,7 +232,8 @@ class TestDebugFormatSelector:
         old.write_bytes(b"MZ\x90\x00\x03\x00\x00\x00")  # PE magic
         new.write_bytes(b"MZ\x90\x00\x03\x00\x00\x00")
         result = CliRunner().invoke(
-            main, ["compare", str(old), str(new), "--debug-format", "dwarf"],
+            main,
+            ["compare", str(old), str(new), "--debug-format", "dwarf"],
         )
         assert result.exit_code != 0
         combined = result.output + (result.stderr or "")
@@ -221,7 +253,8 @@ class TestReportModeImpact:
     def test_impact_mode_runs(self, tmp_path):
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--report-mode", "impact"],
+            main,
+            ["compare", str(old_p), str(new_p), "--report-mode", "impact"],
         )
         # Exit code unchanged: a removed symbol is still a 4 (BREAKING).
         assert result.exit_code == 4
@@ -236,8 +269,11 @@ class TestCompareReleaseDefaults:
         # The flag is documented (rich-click wraps the long toggle across panel
         # lines, so assert the stable primary name) and is a boolean toggle.
         assert "--scope-public-headers" in out
-        opt = next(p for p in main.commands["compare"].params
-                   if getattr(p, "name", "") == "scope_public_headers")
+        opt = next(
+            p
+            for p in main.commands["compare"].params
+            if getattr(p, "name", "") == "scope_public_headers"
+        )
         assert "--no-scope-public-headers" in opt.secondary_opts
 
     def test_jobs_default_zero(self):
@@ -266,9 +302,16 @@ class TestCompareReleaseSeverityExit:
         old_dir.mkdir()
         new_dir.mkdir()
         old = AbiSnapshot(
-            library="libtest.so", version="1.0",
-            functions=[Function(name="foo", mangled="_Z3foov", return_type="int",
-                                 visibility=Visibility.PUBLIC)],
+            library="libtest.so",
+            version="1.0",
+            functions=[
+                Function(
+                    name="foo",
+                    mangled="_Z3foov",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
         )
         new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
         (old_dir / "libtest.json").write_text(snapshot_to_json(old), encoding="utf-8")
@@ -279,8 +322,7 @@ class TestCompareReleaseSeverityExit:
         old_dir, new_dir = self._make_release(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_dir), str(new_dir),
-             "--severity-preset", "info-only"],
+            ["compare", str(old_dir), str(new_dir), "--severity-preset", "info-only"],
         )
         # info-only downgrades everything below error -> exit 0 despite the break.
         assert result.exit_code == 0
@@ -289,15 +331,15 @@ class TestCompareReleaseSeverityExit:
         old_dir, new_dir = self._make_release(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_dir), str(new_dir),
-             "--severity-preset", "default"],
+            ["compare", str(old_dir), str(new_dir), "--severity-preset", "default"],
         )
         assert result.exit_code == 4
 
     def test_no_severity_keeps_legacy_exit(self, tmp_path):
         old_dir, new_dir = self._make_release(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_dir), str(new_dir)],
+            main,
+            ["compare", str(old_dir), str(new_dir)],
         )
         # Removed C++ symbol == BREAKING == legacy exit 4.
         assert result.exit_code == 4
@@ -321,30 +363,48 @@ class TestScopedExitRespectsSeverity:
         )
         assert result.exit_code == 4
 
-    def test_required_symbol_severity_info_only_exits_zero(self, tmp_path: Path) -> None:
+    def test_required_symbol_severity_info_only_exits_zero(
+        self, tmp_path: Path
+    ) -> None:
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p), "--required-symbol", "_Z3foov",
-             "--severity-preset", "info-only"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--required-symbol",
+                "_Z3foov",
+                "--severity-preset",
+                "info-only",
+            ],
         )
         # Before the fix this always exited 4 (the legacy scoped-verdict
         # floor), ignoring --severity-preset entirely.
         assert result.exit_code == 0
 
     def test_required_symbol_severity_default_still_exits_breaking(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p), "--required-symbol", "_Z3foov",
-             "--severity-preset", "default"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--required-symbol",
+                "_Z3foov",
+                "--severity-preset",
+                "default",
+            ],
         )
         assert result.exit_code == 4
 
     def test_required_symbol_never_present_floors_severity_at_4(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Regression (Codex P1): a required symbol absent from *both* old and
         # new is a missing contract with no corresponding diff Change (the
@@ -356,24 +416,40 @@ class TestScopedExitRespectsSeverity:
         old_p, new_p = _write_identical(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p), "--required-symbol", "never_existed",
-             "--severity-preset", "default"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--required-symbol",
+                "never_existed",
+                "--severity-preset",
+                "default",
+            ],
         )
         assert result.exit_code == 4
 
     def test_required_symbol_never_present_severity_info_only_exits_zero(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         old_p, new_p = _write_identical(tmp_path)
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p), "--required-symbol", "never_existed",
-             "--severity-preset", "info-only"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--required-symbol",
+                "never_existed",
+                "--severity-preset",
+                "info-only",
+            ],
         )
         assert result.exit_code == 0
 
     def test_required_symbol_json_severity_block_reflects_scoped_gate(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Regression (Codex P2): the JSON `severity` block used to always
         # describe the full-library gate, even for a --required-symbol scope
@@ -381,19 +457,33 @@ class TestScopedExitRespectsSeverity:
         # unrelated symbol -- the scoped gate here is COMPATIBLE/exit 0, but
         # `severity.exit_code` used to still report the full library's 4.
         old = AbiSnapshot(
-            library="libtest.so", version="1.0",
+            library="libtest.so",
+            version="1.0",
             functions=[
-                Function(name="_Z10kept_entryv", mangled="_Z10kept_entryv",
-                          return_type="int", visibility=Visibility.PUBLIC),
-                Function(name="_Z9unrelatedv", mangled="_Z9unrelatedv",
-                          return_type="int", visibility=Visibility.PUBLIC),
+                Function(
+                    name="_Z10kept_entryv",
+                    mangled="_Z10kept_entryv",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(
+                    name="_Z9unrelatedv",
+                    mangled="_Z9unrelatedv",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                ),
             ],
         )
         new = AbiSnapshot(
-            library="libtest.so", version="2.0",
+            library="libtest.so",
+            version="2.0",
             functions=[
-                Function(name="_Z10kept_entryv", mangled="_Z10kept_entryv",
-                          return_type="int", visibility=Visibility.PUBLIC),
+                Function(
+                    name="_Z10kept_entryv",
+                    mangled="_Z10kept_entryv",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                ),
             ],
         )
         old_p = tmp_path / "old.json"
@@ -403,9 +493,17 @@ class TestScopedExitRespectsSeverity:
 
         result = CliRunner().invoke(
             main,
-            ["compare", str(old_p), str(new_p),
-             "--required-symbol", "_Z10kept_entryv",
-             "--format", "json", "--severity-preset", "default"],
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--required-symbol",
+                "_Z10kept_entryv",
+                "--format",
+                "json",
+                "--severity-preset",
+                "default",
+            ],
         )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
@@ -440,10 +538,18 @@ class TestScopedExitRespectsSeverity:
 def _breaking_diff():
     """A real DiffResult with one BREAKING change (func removed)."""
     from abicheck.checker import compare
+
     old = AbiSnapshot(
-        library="libtest.so", version="1.0",
-        functions=[Function(name="_Z3foov", mangled="_Z3foov", return_type="int",
-                             visibility=Visibility.PUBLIC)],
+        library="libtest.so",
+        version="1.0",
+        functions=[
+            Function(
+                name="_Z3foov",
+                mangled="_Z3foov",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+            )
+        ],
     )
     new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
     return compare(old, new)
@@ -485,32 +591,46 @@ class TestCompareReleaseExitFloors:
         from abicheck.cli_compare_release import _exit_compare_release
 
         # severity says clean and no operational error -> returns without exiting.
-        assert _exit_compare_release("COMPATIBLE", False, [], severity_exit_code=0) is None
+        assert (
+            _exit_compare_release("COMPATIBLE", False, [], severity_exit_code=0) is None
+        )
 
 
 class TestComputeReleaseSeverityExitCode:
     def test_none_without_flags(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
-        assert _compute_release_severity_exit_code(
-            [], None, None, None, None, None) is None
+        assert (
+            _compute_release_severity_exit_code([], None, None, None, None, None)
+            is None
+        )
 
     def test_zero_with_flag_and_no_changes(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
-        assert _compute_release_severity_exit_code(
-            [], "info-only", None, None, None, None) == 0
+        assert (
+            _compute_release_severity_exit_code([], "info-only", None, None, None, None)
+            == 0
+        )
 
     def test_aggregates_breaking_change(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
         entry = {"library": "libtest.so", "_diff_result": _breaking_diff()}
         # default preset: abi_breaking == error -> exit 4.
-        assert _compute_release_severity_exit_code(
-            [entry], "default", None, None, None, None) == 4
+        assert (
+            _compute_release_severity_exit_code(
+                [entry], "default", None, None, None, None
+            )
+            == 4
+        )
         # info-only downgrades everything below error -> exit 0.
-        assert _compute_release_severity_exit_code(
-            [entry], "info-only", None, None, None, None) == 0
+        assert (
+            _compute_release_severity_exit_code(
+                [entry], "info-only", None, None, None, None
+            )
+            == 0
+        )
 
 
 class TestReleaseSeverityPolicyAndGlobal:
@@ -526,12 +646,17 @@ class TestReleaseSeverityPolicyAndGlobal:
         empty = frozenset()
         all_kinds = frozenset(c.kind for c in diff.changes)
         monkeypatch.setattr(
-            diff, "_effective_kind_sets",
+            diff,
+            "_effective_kind_sets",
             lambda: (empty, empty, all_kinds, empty),
         )
         entry = {"_diff_result": diff}
-        assert _compute_release_severity_exit_code(
-            [entry], "default", None, None, None, None) == 0
+        assert (
+            _compute_release_severity_exit_code(
+                [entry], "default", None, None, None, None
+            )
+            == 0
+        )
 
     def test_per_library_honours_frozen_namespace_floor(self):
         """Codex review on #549: a policy-file override that demotes a kind
@@ -543,20 +668,30 @@ class TestReleaseSeverityPolicyAndGlobal:
         from abicheck.policy_file import PolicyFile
 
         c = Change(
-            ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo",
+            ChangeKind.FUNC_REMOVED,
+            "_Z3foov",
+            "removed: foo",
             frozen_namespace_violation="**::detail::r1::*",
         )
         pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
         diff = DiffResult(
-            old_version="1.0", new_version="2.0", library="libtest.so",
-            changes=[c], verdict=Verdict.BREAKING, policy_file=pf,
+            old_version="1.0",
+            new_version="2.0",
+            library="libtest.so",
+            changes=[c],
+            verdict=Verdict.BREAKING,
+            policy_file=pf,
         )
         entry = {"_diff_result": diff}
         # default preset: abi_breaking == error. Without the policy_file floor
         # this would wrongly exit 0 (the override demotes FUNC_REMOVED to
         # COMPATIBLE); the frozen guard must keep it at its raw BREAKING exit.
-        assert _compute_release_severity_exit_code(
-            [entry], "default", None, None, None, None) == 4
+        assert (
+            _compute_release_severity_exit_code(
+                [entry], "default", None, None, None, None
+            )
+            == 4
+        )
 
     def test_format_release_junit_forwards_severity_config(self):
         """Codex review on #549: `compare-release --format junit` with a
@@ -569,8 +704,11 @@ class TestReleaseSeverityPolicyAndGlobal:
 
         c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
         diff = DiffResult(
-            old_version="1", new_version="2", library="libfoo.so",
-            changes=[c], verdict=Verdict.COMPATIBLE,
+            old_version="1",
+            new_version="2",
+            library="libfoo.so",
+            changes=[c],
+            verdict=Verdict.COMPATIBLE,
         )
         cfg = resolve_severity_config("default", addition="error")
 
@@ -578,7 +716,10 @@ class TestReleaseSeverityPolicyAndGlobal:
         assert 'failures="0"' in xml_without_config
 
         xml_with_config = _format_release_junit(
-            [(diff, None)], None, [], severity_config=cfg,
+            [(diff, None)],
+            None,
+            [],
+            severity_config=cfg,
         )
         assert 'failures="1"' in xml_with_config
 
@@ -611,8 +752,12 @@ class TestReleaseSeverityPolicyAndGlobal:
 
         # Per-library clean (base 0), but a matrix DiffResult carries a break.
         matrix = _breaking_diff()
-        assert _fold_release_global_severity(
-            0, None, matrix, "default", None, None, None, None) == 4
+        assert (
+            _fold_release_global_severity(
+                0, None, matrix, "default", None, None, None, None
+            )
+            == 4
+        )
 
     def test_fold_bundle_break_raises_exit(self):
         import types
@@ -621,35 +766,92 @@ class TestReleaseSeverityPolicyAndGlobal:
 
         change = _breaking_diff().changes[0]
         finding = types.SimpleNamespace(to_change=lambda: change)
-        bundle = types.SimpleNamespace(bundle_findings=[finding])
-        assert _fold_release_global_severity(
-            0, bundle, None, "default", None, None, None, None) == 4
+        bundle = types.SimpleNamespace(bundle_findings=[finding], policy="strict_abi")
+        assert (
+            _fold_release_global_severity(
+                0, bundle, None, "default", None, None, None, None
+            )
+            == 4
+        )
+
+    def test_fold_bundle_honors_the_bundle_result_own_policy(self):
+        # G38 stabilization Phase 10 (Codex review, fresh evidence): this
+        # fold previously omitted `policy=` entirely when scoring bundle
+        # findings, unlike the sibling matrix_result branch right below it
+        # -- so a policy that demotes a bundle-promoted kind (plugin_abi
+        # demoting calling_convention_changed) never reached the
+        # severity-aware exit code, even though BundleDiffResult.
+        # bundle_verdict (the displayed verdict) already honors it via its
+        # own `.policy` field.
+        import types
+
+        from abicheck.checker_policy import ChangeKind
+        from abicheck.checker_types import Change
+        from abicheck.cli_compare_release import _fold_release_global_severity
+
+        change = Change(
+            kind=ChangeKind.CALLING_CONVENTION_CHANGED,
+            symbol="core_fn",
+            description="cdecl->fastcall",
+            old_value="cdecl",
+            new_value="fastcall",
+        )
+        finding = types.SimpleNamespace(to_change=lambda: change)
+
+        strict_bundle = types.SimpleNamespace(
+            bundle_findings=[finding], policy="strict_abi"
+        )
+        assert (
+            _fold_release_global_severity(
+                0, strict_bundle, None, "default", None, None, None, None
+            )
+            == 4
+        )
+
+        plugin_bundle = types.SimpleNamespace(
+            bundle_findings=[finding], policy="plugin_abi"
+        )
+        assert (
+            _fold_release_global_severity(
+                0, plugin_bundle, None, "default", None, None, None, None
+            )
+            == 0
+        )
 
     def test_fold_info_only_does_not_escalate(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 
         matrix = _breaking_diff()
         # info-only downgrades the matrix break below error -> base 0 preserved.
-        assert _fold_release_global_severity(
-            0, None, matrix, "info-only", None, None, None, None) == 0
+        assert (
+            _fold_release_global_severity(
+                0, None, matrix, "info-only", None, None, None, None
+            )
+            == 0
+        )
 
     def test_fold_no_extras_returns_base(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 
-        assert _fold_release_global_severity(
-            2, None, None, "default", None, None, None, None) == 2
+        assert (
+            _fold_release_global_severity(
+                2, None, None, "default", None, None, None, None
+            )
+            == 2
+        )
 
     def test_resolve_config_none_without_flags(self):
         from abicheck.cli_compare_release import _resolve_release_severity_config
 
-        assert _resolve_release_severity_config(
-            None, None, None, None, None) is None
+        assert _resolve_release_severity_config(None, None, None, None, None) is None
 
     def test_resolve_config_set_with_flag(self):
         from abicheck.cli_compare_release import _resolve_release_severity_config
 
-        assert _resolve_release_severity_config(
-            "strict", None, None, None, None) is not None
+        assert (
+            _resolve_release_severity_config("strict", None, None, None, None)
+            is not None
+        )
 
 
 # ── §6 follow-ups: debug-format auto override + parallel determinism ─────────
@@ -662,7 +864,8 @@ class TestDebugFormatAutoOverride:
         # not error and must exit 0 on identical input).
         old_p, new_p = _write_identical(tmp_path)
         result = CliRunner().invoke(
-            main, ["compare", str(old_p), str(new_p), "--debug-format", "auto", "--dwarf"],
+            main,
+            ["compare", str(old_p), str(new_p), "--debug-format", "auto", "--dwarf"],
         )
         assert result.exit_code == 0
 
@@ -674,7 +877,8 @@ class TestCompareReleaseParallelOrdering:
         import abicheck.cli_compare_release as _cr
 
         monkeypatch.setattr(
-            _cr, "_compare_one_library",
+            _cr,
+            "_compare_one_library",
             lambda key, *a: {"library": key, "key": key},
         )
         keys = ["libc", "liba", "libb"]


### PR DESCRIPTION
## Summary

Implements ADR-023&#39;s G38 amendment end to end (Phases 1-4: bundle-finding
taxonomy, persisted `BundleFacts`, multibuild variant pairing, and the
C-boundary signature-evidence gate, wired into the live `compare --release`
path), then works through the stabilization sequence an external review of
that state identified, closing all four P0 defects from that review.

## Motivation

`compare_bundle()`'s live directory/package analysis only ever reopened
`.so` files and treated a resolved-by-name C-boundary import as proof the
signature agreed, even when the provider was stripped or L0-only. G38 adds
a persisted bundle-facts model, an explicit multibuild-variant pairing
primitive (never silently unions two variants), and a dedicated finding for
"this import resolves by name, but nothing establishes the signature
agrees." A follow-up review of the resulting state found four P0 defects:
(P0-A) `CTOR_EXPLICIT_*` incorrectly suppressed (fixed pre-PR), a kind-set
disagreement between promotion and suppression (fixed, this PR's early
commits), (P0-B) a real multi-binary memory regression from retaining full
`AbiSnapshot`s across the whole release, (P0-C) the bundle-findings exit
code ignoring the resolved policy while the displayed verdict honored it,
and (P0-D) bundle-analysis failures being visible only on stderr instead of
in the structured report. All four are now fixed.

## Changes

- G38 Phase 1: bundle-finding taxonomy documentation (graph-native vs.
  diff-derived findings, scoping, suppression, bundle semantics).
- G38 Phase 2: persisted `BundleFacts` — schema, serialization, per-library
  snapshots, manifest/alias/canonical-filename handling, `--bundle-facts-out`
  producer.
- G38 Phase 3: `bundle_multibuild.py` — deterministic variant fingerprinting,
  one-to-one pairing with no silent union, `bundle_variant_coverage_regressed`.
- G38 Phase 4: `bundle_signature_evidence.py` — the C-boundary
  signature-evidence gate (`bundle_intra_dep_signature_unverified`), wired
  into the live `compare --release` bundle-analysis path.
- G38 Phase 5 (stabilization): unify `bundle._detect_intra_dep_signature_
  changed`'s promotion set and `bundle_signature_evidence`'s suppression set
  into shared `bundle_models` frozensets (split into a broad
  `CONFIRMED_...` suppression set and a narrower `PROMOTABLE_...` promotion
  set, after review found sharing one set would fabricate findings for a
  COMPATIBLE-by-default kind), plus provider-key normalization
  (`basename_to_bundle_key`) and preserving the `plugin_abi` policy's
  demotion through bundle promotion.
- **G38 Phase 9 (P0-B, memory):** `_compare_one_library` only retains full
  `AbiSnapshot`s when a consumer actually needs them (JUnit output,
  `--bundle-facts-out`); every other path now stashes a compact
  `BundleSignatureEvidence` projection (`function_map`/`variable_map`/
  `elf_only_mode` only) instead, so a large release no longer holds two full
  `AbiSnapshot`s per library in memory for the whole run.
- **G38 Phase 10 (P0-C, policy/severity):** `_fold_release_global_severity`'s
  bundle-findings branch now passes `policy=bundle_result.policy` into
  `compute_exit_code`, matching the sibling `matrix_result` branch — a
  built-in policy profile that demotes a bundle-promoted kind (e.g.
  `plugin_abi` demoting `calling_convention_changed`) now agrees between the
  displayed `bundle_verdict` and the severity-aware exit code.
- **G38 Phase 11 (P0-D, structured degradation):** `BundleDiffResult` gains
  `analysis_errors: list[str]`; a `compare_bundle()` or Phase 4
  signature-evidence failure is now recorded there (in addition to the
  existing stderr warning) and surfaced in both the JSON summary
  (`bundle_analysis_errors`, present only when non-empty) and a new
  Markdown "Bundle Analysis Warnings" section.
- Extends the G38 plan doc with real-world oneDAL validation findings
  (headerless-bundle scoping, `scan --artifact-set` system-provider
  blockers, cross-pair header/source cache cost) and the remaining
  stabilization phases (live/stored Phase-4 parity, stored-facts CLI
  consumer + multibuild wiring), scoping the not-yet-attempted work rather
  than leaving it as loose review findings.

## Bug-fix test contract

- Bug class: (1) two independently-maintained `ChangeKind` sets drifted
  apart; (2) full `AbiSnapshot`s retained in memory for an entire release
  regardless of whether any consumer needed them; (3) the bundle-findings
  severity-aware exit code ignored the resolved policy while the displayed
  verdict honored it; (4) a bundle-analysis-step failure was visible only
  on stderr, indistinguishable in the structured report from "ran cleanly
  and found nothing."
- Publicly observable failure: (1) a confirmed `calling_convention_changed`
  (or 8 sibling kinds) on a bundled provider's export never produced the
  expected `BUNDLE_INTRA_DEP_SIGNATURE_CHANGED` consumer-attributed
  finding; (2) `compare --release` over a large directory held two full
  `AbiSnapshot`s per library simultaneously even when only a compact
  projection was needed; (3) a `plugin_abi`-demoted bundle finding still
  forced a nonzero severity-aware exit code despite reading `COMPATIBLE` in
  the displayed verdict; (4) a raised exception inside bundle analysis
  produced an empty `bundle_findings` list in the JSON/Markdown report with
  no way to tell that from a clean, empty result.
- Regression test fails on base: yes for all four — `test_promotes_
  calling_convention_change_to_consumer`, `test_compare_one_library_stashes_
  old_snapshot_only_when_requested` (rewritten for the three retention
  states), `test_fold_bundle_honors_the_bundle_result_own_policy`, and
  `TestBundleAnalysisErrorsAreStructural`'s five cases all fail against
  their respective pre-fix code.
- Negative control: `test_no_finding_when_no_consumers` (confirmed change,
  no sibling consumer, still no bundle finding); the default
  `collect_diff_results=False` path still stashes nothing;
  `test_fold_bundle_break_raises_exit` under `strict_abi` still exits
  nonzero; `test_no_analysis_errors_key_when_bundle_analysis_is_clean`
  confirms a clean result carries no `bundle_analysis_errors` key at all.
- Public-surface test: yes for all four — exercised through
  `compare_bundle()`'s public `bundle_findings`, the real `_compare_one_
  library`/`_compare_release_libraries` stash logic, `_fold_release_
  global_severity`'s real exit-code computation, and `_format_release_
  json`/`_release_md_bundle_findings`'s real report rendering.
- Axes covered: the promoted-vs-suppressed kind-set disagreement plus one
  concrete kind (`CALLING_CONVENTION_CHANGED`); all three snapshot-
  retention states (none/compact/full) plus JSON-serialization safety
  (compact evidence never leaks an `AbiSnapshot` into the stripped JUnit
  entry); both `strict_abi` and `plugin_abi` policies on the same finding;
  both failure points (`compare_bundle()`, the Phase 4 signature check)
  surfaced in both report formats (JSON, Markdown), including the
  no-findings-but-degraded case.
- General invariant: a confirmed C-boundary signature break always reaches
  its consumer-attributed bundle finding through one shared kind set that
  cannot independently drift; a full `AbiSnapshot` is retained only when a
  named consumer actually reads it; the severity-aware exit code and the
  displayed verdict always agree on which policy classified a bundle
  finding; and a JSON/Markdown bundle report never silently conflates "no
  findings" with "analysis did not complete."

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (G38 plan doc: Phases 5-13)
- [x] `ruff check` / `ruff format` clean on touched files; `mypy abicheck/` clean on touched files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
