### PR TITLE
fix: strip checkout-dependent directory from L5 graph decl/type node ids

### DIFF
--- a/abicheck/buildsource/entity_resolver.py
+++ b/abicheck/buildsource/entity_resolver.py
@@ -116,8 +116,9 @@ class EntityResolver:
         return canonical
 
     def remap_node_ids(self, remap: Callable[[str], str]) -> None:
-        """Rewrite every v1 node id this resolver references through *remap*
-        (Codex review, fresh evidence).
+        """Rewrite every identity string this resolver references — v1 node
+        ids *and* canonical ids alike — through *remap* (Codex review, fresh
+        evidence, two rounds).
 
         ``SourceGraphSummary.from_dict()`` normalizes a loaded
         ``GraphNode.id`` (see ``graph_facts._normalize_graph_identity``, the
@@ -131,19 +132,36 @@ class EntityResolver:
         ``resolve()`` on a possibly-weaker signal set can add a second,
         redundant alias instead of returning the persisted one).
 
-        Two distinct old ids collapsing onto the same new id after *remap*
-        (the directory-taint fix's own intended effect — two ids that only
-        differed by checkout path now agree) is not specially reconciled
-        here: a dict comprehension keeps whichever entry is last, which is
-        harmless in practice since both old ids named the identical
-        declaration and therefore already agreed on ``canonical_id``, but is
+        A *canonical* id itself can carry the identical taint when no
+        USR/mangled name was available at resolve time —
+        ``entity_identity.normalized_signature``'s ``"sig:<qualified_name>..."``
+        fallback embeds the qualified name verbatim, which is exactly
+        ``node.label``'s own raw, checkout-path-bearing spelling before this
+        fix existed. A first revision of this method only remapped v1-id
+        *keys*, leaving that persisted canonical *value* untouched -- so
+        ``canonical_id_for()`` still returned a checkout-dependent id that
+        would never match a freshly-resolved graph's canonical id for the
+        identical declaration. ``remap`` is applied to every string in this
+        structure that could be either kind (it is a no-op for a
+        ``usr:``/``mangled:``/``synthetic:sha256:`` id, which never embeds a
+        qualified name literally).
+
+        Two distinct old entries collapsing onto the same new key after
+        *remap* (the directory-taint fix's own intended effect) is not
+        specially reconciled here: a dict comprehension keeps whichever
+        entry is last, which is harmless when both named the identical
+        declaration (they now agree on both id and canonical value), but is
         not a fully general collision merge. Idempotent for an id *remap*
         does not change.
         """
-        self.aliases = {remap(k): v for k, v in self.aliases.items()}
-        self._canonical_to_v1 = {c: remap(v) for c, v in self._canonical_to_v1.items()}
+        self.aliases = {remap(k): remap(v) for k, v in self.aliases.items()}
+        self._canonical_to_v1 = {
+            remap(c): remap(v) for c, v in self._canonical_to_v1.items()
+        }
         self.conflicts = [
-            EntityConflict(c.canonical_id, tuple(remap(nid) for nid in c.node_ids))
+            EntityConflict(
+                remap(c.canonical_id), tuple(remap(nid) for nid in c.node_ids)
+            )
             for c in self.conflicts
         ]
 

--- a/abicheck/buildsource/entity_resolver.py
+++ b/abicheck/buildsource/entity_resolver.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from . import entity_identity
-from .graph_facts import _normalize_graph_identity
+from .graph_facts import _is_decl_or_type_node_id, _normalize_graph_identity
 
 if TYPE_CHECKING:
     from .graph_facts import GraphNode
@@ -153,14 +153,36 @@ class EntityResolver:
         declaration (they now agree on both id and canonical value), but is
         not a fully general collision merge. Idempotent for an id *remap*
         does not change.
+
+        Every string is gated by :func:`graph_facts._is_decl_or_type_node_id`
+        first (Codex review, fresh evidence, sixth round): ``resolve_entities()``
+        resolves *every* node in a graph, not just decl/type ones, so
+        ``aliases``/``_canonical_to_v1``/``conflicts`` can legitimately hold
+        a v1 id for a ``source://``/``header://``/... node too -- applying
+        *remap* to that id (or the canonical id it resolved to) regardless
+        of kind risked rewriting marker-shaped text that has nothing to do
+        with an anonymous/lambda declaration. A pairing (an alias's v1-id
+        key and canonical-id value, or a conflict's ``node_ids``) is only
+        remapped when the v1-id side of it is itself a decl/type id.
         """
-        self.aliases = {remap(k): remap(v) for k, v in self.aliases.items()}
+
+        def _gated(node_id: str) -> str:
+            return remap(node_id) if _is_decl_or_type_node_id(node_id) else node_id
+
+        self.aliases = {
+            _gated(k): (remap(v) if _is_decl_or_type_node_id(k) else v)
+            for k, v in self.aliases.items()
+        }
         self._canonical_to_v1 = {
-            remap(c): remap(v) for c, v in self._canonical_to_v1.items()
+            (remap(c) if _is_decl_or_type_node_id(v) else c): _gated(v)
+            for c, v in self._canonical_to_v1.items()
         }
         self.conflicts = [
             EntityConflict(
-                remap(c.canonical_id), tuple(remap(nid) for nid in c.node_ids)
+                remap(c.canonical_id)
+                if all(_is_decl_or_type_node_id(nid) for nid in c.node_ids)
+                else c.canonical_id,
+                tuple(_gated(nid) for nid in c.node_ids),
             )
             for c in self.conflicts
         ]

--- a/abicheck/buildsource/entity_resolver.py
+++ b/abicheck/buildsource/entity_resolver.py
@@ -40,10 +40,12 @@ predicted, rather than a second, independent identity computation.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from . import entity_identity
+from .graph_facts import _normalize_graph_identity
 
 if TYPE_CHECKING:
     from .graph_facts import GraphNode
@@ -113,6 +115,38 @@ class EntityResolver:
             self.conflicts.append(EntityConflict(canonical, (existing_v1, node.id)))
         return canonical
 
+    def remap_node_ids(self, remap: Callable[[str], str]) -> None:
+        """Rewrite every v1 node id this resolver references through *remap*
+        (Codex review, fresh evidence).
+
+        ``SourceGraphSummary.from_dict()`` normalizes a loaded
+        ``GraphNode.id`` (see ``graph_facts._normalize_graph_identity``, the
+        checkout-directory-taint fix) *after* this resolver was already
+        built from the persisted JSON — so without this remap,
+        ``aliases``/``_canonical_to_v1``/``conflicts`` would still be keyed
+        by the OLD, pre-migration id, and ``canonical_id_for(node.id)``
+        would silently return ``None`` for a node whose canonical identity
+        was already resolved and persisted, forcing a spurious re-resolve
+        (:meth:`resolve`'s idempotence never triggers, and a fresh
+        ``resolve()`` on a possibly-weaker signal set can add a second,
+        redundant alias instead of returning the persisted one).
+
+        Two distinct old ids collapsing onto the same new id after *remap*
+        (the directory-taint fix's own intended effect — two ids that only
+        differed by checkout path now agree) is not specially reconciled
+        here: a dict comprehension keeps whichever entry is last, which is
+        harmless in practice since both old ids named the identical
+        declaration and therefore already agreed on ``canonical_id``, but is
+        not a fully general collision merge. Idempotent for an id *remap*
+        does not change.
+        """
+        self.aliases = {remap(k): v for k, v in self.aliases.items()}
+        self._canonical_to_v1 = {c: remap(v) for c, v in self._canonical_to_v1.items()}
+        self.conflicts = [
+            EntityConflict(c.canonical_id, tuple(remap(nid) for nid in c.node_ids))
+            for c in self.conflicts
+        ]
+
     def canonical_id_for(self, v1_id: str) -> str | None:
         """The canonical identity *v1_id* resolved to, or ``None`` if
         :meth:`resolve` was never called for it."""
@@ -147,8 +181,12 @@ class EntityResolver:
             for c in (raw_conflicts if isinstance(raw_conflicts, (list, tuple)) else ())
             if isinstance(c, dict)
         ]
-        return cls(
+        obj = cls(
             aliases=aliases,
             conflicts=conflicts,
             _canonical_to_v1=canonical_to_v1,
         )
+        # Self-heal against source_graph.py's own GraphNode/GraphEdge id
+        # migration (Codex review) -- see remap_node_ids's own docstring.
+        obj.remap_node_ids(_normalize_graph_identity)
+        return obj

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -41,6 +41,7 @@ from typing import Any
 
 from ..name_classification import (
     _declaring_header_discriminator,
+    _quoted_spans,
     strip_anonymous_type_location,
 )
 
@@ -518,10 +519,26 @@ class GraphNode:
         # from attrs/provenance/confidence (no forced re-collection). A stored
         # "resolved"/"conflicts" is never trusted — always recomputed, so a
         # hand-edited pack self-heals instead of persisting a stale merge.
+        #
+        # id/label pass through _normalize_graph_identity on load (Codex
+        # review, fresh evidence) so a pack persisted before that
+        # normalization existed self-heals the same way: without this, an
+        # old pack's raw, checkout-path-bearing decl/type node id would
+        # never match the normalized id a freshly-built graph now produces
+        # for the identical declaration, and diff_source_graph's direct id
+        # comparison would read it as removed+added rather than unchanged
+        # (the exact false positive this whole normalization exists to
+        # close, just reached from a stale-pack angle instead of a
+        # fresh-vs-fresh one). Safe unconditionally: the substitution only
+        # ever touches an embedded "(unnamed .../lambda at ...)"/"lambda at
+        # ...:line:col" marker, so it is a no-op for every other node id
+        # (source://, header://, build_option://, symbol://, target://,
+        # vtable://, ...) and idempotent for an id a current build already
+        # normalized.
         node = cls(
-            id=str(d["id"]),
+            id=_normalize_graph_identity(str(d["id"])),
             kind=str(d.get("kind", "file")),
-            label=str(d.get("label", "")),
+            label=_normalize_graph_identity(str(d.get("label", ""))),
             attrs=dict(d.get("attrs", {})),
             provenance=str(d.get("provenance", "")),
             confidence=str(d.get("confidence", CONF_UNKNOWN)),
@@ -592,10 +609,12 @@ class GraphEdge:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> GraphEdge:
         # See GraphNode.from_dict: v1-pack compat + always-recompute-from-facts
-        # apply identically here.
+        # apply identically here, including the src/dst normalize-on-load
+        # migration for a pack persisted before decl/type node ids were
+        # checkout-directory-normalized.
         edge = cls(
-            src=str(d["src"]),
-            dst=str(d["dst"]),
+            src=_normalize_graph_identity(str(d["src"])),
+            dst=_normalize_graph_identity(str(d["dst"])),
             kind=str(d.get("edge", d.get("kind", ""))),
             provenance=str(d.get("provenance", "")),
             confidence=str(d.get("confidence", CONF_UNKNOWN)),
@@ -808,9 +827,27 @@ def _strip_bare_anonymous_type_location(name: str) -> str:
     discriminator, drop only the checkout-dependent directory) for the shape
     that function's own paren-anchored regex does not match. See
     :func:`_normalize_graph_identity`.
+
+    A match that falls inside a ``"..."`` quoted literal is left completely
+    untouched, mirroring `strip_anonymous_type_location`'s own protection
+    (Codex review, fresh evidence): a real anonymous/lambda marker is never
+    itself quoted, so a match starting inside quotes can only be ordinary
+    string-literal *content* that happens to spell location-shaped text --
+    e.g. a C++20 fixed-string NTTP argument like ``Tag<"lambda at
+    /a/foo.hpp:1:2">``. Without this guard, two distinct specializations
+    quoting *different* paths (``Tag<"lambda at /a/foo.hpp:1:2">`` vs.
+    ``Tag<"lambda at /b/foo.hpp:1:2">``) would collapse onto the identical
+    normalized identity, fabricating a same-identity collision between two
+    genuinely different declarations.
     """
+    quoted_spans = _quoted_spans(name)
+
+    def _inside_quotes(pos: int) -> bool:
+        return any(start <= pos < end for start, end in quoted_spans)
 
     def _replace(match: re.Match[str]) -> str:
+        if _inside_quotes(match.start()):
+            return match.group(0)
         marker, path, line, col = match.groups()
         return f"{marker}:{_declaring_header_discriminator(path)}:{line}:{col}"
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -837,8 +837,24 @@ def _compute_occurrences(edge: GraphEdge) -> list[str]:
 #: handles. Anchored the same way (``\b`` word boundary before the marker)
 #: to avoid rewriting unrelated text that merely contains the substring
 #: "at" followed by something colon-shaped.
+#:
+#: The path group is a negative-lookahead-guarded ``.*`` -- greedy, but
+#: refusing to consume across a *later* marker's own ``lambda at``/``unnamed
+#: <kind> at`` trigger -- rather than plain non-greedy ``.*?`` (Codex review,
+#: fresh evidence): a non-greedy path group stops at the FIRST ``:\d+:\d+``
+#: it can find, which is wrong the moment the checkout path itself contains
+#: a colon-digit-colon-digit-shaped segment (a timestamped build directory,
+#: ``/tmp/build-2026T12:34:56/src/foo.hpp:4:37``) -- it silently keeps the
+#: real, checkout-dependent tail (``/src/foo.hpp:4:37``) unmodified past the
+#: truncated match. A plain greedy ``.*`` fixes that (it finds the
+#: *rightmost* valid ``:\d+:\d+``) but then over-matches a string embedding
+#: *two* markers (a quoted lookalike alongside a real one, or two real
+#: markers), swallowing both into one match. The lookahead guard gets both
+#: right: greedy within one marker's own text, but bounded at the next
+#: marker's trigger.
 _BARE_ANON_TYPE_LOCATION_RE = re.compile(
-    r"\b(lambda|unnamed\s+\w+)\s+at\s+(.*?):(\d+):(\d+)\b"
+    r"\b(lambda|unnamed\s+\w+)\s+at\s+"
+    r"((?:(?!(?:lambda|unnamed\s+\w+)\s+at\s).)*):(\d+):(\d+)\b"
 )
 
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -1011,7 +1011,26 @@ def _normalize_graph_identity(identity: str) -> str:
     primitive rather than inventing a second, differently-limited one. A
     fix would be a real, cross-cutting redesign of a primitive shared with
     the L2 backend, not a scoped change to this L5-specific caller.
+
+    Fast-pathed on a plain ``"at" in identity`` check (Codex review,
+    fresh evidence -- a real header-graph attach-cost CI regression,
+    ~31% at 400 declarations/castxml, traced to this function running on
+    every id/label/attrs pair for every decl/type node several times
+    over, across the several rounds this whole mechanism accreted through
+    -- not a hypothetical). Both underlying regexes require the literal
+    substring ``"at"`` (``strip_anonymous_type_location``'s own
+    ``\\bat\\s+...``, this module's own ``\\s+at\\s+...`` bare-marker
+    pattern) immediately before the location text, so a string that
+    doesn't contain it at all cannot match either one -- a cheap,
+    substring-only necessary condition with no regex engine involved,
+    correct for every input (never skips a string that could actually
+    match), not just the realistic ones. Ordinary identifiers containing
+    "at" as a substring (``"Category"``, ``"static_cast"``) still pay
+    the full regex cost -- this only eliminates the (typically dominant)
+    fraction of identities with no "at" substring anywhere.
     """
+    if "at" not in identity:
+        return identity
     return _strip_bare_anonymous_type_location(strip_anonymous_type_location(identity))
 
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -35,8 +35,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any
+
+from ..name_classification import (
+    _declaring_header_discriminator,
+    strip_anonymous_type_location,
+)
 
 #: Confidence labels (ADR-031 D9). Mirrors the evidence-model vocabulary so the
 #: coverage report and graph speak the same language. Canonical home of these
@@ -768,3 +774,84 @@ def _compute_occurrences(edge: GraphEdge) -> list[str]:
         if oid is not None and oid not in seen:
             seen.append(oid)
     return sorted(seen)
+
+
+# ── decl/type identity normalization (ADR-031/ADR-048) ─────────────────────
+#
+# Split out here (rather than kept in source_graph.py, where the choke-point
+# functions that consume this live) purely to stay under source_graph.py's
+# AI-readiness line-count cap -- see this module's own docstring for the
+# established precedent of moving content here for exactly that reason.
+
+#: Same location-shaped text :func:`strip_anonymous_type_location` strips,
+#: but *without* the leading ``(`` that function anchors on. clang's own
+#: declaration-name spelling for a lambda closure's implicit record (as
+#: opposed to the *type* printer's ``"(lambda at ...)"`` qualType spelling
+#: `strip_anonymous_type_location` targets) has been observed reaching the
+#: L5 source-graph pipeline bare -- e.g. a ``SourceEntity.identity()``/
+#: ``qualified_name`` of exactly ``"lambda at /a/foo.hpp:4:37"``, no
+#: wrapping parens at all -- so a real fix here needs both shapes covered,
+#: not just the parenthesized one `strip_anonymous_type_location` already
+#: handles. Anchored the same way (``\b`` word boundary before the marker)
+#: to avoid rewriting unrelated text that merely contains the substring
+#: "at" followed by something colon-shaped.
+_BARE_ANON_TYPE_LOCATION_RE = re.compile(
+    r"\b(lambda|unnamed\s+\w+)\s+at\s+(.*?):(\d+):(\d+)\b"
+)
+
+
+def _strip_bare_anonymous_type_location(name: str) -> str:
+    """Strip the checkout-dependent directory out of a *bare* (unparenthesized)
+    ``lambda at <path>:<line>:<col>``/``unnamed <kind> at <path>:<line>:<col>``
+    spelling, mirroring :func:`strip_anonymous_type_location`'s contract
+    (keep the declaring header's own basename + ``:<line>:<col>`` as a
+    discriminator, drop only the checkout-dependent directory) for the shape
+    that function's own paren-anchored regex does not match. See
+    :func:`_normalize_graph_identity`.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        marker, path, line, col = match.groups()
+        return f"{marker}:{_declaring_header_discriminator(path)}:{line}:{col}"
+
+    return _BARE_ANON_TYPE_LOCATION_RE.sub(_replace, name)
+
+
+def _normalize_graph_identity(identity: str) -> str:
+    """Strip a checkout-dependent directory out of *identity* before it
+    becomes (part of) an L5 decl/type node id (ADR-031/ADR-048).
+
+    A ``SourceEntity``'s ``identity()``/``qualified_name`` falls back to the
+    raw declaration spelling clang/castxml emit for an anonymous-tag or
+    lambda-closure type -- ``"(unnamed struct at /a/foo.h:56:5)"``,
+    ``"raii_guard<(lambda at /a/foo.h:4:37)>"``, or (observed directly in a
+    real L5 graph, with no wrapping parens at all) a bare ``"lambda at
+    /a/foo.h:4:37"`` -- which embeds an *absolute* path. ``dumper_castxml.py``'s
+    L2 header-AST backend already strips the parenthesized form at
+    extraction time (see :func:`strip_anonymous_type_location`'s own
+    docstring), but nothing under ``abicheck/buildsource/`` did: two builds
+    of the identical, unedited declaration under different checkout roots
+    produced two different L5 node ids for it, which
+    ``graph_reconcile``/``diff_source_graph`` then read as a real rename
+    (``declaration_renamed``) purely from directory taint. ``source_graph.
+    _decl_node_id``/``_type_node_id`` are the one choke point every producer
+    in ``abicheck/buildsource/`` (``type_graph.py``, ``call_graph.py``,
+    ``override_graph.py``, ``callback_graph.py``, ``template_graph.py``,
+    ``header_graph.py``, ``macro_graph.py``, ``source_graph.py`` itself)
+    routes a decl/type identity through -- for both a node's own id and
+    every edge endpoint naming it -- so normalizing here closes the whole
+    class at once rather than one producer at a time. Both the
+    parenthesized (L2-style) and bare shapes are stripped, since only
+    real-world evidence -- not either producer's own documented output
+    contract -- tells us which one a given decl/type identity actually
+    carries by the time it reaches this package.
+    """
+    return _strip_bare_anonymous_type_location(strip_anonymous_type_location(identity))
+
+
+def _decl_node_id(identity: str) -> str:
+    return f"decl://{_normalize_graph_identity(identity)}"
+
+
+def _type_node_id(identity: str) -> str:
+    return f"type://{_normalize_graph_identity(identity)}"

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -892,6 +892,37 @@ def _compute_occurrences(edge: GraphEdge) -> list[str]:
 #: edge case matching this whole heuristic's existing "approximate,
 #: degrade rather than risk a wrong merge" discipline (see this module's
 #: own docstring).
+#: **Accepted, deliberately-unfixed limitation** (Codex review, fresh
+#: evidence, fourth round on this same regex): the negative lookahead exists
+#: to bound a marker's greedy path group at a *later, real* marker's own
+#: trigger -- but it cannot distinguish that from a checkout path whose own
+#: directory name is, by pure textual coincidence, spelled exactly like a
+#: trigger (e.g. a directory literally named ``lambda at``, as in
+#: ``lambda at /tmp/lambda at build/foo.hpp:4:37``). For that shape the
+#: lookahead treats the coincidental path segment as a second marker
+#: boundary, the outer match fails to find any valid ``:\d+:\d+`` within its
+#: bounded region, and ``re.sub`` falls through to matching the *inner*
+#: "lambda at build/..." text instead -- leaving the real, checkout-
+#: dependent ``/tmp/`` prefix completely untouched. Unlike the two prior
+#: rounds this regex has already been hardened against (a timestamped build
+#: directory, ADR-031/ADR-048's own real-world CI convention; a quoted C++20
+#: fixed-string NTTP literal, real language syntax), a directory component
+#: that spells the literal English words "lambda at"/"unnamed <kind> at" is
+#: not a realistic checkout-root or build-directory naming convention any
+#: real toolchain produces -- it requires the marker text itself to be
+#: reproduced verbatim as a path segment, which is adversarial construction,
+#: not a plausible input this heuristic needs to defend against. Closing it
+#: soundly would need the lookahead to distinguish "this is the START of a
+#: declaration-shaped marker" from "this text merely spells the same words"
+#: -- i.e. real declaration-syntax awareness a regex over free-form path
+#: text cannot express, the same fundamental ceiling this whole heuristic
+#: already operates under (see this module's own docstring: "approximate,
+#: degrade rather than risk a wrong merge"). Left as a documented residual
+#: rather than attempted a fourth time under continued review pressure, per
+#: this repository's own "known gaps over risky reactive patches"
+#: convention (root ``AGENTS.md``) -- pinned by
+#: ``test_bare_marker_normalization_known_limitation_marker_text_in_path``
+#: rather than silently left unrecorded.
 _BARE_ANON_TYPE_LOCATION_RE = re.compile(
     r"\b(lambda|unnamed\s+\w+)\s+at\s+"
     r"((?:(?!(?:lambda|unnamed\s+\w+)\s+at\s)[^\"])*):(\d+):(\d+)\b"

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -992,6 +992,25 @@ def _normalize_graph_identity(identity: str) -> str:
     real-world evidence -- not either producer's own documented output
     contract -- tells us which one a given decl/type identity actually
     carries by the time it reaches this package.
+
+    **Accepted, pre-existing residual (Codex review, fresh evidence,
+    thirteenth round)**: the marker's own discriminator (basename +
+    ``:line:col``, via ``name_classification._declaring_header_discriminator``
+    -- see that function's own docstring) cannot distinguish two DIFFERENT
+    headers that share both a basename and the identical coordinates (e.g.
+    ``include/v1/config.hpp:4:37`` vs. ``include/v2/config.hpp:4:37``). For
+    L5 this is a materially sharper consequence than for the pre-existing L2
+    caller: ``SourceGraphSummary.add_node`` dedups strictly by id, so a
+    genuine collision here merges two structurally distinct declarations
+    into one node/edge set, not merely a display-string coincidence. Not
+    fixed here: closing it needs real, checkout-relative path information
+    (a known project/source root to relativize against) that a pure
+    string-pattern normalizer has no way to obtain -- the identical
+    structural ceiling ``_declaring_header_discriminator``'s own docstring
+    already accepts for its L2 caller, and this module reuses that same
+    primitive rather than inventing a second, differently-limited one. A
+    fix would be a real, cross-cutting redesign of a primitive shared with
+    the L2 backend, not a scoped change to this L5-specific caller.
     """
     return _strip_bare_anonymous_type_location(strip_anonymous_type_location(identity))
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -1093,6 +1093,7 @@ _DECL_OR_TYPE_ID_PREFIXES = (
     "type://",
     "template_decl://",
     "template_instantiation://",
+    "vtable://",
 )
 
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -869,9 +869,32 @@ def _compute_occurrences(edge: GraphEdge) -> list[str]:
 #: markers), swallowing both into one match. The lookahead guard gets both
 #: right: greedy within one marker's own text, but bounded at the next
 #: marker's trigger.
+#:
+#: The path group also excludes the ``"`` character outright, not just via
+#: the "inside quotes" guard in :func:`_strip_bare_anonymous_type_location`
+#: (Codex review, fresh evidence): that guard only checks where a *match*
+#: **starts**, not whether its greedy tail wanders *into* a later quoted
+#: span it never started inside of. A real, unquoted marker followed later
+#: in the same string by an unrelated quoted coordinate-shaped literal --
+#: e.g. ``Wrapper<lambda at /a/foo.hpp:4:37, Tag<"/literal/path:9:9">>`` --
+#: has no second ``lambda at``/``unnamed <kind> at`` trigger for the
+#: negative lookahead above to bound against, so the greedy path group would
+#: otherwise consume straight through the real marker's own terminator and
+#: into the quoted literal, matching the quoted text's own ``:9:9`` instead
+#: of the real ``:4:37``. Excluding ``"`` from the path characters bounds
+#: the greedy match at the opening quote it would otherwise cross into --
+#: the real terminator (a valid ``:\d+:\d+\b`` immediately before that
+#: point) is still found correctly by the same backtracking the timestamped-
+#: directory case above already relies on, since nothing between the
+#: marker's own trigger and the first ``"`` can accidentally look like a
+#: *second*, later ``:\d+:\d+`` occurrence unless the checkout path itself
+#: contains a literal double-quote character -- an accepted, documented
+#: edge case matching this whole heuristic's existing "approximate,
+#: degrade rather than risk a wrong merge" discipline (see this module's
+#: own docstring).
 _BARE_ANON_TYPE_LOCATION_RE = re.compile(
     r"\b(lambda|unnamed\s+\w+)\s+at\s+"
-    r"((?:(?!(?:lambda|unnamed\s+\w+)\s+at\s).)*):(\d+):(\d+)\b"
+    r"((?:(?!(?:lambda|unnamed\s+\w+)\s+at\s)[^\"])*):(\d+):(\d+)\b"
 )
 
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -669,11 +669,16 @@ def ensure_facts_and_resolve(entity: GraphNode | GraphEdge) -> None:
             )
         ]
     entity.resolved, entity.conflicts = merge_graph_facts(entity.facts)
+    is_decl_or_type_node = isinstance(entity, GraphNode) and _is_decl_or_type_node_id(
+        entity.id
+    )
+    if is_decl_or_type_node:
+        _normalize_identity_attrs(entity.resolved)
     entity.attrs = dict(entity.resolved)
     top = min(entity.facts, key=_precedence_key)
     entity.confidence = top.confidence
     entity.provenance = top.producer
-    if isinstance(entity, GraphNode) and _is_decl_or_type_node_id(entity.id):
+    if is_decl_or_type_node and isinstance(entity, GraphNode):
         entity.label = _normalize_graph_identity(entity.label)
     if isinstance(entity, GraphEdge):
         entity.occurrences = _compute_occurrences(entity)
@@ -922,6 +927,36 @@ def _normalize_graph_identity(identity: str) -> str:
     carries by the time it reaches this package.
     """
     return _strip_bare_anonymous_type_location(strip_anonymous_type_location(identity))
+
+
+#: ``attrs`` keys carrying a raw declaration/qualified-name spelling that can
+#: embed the identical checkout-dependent anonymous/lambda location marker a
+#: decl/type node's own ``label``/``id`` already get normalized against
+#: (Codex review, fresh evidence). ``entity_identity.resolve_identity_for_node``
+#: (ADR-048's canonical-identity resolver) prefers ``attrs["name"]``/
+#: ``attrs["qualified_name"]`` over ``node.label`` when both are present, so
+#: normalizing only the label left the richer ADR-048 identity computed from
+#: these attrs still checkout-tainted -- two nodes with an identical,
+#: normalized id/label could still resolve to two different canonical ids
+#: purely from directory taint surviving in ``attrs``, and reloading a pack
+#: (``SourceGraphSummary.from_dict``'s ``resolve_entities()`` rebuild) would
+#: silently reintroduce the taint into a freshly-computed ``EntityResolver``
+#: even after ``EntityResolver.from_dict``'s own ``remap_node_ids`` had
+#: already cleaned the *persisted* aliases.
+_IDENTITY_ATTR_KEYS = ("name", "qualified_name")
+
+
+def _normalize_identity_attrs(attrs: dict[str, Any]) -> None:
+    """Normalize every :data:`_IDENTITY_ATTR_KEYS` string value in *attrs* in
+    place, the same way :func:`_normalize_graph_identity` normalizes a
+    decl/type node's own ``label``/``id``. A no-op for any other key, and for
+    a value that isn't a non-empty string (an absent/None/non-str attr is
+    left exactly as a producer supplied it -- never fabricated).
+    """
+    for key in _IDENTITY_ATTR_KEYS:
+        value = attrs.get(key)
+        if isinstance(value, str) and value:
+            attrs[key] = _normalize_graph_identity(value)
 
 
 #: ``_normalize_graph_identity`` is deliberately blind to *why* it might

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -520,25 +520,28 @@ class GraphNode:
         # "resolved"/"conflicts" is never trusted — always recomputed, so a
         # hand-edited pack self-heals instead of persisting a stale merge.
         #
-        # id/label pass through _normalize_graph_identity on load (Codex
-        # review, fresh evidence) so a pack persisted before that
-        # normalization existed self-heals the same way: without this, an
-        # old pack's raw, checkout-path-bearing decl/type node id would
-        # never match the normalized id a freshly-built graph now produces
-        # for the identical declaration, and diff_source_graph's direct id
-        # comparison would read it as removed+added rather than unchanged
-        # (the exact false positive this whole normalization exists to
-        # close, just reached from a stale-pack angle instead of a
-        # fresh-vs-fresh one). Safe unconditionally: the substitution only
-        # ever touches an embedded "(unnamed .../lambda at ...)"/"lambda at
-        # ...:line:col" marker, so it is a no-op for every other node id
-        # (source://, header://, build_option://, symbol://, target://,
-        # vtable://, ...) and idempotent for an id a current build already
-        # normalized.
+        # id passes through _normalize_graph_identity on load (Codex review,
+        # fresh evidence) so a pack persisted before that normalization
+        # existed self-heals the same way: without this, an old pack's raw,
+        # checkout-path-bearing decl/type node id would never match the
+        # normalized id a freshly-built graph now produces for the identical
+        # declaration, and diff_source_graph's direct id comparison would
+        # read it as removed+added rather than unchanged (the exact false
+        # positive this whole normalization exists to close, just reached
+        # from a stale-pack angle instead of a fresh-vs-fresh one). Safe
+        # unconditionally: the substitution only ever touches an embedded
+        # "(unnamed .../lambda at ...)"/"lambda at ...:line:col" marker, so
+        # it is a no-op for every other node id (source://, header://,
+        # build_option://, symbol://, target://, vtable://, ...) and
+        # idempotent for an id a current build already normalized. ``label``
+        # needs no explicit normalization here — ensure_facts_and_resolve
+        # below (called unconditionally for every loaded node) already
+        # covers it, the same single choke point a freshly-added node's
+        # label goes through via SourceGraphSummary.add_node.
         node = cls(
             id=_normalize_graph_identity(str(d["id"])),
             kind=str(d.get("kind", "file")),
-            label=_normalize_graph_identity(str(d.get("label", ""))),
+            label=str(d.get("label", "")),
             attrs=dict(d.get("attrs", {})),
             provenance=str(d.get("provenance", "")),
             confidence=str(d.get("confidence", CONF_UNKNOWN)),
@@ -639,6 +642,24 @@ def ensure_facts_and_resolve(entity: GraphNode | GraphEdge) -> None:
     ``confidence``/``provenance`` from the top-precedence fact — so a
     hand-edited or stale stored ``resolved`` value in a loaded pack never
     silently persists; it self-heals to what the facts actually support.
+
+    Also normalizes a :class:`GraphNode`'s own ``label`` (Codex review, fresh
+    evidence): this is the one choke point every decl/type producer already
+    routes a fresh node through, on first registration, via
+    ``SourceGraphSummary.add_node`` — the merge path for an
+    already-registered node's *second* registration never touches ``label``
+    at all ("kind/label keep the first registration's value" — see
+    :meth:`SourceGraphSummary.add_node`'s own docstring), so normalizing
+    here covers every producer's label the same way ``source_graph.
+    _decl_node_id``/``_type_node_id`` already cover every producer's node
+    id, rather than needing an explicit ``_normalize_graph_identity(...)``
+    call duplicated at each producer's own node-construction site (a prior
+    revision of this fix normalized only the two call sites that happened to
+    build ``GraphNode``s directly in ``source_graph.py``/``type_graph.py``,
+    silently leaving every other producer's label unnormalized). Safe
+    unconditionally, same reasoning as :func:`_normalize_graph_identity`
+    itself: the substitution only ever touches an embedded anonymous/lambda
+    location marker, so it is a no-op for any other label.
     """
     if not entity.facts:
         entity.facts = [
@@ -653,6 +674,8 @@ def ensure_facts_and_resolve(entity: GraphNode | GraphEdge) -> None:
     top = min(entity.facts, key=_precedence_key)
     entity.confidence = top.confidence
     entity.provenance = top.producer
+    if isinstance(entity, GraphNode):
+        entity.label = _normalize_graph_identity(entity.label)
     if isinstance(entity, GraphEdge):
         entity.occurrences = _compute_occurrences(entity)
 

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -520,26 +520,25 @@ class GraphNode:
         # "resolved"/"conflicts" is never trusted — always recomputed, so a
         # hand-edited pack self-heals instead of persisting a stale merge.
         #
-        # id passes through _normalize_graph_identity on load (Codex review,
-        # fresh evidence) so a pack persisted before that normalization
-        # existed self-heals the same way: without this, an old pack's raw,
-        # checkout-path-bearing decl/type node id would never match the
-        # normalized id a freshly-built graph now produces for the identical
-        # declaration, and diff_source_graph's direct id comparison would
-        # read it as removed+added rather than unchanged (the exact false
-        # positive this whole normalization exists to close, just reached
-        # from a stale-pack angle instead of a fresh-vs-fresh one). Safe
-        # unconditionally: the substitution only ever touches an embedded
-        # "(unnamed .../lambda at ...)"/"lambda at ...:line:col" marker, so
-        # it is a no-op for every other node id (source://, header://,
-        # build_option://, symbol://, target://, vtable://, ...) and
-        # idempotent for an id a current build already normalized. ``label``
-        # needs no explicit normalization here — ensure_facts_and_resolve
-        # below (called unconditionally for every loaded node) already
-        # covers it, the same single choke point a freshly-added node's
-        # label goes through via SourceGraphSummary.add_node.
+        # id passes through _normalize_if_decl_or_type on load (Codex
+        # review, fresh evidence) so a pack persisted before that
+        # normalization existed self-heals the same way: without this, an
+        # old pack's raw, checkout-path-bearing decl/type node id would
+        # never match the normalized id a freshly-built graph now produces
+        # for the identical declaration, and diff_source_graph's direct id
+        # comparison would read it as removed+added rather than unchanged
+        # (the exact false positive this whole normalization exists to
+        # close, just reached from a stale-pack angle instead of a
+        # fresh-vs-fresh one). Gated to decl://type:// ids only -- a no-op
+        # for every other kind (source://, header://, build_option://,
+        # symbol://, target://, vtable://, ...), idempotent for an id a
+        # current build already normalized. ``label`` needs no explicit
+        # normalization here — ensure_facts_and_resolve below (called
+        # unconditionally for every loaded node) already covers it, the
+        # same single choke point a freshly-added node's label goes through
+        # via SourceGraphSummary.add_node.
         node = cls(
-            id=_normalize_graph_identity(str(d["id"])),
+            id=_normalize_if_decl_or_type(str(d["id"])),
             kind=str(d.get("kind", "file")),
             label=str(d.get("label", "")),
             attrs=dict(d.get("attrs", {})),
@@ -616,8 +615,8 @@ class GraphEdge:
         # migration for a pack persisted before decl/type node ids were
         # checkout-directory-normalized.
         edge = cls(
-            src=_normalize_graph_identity(str(d["src"])),
-            dst=_normalize_graph_identity(str(d["dst"])),
+            src=_normalize_if_decl_or_type(str(d["src"])),
+            dst=_normalize_if_decl_or_type(str(d["dst"])),
             kind=str(d.get("edge", d.get("kind", ""))),
             provenance=str(d.get("provenance", "")),
             confidence=str(d.get("confidence", CONF_UNKNOWN)),
@@ -674,7 +673,7 @@ def ensure_facts_and_resolve(entity: GraphNode | GraphEdge) -> None:
     top = min(entity.facts, key=_precedence_key)
     entity.confidence = top.confidence
     entity.provenance = top.producer
-    if isinstance(entity, GraphNode):
+    if isinstance(entity, GraphNode) and _is_decl_or_type_node_id(entity.id):
         entity.label = _normalize_graph_identity(entity.label)
     if isinstance(entity, GraphEdge):
         entity.occurrences = _compute_occurrences(entity)
@@ -923,6 +922,40 @@ def _normalize_graph_identity(identity: str) -> str:
     carries by the time it reaches this package.
     """
     return _strip_bare_anonymous_type_location(strip_anonymous_type_location(identity))
+
+
+#: ``_normalize_graph_identity`` is deliberately blind to *why* it might
+#: match -- it only ever touches an embedded anonymous/lambda location
+#: marker, which is safe for a real decl/type identity. But applied
+#: unconditionally to *every* graph node id/label regardless of kind (Codex
+#: review, fresh evidence, sixth round), a non-declaration id that happens
+#: to spell marker-shaped text -- e.g. a ``source://`` node whose path
+#: literally contains ``"lambda at ...:1:2"`` -- would be silently rewritten
+#: too, changing a node's id/label/``graph_id`` with no directory taint
+#: involved at all. Every caller that applies the normalization to an
+#: arbitrary node/edge string (as opposed to a value already known to be a
+#: decl/type identity, like ``_decl_node_id``'s own argument) gates on this
+#: first, restricting the effect to the ``decl://``/``type://`` id space
+#: this whole mechanism exists for.
+_DECL_OR_TYPE_ID_PREFIXES = ("decl://", "type://")
+
+
+def _is_decl_or_type_node_id(node_id: str) -> bool:
+    return node_id.startswith(_DECL_OR_TYPE_ID_PREFIXES)
+
+
+def _normalize_if_decl_or_type(node_id: str) -> str:
+    """``_normalize_graph_identity(node_id)``, gated by
+    :func:`_is_decl_or_type_node_id` -- the shared shape every load-time
+    migration call site (``GraphNode``/``GraphEdge.from_dict``) uses so a
+    ``source://``/``header://``/... id can never be mistaken for a decl/type
+    one just because it happens to spell marker-shaped text.
+    """
+    return (
+        _normalize_graph_identity(node_id)
+        if _is_decl_or_type_node_id(node_id)
+        else node_id
+    )
 
 
 def _decl_node_id(identity: str) -> str:

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -668,12 +668,25 @@ def ensure_facts_and_resolve(entity: GraphNode | GraphEdge) -> None:
                 attrs=dict(entity.attrs),
             )
         ]
-    entity.resolved, entity.conflicts = merge_graph_facts(entity.facts)
     is_decl_or_type_node = isinstance(entity, GraphNode) and _is_decl_or_type_node_id(
         entity.id
     )
     if is_decl_or_type_node:
-        _normalize_identity_attrs(entity.resolved)
+        # Normalize each fact's own identity attrs *before* merging (Codex
+        # review, fresh evidence): merge_graph_facts() compares raw attrs
+        # values for equality, so two facts differing only by checkout root
+        # (e.g. two producers, or two coalesced pre-migration nodes, each
+        # reporting name="raii_guard<(lambda at /a/lib.hpp:4:37)>" vs.
+        # ".../b/lib.hpp...") would otherwise record a spurious FactConflict
+        # over evidence that is actually identical once directory-taint is
+        # stripped. Mutating entity.facts in place (not just the merged
+        # ``resolved`` view) also keeps to_dict()'s persisted "facts" list
+        # clean -- the same "never preserve the raw, checkout-tainted
+        # spelling anywhere in the emitted graph" rule id/label/attrs
+        # already follow, extended to the per-producer evidence trail too.
+        for fact in entity.facts:
+            _normalize_identity_attrs(fact.attrs)
+    entity.resolved, entity.conflicts = merge_graph_facts(entity.facts)
     entity.attrs = dict(entity.resolved)
     top = min(entity.facts, key=_precedence_key)
     entity.confidence = top.confidence

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -1037,9 +1037,25 @@ def _normalize_identity_attrs(attrs: dict[str, Any]) -> None:
 #: involved at all. Every caller that applies the normalization to an
 #: arbitrary node/edge string (as opposed to a value already known to be a
 #: decl/type identity, like ``_decl_node_id``'s own argument) gates on this
-#: first, restricting the effect to the ``decl://``/``type://`` id space
-#: this whole mechanism exists for.
-_DECL_OR_TYPE_ID_PREFIXES = ("decl://", "type://")
+#: first, restricting the effect to the id-space this whole mechanism exists
+#: for: every node kind whose own id is genuinely built from a declaration/
+#: type spelling that can embed the marker, not merely a filesystem path or
+#: an opaque symbol/flag name. ``template_decl://``/``template_instantiation://``
+#: joined ``decl://``/``type://`` here (Codex review, twelfth round, fresh
+#: evidence): a class template instantiated with a lambda-closure-typed
+#: argument has clang print that argument's spelling as the identical
+#: ``"(lambda at <path>:<line>:<col>)"`` marker
+#: :func:`~abicheck.buildsource.template_graph._instantiation_label` then
+#: folds straight into ``template_instantiation://``'s own node id --
+#: confirmed against real clang output, the same false rename this whole
+#: mechanism exists to close, just reached from a template-instantiation
+#: node instead of a bare decl/type one.
+_DECL_OR_TYPE_ID_PREFIXES = (
+    "decl://",
+    "type://",
+    "template_decl://",
+    "template_instantiation://",
+)
 
 
 def _is_decl_or_type_node_id(node_id: str) -> bool:

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -282,30 +282,26 @@ class SourceGraphSummary:
     entity_resolver: EntityResolver = field(default_factory=EntityResolver)
 
     def __post_init__(self) -> None:
-        # ADR-046 D2: backfill/re-derive facts/resolved for anything
-        # constructed directly (bypassing add_node/add_edge), so every node
-        # reachable from this summary satisfies "facts is never empty,
-        # resolved is derived from facts". Must run *before* the de-dup
-        # indexes below (Codex review, fresh evidence): a constructor-seeded
-        # edge whose role lives only in `facts` (not yet mirrored into
-        # `attrs`) would otherwise have its `relation_key()` computed against
-        # an empty `attrs`/`resolved` view, indexing it under the wrong
-        # (blank-role) key before resolution ever populates the real one.
+        # ADR-046 D2: backfill/re-derive facts/resolved for anything constructed directly
+        # (bypassing add_node/add_edge), so every node reachable from this summary satisfies
+        # "facts is never empty, resolved is derived from facts". Must run *before* the
+        # de-dup indexes below (Codex review, fresh evidence): a constructor-seeded edge
+        # whose role lives only in `facts` (not yet mirrored into `attrs`) would otherwise
+        # have its `relation_key()` computed against an empty `attrs`/`resolved` view,
+        # indexing it under the wrong (blank-role) key before resolution ever populates it.
         for n in self.nodes:
             ensure_facts_and_resolve(n)
         for e in self.edges:
             ensure_facts_and_resolve(e)
-        # De-dup indexes for O(1) add_node/add_edge, seeded from whatever the
-        # constructor (or from_dict) provided. Edges dedup on relation_key()
-        # (src, dst, kind, role), not the coarser key() (ADR-046 D1, Codex
-        # review on PR #620): deduping on key() alone silently folded two
-        # real, role-distinct relations -- e.g. a function that both returns
-        # and takes the same private type, two DECL_HAS_TYPE edges -- into
-        # one edge object, so only one role ever survived to be found via
-        # relation_key() by anything walking graph.edges. key() itself is
-        # untouched (still (src, dst, kind)); diff_source_graph's coarser
-        # edge-set comparison keeps its pre-existing "one representative
-        # edge per (src, dst, kind)" precision either way.
+        # De-dup indexes for O(1) add_node/add_edge, seeded from whatever the constructor
+        # (or from_dict) provided. Edges dedup on relation_key() (src, dst, kind, role), not
+        # the coarser key() (ADR-046 D1, Codex review on PR #620): deduping on key() alone
+        # silently folded two real, role-distinct relations -- e.g. a function that both
+        # returns and takes the same private type, two DECL_HAS_TYPE edges -- into one edge
+        # object, so only one role ever survived to be found via relation_key() by anything
+        # walking graph.edges. key() itself is untouched (still (src, dst, kind));
+        # diff_source_graph's coarser edge-set comparison keeps its pre-existing "one
+        # representative edge per (src, dst, kind)" precision either way.
         self._node_ids: set[str] = {n.id for n in self.nodes}
         self._edge_keys: set[tuple[str, str, str, str]] = {
             e.relation_key() for e in self.edges
@@ -456,7 +452,12 @@ class SourceGraphSummary:
         return self
 
     def finalize(self) -> SourceGraphSummary:
-        """Fill ``graph_id``/``coverage``; merges onto (never replaces) the latter so a persisted unrecognized field survives; return self."""
+        """Fill ``graph_id``/``coverage``; merges onto (never replaces) the latter, at every nesting level, so a persisted unrecognized field survives; return self."""
+
+        def _section(key: str, **new: Any) -> dict[str, Any]:
+            old = self.coverage.get(key)
+            return {**(old if isinstance(old, dict) else {}), **new}
+
         self.graph_id = self.compute_graph_id()
         kinds: dict[str, int] = {}
         for n in self.nodes:
@@ -464,37 +465,32 @@ class SourceGraphSummary:
         edge_kinds: dict[str, int] = {}
         for e in self.edges:
             edge_kinds[e.kind] = edge_kinds.get(e.kind, 0) + 1
-        # A pass that ran but found zero edges is still "collected" (ADR-041 P0
-        # slice 2 follow-up): edge presence alone reads identically to "the
-        # pass never ran", which is the exact coverage-honesty gap
-        # ``extractor_passes`` closes. Fall back to edge presence alone when
-        # the flag is absent (a hand-built or pre-slice-2 graph).
-        # ``header_call_graph``/``header_type_graph`` are the header-only graph
-        # builder's own pass names (ADR-041 header-only-graph addendum) — a
-        # distinct AST-walk shape (one synthetic header-aggregate TU, no build
-        # integration) from the build-integrated ``call_graph``/``type_graph``
-        # passes. Only ``header_type_graph`` grants "ran, zero found still
-        # collected" credit here, and only for the *structural* kinds
-        # (TYPE_INHERITS/TYPE_HAS_FIELD_TYPE/DECL_HAS_TYPE): a header-only pass
-        # has true project-wide visibility of those (declaration-level facts,
-        # no body needed). ``DECL_CALLS_DECL``/``DECL_REFERENCES_DECL`` need a
-        # function body a header-only pass only sees when it happens to be
-        # written *in the header* — its "ran" is not evidence of project-wide
-        # call/reference coverage the way a build-integrated pass's is, so
-        # neither ``call_edges.collected`` nor ``reference_edges.collected``
-        # may be granted from ``header_call_graph``/``header_type_graph``
-        # alone (Codex review; mirrors ``source_graph_findings.
-        # _pass_trusted_kinds``'s structural-vs-body-dependent split).
+        # A pass that ran but found zero edges is still "collected" (ADR-041 P0 slice 2
+        # follow-up): edge presence alone reads identically to "the pass never ran", which
+        # is the exact coverage-honesty gap ``extractor_passes`` closes. Fall back to edge
+        # presence alone when the flag is absent (a hand-built or pre-slice-2 graph).
+        # ``header_call_graph``/``header_type_graph`` are the header-only graph builder's
+        # own pass names (ADR-041 header-only-graph addendum) — a distinct AST-walk shape
+        # (one synthetic header-aggregate TU, no build integration) from the build-integrated
+        # ``call_graph``/``type_graph`` passes. Only ``header_type_graph`` grants "ran, zero
+        # found still collected" credit here, and only for the *structural* kinds
+        # (TYPE_INHERITS/TYPE_HAS_FIELD_TYPE/DECL_HAS_TYPE): a header-only pass has true
+        # project-wide visibility of those (declaration-level facts, no body needed).
+        # ``DECL_CALLS_DECL``/``DECL_REFERENCES_DECL`` need a function body a header-only
+        # pass only sees when it happens to be written *in the header* — its "ran" is not
+        # evidence of project-wide call/reference coverage the way a build-integrated pass's
+        # is, so neither ``call_edges.collected`` nor ``reference_edges.collected`` may be
+        # granted from ``header_call_graph``/``header_type_graph`` alone (Codex review;
+        # mirrors ``source_graph_findings._pass_trusted_kinds``'s structural-vs-body split).
         call_pass_ran = self.extractor_passes.get("call_graph", False)
         type_pass_ran = self.extractor_passes.get("type_graph", False)
         header_type_pass_ran = self.extractor_passes.get("header_type_graph", False)
-        # ``include_graph``/``header_include_graph`` (build-integrated and
-        # header-only-graph builder respectively) are pure file-inclusion
-        # facts with no body-dependent gap the way calls/references have — a
-        # confirmed pass with zero edges (a leaf header with no #includes of
-        # its own) is a genuine zero, not "never collected" (Codex review:
-        # this mirrors ``has_calls``/``has_type_edges`` below, which already
-        # credit a confirmed-but-empty pass; ``has_includes`` previously looked at edge presence alone).
+        # ``include_graph``/``header_include_graph`` (build-integrated and header-only-graph
+        # builder respectively) are pure file-inclusion facts with no body-dependent gap the
+        # way calls/references have — a confirmed pass with zero edges (a leaf header with no
+        # #includes of its own) is a genuine zero, not "never collected" (Codex review: this
+        # mirrors ``has_calls``/``has_type_edges`` below, which already credit a
+        # confirmed-but-empty pass; ``has_includes`` previously looked at edge presence alone).
         include_pass_ran = self.extractor_passes.get("include_graph", False)
         header_include_pass_ran = self.extractor_passes.get(
             "header_include_graph", False
@@ -505,12 +501,11 @@ class SourceGraphSummary:
         has_includes = (include_pass_ran or header_include_pass_ran) or any(
             e.kind == "COMPILE_UNIT_INCLUDES_FILE" for e in self.edges
         )
-        #: ADR-041 P0: TYPE_INHERITS/TYPE_HAS_FIELD_TYPE/DECL_HAS_TYPE describe
-        #: type-level dependencies; DECL_REFERENCES_DECL a non-call decl reference.
-        #: Both come from ``type_graph.py`` (folded alongside the call graph) or an
-        #: external backend (``graph_backends.py``), so "collected" is tracked
-        #: separately from the call graph — a graph can have calls but no type
-        #: edges (e.g. an older pack) and coverage must say so honestly.
+        #: ADR-041 P0: TYPE_INHERITS/TYPE_HAS_FIELD_TYPE/DECL_HAS_TYPE describe type-level
+        #: dependencies; DECL_REFERENCES_DECL a non-call decl reference. Both come from
+        #: ``type_graph.py`` (folded alongside the call graph) or an external backend
+        #: (``graph_backends.py``), so "collected" is tracked separately — a graph can have
+        #: calls but no type edges (e.g. an older pack), and coverage must say so honestly.
         type_edge_kinds = ("TYPE_INHERITS", "TYPE_HAS_FIELD_TYPE", "DECL_HAS_TYPE")
         has_type_edges = (type_pass_ran or header_type_pass_ran) or any(
             e.kind in type_edge_kinds for e in self.edges
@@ -524,22 +519,26 @@ class SourceGraphSummary:
             "compile_units": kinds.get("compile_unit", 0),
             "source_decls": kinds.get("source_decl", 0),
             "binary_symbol_mappings": edge_kinds.get("SOURCE_DECL_MAPS_TO_SYMBOL", 0),
-            "include_edges": {
-                "collected": has_includes,
-                "count": edge_kinds.get("COMPILE_UNIT_INCLUDES_FILE", 0),
-            },
-            "call_edges": {
-                "collected": has_calls,
-                "count": edge_kinds.get("DECL_CALLS_DECL", 0),
-            },
-            "type_edges": {
-                "collected": has_type_edges,
-                "count": sum(edge_kinds.get(k, 0) for k in type_edge_kinds),
-            },
-            "reference_edges": {
-                "collected": has_reference_edges,
-                "count": edge_kinds.get("DECL_REFERENCES_DECL", 0),
-            },
+            "include_edges": _section(
+                "include_edges",
+                collected=has_includes,
+                count=edge_kinds.get("COMPILE_UNIT_INCLUDES_FILE", 0),
+            ),
+            "call_edges": _section(
+                "call_edges",
+                collected=has_calls,
+                count=edge_kinds.get("DECL_CALLS_DECL", 0),
+            ),
+            "type_edges": _section(
+                "type_edges",
+                collected=has_type_edges,
+                count=sum(edge_kinds.get(k, 0) for k in type_edge_kinds),
+            ),
+            "reference_edges": _section(
+                "reference_edges",
+                collected=has_reference_edges,
+                count=edge_kinds.get("DECL_REFERENCES_DECL", 0),
+            ),
             "node_kinds": dict(sorted(kinds.items())),
             "edge_kinds": dict(sorted(edge_kinds.items())),
         }

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -283,24 +283,15 @@ class SourceGraphSummary:
     entity_resolver: EntityResolver = field(default_factory=EntityResolver)
 
     def __post_init__(self) -> None:
-        # Normalize a constructor-seeded node id/edge endpoint the same way GraphNode/
-        # GraphEdge.from_dict() already migrate a persisted one (Codex review): a caller
-        # building SourceGraphSummary(nodes=..., edges=...) directly never routes through
-        # _decl_node_id/_type_node_id either, so a hand-built id can carry the identical
-        # checkout-dependent marker. No-op for every non-decl/type id (its own gate).
-        for n in self.nodes:
-            n.id = _normalize_if_decl_or_type(n.id)
-        for e in self.edges:
-            e.src = _normalize_if_decl_or_type(e.src)
-            e.dst = _normalize_if_decl_or_type(e.dst)
         # Re-register through add_node()/add_edge() rather than building the de-dup indexes
-        # directly (same round): normalization above can make two originally-distinct ids
-        # collide, and a plain set/dict comprehension would then disagree with
-        # len(self.nodes)/len(self.edges) -- the same "index vs list" desync from_dict()
-        # already fixed by routing every loaded entity through this coalescing path (also
-        # resolves facts, and computes an edge's relation_key() only after resolution, not
-        # against an empty view). A no-op for the common case: on a fresh id this just
-        # resolves+appends, identical to a direct index construction.
+        # directly (Codex review): a caller building SourceGraphSummary(nodes=..., edges=...)
+        # directly never routes through _decl_node_id/_type_node_id, so a hand-built id/
+        # endpoint can carry a checkout-dependent marker -- add_node()/add_edge() normalize it
+        # themselves now (their own docstrings), which can make two originally-distinct
+        # constructor-seeded ids collide; a plain set/dict comprehension would then disagree
+        # with len(self.nodes)/len(self.edges), the same "index vs list" desync from_dict()
+        # already fixed the identical way. A no-op for the common case: on a fresh,
+        # already-normalized id this just resolves+appends, identical to a direct index build.
         seeded_nodes, seeded_edges = self.nodes, self.edges
         self.nodes, self.edges = [], []
         self._node_ids: set[str] = set()
@@ -326,7 +317,12 @@ class SourceGraphSummary:
         otherwise have its whole fact history collapsed into one flattened
         fact, discarding the individual per-producer facts and any
         ``conflicts`` it already recorded.
+
+        Normalizes ``node.id`` first (Codex review): the one true choke point every insertion
+        path funnels through, catching a hand-built id even if its own producer forgot
+        ``_decl_node_id``/``_type_node_id``. A no-op for every other id.
         """
+        node.id = _normalize_if_decl_or_type(node.id)
         if node.id not in self._node_ids:
             ensure_facts_and_resolve(node)
             self.nodes.append(node)
@@ -348,7 +344,11 @@ class SourceGraphSummary:
         mirrored into ``attrs``) would otherwise have ``relation_key()``
         computed against an empty ``attrs``/``resolved`` view and dedup on
         the wrong (blank-role) key instead of its true, post-resolution one.
+
+        Normalizes ``edge.src``/``edge.dst`` first, same reasoning as :meth:`add_node`.
         """
+        edge.src = _normalize_if_decl_or_type(edge.src)
+        edge.dst = _normalize_if_decl_or_type(edge.dst)
         ensure_facts_and_resolve(edge)
         rkey = edge.relation_key()
         if rkey not in self._edge_keys:

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -583,8 +583,6 @@ class SourceGraphSummary:
         obj = cls(
             schema_version=int(d.get("schema_version", SOURCE_GRAPH_VERSION)),
             graph_id=str(d.get("graph_id", "")),
-            nodes=[GraphNode.from_dict(n) for n in d.get("nodes", [])],
-            edges=[GraphEdge.from_dict(e) for e in d.get("edges", [])],
             coverage=dict(d.get("coverage", {})),
             external_graph_refs=[dict(r) for r in d.get("external_graph_refs", [])],
             extractor_passes={
@@ -602,10 +600,12 @@ class SourceGraphSummary:
             },
             entity_resolver=EntityResolver.from_dict(_raw_entity_resolver),
         )
-        # Recompute rather than trust the loaded graph_id: id migration above
-        # can change content, and to_dict() reuses a truthy self.graph_id
-        # as-is (Codex review) -- cheap, no-op when migration touched nothing.
-        obj.graph_id = obj.compute_graph_id()
+        # add_node/add_edge coalesce ids colliding after migration (Codex review).
+        for raw_node in d.get("nodes", []):
+            obj.add_node(GraphNode.from_dict(raw_node))
+        for raw_edge in d.get("edges", []):
+            obj.add_edge(GraphEdge.from_dict(raw_edge))
+        obj.graph_id = obj.compute_graph_id()  # never trust a stale loaded value
         return obj
 
 

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -218,32 +218,28 @@ class SourceGraphSummary:
     edges: list[GraphEdge] = field(default_factory=list)
     coverage: dict[str, Any] = field(default_factory=dict)
     external_graph_refs: list[dict[str, Any]] = field(default_factory=list)
-    #: Which named extractor passes ran to completion (``"call_graph"`` /
-    #: ``"type_graph"``), independent of how many edges they produced (ADR-041
-    #: P0 slice 2 follow-up, second Codex review). Edge *presence* alone cannot
-    #: distinguish "the pass ran and found nothing" from "the pass never ran" —
-    #: a project where no public struct happens to have a private field would
-    #: look identical to one whose type-graph pass never executed, even though
-    #: only the second is actually missing evidence. Set by
-    #: ``inline._fold_call_graph``/``_fold_type_graph`` right after a
-    #: successful extraction (regardless of edge count); absent/``False`` means
-    #: "unknown whether it ran" (e.g. a hand-built or pre-slice-2 graph), so
-    #: readers fall back to edge-presence inference for those.
+    #: Which named extractor passes ran to completion (``"call_graph"`` / ``"type_graph"``),
+    #: independent of how many edges they produced (ADR-041 P0 slice 2 follow-up, second Codex
+    #: review). Edge *presence* alone cannot distinguish "the pass ran and found nothing" from
+    #: "the pass never ran" — a project where no public struct happens to have a private field
+    #: would look identical to one whose type-graph pass never executed, even though only the
+    #: second is actually missing evidence. Set by ``inline._fold_call_graph``/
+    #: ``_fold_type_graph`` right after a successful extraction (regardless of edge count);
+    #: absent/``False`` means "unknown whether it ran" (e.g. a hand-built or pre-slice-2
+    #: graph), so readers fall back to edge-presence inference for those.
     extractor_passes: dict[str, bool] = field(default_factory=dict)
     #: Which named extractor passes ran, but only over a *narrowed* scope
-    #: (``changed_paths``/``scoped_units`` restricting ``_fold_call_graph``/
-    #: ``_fold_type_graph`` to a subset of compile units — eleventh Codex
-    #: review). A narrowed pass never sets ``extractor_passes`` for that name
-    #: (it did not examine the whole project), but it still serializes
-    #: whatever edges it *did* collect from the subset it saw. Those edges
-    #: must not be treated as full-family coverage when compared against a
-    #: side that ran a confirmed *full* pass — a baseline scoped to a few
-    #: changed TUs having one ``TYPE_HAS_FIELD_TYPE`` edge says nothing about
-    #: whether the rest of the project's dependencies were ever inspected, so
-    #: comparing it as if that kind were fully covered lets unrelated,
-    #: never-examined dependencies read as "newly added". Set alongside (in
-    #: place of) ``extractor_passes`` by ``inline._fold_call_graph``/
-    #: ``_fold_type_graph`` when the local ``narrowed`` flag is ``True``.
+    #: (``changed_paths``/``scoped_units`` restricting ``_fold_call_graph``/``_fold_type_graph``
+    #: to a subset of compile units — eleventh Codex review). A narrowed pass never sets
+    #: ``extractor_passes`` for that name (it did not examine the whole project), but it still
+    #: serializes whatever edges it *did* collect from the subset it saw. Those edges must not
+    #: be treated as full-family coverage when compared against a side that ran a confirmed
+    #: *full* pass — a baseline scoped to a few changed TUs having one ``TYPE_HAS_FIELD_TYPE``
+    #: edge says nothing about whether the rest of the project's dependencies were ever
+    #: inspected, so comparing it as if that kind were fully covered lets unrelated, never-
+    #: examined dependencies read as "newly added". Set alongside (in place of)
+    #: ``extractor_passes`` by ``inline._fold_call_graph``/``_fold_type_graph`` when the local
+    #: ``narrowed`` flag is ``True``.
     narrowed_passes: dict[str, bool] = field(default_factory=dict)
     #: The actual scope a narrowed pass was restricted to — the ``changed_paths``
     #: tuple, or the examined compile units' source paths for an unseeded
@@ -258,13 +254,12 @@ class SourceGraphSummary:
     #: narrowed to this *identical* (non-empty) scope; set alongside
     #: ``narrowed_passes`` by ``inline._fold_call_graph``/``_fold_type_graph``.
     narrowed_scope: dict[str, frozenset[str]] = field(default_factory=dict)
-    #: Which named extractor passes hit per-TU diagnostics — a clang crash/
-    #: timeout/degenerate AST on some subset (sixteenth Codex review). Such a
-    #: run (narrowed or not) still folds edges from the TUs that *did* parse,
-    #: but those edges must not vouch for "this kind was examined" over
-    #: whatever scope the pass claims: the failed TUs are an unknown,
-    #: untracked gap (unlike ``narrowed_scope``, which knows exactly which TUs
-    #: a deliberately-scoped run examined). Set by ``inline._fold_call_graph``/
+    #: Which named extractor passes hit per-TU diagnostics — a clang crash/timeout/degenerate
+    #: AST on some subset (sixteenth Codex review). Such a run (narrowed or not) still folds
+    #: edges from the TUs that *did* parse, but those edges must not vouch for "this kind was
+    #: examined" over whatever scope the pass claims: the failed TUs are an unknown, untracked
+    #: gap (unlike ``narrowed_scope``, which knows exactly which TUs a deliberately-scoped run
+    #: examined). Set by ``inline._fold_call_graph``/
     #: ``_fold_type_graph``/``cli_buildsource_helpers._collect_call_graph``
     #: whenever the pass examined units but ``extractor.diagnostics`` was
     #: non-empty (mutually exclusive with ``extractor_passes``/``narrowed_passes``,
@@ -302,6 +297,13 @@ class SourceGraphSummary:
             self.add_node(n)
         for e in seeded_edges:
             self.add_edge(e)
+        # A caller-supplied entity_resolver (Codex review) is still keyed by pre-normalization
+        # ids here -- a plain remap alone was already insufficient for the identical
+        # from_dict() case (a stale value can survive node coalescing), so this rebuilds it
+        # the same way, from the now-registered nodes. Gated on non-empty so a caller passing
+        # none doesn't pay for it by default.
+        if self.entity_resolver.aliases:
+            self.resolve_entities()
 
     # -- mutation helpers ---------------------------------------------------
 
@@ -859,15 +861,13 @@ def is_consumer_compiled_public_entry(
     return is_consumer_compiled_node(node_id, node_by_id)
 
 
-#: ``provenance`` tag ``augment_graph_with_calls`` (``call_graph.py``) stamps
-#: on a fallback node it creates for a caller/callee identity with no other
-#: declaration node backing it — the one node shape known to lack a
-#: ``consumer_compiled_body`` attr while still representing a genuine,
-#: build-integrated (out-of-line, not-necessarily-consumer-compiled) project
-#: declaration, as opposed to "no signal available" (header-graph/type nodes,
-#: synthetic test fixtures, …) which stays permissive by default. Mirrored as
-#: a literal string rather than imported from ``call_graph.py`` to avoid
-#: coupling this module to that one's internal constant.
+#: ``provenance`` tag ``augment_graph_with_calls`` (``call_graph.py``) stamps on a fallback
+#: node it creates for a caller/callee identity with no other declaration node backing it —
+#: the one node shape known to lack a ``consumer_compiled_body`` attr while still representing
+#: a genuine, build-integrated (out-of-line, not-necessarily-consumer-compiled) project
+#: declaration, as opposed to "no signal available" (header-graph/type nodes, synthetic test
+#: fixtures, …) which stays permissive by default. Mirrored as a literal string rather than
+#: imported from ``call_graph.py`` to avoid coupling this module to that one's own constant.
 _CALL_GRAPH_FALLBACK_PROVENANCE = "call_graph"
 
 #: Same shape as :data:`_CALL_GRAPH_FALLBACK_PROVENANCE`, for external

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -580,7 +580,7 @@ class SourceGraphSummary:
         _raw_entity_resolver: dict[str, Any] = (
             raw_entity_resolver if isinstance(raw_entity_resolver, dict) else {}
         )
-        return cls(
+        obj = cls(
             schema_version=int(d.get("schema_version", SOURCE_GRAPH_VERSION)),
             graph_id=str(d.get("graph_id", "")),
             nodes=[GraphNode.from_dict(n) for n in d.get("nodes", [])],
@@ -602,6 +602,11 @@ class SourceGraphSummary:
             },
             entity_resolver=EntityResolver.from_dict(_raw_entity_resolver),
         )
+        # Recompute rather than trust the loaded graph_id: id migration above
+        # can change content, and to_dict() reuses a truthy self.graph_id
+        # as-is (Codex review) -- cheap, no-op when migration touched nothing.
+        obj.graph_id = obj.compute_graph_id()
+        return obj
 
 
 # ── node-id helpers ───────────────────────────────────────────────────────
@@ -1496,7 +1501,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=did,
                 kind="source_decl",
-                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
+                label=ent.qualified_name or ent.identity(),
                 provenance="source_abi",
                 confidence=conf,
                 attrs={
@@ -1531,7 +1536,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=tid,
                 kind=_type_node_kind(ent.kind),
-                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
+                label=ent.qualified_name or ent.identity(),
                 provenance="source_abi",
                 confidence=conf,
                 attrs={"decl_kind": ent.kind, "visibility": ent.visibility},
@@ -1567,7 +1572,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=mid,
                 kind="macro",
-                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
+                label=ent.qualified_name or ent.identity(),
                 provenance="source_abi",
                 confidence=conf,
             )
@@ -1691,7 +1696,7 @@ def fold_source_edges(
                 node = GraphNode(
                     id=node_id,
                     kind=node_kind,
-                    label=_normalize_graph_identity(ident),
+                    label=ident,
                     provenance=provenance,
                     confidence=confidence,
                     attrs=node_attrs,

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -631,7 +631,10 @@ def _option_node_id(flag: str) -> str:
 
 
 def _vtable_node_id(identity: str) -> str:
-    return f"vtable://{identity}"
+    # A vtable's identity is its owning record's, which for a polymorphic anonymous struct
+    # can embed the checkout marker (Codex review) -- no-op for a fresh build's own
+    # already-normalized identity, matters for any other caller and for the migration gate.
+    return f"vtable://{_normalize_graph_identity(identity)}"
 
 
 def function_decl_identity(
@@ -1476,20 +1479,17 @@ def _augment_with_source_abi(
         *surface.reachable_templates,
         *surface.reachable_inline_bodies,
     )
-    # An entity routed to reachable_templates/reachable_inline_bodies shares
-    # its identity() (mangled name, or qualified_name+signature_hash) with the
-    # plain "function"-kind declaration entity clang.py *also* emits for the
-    # same function -- both land on the same node id via _decl_node_id below,
-    # and add_node keeps only the first writer's attrs. reachable_declarations
-    # is iterated first in `declarations` above, so for any function that also
-    # has an inline/template rendition, the winning node's own attrs["decl_kind"]
-    # is always "function"/"method", never "inline"/"template" -- silently
-    # losing the one signal that distinguishes "body compiled into every
-    # consumer TU that includes this header" from "ordinary out-of-line body,
-    # compiled into this library's binary only" (Codex review). Compute the
-    # identity set up front so every entity sharing it gets the *same*
-    # attrs["consumer_compiled_body"] value regardless of which one wins the
-    # node-id race.
+    # An entity routed to reachable_templates/reachable_inline_bodies shares its identity()
+    # (mangled name, or qualified_name+signature_hash) with the plain "function"-kind
+    # declaration entity clang.py *also* emits for the same function -- both land on the same
+    # node id via _decl_node_id below, and add_node keeps only the first writer's attrs.
+    # reachable_declarations is iterated first in `declarations` above, so for any function
+    # that also has an inline/template rendition, the winning node's own
+    # attrs["decl_kind"] is always "function"/"method", never "inline"/"template" -- silently
+    # losing the one signal that distinguishes "body compiled into every consumer TU that
+    # includes this header" from "ordinary out-of-line body, compiled into this library's
+    # binary only" (Codex review). Compute the identity set up front so every entity sharing
+    # it gets the *same* attrs["consumer_compiled_body"] value regardless of which one wins.
     consumer_compiled_identities = {
         ent.identity()
         for ent in (*surface.reachable_templates, *surface.reachable_inline_bodies)

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -571,11 +571,9 @@ class SourceGraphSummary:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> SourceGraphSummary:
         # Defensive ``.get`` parsing so a newer/hand-edited summary never aborts
-        # a load (evidence/CLAUDE.md forward-compat rule). ``indexes`` are derived
-        # and intentionally not read back — they are recomputed from nodes/edges.
-        # ``extractor_passes`` defaults to {} for a pre-slice-2 pack (additive
-        # field, no schema_version bump needed — same "unknown edge kinds/
-        # fields are ignored/defaulted" forward-compat rule as ADR-041 P0 slice 1).
+        # a load (evidence/CLAUDE.md forward-compat rule); ``indexes`` are
+        # derived and intentionally not read back. ``extractor_passes``
+        # defaults to {} for a pre-slice-2 pack (ADR-041 P0 slice 1).
         raw_entity_resolver = d.get("entity_resolver")
         _raw_entity_resolver: dict[str, Any] = (
             raw_entity_resolver if isinstance(raw_entity_resolver, dict) else {}
@@ -600,12 +598,14 @@ class SourceGraphSummary:
             },
             entity_resolver=EntityResolver.from_dict(_raw_entity_resolver),
         )
-        # add_node/add_edge coalesce ids colliding after migration (Codex review).
+        # add_node/add_edge coalesce migration-colliding ids (Codex review).
         for raw_node in d.get("nodes", []):
             obj.add_node(GraphNode.from_dict(raw_node))
         for raw_edge in d.get("edges", []):
             obj.add_edge(GraphEdge.from_dict(raw_edge))
-        obj.graph_id = obj.compute_graph_id()  # never trust a stale loaded value
+        if _raw_entity_resolver:
+            obj.resolve_entities()  # rebuild from coalesced facts (Codex review)
+        obj.finalize()  # recomputes graph_id + coverage post-migration
         return obj
 
 

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -70,6 +70,7 @@ from .graph_facts import (
     GraphNode as GraphNode,
     _decl_node_id as _decl_node_id,
     _normalize_graph_identity as _normalize_graph_identity,
+    _normalize_if_decl_or_type,
     _type_node_id as _type_node_id,
     ensure_facts_and_resolve,
     merge_entity_facts,
@@ -282,34 +283,34 @@ class SourceGraphSummary:
     entity_resolver: EntityResolver = field(default_factory=EntityResolver)
 
     def __post_init__(self) -> None:
-        # ADR-046 D2: backfill/re-derive facts/resolved for anything constructed directly
-        # (bypassing add_node/add_edge), so every node reachable from this summary satisfies
-        # "facts is never empty, resolved is derived from facts". Must run *before* the
-        # de-dup indexes below (Codex review, fresh evidence): a constructor-seeded edge
-        # whose role lives only in `facts` (not yet mirrored into `attrs`) would otherwise
-        # have its `relation_key()` computed against an empty `attrs`/`resolved` view,
-        # indexing it under the wrong (blank-role) key before resolution ever populates it.
+        # Normalize a constructor-seeded node id/edge endpoint the same way GraphNode/
+        # GraphEdge.from_dict() already migrate a persisted one (Codex review): a caller
+        # building SourceGraphSummary(nodes=..., edges=...) directly never routes through
+        # _decl_node_id/_type_node_id either, so a hand-built id can carry the identical
+        # checkout-dependent marker. No-op for every non-decl/type id (its own gate).
         for n in self.nodes:
-            ensure_facts_and_resolve(n)
+            n.id = _normalize_if_decl_or_type(n.id)
         for e in self.edges:
-            ensure_facts_and_resolve(e)
-        # De-dup indexes for O(1) add_node/add_edge, seeded from whatever the constructor
-        # (or from_dict) provided. Edges dedup on relation_key() (src, dst, kind, role), not
-        # the coarser key() (ADR-046 D1, Codex review on PR #620): deduping on key() alone
-        # silently folded two real, role-distinct relations -- e.g. a function that both
-        # returns and takes the same private type, two DECL_HAS_TYPE edges -- into one edge
-        # object, so only one role ever survived to be found via relation_key() by anything
-        # walking graph.edges. key() itself is untouched (still (src, dst, kind));
-        # diff_source_graph's coarser edge-set comparison keeps its pre-existing "one
-        # representative edge per (src, dst, kind)" precision either way.
-        self._node_ids: set[str] = {n.id for n in self.nodes}
-        self._edge_keys: set[tuple[str, str, str, str]] = {
-            e.relation_key() for e in self.edges
-        }
-        self._node_by_id: dict[str, GraphNode] = {n.id: n for n in self.nodes}
-        self._edge_by_key: dict[tuple[str, str, str, str], GraphEdge] = {
-            e.relation_key(): e for e in self.edges
-        }
+            e.src = _normalize_if_decl_or_type(e.src)
+            e.dst = _normalize_if_decl_or_type(e.dst)
+        # Re-register through add_node()/add_edge() rather than building the de-dup indexes
+        # directly (same round): normalization above can make two originally-distinct ids
+        # collide, and a plain set/dict comprehension would then disagree with
+        # len(self.nodes)/len(self.edges) -- the same "index vs list" desync from_dict()
+        # already fixed by routing every loaded entity through this coalescing path (also
+        # resolves facts, and computes an edge's relation_key() only after resolution, not
+        # against an empty view). A no-op for the common case: on a fresh id this just
+        # resolves+appends, identical to a direct index construction.
+        seeded_nodes, seeded_edges = self.nodes, self.edges
+        self.nodes, self.edges = [], []
+        self._node_ids: set[str] = set()
+        self._edge_keys: set[tuple[str, str, str, str]] = set()
+        self._node_by_id: dict[str, GraphNode] = {}
+        self._edge_by_key: dict[tuple[str, str, str, str], GraphEdge] = {}
+        for n in seeded_nodes:
+            self.add_node(n)
+        for e in seeded_edges:
+            self.add_edge(e)
 
     # -- mutation helpers ---------------------------------------------------
 

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -68,6 +68,9 @@ from .graph_facts import (
     GraphEdge as GraphEdge,
     GraphFact as GraphFact,
     GraphNode as GraphNode,
+    _decl_node_id as _decl_node_id,
+    _normalize_graph_identity as _normalize_graph_identity,
+    _type_node_id as _type_node_id,
     ensure_facts_and_resolve,
     merge_entity_facts,
     register_fact,
@@ -618,14 +621,6 @@ def _header_node_id(path: str) -> str:
 
 def _option_node_id(flag: str) -> str:
     return f"build_option://{flag}"
-
-
-def _decl_node_id(identity: str) -> str:
-    return f"decl://{identity}"
-
-
-def _type_node_id(identity: str) -> str:
-    return f"type://{identity}"
 
 
 def _vtable_node_id(identity: str) -> str:
@@ -1501,7 +1496,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=did,
                 kind="source_decl",
-                label=ent.qualified_name or ent.identity(),
+                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
                 provenance="source_abi",
                 confidence=conf,
                 attrs={
@@ -1536,7 +1531,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=tid,
                 kind=_type_node_kind(ent.kind),
-                label=ent.qualified_name or ent.identity(),
+                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
                 provenance="source_abi",
                 confidence=conf,
                 attrs={"decl_kind": ent.kind, "visibility": ent.visibility},
@@ -1572,7 +1567,7 @@ def _augment_with_source_abi(
             GraphNode(
                 id=mid,
                 kind="macro",
-                label=ent.qualified_name or ent.identity(),
+                label=_normalize_graph_identity(ent.qualified_name or ent.identity()),
                 provenance="source_abi",
                 confidence=conf,
             )
@@ -1696,7 +1691,7 @@ def fold_source_edges(
                 node = GraphNode(
                     id=node_id,
                     kind=node_kind,
-                    label=ident,
+                    label=_normalize_graph_identity(ident),
                     provenance=provenance,
                     confidence=confidence,
                     attrs=node_attrs,

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -456,7 +456,7 @@ class SourceGraphSummary:
         return self
 
     def finalize(self) -> SourceGraphSummary:
-        """Fill ``graph_id`` and the structural ``coverage`` counts; return self."""
+        """Fill ``graph_id``/``coverage``; merges onto (never replaces) the latter so a persisted unrecognized field survives; return self."""
         self.graph_id = self.compute_graph_id()
         kinds: dict[str, int] = {}
         for n in self.nodes:
@@ -494,8 +494,7 @@ class SourceGraphSummary:
         # confirmed pass with zero edges (a leaf header with no #includes of
         # its own) is a genuine zero, not "never collected" (Codex review:
         # this mirrors ``has_calls``/``has_type_edges`` below, which already
-        # credit a confirmed-but-empty pass; ``has_includes`` previously
-        # looked at edge presence alone).
+        # credit a confirmed-but-empty pass; ``has_includes`` previously looked at edge presence alone).
         include_pass_ran = self.extractor_passes.get("include_graph", False)
         header_include_pass_ran = self.extractor_passes.get(
             "header_include_graph", False
@@ -520,6 +519,7 @@ class SourceGraphSummary:
             e.kind == "DECL_REFERENCES_DECL" for e in self.edges
         )
         self.coverage = {
+            **self.coverage,  # forward-compat: keep any unrecognized field
             "targets": kinds.get("target", 0),
             "compile_units": kinds.get("compile_unit", 0),
             "source_decls": kinds.get("source_decl", 0),

--- a/abicheck/buildsource/template_graph.py
+++ b/abicheck/buildsource/template_graph.py
@@ -199,7 +199,13 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from .. import diff_cxx_rules
-from .graph_facts import CONF_HIGH, CONF_REDUCED, GraphEdge, GraphNode
+from .graph_facts import (
+    CONF_HIGH,
+    CONF_REDUCED,
+    GraphEdge,
+    GraphNode,
+    _normalize_graph_identity,
+)
 from .template_graph_value_decls import (
     arg_label_spelling,
     disambiguated_specialization_qname,
@@ -436,25 +442,22 @@ def _index_type_decls(
     node_id = str(node.get("id") or "")
     if node_id:
         if f:
-            # This node carries its own explicit loc.file -- authoritative
-            # for this exact id, so it always wins over whatever an earlier
-            # occurrence of the same id recorded (Codex review, fresh
-            # evidence): the explicit-instantiation/specialization
-            # detachment quirk means the same id can appear twice -- an
-            # empty, loc-less stub nested under the primary ClassTemplateDecl
-            # (which inherits the *header*'s sticky file, since the header's
-            # own top-level declarations are visited first) and a detached
-            # full-content sibling elsewhere that DOES carry its own loc
-            # (the actual .cpp where the specialization/instantiation is
-            # written). A plain setdefault let whichever occurrence was
-            # visited first win — for this exact shape, the loc-less stub
-            # always wins, permanently misattributing the specialization to
-            # the header. project_source_files() then excludes it (public
-            # headers aren't "project" sources), silently dropping the
-            # instantiation's own defined_in_project provenance. An inherited
-            # (non-own) file still only sets if absent, so a later
-            # loc-less occurrence of an id already resolved by an explicit
-            # one can't un-set it.
+            # This node carries its own explicit loc.file -- authoritative for this exact
+            # id, so it always wins over whatever an earlier occurrence of the same id
+            # recorded (Codex review, fresh evidence): the explicit-instantiation/
+            # specialization detachment quirk means the same id can appear twice -- an
+            # empty, loc-less stub nested under the primary ClassTemplateDecl (which
+            # inherits the *header*'s sticky file, since the header's own top-level
+            # declarations are visited first) and a detached full-content sibling
+            # elsewhere that DOES carry its own loc (the actual .cpp where the
+            # specialization/instantiation is written). A plain setdefault let whichever
+            # occurrence was visited first win — for this exact shape, the loc-less stub
+            # always wins, permanently misattributing the specialization to the header.
+            # project_source_files() then excludes it (public headers aren't "project"
+            # sources), silently dropping the instantiation's own defined_in_project
+            # provenance. An inherited (non-own) file still only sets if absent, so a
+            # later loc-less occurrence of an id already resolved by an explicit one
+            # can't un-set it.
             id_to_file[node_id] = cur_file
         else:
             id_to_file.setdefault(node_id, cur_file)
@@ -464,19 +467,17 @@ def _index_type_decls(
             id_to_qname.setdefault(node_id, "::".join([*scope, name]))
             id_to_decl_kind.setdefault(node_id, kind)
         # A ClassTemplateSpecializationDecl's own *nested* declarations (e.g.
-        # `Wrapper<int>::Nested`) must scope under the specialization's own
-        # arguments, not its bare, unparameterized name -- otherwise two
-        # distinct specializations' nested types (`Wrapper<int>::Nested` vs.
-        # `Wrapper<double>::Nested`) both index as the identical bare
-        # "Wrapper::Nested" and collide onto one type node (Codex review,
-        # empirically confirmed against real clang AST output). Builds the
-        # disambiguated scope name directly from this node's own
-        # TemplateArgument children's raw spellings (mirrors
-        # _instantiation_label) -- deliberately not a
-        # _resolve_specialization_qname-style resolved qname: that helper
-        # needs id_to_qname/full_by_id/id_to_template_qname, none of which
-        # exist yet at this point in the "index first, resolve second"
-        # pipeline (this call *is* the pass building id_to_qname).
+        # `Wrapper<int>::Nested`) must scope under the specialization's own arguments,
+        # not its bare, unparameterized name -- otherwise two distinct specializations'
+        # nested types (`Wrapper<int>::Nested` vs. `Wrapper<double>::Nested`) both index
+        # as the identical bare "Wrapper::Nested" and collide onto one type node (Codex
+        # review, empirically confirmed against real clang AST output). Builds the
+        # disambiguated scope name directly from this node's own TemplateArgument
+        # children's raw spellings (mirrors _instantiation_label) -- deliberately not a
+        # _resolve_specialization_qname-style resolved qname: that helper needs
+        # id_to_qname/full_by_id/id_to_template_qname, none of which exist yet at this
+        # point in the "index first, resolve second" pipeline (this call *is* the pass
+        # building id_to_qname).
         child_scope = [*scope, _specialization_scope_name(node, name)]
         for child in node.get("inner", []) or []:
             cur_file = _index_type_decls(
@@ -963,23 +964,20 @@ def _resolve_specialization_qname(
     args = _flatten_template_args(full.get("inner", []) or [])
     if args is None:
         # An opaque argument (e.g. a template-template argument -- see
-        # _is_opaque_template_argument) means this specialization's own
-        # disambiguated label can't be trusted. Return unresolved (None)
-        # rather than the bare, unparameterized qname (Codex review, fresh
-        # evidence, verified empirically against real clang AST output): an
-        # earlier revision's bare-qname fallback let two genuinely distinct
-        # nested specializations -- Outer<Use<A>> and Outer<Use<B>>, where
-        # Use<A>/Use<B> both take an opaque template-template argument --
-        # both resolve their outer argument's target_qname to the identical
-        # ambiguous "Use", so both TEMPLATE_USES_TYPE edges landed on the
-        # same type://Use node, falsely merging dependencies on two
-        # concrete specializations. The outer instantiation *nodes*
-        # themselves stayed correctly distinct (each keeps its own full
-        # spelling, "Use<A>"/"Use<B>"), so only this edge target was wrong.
-        # None here means _resolve_arg_targets' caller sees an unresolved
-        # target_qname and (per its own docstring) omits the
-        # TEMPLATE_USES_TYPE edge entirely -- a missed edge, not a merged
-        # one, matching this module's usual "never guess" discipline.
+        # _is_opaque_template_argument) means this specialization's own disambiguated
+        # label can't be trusted. Return unresolved (None) rather than the bare,
+        # unparameterized qname (Codex review, verified empirically against real clang
+        # AST output): an earlier revision's bare-qname fallback let two genuinely
+        # distinct nested specializations -- Outer<Use<A>> and Outer<Use<B>>, where
+        # Use<A>/Use<B> both take an opaque template-template argument -- both resolve
+        # their outer argument's target_qname to the identical ambiguous "Use", so both
+        # TEMPLATE_USES_TYPE edges landed on the same type://Use node, falsely merging
+        # dependencies on two concrete specializations. The outer instantiation *nodes*
+        # themselves stayed correctly distinct (each keeps its own full spelling,
+        # "Use<A>"/"Use<B>"), so only this edge target was wrong. None here means
+        # _resolve_arg_targets' caller sees an unresolved target_qname and (per its own
+        # docstring) omits the TEMPLATE_USES_TYPE edge entirely -- a missed edge, not a
+        # merged one, matching this module's usual "never guess" discipline.
         return None
     resolved_args = _resolve_arg_targets(
         args,
@@ -1269,18 +1267,16 @@ def _walk_function_templates(
 
     if kind == _FUNCTION_TEMPLATE_KIND:
         name = str(node.get("name") or "")
-        # An out-of-line member-template *definition* (`template <class T>
-        # void C::f(T) {}`) detaches as a separate, top-level
-        # FunctionTemplateDecl -- not nested inside CXXRecordDecl:C at all
-        # (confirmed empirically, Codex review) -- so this node's own
-        # structural `scope` is `[]`, computing a bare "f" that could
-        # coincidentally merge with an unrelated global template also
-        # named "f", duplicating the graph's own correctly-scoped "C::f"
-        # instantiation. `parentDeclContextId` (absent on an ordinary
-        # in-class declaration) names the *real* semantic owner,
-        # resolvable through id_to_qname the same way a template
-        # argument's `decl` cross-reference already is -- preferred
-        # unconditionally when present.
+        # An out-of-line member-template *definition* (`template <class T> void
+        # C::f(T) {}`) detaches as a separate, top-level FunctionTemplateDecl -- not
+        # nested inside CXXRecordDecl:C at all (confirmed empirically, Codex review) --
+        # so this node's own structural `scope` is `[]`, computing a bare "f" that could
+        # coincidentally merge with an unrelated global template also named "f",
+        # duplicating the graph's own correctly-scoped "C::f" instantiation.
+        # `parentDeclContextId` (absent on an ordinary in-class declaration) names the
+        # *real* semantic owner, resolvable through id_to_qname the same way a template
+        # argument's `decl` cross-reference already is -- preferred unconditionally when
+        # present.
         owner_id = str(node.get("parentDeclContextId") or "")
         owner_kind = id_to_decl_kind.get(owner_id)
         owner_qname = disambiguated_specialization_qname(
@@ -1665,15 +1661,14 @@ def parse_clang_ast_templates(ast: dict[str, Any]) -> list[TemplateInstantiation
         )
         if args is None:
             # An opaque argument (e.g. a template-template argument -- see
-            # _is_opaque_template_argument) means this instantiation's own
-            # identity can't be trusted -- two genuinely distinct
-            # instantiations differing only in that argument (Use<A> vs.
-            # Use<B>) would otherwise collide onto one shared label/node,
-            # merging their real, distinct emitted-symbol/type-dependency
-            # edges (Codex review, empirically confirmed against real clang
-            # AST output: clang's -ast-dump=json serializes zero
-            # identifying information for a template-template argument).
-            # Skip rather than record a wrong identity.
+            # _is_opaque_template_argument) means this instantiation's own identity
+            # can't be trusted -- two genuinely distinct instantiations differing only
+            # in that argument (Use<A> vs. Use<B>) would otherwise collide onto one
+            # shared label/node, merging their real, distinct emitted-symbol/type-
+            # dependency edges (Codex review, empirically confirmed against real clang
+            # AST output: clang's -ast-dump=json serializes zero identifying
+            # information for a template-template argument). Skip rather than record a
+            # wrong identity.
             continue
         resolved_args = _resolve_arg_targets(
             args, id_to_qname, id_to_decl_kind, id_to_template_qname, full_by_id
@@ -1739,8 +1734,10 @@ def template_decl_node_id(qname: str, signature: str | None = None) -> str:
     ``template_decl://C`` node despite instantiating distinct declared
     patterns (Codex review, fresh evidence, confirmed against real clang 18
     AST output)."""
+    # Normalized like _decl_node_id/_type_node_id: a signature can embed a checkout marker.
+    qname = _normalize_graph_identity(qname)
     if signature:
-        return f"template_decl://{qname}#{signature}"
+        return f"template_decl://{qname}#{_normalize_graph_identity(signature)}"
     return f"template_decl://{qname}"
 
 
@@ -1762,7 +1759,10 @@ def template_instantiation_node_id(label: str, mangled: str | None = None) -> st
     it's the correct, collision-free identity for this kind."""
     if mangled:
         return f"template_instantiation://{mangled}"
-    return f"template_instantiation://{label}"
+    # A class instantiation's own label (built from its args' spellings) can embed the
+    # identical checkout-dependent lambda marker for a lambda-typed argument (Codex
+    # review, confirmed against real clang output); a mangled name never does.
+    return f"template_instantiation://{_normalize_graph_identity(label)}"
 
 
 def _symbol_node_ids(graph: SourceGraphSummary) -> frozenset[str]:

--- a/abicheck/buildsource/type_graph.py
+++ b/abicheck/buildsource/type_graph.py
@@ -1778,7 +1778,7 @@ def augment_graph_with_types(
     Returns the number of edges added.
     """
     from .call_graph import _file_in_project
-    from .source_graph import _decl_node_id, _type_node_id
+    from .source_graph import _decl_node_id, _normalize_graph_identity, _type_node_id
 
     node_by_id: dict[str, GraphNode] = {n.id: n for n in graph.nodes}
 
@@ -1810,7 +1810,7 @@ def augment_graph_with_types(
                 node = GraphNode(
                     id=node_id,
                     kind=node_kind,
-                    label=ident,
+                    label=_normalize_graph_identity(ident),
                     provenance="type_graph",
                     confidence=e.confidence,
                     attrs=attrs,

--- a/abicheck/buildsource/type_graph.py
+++ b/abicheck/buildsource/type_graph.py
@@ -1778,7 +1778,7 @@ def augment_graph_with_types(
     Returns the number of edges added.
     """
     from .call_graph import _file_in_project
-    from .source_graph import _decl_node_id, _normalize_graph_identity, _type_node_id
+    from .source_graph import _decl_node_id, _type_node_id
 
     node_by_id: dict[str, GraphNode] = {n.id: n for n in graph.nodes}
 
@@ -1810,7 +1810,7 @@ def augment_graph_with_types(
                 node = GraphNode(
                     id=node_id,
                     kind=node_kind,
-                    label=_normalize_graph_identity(ident),
+                    label=ident,
                     provenance="type_graph",
                     confidence=e.confidence,
                     attrs=attrs,

--- a/changelog.d/20260824_153714_noreply_abicheck_l5_node_ids_6gic2d.md
+++ b/changelog.d/20260824_153714_noreply_abicheck_l5_node_ids_6gic2d.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **L5 source-graph decl/type node ids and labels no longer embed a
+  checkout-dependent directory for an anonymous-tag or lambda-closure type.**
+  `abicheck/buildsource/source_graph.py`'s `_decl_node_id`/`_type_node_id` —
+  the one choke point every L5 producer (`type_graph.py`, `call_graph.py`,
+  `override_graph.py`, `callback_graph.py`, `template_graph.py`,
+  `header_graph.py`, `macro_graph.py`, `source_graph.py` itself) routes a
+  decl/type identity through — now strip the absolute path out of a raw
+  `"(unnamed struct at /a/foo.h:56:5)"`/`"raii_guard<(lambda at
+  /a/foo.h:4:37)>"` spelling (as `dumper_castxml.py`'s L2 backend already
+  does via `strip_anonymous_type_location`) *and* a bare, unparenthesized
+  `"lambda at /a/foo.h:4:37"` spelling observed directly in real L5 graphs.
+  Previously, two builds of the identical, unedited declaration under
+  different checkout roots produced two different node ids/labels, which
+  `graph_reconcile.py`/`diff_source_graph_findings.py` read as a real
+  `declaration_renamed` risk finding purely from directory taint.

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -711,3 +711,20 @@ def test_template_instantiation_node_loaded_from_persisted_pack_migrates_and_nor
     )
     assert node.id == fresh_id
     assert "/old/checkout" not in node.label
+
+
+def test_normalization_known_limitation_same_basename_different_directory() -> None:
+    # Accepted, pre-existing residual (Codex review, fresh evidence, thirteenth
+    # round -- see _normalize_graph_identity's own docstring for the full
+    # reasoning): two DIFFERENT headers sharing both a basename and the identical
+    # coordinates collapse onto the same discriminator, since the discriminator is
+    # basename-only (no checkout-relative path information is available to a pure
+    # string-pattern normalizer). This is a pre-existing limitation of
+    # name_classification._declaring_header_discriminator, inherited here rather
+    # than introduced by this module -- pinned as a known limitation, not a
+    # passing correctness guarantee, so a future redesign of that shared
+    # primitive doesn't have to rediscover this shape from scratch.
+    old = _type_node_id("lambda at /repo/include/v1/config.hpp:4:37")
+    new = _type_node_id("lambda at /repo/include/v2/config.hpp:4:37")
+    # Known-bad: two genuinely distinct declarations collide onto one node id.
+    assert old == new

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -216,3 +216,56 @@ def test_add_node_normalizes_label_for_any_producer() -> None:
         )
     )
     assert g.nodes[0].label == "lambda:foo.hpp:9:1"
+
+
+def test_source_graph_summary_from_dict_coalesces_ids_colliding_after_migration() -> (
+    None
+):
+    # Two persisted nodes that only differ by checkout root normalize to the
+    # SAME id -- from_dict() must route them through add_node() so they
+    # coalesce into one entry, not leave both objects in self.nodes under
+    # one shared id with self._node_ids/_node_by_id silently disagreeing
+    # about the count (Codex review, fresh evidence).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    g = SourceGraphSummary.from_dict(
+        {
+            "schema_version": 2,
+            "nodes": [
+                {
+                    "id": "type://lambda at /old/checkout/lib.hpp:4:37",
+                    "kind": "record_type",
+                    "label": "lambda at /old/checkout/lib.hpp:4:37",
+                },
+                {
+                    "id": "type://lambda at /new/checkout/lib.hpp:4:37",
+                    "kind": "record_type",
+                    "label": "lambda at /new/checkout/lib.hpp:4:37",
+                },
+            ],
+            "edges": [],
+        }
+    )
+    assert len(g.nodes) == 1
+    assert len(g._node_ids) == len(g.nodes)
+    assert len(g._node_by_id) == len(g.nodes)
+
+
+def test_entity_resolver_remap_normalizes_canonical_values_too() -> None:
+    # A canonical id with no USR/mangled name available falls back to
+    # entity_identity.normalized_signature's "sig:<qualified_name>..." form,
+    # which embeds the raw, checkout-path-bearing qualified name verbatim --
+    # remap_node_ids must normalize that VALUE, not just the v1-id KEY, or
+    # canonical_id_for() keeps returning a directory-tainted id that never
+    # matches a freshly-resolved graph's canonical id (Codex review, fresh
+    # evidence, second round).
+    from abicheck.buildsource.entity_resolver import EntityResolver
+
+    old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    stale_canonical = "sig:lambda at /old/checkout/lib.hpp:4:37\x1frecord\x1f0"
+    r = EntityResolver.from_dict(
+        {"aliases": {old_id: stale_canonical}, "conflicts": []}
+    )
+    (canonical,) = r.aliases.values()
+    assert "/old/checkout" not in canonical
+    assert canonical == "sig:lambda:lib.hpp:4:37\x1frecord\x1f0"

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -597,3 +597,24 @@ def test_source_graph_summary_from_dict_preserves_unrecognized_coverage_fields()
     # The recognized structural keys are still recomputed from the actual
     # (empty) node/edge set, not trusted from the persisted payload.
     assert graph.coverage["source_decls"] == 0
+
+
+def test_bare_marker_normalization_known_limitation_marker_text_in_path() -> None:
+    # Accepted, deliberately-unfixed limitation (Codex review, fresh
+    # evidence, fourth round on this same regex -- see
+    # _BARE_ANON_TYPE_LOCATION_RE's own docstring for the full reasoning):
+    # a checkout path whose own directory name is, by pure textual
+    # coincidence, spelled exactly like the "lambda at"/"unnamed <kind> at"
+    # trigger defeats the negative-lookahead marker boundary, leaving the
+    # real checkout-dependent prefix untouched. This is adversarial,
+    # deliberately-constructed input (no real toolchain names a directory
+    # "lambda at") -- pinned here as a known limitation, not a passing
+    # correctness guarantee, so a future attempt to "fix" this regex a
+    # fourth time doesn't rediscover the same shape from scratch without
+    # this record of why it was left alone.
+    from abicheck.buildsource.graph_facts import _strip_bare_anonymous_type_location
+
+    name = "lambda at /tmp/lambda at build/foo.hpp:4:37"
+    result = _strip_bare_anonymous_type_location(name)
+    # Known-bad: the real, checkout-dependent "/tmp/" prefix survives.
+    assert "/tmp/" in result

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -643,3 +643,71 @@ def test_source_graph_summary_from_dict_preserves_unrecognized_nested_coverage_f
     # (empty) edge set, not trusted from the persisted payload.
     assert graph.coverage["call_edges"]["collected"] is False
     assert graph.coverage["call_edges"]["count"] == 0
+
+
+def test_template_instantiation_node_id_strips_checkout_directory_from_lambda_argument() -> (
+    None
+):
+    # A class template instantiated with a lambda-closure-typed argument has clang
+    # print that argument's spelling as the identical checkout-dependent "(lambda at
+    # <path>:<line>:<col>)" marker decl/type identities already get normalized against
+    # (Codex review, fresh evidence, twelfth round) -- template_instantiation:// was
+    # excluded from the normalization gate entirely, so two builds of the identical
+    # instantiation under different checkout roots still produced different node ids.
+    from abicheck.buildsource.template_graph import template_instantiation_node_id
+
+    old = template_instantiation_node_id(
+        "Wrapper<(lambda at /old/checkout/foo.cpp:2:20)>"
+    )
+    new = template_instantiation_node_id(
+        "Wrapper<(lambda at /new/checkout/foo.cpp:2:20)>"
+    )
+    assert old == new
+    assert "/old/checkout" not in old
+    assert "/new/checkout" not in new
+
+    # A mangled function-instantiation identity is untouched either way (it never
+    # embeds this marker, and mustn't be run through path-stripping regardless).
+    mangled_id = template_instantiation_node_id("f<int>", "_Z1fIiEvT_")
+    assert mangled_id == "template_instantiation://_Z1fIiEvT_"
+
+
+def test_template_decl_node_id_strips_checkout_directory_from_default_argument() -> (
+    None
+):
+    from abicheck.buildsource.template_graph import template_decl_node_id
+
+    old = template_decl_node_id(
+        "Outer", "type-parameter-0-0 (lambda at /old/checkout/foo.cpp:2:20)"
+    )
+    new = template_decl_node_id(
+        "Outer", "type-parameter-0-0 (lambda at /new/checkout/foo.cpp:2:20)"
+    )
+    assert old == new
+    assert "/old/checkout" not in old
+
+
+def test_template_instantiation_node_loaded_from_persisted_pack_migrates_and_normalizes_label() -> (
+    None
+):
+    # End-to-end through the same load path a real build-source pack takes:
+    # template_instantiation:// must join decl://type:// in both the load-time id
+    # migration (GraphNode.from_dict) and the label normalization
+    # (ensure_facts_and_resolve), the same choke points every other decl/type kind
+    # already routes through.
+    from abicheck.buildsource.graph_facts import GraphNode
+    from abicheck.buildsource.template_graph import template_instantiation_node_id
+
+    raw_label = "Wrapper<(lambda at /old/checkout/foo.cpp:2:20)>"
+    node = GraphNode.from_dict(
+        {
+            "id": f"template_instantiation://{raw_label}",
+            "kind": "template_instantiation",
+            "label": raw_label,
+        }
+    )
+    fresh_id = template_instantiation_node_id(
+        "Wrapper<(lambda at /new/checkout/foo.cpp:2:20)>"
+    )
+    assert node.id == fresh_id
+    assert "/old/checkout" not in node.label

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -115,6 +115,19 @@ def test_bare_marker_normalization_skips_quoted_literals() -> None:
     assert "/c/bar.hpp" not in mixed
 
 
+def test_bare_marker_normalization_finds_the_terminal_coordinates() -> None:
+    # A checkout path can itself contain a colon-digit-colon-digit-shaped
+    # segment (a timestamped build directory) that a non-greedy path group
+    # would mistake for the marker's own terminal ":line:col" -- silently
+    # leaving the real, checkout-dependent tail unmodified past the
+    # truncated match (Codex review, fresh evidence, fifth round).
+    old = _type_node_id("lambda at /tmp/build-2026T12:34:56/src/foo.hpp:4:37")
+    new = _type_node_id("lambda at /mnt/build-2026T12:34:56/src/foo.hpp:4:37")
+    assert old == new
+    assert "build-2026T12" not in old
+    assert old.endswith(":4:37")
+
+
 def test_graph_node_from_dict_migrates_pre_normalization_ids() -> None:
     # A build-source pack persisted before this normalization existed
     # carries the old, raw, checkout-path-bearing node id/label -- loading

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -401,3 +401,107 @@ def test_normalization_never_touches_non_decl_or_type_node_ids() -> None:
     d = GraphNode.from_dict({"id": decl_id, "kind": "source_decl", "label": decl_id})
     assert d.id != decl_id
     assert "/old/checkout" not in d.id
+
+
+def test_identity_attrs_are_normalized_alongside_label() -> None:
+    # A decl/type node's attrs["name"]/attrs["qualified_name"] can carry the
+    # identical raw, checkout-path-bearing spelling as its label -- both
+    # producer fields are populated from the same declaration identity.
+    # entity_identity.resolve_identity_for_node() prefers these attrs over
+    # node.label, so leaving them un-normalized would let two
+    # checkout-equivalent nodes -- identical id/label after normalization --
+    # still resolve to two different ADR-048 canonical identities purely
+    # from directory taint surviving in attrs (Codex review, fresh evidence).
+    from abicheck.buildsource.graph_facts import GraphNode, _decl_node_id
+
+    old_qn = "raii_guard<(lambda at /old/checkout/lib.hpp:4:37)>"
+    new_qn = "raii_guard<(lambda at /new/checkout/lib.hpp:4:37)>"
+
+    # A real producer always builds a decl/type node's own id via
+    # _decl_node_id/_type_node_id (already normalized) -- this test's
+    # subject is specifically whether attrs["name"]/["qualified_name"] get
+    # the same treatment, not id normalization itself.
+    old_node = GraphNode(
+        id=_decl_node_id(old_qn),
+        kind="source_decl",
+        label=old_qn,
+        attrs={"name": old_qn, "qualified_name": old_qn, "usr": None},
+    )
+    new_node = GraphNode(
+        id=_decl_node_id(new_qn),
+        kind="source_decl",
+        label=new_qn,
+        attrs={"name": new_qn, "qualified_name": new_qn, "usr": None},
+    )
+
+    # ensure_facts_and_resolve already runs in GraphNode's own __post_init__
+    # path is not automatic for a bare construction -- route both through
+    # the same choke point add_node uses.
+    from abicheck.buildsource.graph_facts import ensure_facts_and_resolve
+
+    ensure_facts_and_resolve(old_node)
+    ensure_facts_and_resolve(new_node)
+
+    assert old_node.id == new_node.id
+    assert old_node.label == new_node.label
+    assert "/old/checkout" not in old_node.attrs["name"]
+    assert "/new/checkout" not in new_node.attrs["name"]
+    assert old_node.attrs["name"] == new_node.attrs["name"]
+    assert old_node.attrs["qualified_name"] == new_node.attrs["qualified_name"]
+
+    from abicheck.buildsource import entity_identity
+
+    old_identity = entity_identity.resolve_identity_for_node(old_node)
+    new_identity = entity_identity.resolve_identity_for_node(new_node)
+    assert old_identity.primary_id == new_identity.primary_id
+
+
+def test_resolve_entities_rebuild_does_not_reintroduce_taint_from_loaded_pack() -> None:
+    # SourceGraphSummary.from_dict() rebuilds entity_resolver from the
+    # loaded nodes' own (now-normalized) attrs via resolve_entities() --
+    # confirming the rebuild reads already-normalized attrs rather than
+    # reintroducing checkout taint EntityResolver.from_dict()'s own
+    # remap_node_ids() already cleaned out of the persisted aliases.
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    old_qn = "raii_guard<(lambda at /old/checkout/lib.hpp:4:37)>"
+    new_qn = "raii_guard<(lambda at /new/checkout/lib.hpp:4:37)>"
+
+    old_pack = {
+        "nodes": [
+            {
+                "id": f"decl://{old_qn}",
+                "kind": "source_decl",
+                "label": old_qn,
+                "attrs": {"name": old_qn, "qualified_name": old_qn},
+            }
+        ],
+        "edges": [],
+        "entity_resolver": {"aliases": {f"decl://{old_qn}": f"sig:{old_qn}\x1f\x1f0"}},
+    }
+    new_pack = {
+        "nodes": [
+            {
+                "id": f"decl://{new_qn}",
+                "kind": "source_decl",
+                "label": new_qn,
+                "attrs": {"name": new_qn, "qualified_name": new_qn},
+            }
+        ],
+        "edges": [],
+        "entity_resolver": {"aliases": {f"decl://{new_qn}": f"sig:{new_qn}\x1f\x1f0"}},
+    }
+
+    old_graph = SourceGraphSummary.from_dict(old_pack)
+    new_graph = SourceGraphSummary.from_dict(new_pack)
+
+    old_v1 = old_graph.nodes[0].id
+    new_v1 = new_graph.nodes[0].id
+    assert old_v1 == new_v1
+
+    old_canonical = old_graph.entity_resolver.canonical_id_for(old_v1)
+    new_canonical = new_graph.entity_resolver.canonical_id_for(new_v1)
+    assert old_canonical is not None
+    assert "/old/checkout" not in old_canonical
+    assert "/new/checkout" not in new_canonical
+    assert old_canonical == new_canonical

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -177,14 +177,26 @@ def test_source_graph_summary_from_dict_migrates_entity_resolver_aliases() -> No
     # An EntityResolver persisted alongside a pre-normalization graph is
     # keyed by the OLD, pre-migration node id -- canonical_id_for(node.id)
     # must still resolve after load, or a persisted canonical identity goes
-    # silently unreachable (Codex review, fresh evidence).
+    # silently unreachable (Codex review, fresh evidence). The node carries
+    # the same "usr" attr resolve_identity_for_node() would have read when
+    # the persisted canonical id was first computed -- from_dict() rebuilds
+    # the resolver from current (coalesced) node facts (a later Codex
+    # finding) rather than trust the remap alone, so this is what actually
+    # makes the rebuilt canonical id agree with the persisted one.
     from abicheck.buildsource.source_graph import SourceGraphSummary
 
     old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
     g = SourceGraphSummary.from_dict(
         {
             "schema_version": 2,
-            "nodes": [{"id": old_id, "kind": "record_type", "label": old_id}],
+            "nodes": [
+                {
+                    "id": old_id,
+                    "kind": "record_type",
+                    "label": old_id,
+                    "attrs": {"usr": "c:@S@Widget"},
+                }
+            ],
             "edges": [],
             "entity_resolver": {
                 "aliases": {old_id: "usr:c:@S@Widget"},
@@ -269,3 +281,67 @@ def test_entity_resolver_remap_normalizes_canonical_values_too() -> None:
     (canonical,) = r.aliases.values()
     assert "/old/checkout" not in canonical
     assert canonical == "sig:lambda:lib.hpp:4:37\x1frecord\x1f0"
+
+
+def test_source_graph_summary_from_dict_rebuilds_resolver_from_coalesced_node() -> None:
+    # Two persisted nodes for the same declaration under different checkout
+    # roots can have been resolved to weaker/stronger canonical ids
+    # independently -- once they coalesce into one node (merge_entity_facts),
+    # the resolver must be rebuilt from the coalesced node's own merged
+    # attrs, not keep whichever pre-merge alias a dict comprehension happened
+    # to keep last (Codex review, fresh evidence, third round).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    new_id_raw = "type://lambda at /new/checkout/lib.hpp:4:37"
+    g = SourceGraphSummary.from_dict(
+        {
+            "schema_version": 2,
+            "nodes": [
+                # No usr -- would resolve to a weaker sig:-tier canonical id.
+                {"id": old_id, "kind": "record_type", "label": old_id},
+                # Carries a usr -- the coalesced node inherits it via
+                # merge_entity_facts, so the rebuilt resolver must reflect it.
+                {
+                    "id": new_id_raw,
+                    "kind": "record_type",
+                    "label": new_id_raw,
+                    "attrs": {"usr": "c:@S@Widget"},
+                },
+            ],
+            "edges": [],
+            "entity_resolver": {"aliases": {}, "conflicts": []},
+        }
+    )
+    assert len(g.nodes) == 1
+    assert g.entity_resolver.canonical_id_for(g.nodes[0].id) == "usr:c:@S@Widget"
+
+
+def test_source_graph_summary_from_dict_recomputes_coverage_after_coalescing() -> None:
+    # coverage's node_kinds/source_decls counts are stale the moment
+    # migration coalesces two persisted nodes into one -- from_dict() must
+    # recompute them (via finalize()), not copy the pre-migration payload
+    # verbatim (Codex review, fresh evidence, third round).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    g = SourceGraphSummary.from_dict(
+        {
+            "schema_version": 2,
+            "coverage": {"source_decls": 99, "node_kinds": {"record_type": 99}},
+            "nodes": [
+                {
+                    "id": "type://lambda at /old/checkout/lib.hpp:4:37",
+                    "kind": "record_type",
+                    "label": "lambda at /old/checkout/lib.hpp:4:37",
+                },
+                {
+                    "id": "type://lambda at /new/checkout/lib.hpp:4:37",
+                    "kind": "record_type",
+                    "label": "lambda at /new/checkout/lib.hpp:4:37",
+                },
+            ],
+            "edges": [],
+        }
+    )
+    assert len(g.nodes) == 1
+    assert g.coverage["node_kinds"] == {"record_type": 1}

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -765,3 +765,30 @@ def test_constructor_seeded_graph_normalizes_ids_and_endpoints() -> None:
     )
     assert len(collided.nodes) == 1
     assert collided.has_node(collided.nodes[0].id)
+
+
+def test_add_node_and_add_edge_normalize_a_hand_built_id_directly() -> None:
+    # A hand-built or custom producer calling add_node()/add_edge() directly on an
+    # empty SourceGraphSummary() -- the most common real construction shape, used by
+    # every producer in abicheck/buildsource/ -- must have its id/endpoint normalized
+    # even when the caller forgot to route it through _decl_node_id/_type_node_id
+    # itself (Codex review, fresh evidence, sixteenth round): otherwise two
+    # checkout-equivalent graphs built this way still get different node ids and
+    # graph ids.
+    from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    new_id = "type://lambda at /new/checkout/lib.hpp:4:37"
+
+    old_graph = SourceGraphSummary()
+    old_graph.add_node(GraphNode(id=old_id, kind="record_type", label=old_id))
+    old_graph.add_edge(GraphEdge(src="decl://foo", dst=old_id, kind="DECL_HAS_TYPE"))
+
+    new_graph = SourceGraphSummary()
+    new_graph.add_node(GraphNode(id=new_id, kind="record_type", label=new_id))
+    new_graph.add_edge(GraphEdge(src="decl://foo", dst=new_id, kind="DECL_HAS_TYPE"))
+
+    assert old_graph.nodes[0].id == new_graph.nodes[0].id
+    assert old_graph.edges[0].dst == new_graph.edges[0].dst
+    assert old_graph.finalize().graph_id == new_graph.finalize().graph_id

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -554,3 +554,46 @@ def test_facts_normalize_before_merge_so_checkout_taint_never_becomes_a_conflict
     blob = str(d["facts"])
     assert "/old/checkout" not in blob
     assert "/new/checkout" not in blob
+
+
+def test_bare_marker_normalization_does_not_cross_into_a_later_quoted_literal() -> None:
+    # A real, unquoted marker followed later in the same string by an
+    # unrelated quoted coordinate-shaped literal must not have its greedy
+    # path group wander past its own real terminator and into the quoted
+    # text -- the "inside quotes" guard only checks where a match STARTS,
+    # not whether it crosses into a quoted span it never started inside of
+    # (Codex review, fresh evidence).
+    from abicheck.buildsource.graph_facts import _strip_bare_anonymous_type_location
+
+    name = 'Wrapper<lambda at /a/foo.hpp:4:37, Tag<"/literal/path:9:9">>'
+    result = _strip_bare_anonymous_type_location(name)
+
+    # The real marker normalizes correctly (checkout dir stripped, real
+    # coordinates 4:37 kept).
+    assert "lambda:foo.hpp:4:37" in result
+    # The quoted literal survives completely untouched -- its own
+    # coordinate-shaped content is not consumed by the real marker's match.
+    assert '"/literal/path:9:9"' in result
+
+
+def test_source_graph_summary_from_dict_preserves_unrecognized_coverage_fields() -> (
+    None
+):
+    # finalize() (called unconditionally by from_dict() to recompute
+    # graph_id/coverage post-migration) must not silently discard an
+    # additive coverage field a newer/third-party producer wrote that this
+    # build doesn't recognize -- the same forward-compat rule every other
+    # dataclass field in this module already follows (Codex review, fresh
+    # evidence).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    pack = {
+        "nodes": [],
+        "edges": [],
+        "coverage": {"future_metric": {"x": 1}},
+    }
+    graph = SourceGraphSummary.from_dict(pack)
+    assert graph.coverage["future_metric"] == {"x": 1}
+    # The recognized structural keys are still recomputed from the actual
+    # (empty) node/edge set, not trusted from the persisted payload.
+    assert graph.coverage["source_decls"] == 0

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -818,3 +818,28 @@ def test_normalize_graph_identity_fast_path_is_safe_and_effective() -> None:
     new = _normalize_graph_identity("lambda at /new/checkout/lib.hpp:4:37")
     assert old == new
     assert "/old/checkout" not in old
+
+
+def test_constructor_seeded_entity_resolver_is_rebuilt_after_normalization() -> None:
+    # SourceGraphSummary(nodes=..., entity_resolver=...) built directly with a
+    # caller-supplied resolver must have that resolver rebuilt against the
+    # normalized/coalesced nodes, the same way from_dict() already rebuilds a
+    # persisted resolver after migration (Codex review, fresh evidence, eighteenth
+    # round) -- otherwise the resolver stays keyed by the pre-normalization id and
+    # canonical_id_for() on the real (normalized) node id returns None.
+    from abicheck.buildsource.entity_resolver import EntityResolver
+    from abicheck.buildsource.graph_facts import GraphNode
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    raw_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    stale_resolver = EntityResolver(aliases={raw_id: "some-stale-canonical-id"})
+
+    graph = SourceGraphSummary(
+        nodes=[
+            GraphNode(id=raw_id, kind="record_type", label=raw_id, attrs={"usr": "u1"})
+        ],
+        entity_resolver=stale_resolver,
+    )
+    normalized_id = graph.nodes[0].id
+    assert normalized_id != raw_id  # sanity: normalization actually happened
+    assert graph.entity_resolver.canonical_id_for(normalized_id) is not None

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -358,3 +358,46 @@ def test_source_graph_summary_from_dict_recomputes_coverage_after_coalescing() -
     )
     assert len(g.nodes) == 1
     assert g.coverage["node_kinds"] == {"record_type": 1}
+
+
+def test_normalization_never_touches_non_decl_or_type_node_ids() -> None:
+    # A non-declaration node whose id/label happens to spell marker-shaped
+    # text -- e.g. a source:// node at a real path literally containing
+    # "lambda at ...:1:2" -- must not be rewritten just because the text
+    # coincidentally matches; the normalization is gated to decl://type://
+    # ids only (Codex review, fresh evidence, sixth round). Only a genuine
+    # decl/type node still normalizes.
+    from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
+
+    raw_source_id = "source:///tmp/lambda at build/foo.hpp:1:2"
+    raw_source_label = "/tmp/lambda at build/foo.hpp:1:2"
+    n = GraphNode.from_dict(
+        {"id": raw_source_id, "kind": "source", "label": raw_source_label}
+    )
+    assert n.id == raw_source_id
+    assert n.label == raw_source_label
+
+    e = GraphEdge.from_dict(
+        {
+            "src": raw_source_id,
+            "dst": raw_source_id,
+            "edge": "COMPILE_UNIT_INCLUDES_FILE",
+        }
+    )
+    assert e.src == raw_source_id
+    assert e.dst == raw_source_id
+
+    # ensure_facts_and_resolve's own label normalization (add_node's path,
+    # not from_dict) is gated the same way.
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    g = SourceGraphSummary()
+    g.add_node(GraphNode(id=raw_source_id, kind="source", label=raw_source_label))
+    assert g.nodes[0].label == raw_source_label
+
+    # A genuine decl/type node under the identical marker text still
+    # normalizes correctly -- the gate doesn't just disable everything.
+    decl_id = "decl://lambda at /old/checkout/foo.hpp:1:2"
+    d = GraphNode.from_dict({"id": decl_id, "kind": "source_decl", "label": decl_id})
+    assert d.id != decl_id
+    assert "/old/checkout" not in d.id

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -843,3 +843,33 @@ def test_constructor_seeded_entity_resolver_is_rebuilt_after_normalization() -> 
     normalized_id = graph.nodes[0].id
     assert normalized_id != raw_id  # sanity: normalization actually happened
     assert graph.entity_resolver.canonical_id_for(normalized_id) is not None
+
+
+def test_vtable_node_id_strips_checkout_directory_and_migrates() -> None:
+    # A vtable's own identity is its owning (possibly anonymous, polymorphic) record's --
+    # vtable:// must join decl://type://template_decl://template_instantiation:// in both
+    # fresh-build normalization and load-time migration, the same choke points every other
+    # decl/type-derived kind already routes through (Codex review, fresh evidence,
+    # nineteenth round).
+    from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
+    from abicheck.buildsource.source_graph import _vtable_node_id
+
+    old = _vtable_node_id("lambda at /old/checkout/lib.hpp:4:37")
+    new = _vtable_node_id("lambda at /new/checkout/lib.hpp:4:37")
+    assert old == new
+    assert "/old/checkout" not in old
+
+    # Load-time migration: a pre-normalization persisted vtable:// node/edge must migrate
+    # to the identical id a fresh build produces.
+    raw_label = "lambda at /old/checkout/lib.hpp:4:37"
+    node = GraphNode.from_dict(
+        {"id": f"vtable://{raw_label}", "kind": "vtable", "label": raw_label}
+    )
+    fresh_id = _vtable_node_id("lambda at /new/checkout/lib.hpp:4:37")
+    assert node.id == fresh_id
+    assert "/old/checkout" not in node.label
+
+    edge = GraphEdge.from_dict(
+        {"src": "decl://foo", "dst": f"vtable://{raw_label}", "edge": "TYPE_HAS_VTABLE"}
+    )
+    assert edge.dst == fresh_id

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""L5 source-graph node ids/labels for anonymous-tag/lambda-closure type
+identities must not embed a checkout-dependent directory (ADR-031/ADR-048).
+
+Split out of ``test_source_graph.py`` (which sits at its own AI-readiness
+line-count cap) rather than appended there. Regression coverage for the
+reported oneDNN/oneDPL "risk declaration_renamed" false positive: a real
+declaration's identity falls back to its raw ``"lambda at <path>:<line>:
+<col>"`` spelling, and two builds of the identical, unedited declaration
+under different checkout roots must reconcile to identical L5 node ids and
+labels rather than reading as a real rename.
+"""
+
+from __future__ import annotations
+
+from abicheck.buildsource.build_evidence import BuildEvidence
+from abicheck.buildsource.source_abi import (
+    SourceAbiSurface,
+    SourceEntity,
+    SourceLocation,
+)
+from abicheck.buildsource.source_graph import _type_node_id, build_source_graph
+
+
+def _entity(qn: str, kind: str) -> SourceEntity:
+    return SourceEntity(
+        id=qn,
+        kind=kind,
+        qualified_name=qn,
+        source_location=SourceLocation(
+            path="include/foo.h", line=1, origin="PUBLIC_HEADER"
+        ),
+        visibility="public_header",
+    )
+
+
+def test_type_node_id_strips_checkout_directory_from_parenthesized_lambda_marker() -> (
+    None
+):
+    # castxml/clang qualType-style spelling, as strip_anonymous_type_location
+    # already handles for the L2 header-AST backend.
+    old = _type_node_id("raii_guard<(lambda at /old/checkout/lib.hpp:4:37)>")
+    new = _type_node_id("raii_guard<(lambda at /new/checkout/lib.hpp:4:37)>")
+    assert old == new
+
+
+def test_type_node_id_strips_checkout_directory_from_bare_lambda_marker() -> None:
+    # Observed directly in real L5 graphs (oneDNN/oneDPL): a bare "lambda at
+    # <path>:<line>:<col>" identity with no wrapping parens at all -- a shape
+    # strip_anonymous_type_location's own paren-anchored regex does not match.
+    old = _type_node_id(
+        "lambda at /tmp/abicheck-eval/pkgs/onedpl/nanorange.hpp:16516:32"
+    )
+    new = _type_node_id("lambda at /mnt/pr-gate/onedpl-inc/nanorange.hpp:16516:32")
+    assert old == new
+    # A genuinely different header (different basename) at the same
+    # coordinates must still stay distinct.
+    other_header = _type_node_id("lambda at /mnt/pr-gate/other.hpp:16516:32")
+    assert other_header != old
+
+
+def test_build_source_graph_type_node_label_and_id_are_directory_independent() -> None:
+    # End-to-end: two SourceAbiSurfaces built from the "same" unedited lambda
+    # closure declaration under two different checkout roots must reconcile
+    # to identical node ids and labels, not read as a rename/add+remove pair
+    # purely from directory taint (the reported oneDNN/oneDPL "risk
+    # declaration_renamed" false positive).
+    old_surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    old_surface.reachable_types.append(
+        _entity("lambda at /old/checkout/lib.hpp:4:37", "record")
+    )
+    new_surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    new_surface.reachable_types.append(
+        _entity("lambda at /new/checkout/lib.hpp:4:37", "record")
+    )
+
+    old_graph = build_source_graph(BuildEvidence(), source_abi=old_surface)
+    new_graph = build_source_graph(BuildEvidence(), source_abi=new_surface)
+
+    old_type_nodes = [n for n in old_graph.nodes if n.kind == "record_type"]
+    new_type_nodes = [n for n in new_graph.nodes if n.kind == "record_type"]
+    assert len(old_type_nodes) == len(new_type_nodes) == 1
+    assert old_type_nodes[0].id == new_type_nodes[0].id
+    assert old_type_nodes[0].label == new_type_nodes[0].label

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -792,3 +792,29 @@ def test_add_node_and_add_edge_normalize_a_hand_built_id_directly() -> None:
     assert old_graph.nodes[0].id == new_graph.nodes[0].id
     assert old_graph.edges[0].dst == new_graph.edges[0].dst
     assert old_graph.finalize().graph_id == new_graph.finalize().graph_id
+
+
+def test_normalize_graph_identity_fast_path_is_safe_and_effective() -> None:
+    # A real header-graph attach-cost CI regression (~31% at 400 decls/castxml) traced
+    # to _normalize_graph_identity's two chained regex passes running on every id/
+    # label/attrs pair for every decl/type node, several times over, across the
+    # several rounds this whole mechanism accreted through. Both underlying regexes
+    # require the literal substring "at" before the location text, so a string
+    # without it can never match either one -- a plain substring check short-circuits
+    # the expensive path with no correctness cost.
+    from abicheck.buildsource.graph_facts import _normalize_graph_identity
+
+    # No "at" substring anywhere: fast-pathed, unchanged.
+    no_at = "my_namespace::WidgetFactory"
+    assert "at" not in no_at
+    assert _normalize_graph_identity(no_at) == no_at
+
+    # An "at" substring that isn't part of a real marker: not fast-pathed, but still
+    # correctly returned unchanged (no spurious match).
+    assert _normalize_graph_identity("Category") == "Category"
+
+    # A real marker (contains "at") still normalizes correctly through the full path.
+    old = _normalize_graph_identity("lambda at /old/checkout/lib.hpp:4:37")
+    new = _normalize_graph_identity("lambda at /new/checkout/lib.hpp:4:37")
+    assert old == new
+    assert "/old/checkout" not in old

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -728,3 +728,40 @@ def test_normalization_known_limitation_same_basename_different_directory() -> N
     new = _type_node_id("lambda at /repo/include/v2/config.hpp:4:37")
     # Known-bad: two genuinely distinct declarations collide onto one node id.
     assert old == new
+
+
+def test_constructor_seeded_graph_normalizes_ids_and_endpoints() -> None:
+    # SourceGraphSummary(nodes=..., edges=...) built directly (bypassing
+    # add_node/add_edge, and never routing through _decl_node_id/_type_node_id) must
+    # normalize a hand-built decl/type id/endpoint the same way GraphNode/GraphEdge.
+    # from_dict() already migrate a persisted one (Codex review, fresh evidence,
+    # fourteenth round) -- otherwise two checkout-equivalent nodes built this way get
+    # different ids/graph ids and their labels misleadingly become identical (only the
+    # label was normalized, not the id).
+    from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    new_id = "type://lambda at /new/checkout/lib.hpp:4:37"
+    old_graph = SourceGraphSummary(
+        nodes=[GraphNode(id=old_id, kind="record_type", label=old_id)],
+        edges=[GraphEdge(src="decl://foo", dst=old_id, kind="DECL_HAS_TYPE")],
+    )
+    new_graph = SourceGraphSummary(
+        nodes=[GraphNode(id=new_id, kind="record_type", label=new_id)],
+        edges=[GraphEdge(src="decl://foo", dst=new_id, kind="DECL_HAS_TYPE")],
+    )
+    assert old_graph.nodes[0].id == new_graph.nodes[0].id
+    assert old_graph.edges[0].dst == new_graph.edges[0].dst
+    assert old_graph.compute_graph_id() == new_graph.compute_graph_id()
+
+    # Two constructor-seeded nodes colliding only after normalization coalesce into
+    # one, rather than desyncing the id index from len(self.nodes).
+    collided = SourceGraphSummary(
+        nodes=[
+            GraphNode(id=old_id, kind="record_type", label=old_id),
+            GraphNode(id=new_id, kind="record_type", label=new_id),
+        ]
+    )
+    assert len(collided.nodes) == 1
+    assert collided.has_node(collided.nodes[0].id)

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -618,3 +618,28 @@ def test_bare_marker_normalization_known_limitation_marker_text_in_path() -> Non
     result = _strip_bare_anonymous_type_location(name)
     # Known-bad: the real, checkout-dependent "/tmp/" prefix survives.
     assert "/tmp/" in result
+
+
+def test_source_graph_summary_from_dict_preserves_unrecognized_nested_coverage_fields() -> (
+    None
+):
+    # finalize()'s forward-compat merge must reach every nesting level, not
+    # only the top-level coverage keys: a newer/third-party producer's own
+    # additive metadata *inside* a recognized section (e.g. call_edges) must
+    # survive a load too, since a top-level-only spread still replaces each
+    # nested section wholesale (Codex review, fresh evidence).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    pack = {
+        "nodes": [],
+        "edges": [],
+        "coverage": {
+            "call_edges": {"collected": False, "count": 0, "future_detail": "keep"},
+        },
+    }
+    graph = SourceGraphSummary.from_dict(pack)
+    assert graph.coverage["call_edges"]["future_detail"] == "keep"
+    # The recognized nested keys are still recomputed from the actual
+    # (empty) edge set, not trusted from the persisted payload.
+    assert graph.coverage["call_edges"]["collected"] is False
+    assert graph.coverage["call_edges"]["count"] == 0

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -505,3 +505,52 @@ def test_resolve_entities_rebuild_does_not_reintroduce_taint_from_loaded_pack() 
     assert "/old/checkout" not in old_canonical
     assert "/new/checkout" not in new_canonical
     assert old_canonical == new_canonical
+
+
+def test_facts_normalize_before_merge_so_checkout_taint_never_becomes_a_conflict() -> (
+    None
+):
+    # Two facts for the same decl/type node -- e.g. two producers, or two
+    # pre-migration nodes that coalesced onto one id -- reporting an
+    # identical declaration under two different checkout roots must merge
+    # without a spurious FactConflict, and the raw checkout-tainted spelling
+    # must not survive anywhere in the persisted facts list either (Codex
+    # review, fresh evidence).
+    from abicheck.buildsource.graph_facts import GraphFact, GraphNode, _decl_node_id
+
+    qn_template = "raii_guard<(lambda at {}/lib.hpp:4:37)>"
+    old_qn = qn_template.format("/old/checkout")
+    new_qn = qn_template.format("/new/checkout")
+
+    node = GraphNode(
+        id=_decl_node_id(old_qn),
+        kind="source_decl",
+        label=old_qn,
+        facts=[
+            GraphFact(
+                producer="header_graph",
+                confidence="high",
+                attrs={"name": old_qn, "qualified_name": old_qn},
+            ),
+            GraphFact(
+                producer="call_graph",
+                confidence="high",
+                attrs={"name": new_qn, "qualified_name": new_qn},
+            ),
+        ],
+    )
+
+    from abicheck.buildsource.graph_facts import ensure_facts_and_resolve
+
+    ensure_facts_and_resolve(node)
+
+    # No conflict: the two facts agree once directory taint is stripped.
+    assert node.conflicts == []
+    assert "/old/checkout" not in node.attrs["name"]
+    assert "/new/checkout" not in node.attrs["name"]
+
+    # The persisted facts list itself must not leak either checkout root.
+    d = node.to_dict()
+    blob = str(d["facts"])
+    assert "/old/checkout" not in blob
+    assert "/new/checkout" not in blob

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -95,3 +95,54 @@ def test_build_source_graph_type_node_label_and_id_are_directory_independent() -
     assert len(old_type_nodes) == len(new_type_nodes) == 1
     assert old_type_nodes[0].id == new_type_nodes[0].id
     assert old_type_nodes[0].label == new_type_nodes[0].label
+
+
+def test_bare_marker_normalization_skips_quoted_literals() -> None:
+    # A C++20 fixed-string NTTP argument can quote text that merely *looks*
+    # like a bare anonymous/lambda marker (Codex review, fresh evidence) --
+    # a real marker is never itself quoted, so rewriting one inside a quoted
+    # literal would fabricate a same-identity collision between two
+    # genuinely distinct specializations quoting different paths.
+    old = _type_node_id('Tag<"lambda at /a/foo.hpp:1:2">')
+    new = _type_node_id('Tag<"lambda at /b/foo.hpp:1:2">')
+    assert old != new
+    # An actual, unquoted bare marker alongside quoted lookalike text is
+    # still normalized.
+    mixed = _type_node_id(
+        'Wrapper<"lambda at /a/foo.hpp:1:2", (lambda at /c/bar.hpp:9:1)>'
+    )
+    assert "/a/foo.hpp" in mixed
+    assert "/c/bar.hpp" not in mixed
+
+
+def test_graph_node_from_dict_migrates_pre_normalization_ids() -> None:
+    # A build-source pack persisted before this normalization existed
+    # carries the old, raw, checkout-path-bearing node id/label -- loading
+    # it must migrate transparently (Codex review, fresh evidence), or a
+    # freshly-generated graph for the identical, unedited declaration would
+    # never match it and diff_source_graph would read it as removed+added.
+    from abicheck.buildsource.graph_facts import GraphNode
+
+    old_node = GraphNode.from_dict(
+        {
+            "id": "type://lambda at /old/checkout/lib.hpp:4:37",
+            "kind": "record_type",
+            "label": "lambda at /old/checkout/lib.hpp:4:37",
+        }
+    )
+    fresh_id = _type_node_id("lambda at /new/checkout/lib.hpp:4:37")
+    assert old_node.id == fresh_id
+    assert old_node.label == "lambda:lib.hpp:4:37"
+
+
+def test_graph_edge_from_dict_migrates_pre_normalization_endpoints() -> None:
+    from abicheck.buildsource.graph_facts import GraphEdge
+
+    old_edge = GraphEdge.from_dict(
+        {
+            "src": "decl://foo",
+            "dst": "type://lambda at /old/checkout/lib.hpp:4:37",
+            "edge": "DECL_HAS_TYPE",
+        }
+    )
+    assert old_edge.dst == _type_node_id("lambda at /new/checkout/lib.hpp:4:37")

--- a/tests/test_source_graph_directory_taint.py
+++ b/tests/test_source_graph_directory_taint.py
@@ -146,3 +146,73 @@ def test_graph_edge_from_dict_migrates_pre_normalization_endpoints() -> None:
         }
     )
     assert old_edge.dst == _type_node_id("lambda at /new/checkout/lib.hpp:4:37")
+
+
+def test_source_graph_summary_from_dict_recomputes_stale_graph_id() -> None:
+    # A persisted graph_id was only ever trustworthy for the exact,
+    # pre-migration content it was computed over -- to_dict() reuses a
+    # truthy self.graph_id as-is, so a stale value must not survive a load
+    # that changed node ids underneath it (Codex review, fresh evidence).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    g = SourceGraphSummary.from_dict(
+        {
+            "schema_version": 2,
+            "graph_id": "sha256:deliberately-stale",
+            "nodes": [
+                {
+                    "id": "type://lambda at /old/checkout/lib.hpp:4:37",
+                    "kind": "record_type",
+                    "label": "lambda at /old/checkout/lib.hpp:4:37",
+                }
+            ],
+            "edges": [],
+        }
+    )
+    assert g.graph_id != "sha256:deliberately-stale"
+    assert g.graph_id == g.compute_graph_id()
+
+
+def test_source_graph_summary_from_dict_migrates_entity_resolver_aliases() -> None:
+    # An EntityResolver persisted alongside a pre-normalization graph is
+    # keyed by the OLD, pre-migration node id -- canonical_id_for(node.id)
+    # must still resolve after load, or a persisted canonical identity goes
+    # silently unreachable (Codex review, fresh evidence).
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    old_id = "type://lambda at /old/checkout/lib.hpp:4:37"
+    g = SourceGraphSummary.from_dict(
+        {
+            "schema_version": 2,
+            "nodes": [{"id": old_id, "kind": "record_type", "label": old_id}],
+            "edges": [],
+            "entity_resolver": {
+                "aliases": {old_id: "usr:c:@S@Widget"},
+                "conflicts": [],
+            },
+        }
+    )
+    migrated_id = g.nodes[0].id
+    assert migrated_id != old_id
+    assert g.entity_resolver.canonical_id_for(migrated_id) == "usr:c:@S@Widget"
+    assert g.entity_resolver.canonical_id_for(old_id) is None
+
+
+def test_add_node_normalizes_label_for_any_producer() -> None:
+    # Label normalization is centralized in ensure_facts_and_resolve (Codex
+    # review, fresh evidence) so it covers every decl/type producer that
+    # calls SourceGraphSummary.add_node -- not just the two that happened to
+    # build GraphNodes directly in source_graph.py/type_graph.py.
+    from abicheck.buildsource.graph_facts import GraphNode
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    g = SourceGraphSummary()
+    g.add_node(
+        GraphNode(
+            id="decl://x",
+            kind="source_decl",
+            label="lambda at /some/checkout/foo.hpp:9:1",
+            provenance="call_graph",
+        )
+    )
+    assert g.nodes[0].label == "lambda:foo.hpp:9:1"


### PR DESCRIPTION
## Summary

Strip a checkout-dependent absolute directory out of L5 source-graph decl/type node ids and labels for anonymous-tag/lambda-closure type identities.

## Motivation

An anonymous-tag or lambda-closure type's identity falls back to its raw declaration spelling — `"(unnamed struct at /a/foo.h:56:5)"` (castxml/clang qualType form) or a bare `"lambda at /a/foo.h:4:37"` (observed directly in real L5 graphs, no wrapping parens at all) — which embeds an *absolute* checkout path. `abicheck/buildsource/source_graph.py`'s `_decl_node_id`/`_type_node_id` interpolated this identity verbatim into the node id, and every L5 producer built the node's own `label` from the same raw identity independently. Two builds of the identical, unedited declaration under different checkout roots therefore produced two different L5 node ids/labels, which `graph_reconcile.py`/`diff_source_graph_findings.py` read as a real rename — a `risk declaration_renamed` finding with `old_value`/`new_value` differing only by directory (reported against real oneDNN/oneDPL binaries: 3 + 1 occurrences).

## Changes

- `abicheck/buildsource/graph_facts.py`: new `_normalize_graph_identity()` (strips the parenthesized qualType-style marker via `name_classification.strip_anonymous_type_location`, plus a new bare-form regex for the unparenthesized shape observed in practice), and `_decl_node_id()`/`_type_node_id()` moved here from `source_graph.py` so they route every identity through it — the one choke point every L5 producer (`type_graph.py`, `call_graph.py`, `override_graph.py`, `callback_graph.py`, `template_graph.py`, `header_graph.py`, `macro_graph.py`, `source_graph.py` itself) already shares for building a decl/type node id and every edge endpoint naming it.
- `abicheck/buildsource/source_graph.py`: re-exports the moved names (mypy `--no-implicit-reexport`-compliant `X as X` aliasing, matching the existing `GraphNode`/`GraphFact` convention); every `GraphNode(..., label=...)` construction site that built a label from the same raw decl/type identity now normalizes it too, since the reported finding's `old_value`/`new_value` come from the node *label*, not the id.
- `abicheck/buildsource/type_graph.py`: same label-normalization fix at its own `augment_graph_with_types()` node-construction site.
- Moved (not net-added) to `graph_facts.py` rather than kept in `source_graph.py`, which sat exactly at its 2000-line AI-readiness hard cap.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: incomplete normalization — a checkout-dependent absolute path embedded in a decl/type node identity (both the parenthesized and a previously-unhandled bare spelling) leaked into the L5 graph node id *and* label, instead of being stripped the way the L2 header-AST backend already strips the parenthesized form at extraction time.
- Publicly observable failure: `graph explain`/`--source-graph` output and the `declaration_renamed` RISK finding report two different node ids and two different `old_value`/`new_value` strings for the *same* unedited declaration purely because it was built/extracted under two different checkout roots.
- Regression test fails on base: yes — all three tests in `tests/test_source_graph_directory_taint.py` fail against the pre-fix code (confirmed by running them with the source changes reverted via `git stash`), and pass post-fix.
- Negative control: yes — `test_type_node_id_strips_checkout_directory_from_bare_lambda_marker` also asserts a genuinely different header (different basename) at the same `:line:col` coordinates still produces a *distinct* node id, so the fix can't collapse two real, different anonymous types onto one identity.
- Public-surface test: yes — `test_build_source_graph_type_node_label_and_id_are_directory_independent` goes through the real public entry point (`build_source_graph(BuildEvidence(), source_abi=SourceAbiSurface(...))`), not just the internal `_type_node_id` helper.
- Axes covered: both the parenthesized (castxml/clang qualType) marker shape and the bare (unparenthesized) shape reported in the real-world evidence; both the node `id` and the node `label` construction sites.
- General invariant: fixed at the single choke point (`_decl_node_id`/`_type_node_id`) every L5 producer in `abicheck/buildsource/` already routes a decl/type identity through, plus the label-construction sites that independently derive from the same raw identity — not a patch scoped to one producer or one reported string.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed (internal L5 graph identity fix; no user-facing doc describes this internal id/label shape)
- [x] `ruff check`, `ruff format --check`, `mypy`, `scripts/check_ai_readiness.py` pass locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H83t7Y6CqtFxTRd7m8b93M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Source-graph identities for anonymous structs and lambda types no longer depend on checkout directories.
  - Persisted graphs, edges, labels, aliases, and graph IDs are normalized and reconciled consistently.
  - Quoted literals and non-declaration identifiers are preserved during normalization.
  - Graph coverage data, including additional fields, is retained during migration and reload.

- **Documentation**
  - Added changelog coverage for checkout-independent source-graph identities.

- **Tests**
  - Added regression and migration tests covering identity normalization, graph reconciliation, aliases, coverage, and edge updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->