### PR TITLE
fix: typedef bare-name collision and clang lambda-location leak in qualified_name

### DIFF
--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -357,6 +357,34 @@ def build_type_map(types: Iterable[Q]) -> TypeMap[Q]:
     return TypeMap(types)
 
 
+def typedef_diff_maps(
+    old: AbiSnapshot, new: AbiSnapshot
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Return the ``(old, new)`` alias->underlying-type maps to diff typedefs
+    over, preferring the qualified-name-keyed twin when both sides carry one.
+
+    ``AbiSnapshot.typedefs`` is keyed by *bare* (unqualified) name on both
+    header backends, so two distinct member/nested typedefs that happen to
+    share a bare spelling in different classes/namespaces (e.g. two unrelated
+    ``impl_value_t`` member aliases on different classes) silently collapse
+    onto one dict entry, whichever declaration the backend visits last
+    winning (see that field's own docstring in ``model.py`` for the full
+    incident history). Diffing that collapsed dict directly means an
+    unrelated class gaining or losing its own same-named alias can flip the
+    surviving entry's recorded value, fabricating a spurious
+    ``TYPEDEF_BASE_CHANGED`` for a typedef that never itself changed.
+
+    ``AbiSnapshot.typedefs_qualified`` (schema v25) carries the identical set
+    of typedef declarations keyed by qualified name instead, unique per
+    declaration and therefore immune to this collision. Used whenever both
+    sides populate it; falls back to the legacy bare maps otherwise (a
+    DWARF-only or pre-v25 snapshot) so that comparison path is unaffected.
+    """
+    if old.typedefs_qualified and new.typedefs_qualified:
+        return old.typedefs_qualified, new.typedefs_qualified
+    return old.typedefs, new.typedefs
+
+
 def lookup_matched_type(own: TypeMap[Q], other: TypeMap[Q], t: Q) -> Q | None:
     """Look up *t*'s counterpart in *other* (the opposite old/new ``TypeMap``
     from the one *t* itself came from, ``own``), trying both *t*'s own

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -376,11 +376,24 @@ def typedef_diff_maps(
 
     ``AbiSnapshot.typedefs_qualified`` (schema v25) carries the identical set
     of typedef declarations keyed by qualified name instead, unique per
-    declaration and therefore immune to this collision. Used whenever both
-    sides populate it; falls back to the legacy bare maps otherwise (a
-    DWARF-only or pre-v25 snapshot) so that comparison path is unaffected.
+    declaration and therefore immune to this collision. A side "trusts" its
+    own qualified map when that map is non-empty, OR its legacy bare map is
+    itself empty (a side with zero typedefs total loses nothing by reporting
+    zero qualified ones either, whether or not it actually populates the
+    field) -- this is what lets an old side with real qualified typedefs
+    still enumerate every one of them as removed when the new side has
+    genuinely stripped all typedefs (rather than merely never populating the
+    field), instead of collapsing to the legacy bare map and losing
+    per-declaration granularity purely because the empty side's qualified
+    dict is indistinguishable, by non-emptiness alone, from "unsupported"
+    (Codex review). Used only when *both* sides trust their own map this
+    way; falls back to the legacy bare maps otherwise (a DWARF-only or
+    pre-v25 snapshot with real typedefs) so that comparison path is
+    unaffected.
     """
-    if old.typedefs_qualified and new.typedefs_qualified:
+    old_trusts_qualified = bool(old.typedefs_qualified) or not old.typedefs
+    new_trusts_qualified = bool(new.typedefs_qualified) or not new.typedefs
+    if old_trusts_qualified and new_trusts_qualified:
         return old.typedefs_qualified, new.typedefs_qualified
     return old.typedefs, new.typedefs
 

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -31,6 +31,7 @@ from .diff_helpers import (
     lookup_matched_type as _lookup_matched_type,
     make_change,
     type_map_key,
+    typedef_diff_maps as _typedef_diff_maps,
 )
 from .diff_symbols import (
     _PUBLIC_VIS,
@@ -1945,10 +1946,15 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     excl = _exclude_stdlib_namespaces(old, new)
     # RD2-5: don't manufacture phantom TYPEDEF_REMOVED when the new side is stripped.
     suppress_removed = _removals_are_unconfirmed(old, new)
-    for alias, old_type in old.typedefs.items():
-        if _is_non_abi_surface_type(alias, exclude_stdlib_namespaces=excl):
+    old_typedefs, new_typedefs = _typedef_diff_maps(old, new)
+    for alias, old_type in old_typedefs.items():
+        # is_non_abi_surface_type's stdlib/anonymous check is defined over a
+        # bare spelling -- use just the trailing component so the qualified
+        # map above doesn't change what this filter excludes.
+        bare_alias = alias.rsplit("::", 1)[-1]
+        if _is_non_abi_surface_type(bare_alias, exclude_stdlib_namespaces=excl):
             continue
-        new_type = new.typedefs.get(alias)
+        new_type = new_typedefs.get(alias)
         if new_type is None and suppress_removed:
             continue
         if new_type is None:
@@ -1960,7 +1966,7 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             # genuine TYPEDEF_REMOVED breaks for names that merely match the
             # version-stamp pattern.
             if _is_version_stamped_typedef(alias) and _has_version_family_successor(
-                alias, new.typedefs
+                alias, new_typedefs
             ):
                 changes.append(
                     make_change(

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -1948,30 +1948,30 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     suppress_removed = _removals_are_unconfirmed(old, new)
     old_typedefs, new_typedefs = _typedef_diff_maps(old, new)
     for alias, old_type in old_typedefs.items():
-        # Checked against the full alias -- the legacy (DWARF) map already
-        # keys typedefs by their fully-qualified spelling, and the qualified
-        # map above is at least as correct for the same std::-prefix check.
+        # Full alias: correct for both legacy-DWARF's and the qualified map's keys.
         if _is_non_abi_surface_type(alias, exclude_stdlib_namespaces=excl):
             continue
+        # symbol/name stay bare like _diff_types (else _enrich_affected_symbols
+        # breaks); qualified_suffix disambiguates description so dedup can't collapse collisions.
+        bare_alias = alias.rsplit("::", 1)[-1]
+        qualified_suffix = f" ({alias})" if alias != bare_alias else ""
         new_type = new_typedefs.get(alias)
         if new_type is None and suppress_removed:
             continue
         if new_type is None:
             # Version-stamped typedefs (e.g. png_libpng_version_1_6_46) are
-            # compile-time sentinels — their name encodes the version and
-            # changes every release intentionally.  They are never exported as
-            # ELF symbols, so their removal is NOT a binary ABI break.
-            # Require a same-family successor in new_typedefs to avoid hiding
-            # genuine TYPEDEF_REMOVED breaks for names that merely match the
-            # version-stamp pattern.
+            # compile-time sentinels that change every release by design and
+            # are never exported as ELF symbols -- not a binary ABI break.
+            # Require a same-family successor to avoid hiding a genuine
+            # TYPEDEF_REMOVED for a name that merely matches the pattern.
             if _is_version_stamped_typedef(alias) and _has_version_family_successor(
                 alias, new_typedefs
             ):
                 changes.append(
                     make_change(
                         ChangeKind.TYPEDEF_VERSION_SENTINEL,
-                        symbol=alias,
-                        name=alias,
+                        symbol=bare_alias,
+                        name=bare_alias,
                         old_value=old_type,
                     )
                 )
@@ -1980,19 +1980,21 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             changes.append(
                 make_change(
                     ChangeKind.TYPEDEF_REMOVED,
-                    symbol=alias,
-                    name=alias,
+                    symbol=bare_alias,
+                    name=bare_alias,
                     old_value=old_type,
+                    description=f"Typedef removed: {bare_alias}{qualified_suffix}",
                 )
             )
         elif new_type != old_type:
             changes.append(
                 make_change(
                     ChangeKind.TYPEDEF_BASE_CHANGED,
-                    symbol=alias,
-                    name=alias,
+                    symbol=bare_alias,
+                    name=bare_alias,
                     old_value=old_type,
                     new_value=new_type,
+                    description=f"Typedef base type changed: {bare_alias}{qualified_suffix}",
                 )
             )
     return changes

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -1948,11 +1948,10 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     suppress_removed = _removals_are_unconfirmed(old, new)
     old_typedefs, new_typedefs = _typedef_diff_maps(old, new)
     for alias, old_type in old_typedefs.items():
-        # is_non_abi_surface_type's stdlib/anonymous check is defined over a
-        # bare spelling -- use just the trailing component so the qualified
-        # map above doesn't change what this filter excludes.
-        bare_alias = alias.rsplit("::", 1)[-1]
-        if _is_non_abi_surface_type(bare_alias, exclude_stdlib_namespaces=excl):
+        # Checked against the full alias -- the legacy (DWARF) map already
+        # keys typedefs by their fully-qualified spelling, and the qualified
+        # map above is at least as correct for the same std::-prefix check.
+        if _is_non_abi_surface_type(alias, exclude_stdlib_namespaces=excl):
             continue
         new_type = new_typedefs.get(alias)
         if new_type is None and suppress_removed:

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -121,6 +121,7 @@ from .model import (
     Variable,
     Visibility,
 )
+from .name_classification import strip_anonymous_type_location
 from .provenance import (
     build_public_set,
     classify_origin,
@@ -1403,16 +1404,22 @@ class _ClangAstParser:
     ) -> RecordType:
         node = entry.node
         kind = override_kind if is_opaque and override_kind else _record_kind(node)
-        own_name = override_name or str(node.get("name", ""))
+        # See strip_anonymous_type_location's docstring: clang, like castxml,
+        # can spell a lambda closure/anonymous type's own name with an
+        # embedded absolute source path (e.g. inside a template argument
+        # list), which must not leak into RecordType.name/.qualified_name --
+        # mirrors dumper_castxml.py's identical stripping at the equivalent
+        # extraction point.
+        own_name = strip_anonymous_type_location(
+            override_name or str(node.get("name", ""))
+        )
         deprecated = dep_msg if dep_msg is not None else _clang_deprecated_message(node)
         if is_opaque:
             # Mirrors dumper_castxml.py's `incomplete="1"` branch.
             return RecordType(
                 name=own_name,
                 kind=kind,
-                qualified_name=(
-                    "::".join([*entry.scope, own_name]) if entry.scope else None
-                ),
+                qualified_name=_clang_qualified_name(entry.scope, own_name),
                 size_bits=None,
                 alignment_bits=None,
                 fields=[],
@@ -1456,9 +1463,7 @@ class _ClangAstParser:
             # a lookup keyed on the tool's own fully-qualified
             # getQualifiedNameAsString() spelling (e.g. "ns::Foo") fell back
             # to the bare "Foo" and never matched (Codex review, G28 Phase 4).
-            qualified_name=(
-                "::".join([*entry.scope, own_name]) if entry.scope else None
-            ),
+            qualified_name=_clang_qualified_name(entry.scope, own_name),
             # clang's JSON AST does not compute layout — size/align/offsets are
             # left None so the layout detectors skip an unknown-vs-unknown
             # comparison (DWARF remains the layout authority on this host).
@@ -1602,8 +1607,9 @@ class _ClangAstParser:
             node = entry.node
             if _is_builtin_file(entry.file):
                 continue
-            name = str(node.get("name", "")) or typedef_names_by_enum_id.get(
-                str(node.get("id", "")), ""
+            name = strip_anonymous_type_location(
+                str(node.get("name", ""))
+                or typedef_names_by_enum_id.get(str(node.get("id", "")), "")
             )
             if not name or name.startswith("__"):
                 continue
@@ -1631,9 +1637,7 @@ class _ClangAstParser:
                     source_location=self._source_location(entry),
                     # See RecordType.qualified_name (_build_record) for why
                     # this is only set when it differs from the bare name.
-                    qualified_name=(
-                        "::".join([*entry.scope, name]) if entry.scope else None
-                    ),
+                    qualified_name=_clang_qualified_name(entry.scope, name),
                     # G31 Phase C: clang's EnumDecl carries a "scopedEnumTag"
                     # key ("class"/"struct") only for an `enum class`/`enum
                     # struct` -- absent (not merely false) for a plain C-style
@@ -1882,6 +1886,23 @@ def _parse_bases(node: dict[str, Any]) -> tuple[list[str], list[str], dict[str, 
             bases.append(bname)
         access[bname] = str(b.get("access", "public"))
     return bases, virtual_bases, access
+
+
+def _clang_qualified_name(scope: tuple[str, ...], own_name: str) -> str | None:
+    """Namespace/enclosing-class-qualified spelling for a RecordType/EnumType,
+    set only when it actually differs from the bare name (mirrors castxml's
+    own ``RecordType.qualified_name`` convention -- see ``_build_record``'s
+    docstring). Each *scope* segment is stripped via
+    :func:`strip_anonymous_type_location` before joining, the same
+    normalization already applied to *own_name* itself at every call site --
+    an enclosing scope can itself be a lambda's local/closure scope, whose
+    clang-spelled name would otherwise leak an embedded absolute source path
+    into the joined qualified name.
+    """
+    if not scope:
+        return None
+    stripped_scope = [strip_anonymous_type_location(s) for s in scope]
+    return "::".join([*stripped_scope, own_name])
 
 
 def _enum_underlying(node: dict[str, Any]) -> str:

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -1404,22 +1404,16 @@ class _ClangAstParser:
     ) -> RecordType:
         node = entry.node
         kind = override_kind if is_opaque and override_kind else _record_kind(node)
-        # See strip_anonymous_type_location's docstring: clang, like castxml,
-        # can spell a lambda closure/anonymous type's own name with an
-        # embedded absolute source path (e.g. inside a template argument
-        # list), which must not leak into RecordType.name/.qualified_name --
-        # mirrors dumper_castxml.py's identical stripping at the equivalent
-        # extraction point.
-        own_name = strip_anonymous_type_location(
-            override_name or str(node.get("name", ""))
-        )
+        own_name = override_name or str(node.get("name", ""))
         deprecated = dep_msg if dep_msg is not None else _clang_deprecated_message(node)
         if is_opaque:
             # Mirrors dumper_castxml.py's `incomplete="1"` branch.
             return RecordType(
                 name=own_name,
                 kind=kind,
-                qualified_name=_clang_qualified_name(entry.scope, own_name),
+                qualified_name=(
+                    "::".join([*entry.scope, own_name]) if entry.scope else None
+                ),
                 size_bits=None,
                 alignment_bits=None,
                 fields=[],
@@ -1463,7 +1457,9 @@ class _ClangAstParser:
             # a lookup keyed on the tool's own fully-qualified
             # getQualifiedNameAsString() spelling (e.g. "ns::Foo") fell back
             # to the bare "Foo" and never matched (Codex review, G28 Phase 4).
-            qualified_name=_clang_qualified_name(entry.scope, own_name),
+            qualified_name=(
+                "::".join([*entry.scope, own_name]) if entry.scope else None
+            ),
             # clang's JSON AST does not compute layout — size/align/offsets are
             # left None so the layout detectors skip an unknown-vs-unknown
             # comparison (DWARF remains the layout authority on this host).
@@ -1607,9 +1603,8 @@ class _ClangAstParser:
             node = entry.node
             if _is_builtin_file(entry.file):
                 continue
-            name = strip_anonymous_type_location(
-                str(node.get("name", ""))
-                or typedef_names_by_enum_id.get(str(node.get("id", "")), "")
+            name = str(node.get("name", "")) or typedef_names_by_enum_id.get(
+                str(node.get("id", "")), ""
             )
             if not name or name.startswith("__"):
                 continue
@@ -1637,7 +1632,9 @@ class _ClangAstParser:
                     source_location=self._source_location(entry),
                     # See RecordType.qualified_name (_build_record) for why
                     # this is only set when it differs from the bare name.
-                    qualified_name=_clang_qualified_name(entry.scope, name),
+                    qualified_name=(
+                        "::".join([*entry.scope, name]) if entry.scope else None
+                    ),
                     # G31 Phase C: clang's EnumDecl carries a "scopedEnumTag"
                     # key ("class"/"struct") only for an `enum class`/`enum
                     # struct` -- absent (not merely false) for a plain C-style
@@ -1737,9 +1734,34 @@ class _Decl:
 
 
 def _qualtype(node: dict[str, Any]) -> str:
+    """A declaration's own ``type.qualType`` spelling -- the single choke
+    point every field/param/variable/function type string in this module is
+    built from (`_parse_fields`, `_parse_functions`'s own signature and
+    param loop, `parse_variables`, `parse_constants`).
+
+    Stripped via :func:`strip_anonymous_type_location`: verified against
+    real Clang 18 (``-ast-dump=json``) that a lambda closure type embedded in
+    a type spelling -- e.g. a class-template specialization instantiated
+    with a lambda argument, ``Guard<decltype([]{})>`` -- prints its
+    ``qualType`` as ``"(lambda at <path>:<line>:<col>)"`` (Clang's
+    TypePrinter, the same diagnostic-style spelling castxml's own XML `name`
+    attribute uses, confirmed on a `FieldDecl` whose declared type IS the
+    lambda type parameter). Left unstripped, that absolute, checkout-
+    dependent path leaks into `TypeField.type`/`Param.type`/`Variable.type`/
+    `Function.return_type`, so two checkouts of the identical, unchanged
+    declaration would produce two different type spellings and could
+    manufacture a spurious finding on the field/param/variable/function
+    carrying it -- the same class of bug `dumper_castxml.py`'s own
+    `strip_anonymous_type_location` calls guard against for its `name`/
+    `qualified_name` fields, just reached through this backend's type-string
+    printer rather than its declaration-name attribute (which, unlike
+    castxml's, never itself embeds a location -- confirmed empirically: a
+    template specialization's own `name` node stays the bare template name,
+    e.g. ``"Guard"``, never ``"Guard<(lambda at ...)>"``).
+    """
     type_obj = node.get("type")
     if isinstance(type_obj, dict):
-        return str(type_obj.get("qualType", ""))
+        return strip_anonymous_type_location(str(type_obj.get("qualType", "")))
     return ""
 
 
@@ -1886,23 +1908,6 @@ def _parse_bases(node: dict[str, Any]) -> tuple[list[str], list[str], dict[str, 
             bases.append(bname)
         access[bname] = str(b.get("access", "public"))
     return bases, virtual_bases, access
-
-
-def _clang_qualified_name(scope: tuple[str, ...], own_name: str) -> str | None:
-    """Namespace/enclosing-class-qualified spelling for a RecordType/EnumType,
-    set only when it actually differs from the bare name (mirrors castxml's
-    own ``RecordType.qualified_name`` convention -- see ``_build_record``'s
-    docstring). Each *scope* segment is stripped via
-    :func:`strip_anonymous_type_location` before joining, the same
-    normalization already applied to *own_name* itself at every call site --
-    an enclosing scope can itself be a lambda's local/closure scope, whose
-    clang-spelled name would otherwise leak an embedded absolute source path
-    into the joined qualified name.
-    """
-    if not scope:
-        return None
-    stripped_scope = [strip_anonymous_type_location(s) for s in scope]
-    return "::".join([*stripped_scope, own_name])
 
 
 def _enum_underlying(node: dict[str, Any]) -> str:

--- a/changelog.d/1787616000_claude_typedef-and-lambda-qualified-name-collisions.md
+++ b/changelog.d/1787616000_claude_typedef-and-lambda-qualified-name-collisions.md
@@ -15,10 +15,17 @@
   whenever both sides populate it, falling back to the legacy bare-keyed
   diff for a DWARF-only or pre-v25 snapshot.
 - **The direct-clang header-AST backend now strips an embedded absolute
-  source path out of `RecordType`/`EnumType` `name`/`qualified_name` the
-  same way `dumper_castxml.py` already does.** A lambda closure/anonymous
-  type's own spelling (or an enclosing scope segment) can carry
-  `"(lambda at <path>:<line>:<col>)"`-shaped text; left unstripped on the
-  clang backend, two checkout directories of the identical, unchanged
-  declaration produced two different type identities and could manufacture
-  a spurious `type_removed`/`type_added` pair.
+  source path out of a field/parameter/variable/function's own recorded
+  type spelling.** A lambda closure type used directly as a template
+  argument (e.g. a function template instantiated with a lambda,
+  `call_with([]{})`) makes clang print that instantiation's own parameter
+  type as `"(lambda at <path>:<line>:<col>)"` — confirmed against real
+  Clang 18 output. Left unstripped, that absolute, checkout-dependent path
+  leaked into `TypeField.type`/`Param.type`/`Variable.type`/
+  `Function.return_type`, so two checkouts of the identical, unchanged
+  declaration could disagree and manufacture a spurious finding on the
+  field/parameter/variable/function carrying it — the same class of bug
+  `dumper_castxml.py`'s own `strip_anonymous_type_location` (commit
+  3aca095) guards against for its `RecordType`/`EnumType` `name`/
+  `qualified_name`, reached here through the clang backend's shared
+  `qualType`-spelling choke point instead.

--- a/changelog.d/1787616000_claude_typedef-and-lambda-qualified-name-collisions.md
+++ b/changelog.d/1787616000_claude_typedef-and-lambda-qualified-name-collisions.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **`diff_types` no longer diffs typedefs through the bare-name-collapsed
+  `AbiSnapshot.typedefs` dict when the qualified twin is available.**
+  `AbiSnapshot.typedefs` is keyed by unqualified alias name on both header
+  backends, so two unrelated member typedefs sharing a bare spelling in
+  different classes (e.g. `X::impl_value_t` declared on many unrelated
+  classes — an ordinary STL-container-shaped pattern) collapse onto one dict
+  entry, with whichever declaration the backend visited last winning. Diffing
+  that collapsed dict directly could flip the surviving entry's recorded
+  value whenever an *unrelated* class gained or lost its own same-named
+  alias, fabricating a spurious `typedef_base_changed` for a typedef that
+  never itself changed. `_diff_typedefs` now prefers
+  `AbiSnapshot.typedefs_qualified` (schema v25, unique per declaration)
+  whenever both sides populate it, falling back to the legacy bare-keyed
+  diff for a DWARF-only or pre-v25 snapshot.
+- **The direct-clang header-AST backend now strips an embedded absolute
+  source path out of `RecordType`/`EnumType` `name`/`qualified_name` the
+  same way `dumper_castxml.py` already does.** A lambda closure/anonymous
+  type's own spelling (or an enclosing scope segment) can carry
+  `"(lambda at <path>:<line>:<col>)"`-shaped text; left unstripped on the
+  clang backend, two checkout directories of the identical, unchanged
+  declaration produced two different type identities and could manufacture
+  a spurious `type_removed`/`type_added` pair.

--- a/tests/test_clang_header_backend_integration.py
+++ b/tests/test_clang_header_backend_integration.py
@@ -110,6 +110,47 @@ def test_clang_ast_does_not_assign_returned_callback_abi_to_factory(tmp_path: Pa
     assert factory.contract_attributes == []
 
 
+def test_clang_ast_strips_lambda_location_from_instantiated_param_type(
+    tmp_path: Path,
+) -> None:
+    """Use Clang's real ``qualType`` spelling for a lambda closure type, not a
+    hand-written fixture -- confirms the fix at `dumper_clang._qualtype`
+    against real Clang 18 output, not a guessed AST shape.
+
+    A function template instantiated with a lambda argument prints that
+    instantiation's own parameter `type.qualType` as ``"(lambda at
+    <path>:<line>:<col>)"`` (confirmed empirically: unlike a `decltype(...)`-
+    or typedef-sugared spelling, which clang keeps sugared in `qualType` and
+    only desugars into this form in the separate `desugaredQualType` key, a
+    template parameter substituted directly with the deduced lambda type has
+    no sugar to keep). The absolute header path leaking into a parameter's
+    own recorded type would make two checkouts of the identical, unchanged
+    declaration disagree.
+    """
+    if shutil.which("clang") is None or platform.machine().lower() not in {
+        "x86_64",
+        "amd64",
+    }:
+        pytest.skip("requires an x86-64 clang frontend")
+    header = tmp_path / "call_with.h"
+    header.write_text(
+        "template <typename F>\n"
+        "inline void call_with(F f) {}\n"
+        "inline void invoke() { call_with([]{}); }\n",
+        encoding="utf-8",
+    )
+
+    root, _, _ = _clang_header_dump(
+        [header], [], compiler="clang", lang="c++", gcc_options="-std=c++20"
+    )
+    funcs = _ClangAstParser(root, {"invoke"}, set()).parse_functions()
+    (specialization,) = [
+        f for f in funcs if f.name == "call_with" and f.mangled != "call_with"
+    ]
+    assert str(tmp_path) not in specialization.params[0].type
+    assert specialization.params[0].type.startswith("(lambda")
+
+
 def _have(tool: str) -> bool:
     return shutil.which(tool) is not None
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1078,44 +1078,57 @@ def test_parse_types_sets_qualified_name_for_namespaced_record() -> None:
     assert types["Global"].qualified_name is None
 
 
-def test_parse_types_strips_anonymous_type_location_from_qualified_name() -> None:
-    """Mirrors dumper_castxml.py's identical fix (commit 3aca095): a
-    record's own name (or an enclosing scope segment) can embed an absolute
-    source path/line/column the same way castxml's lambda/anonymous-type
-    spelling does, and it must not leak into RecordType.name/.qualified_name
-    -- two checkout directories of the identical, unchanged declaration would
-    otherwise produce two different type identities and manufacture a
-    spurious type_removed/type_added pair.
+def test_qualtype_strips_anonymous_type_location_from_field_and_param_types() -> None:
+    """A field/param whose declared type is itself a lambda closure (e.g. a
+    class-template specialization instantiated with a lambda argument,
+    ``Guard<decltype([]{})>``) has clang print its `type.qualType` as
+    ``"(lambda at <path>:<line>:<col>)"`` -- verified against real Clang 18
+    output (see `_qualtype`'s own docstring). Left unstripped, that embeds an
+    absolute, checkout-dependent path into `TypeField.type`/`Param.type`,
+    which would manufacture a spurious finding across two checkouts of the
+    identical, unchanged declaration.
     """
     root = _tu(
         {
-            "kind": "NamespaceDecl",
-            "name": "ns",
+            "kind": "CXXRecordDecl",
+            "name": "Guard",
+            "tagUsed": "struct",
             "loc": {"file": "include/foo.h", "line": 1},
+            "completeDefinition": True,
             "inner": [
                 {
-                    "kind": "CXXRecordDecl",
-                    "name": "raii_guard<(lambda at /a/foo.h:4:37)>",
-                    "tagUsed": "struct",
-                    "loc": {"line": 2},
-                    "completeDefinition": True,
-                    "inner": [
-                        {"kind": "FieldDecl", "name": "a", "type": {"qualType": "int"}},
-                    ],
+                    "kind": "FieldDecl",
+                    "name": "fn",
+                    "type": {"qualType": "(lambda at /a/foo.h:4:29)"},
+                },
+            ],
+        },
+        {
+            "kind": "FunctionDecl",
+            "name": "take_lambda",
+            "loc": {"file": "include/foo.h", "line": 5},
+            "mangledName": "take_lambda",
+            "type": {"qualType": "void ((lambda at /a/foo.h:4:29))"},
+            "inner": [
+                {
+                    "kind": "ParmVarDecl",
+                    "name": "f",
+                    "type": {"qualType": "(lambda at /a/foo.h:4:29)"},
                 },
             ],
         },
     )
-    types = list(_ClangAstParser(root, set(), set()).parse_types())
-    assert len(types) == 1
-    rec = types[0]
+    (guard,) = _ClangAstParser(root, {"take_lambda"}, set()).parse_types()
+    (fn,) = guard.fields
     # See strip_anonymous_type_location's docstring: line/column and the
     # declaring header's own basename are kept as discriminators -- only the
     # absolute, checkout-dependent directory prefix is stripped.
-    assert rec.name == "raii_guard<(lambda:foo.h:4:37)>"
-    assert rec.qualified_name == "ns::raii_guard<(lambda:foo.h:4:37)>"
-    assert "/a/foo.h" not in (rec.name or "")
-    assert "/a/foo.h" not in (rec.qualified_name or "")
+    assert fn.type == "(lambda:foo.h:4:29)"
+    assert "/a/foo.h" not in fn.type
+
+    (take_lambda,) = _ClangAstParser(root, {"take_lambda"}, set()).parse_functions()
+    assert "/a/foo.h" not in take_lambda.params[0].type
+    assert take_lambda.params[0].type == "(lambda:foo.h:4:29)"
 
 
 def test_parse_enums_sets_qualified_name_for_namespaced_enum() -> None:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1078,6 +1078,46 @@ def test_parse_types_sets_qualified_name_for_namespaced_record() -> None:
     assert types["Global"].qualified_name is None
 
 
+def test_parse_types_strips_anonymous_type_location_from_qualified_name() -> None:
+    """Mirrors dumper_castxml.py's identical fix (commit 3aca095): a
+    record's own name (or an enclosing scope segment) can embed an absolute
+    source path/line/column the same way castxml's lambda/anonymous-type
+    spelling does, and it must not leak into RecordType.name/.qualified_name
+    -- two checkout directories of the identical, unchanged declaration would
+    otherwise produce two different type identities and manufacture a
+    spurious type_removed/type_added pair.
+    """
+    root = _tu(
+        {
+            "kind": "NamespaceDecl",
+            "name": "ns",
+            "loc": {"file": "include/foo.h", "line": 1},
+            "inner": [
+                {
+                    "kind": "CXXRecordDecl",
+                    "name": "raii_guard<(lambda at /a/foo.h:4:37)>",
+                    "tagUsed": "struct",
+                    "loc": {"line": 2},
+                    "completeDefinition": True,
+                    "inner": [
+                        {"kind": "FieldDecl", "name": "a", "type": {"qualType": "int"}},
+                    ],
+                },
+            ],
+        },
+    )
+    types = list(_ClangAstParser(root, set(), set()).parse_types())
+    assert len(types) == 1
+    rec = types[0]
+    # See strip_anonymous_type_location's docstring: line/column and the
+    # declaring header's own basename are kept as discriminators -- only the
+    # absolute, checkout-dependent directory prefix is stripped.
+    assert rec.name == "raii_guard<(lambda:foo.h:4:37)>"
+    assert rec.qualified_name == "ns::raii_guard<(lambda:foo.h:4:37)>"
+    assert "/a/foo.h" not in (rec.name or "")
+    assert "/a/foo.h" not in (rec.qualified_name or "")
+
+
 def test_parse_enums_sets_qualified_name_for_namespaced_enum() -> None:
     # Mirrors test_parse_types_sets_qualified_name_for_namespaced_record --
     # EnumType.qualified_name (PR #608 follow-up) uses the same scope-derived

--- a/tests/test_typedef_qualified_collision.py
+++ b/tests/test_typedef_qualified_collision.py
@@ -1,0 +1,102 @@
+"""Regression coverage for AbiSnapshot.typedefs' bare-name collision.
+
+``AbiSnapshot.typedefs`` is keyed by *bare* (unqualified) alias name on both
+header backends, so two unrelated member typedefs sharing a bare spelling in
+different classes (e.g. ``X::impl_value_t`` on many unrelated classes -- an
+ordinary STL-container-shaped pattern) collapse onto one dict entry. Diffing
+that collapsed dict directly can flip the surviving entry's recorded value
+when an unrelated class gains or loses its own same-named alias, fabricating
+a spurious ``TYPEDEF_BASE_CHANGED`` for a typedef that never itself changed.
+
+``AbiSnapshot.typedefs_qualified`` (schema v25) carries the same set of
+typedef declarations keyed by qualified name instead, which is unique per
+declaration. ``diff_types._diff_typedefs`` should prefer it whenever both
+sides populate it.
+"""
+
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, compare
+from abicheck.model import AbiSnapshot
+
+
+def _snap(typedefs, typedefs_qualified):
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version="1.0",
+        typedefs=typedefs,
+        typedefs_qualified=typedefs_qualified,
+    )
+
+
+class TestTypedefQualifiedCollision:
+    def test_new_colliding_alias_does_not_fabricate_a_base_change(self):
+        """Adding an unrelated class with a same-named member typedef must
+        not report the pre-existing typedef's underlying type as changed,
+        just because the two happen to collapse onto the same bare key.
+        """
+        old = _snap(
+            typedefs={"impl_value_t": "shared_ptr<A_impl>"},
+            typedefs_qualified={"A::impl_value_t": "shared_ptr<A_impl>"},
+        )
+        new = _snap(
+            # The bare dict collapses to whichever entry the backend visited
+            # last -- here the newly-added, unrelated B::impl_value_t wins,
+            # exactly the collision this fix guards against.
+            typedefs={"impl_value_t": "shared_ptr<B_impl>"},
+            typedefs_qualified={
+                "A::impl_value_t": "shared_ptr<A_impl>",
+                "B::impl_value_t": "shared_ptr<B_impl>",
+            },
+        )
+        r = compare(old, new)
+        kinds = {c.kind for c in r.changes}
+        assert ChangeKind.TYPEDEF_BASE_CHANGED not in kinds
+        assert ChangeKind.TYPEDEF_REMOVED not in kinds
+
+    def test_genuine_qualified_change_is_still_reported(self):
+        old = _snap(
+            typedefs={"impl_value_t": "shared_ptr<A_impl>"},
+            typedefs_qualified={"A::impl_value_t": "shared_ptr<A_impl>"},
+        )
+        new = _snap(
+            typedefs={"impl_value_t": "shared_ptr<A_impl2>"},
+            typedefs_qualified={"A::impl_value_t": "shared_ptr<A_impl2>"},
+        )
+        r = compare(old, new)
+        changed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_BASE_CHANGED]
+        assert len(changed) == 1
+        assert changed[0].symbol == "A::impl_value_t"
+
+    def test_genuine_qualified_removal_is_still_reported(self):
+        # Both sides still carry an (unrelated) qualified typedef so the
+        # qualified-key diff path stays active -- an entirely typedef-free
+        # new side is indistinguishable from "not populated" and legitimately
+        # falls back to the legacy bare-key path (see the docstring above).
+        old = _snap(
+            typedefs={
+                "impl_value_t": "shared_ptr<A_impl>",
+                "other": "int",
+            },
+            typedefs_qualified={
+                "A::impl_value_t": "shared_ptr<A_impl>",
+                "other": "int",
+            },
+        )
+        new = _snap(
+            typedefs={"other": "int"},
+            typedefs_qualified={"other": "int"},
+        )
+        r = compare(old, new)
+        removed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_REMOVED]
+        assert len(removed) == 1
+        assert removed[0].symbol == "A::impl_value_t"
+
+    def test_legacy_bare_only_snapshot_is_unaffected(self):
+        """Neither side populates typedefs_qualified (DWARF-only / legacy
+        schema) -- diffing must fall back to the pre-existing bare-key
+        behavior unchanged."""
+        old = _snap(typedefs={"Size": "unsigned int"}, typedefs_qualified={})
+        new = _snap(typedefs={"Size": "unsigned long"}, typedefs_qualified={})
+        r = compare(old, new)
+        assert ChangeKind.TYPEDEF_BASE_CHANGED in {c.kind for c in r.changes}

--- a/tests/test_typedef_qualified_collision.py
+++ b/tests/test_typedef_qualified_collision.py
@@ -17,15 +17,16 @@ sides populate it.
 from __future__ import annotations
 
 from abicheck.checker import ChangeKind, compare
-from abicheck.model import AbiSnapshot
+from abicheck.model import AbiSnapshot, Function, Visibility
 
 
-def _snap(typedefs, typedefs_qualified):
+def _snap(typedefs, typedefs_qualified, functions=None):
     return AbiSnapshot(
         library="libtest.so.1",
         version="1.0",
         typedefs=typedefs,
         typedefs_qualified=typedefs_qualified,
+        functions=functions or [],
     )
 
 
@@ -66,7 +67,12 @@ class TestTypedefQualifiedCollision:
         r = compare(old, new)
         changed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_BASE_CHANGED]
         assert len(changed) == 1
-        assert changed[0].symbol == "A::impl_value_t"
+        # The emitted symbol stays the bare alias -- matching how a header
+        # backend spells a *reference* to the typedef in a function
+        # signature -- even though matching used the qualified key
+        # internally (Codex review: a qualified symbol here would silently
+        # break diff_filtering._enrich_affected_symbols' bare-name matching).
+        assert changed[0].symbol == "impl_value_t"
 
     def test_genuine_qualified_removal_is_still_reported(self):
         # Both sides still carry an (unrelated) qualified typedef so the
@@ -90,7 +96,7 @@ class TestTypedefQualifiedCollision:
         r = compare(old, new)
         removed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_REMOVED]
         assert len(removed) == 1
-        assert removed[0].symbol == "A::impl_value_t"
+        assert removed[0].symbol == "impl_value_t"
 
     def test_all_qualified_typedefs_removed_are_each_reported(self):
         """When every typedef is removed, the new side's typedefs_qualified
@@ -107,10 +113,52 @@ class TestTypedefQualifiedCollision:
         )
         new = _snap(typedefs={}, typedefs_qualified={})
         r = compare(old, new)
-        removed = {
-            c.symbol for c in r.changes if c.kind == ChangeKind.TYPEDEF_REMOVED
+        removed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_REMOVED]
+        # Both collide on the same emitted (bare) symbol, but each
+        # declaration's own removal is still reported -- not collapsed to
+        # one, which was the bug (see the module docstring and the bare-vs-
+        # qualified matching note on test_genuine_qualified_change_is_still_
+        # reported above).
+        assert len(removed) == 2
+        assert {c.symbol for c in removed} == {"impl_value_t"}
+        assert {c.old_value for c in removed} == {
+            "shared_ptr<A_impl>",
+            "shared_ptr<B_impl>",
         }
-        assert removed == {"A::impl_value_t", "B::impl_value_t"}
+
+    def test_qualified_diff_still_attributes_to_the_bare_referencing_function(self):
+        """A namespaced typedef change must still be attributed to the
+        exported function that names it -- but a header dumper spells a
+        *reference* to a typedef bare (``ns::Alias`` is written as ``Alias``
+        in a function's own return/param type, matching castxml's ``Typedef``
+        branch), so the emitted Change.symbol must stay bare too, even while
+        old/new matching uses the qualified key internally (Codex review:
+        `diff_filtering._enrich_affected_symbols`' substring match against
+        function signatures would otherwise silently stop finding the
+        namespaced typedef's own reference).
+        """
+        old = _snap(
+            typedefs={"impl_value_t": "shared_ptr<A_impl>"},
+            typedefs_qualified={"A::impl_value_t": "shared_ptr<A_impl>"},
+            functions=[
+                Function(
+                    name="use_impl",
+                    mangled="use_impl",
+                    return_type="impl_value_t",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+        )
+        new = _snap(
+            typedefs={"impl_value_t": "shared_ptr<A_impl2>"},
+            typedefs_qualified={"A::impl_value_t": "shared_ptr<A_impl2>"},
+        )
+        r = compare(old, new)
+        changed = [c for c in r.changes if c.kind == ChangeKind.TYPEDEF_BASE_CHANGED]
+        assert len(changed) == 1
+        assert changed[0].symbol == "impl_value_t"
+        assert changed[0].affected_symbols == ["use_impl"]
 
     def test_legacy_bare_only_snapshot_is_unaffected(self):
         """Neither side populates typedefs_qualified (DWARF-only / legacy

--- a/tests/test_typedef_qualified_collision.py
+++ b/tests/test_typedef_qualified_collision.py
@@ -92,6 +92,26 @@ class TestTypedefQualifiedCollision:
         assert len(removed) == 1
         assert removed[0].symbol == "A::impl_value_t"
 
+    def test_all_qualified_typedefs_removed_are_each_reported(self):
+        """When every typedef is removed, the new side's typedefs_qualified
+        is legitimately empty -- indistinguishable, by non-emptiness alone,
+        from "field not populated". Both colliding old-side declarations must
+        still be reported individually rather than collapsing to whichever
+        one the legacy bare map happened to retain (Codex review)."""
+        old = _snap(
+            typedefs={"impl_value_t": "shared_ptr<B_impl>"},
+            typedefs_qualified={
+                "A::impl_value_t": "shared_ptr<A_impl>",
+                "B::impl_value_t": "shared_ptr<B_impl>",
+            },
+        )
+        new = _snap(typedefs={}, typedefs_qualified={})
+        r = compare(old, new)
+        removed = {
+            c.symbol for c in r.changes if c.kind == ChangeKind.TYPEDEF_REMOVED
+        }
+        assert removed == {"A::impl_value_t", "B::impl_value_t"}
+
     def test_legacy_bare_only_snapshot_is_unaffected(self):
         """Neither side populates typedefs_qualified (DWARF-only / legacy
         schema) -- diffing must fall back to the pre-existing bare-key


### PR DESCRIPTION
## Summary

Fixes two of the three defects surfaced by this triage: `AbiSnapshot.typedefs`' bare-name collision fabricating spurious `typedef_base_changed`/`typedef_removed`, and the direct-clang header-AST backend leaking a lambda closure type's embedded source path into a field/parameter/variable/function's own recorded type spelling.

## Motivation

- **Typedef collision (oneCCL):** `AbiSnapshot.typedefs` is keyed by unqualified alias name on both header backends. oneCCL has 42 distinct `X::impl_value_t` member typedefs collapsing into one key in a 458-entry map — adding an unrelated new class flipped the collapsed value, producing a spurious `breaking typedef_base_changed impl_value_t: ...`. `AbiSnapshot.typedefs_qualified` (schema v25, unique per declaration) already exists but `_diff_typedefs` never used it.
- **Lambda-location leak (clang backend):** `dumper_castxml.py` already strips `"(lambda at <path>:<line>:<col>)"`-shaped text out of `RecordType`/`EnumType` name/qualified_name (commit 3aca095). I initially assumed the direct-clang backend had the identical gap on those same fields and fixed it there — **verified against real Clang 18 `-ast-dump=json` output this was wrong**: a clang `RecordDecl`'s own `name` attribute never embeds template-argument text at all (unlike castxml's XML, which spells a record's full instantiated name — lambda argument included — directly in `name`). Reverted that unverified change. The actual, empirically-confirmed leak is in `_qualtype()`, the single choke point every field/param/variable/function type spelling on this backend is built from: a function template instantiated with a lambda argument (`call_with([]{})`) prints that instantiation's own parameter `type.qualType` as the raw `"(lambda at <path>:<line>:<col>)"` text — a `decltype(...)`- or typedef-sugared spelling stays sugared and only desugars into this form in a separate `desugaredQualType` key `_qualtype` never reads, but a template parameter substituted directly with the deduced lambda type has no sugar to keep.

## Changes

- `diff_helpers.typedef_diff_maps()`: returns the qualified-keyed typedef maps whenever both snapshot sides populate `typedefs_qualified` *and* both sides "trust" that map (non-empty, or the side's legacy map is itself empty — closing a gap where an entirely typedef-free new side would otherwise fall back to the legacy bare maps and lose per-declaration granularity), falling back to the legacy bare maps otherwise (a DWARF-only/pre-v25 snapshot).
- `diff_types._diff_typedefs`: uses the new helper. The stdlib/anonymous-type surface filter is checked against the *full* alias string in both modes. The emitted `Change.symbol`/`.name` stay the **bare** alias regardless of which map is active (mirroring `_diff_types`'s identical, pre-existing convention) — a header dumper spells a typedef *reference* (e.g. in a function's return/param type) bare, never qualified, so a qualified symbol here would silently break `diff_filtering._enrich_affected_symbols`' substring matching against those signatures. The `description` is disambiguated with the qualified spelling instead, so two colliding declarations don't silently re-collapse into one finding via `diff_filtering._dedup_exact`'s `(kind, description)` key.
- `dumper_clang.py`: `_qualtype()` now strips an embedded absolute source path out of the raw `type.qualType` string via `name_classification.strip_anonymous_type_location`, covering `TypeField.type`, `Param.type`, `Variable.type`, and (via `_return_type`) `Function.return_type` from one shared extraction point.
- `changelog.d/1787616000_claude_typedef-and-lambda-qualified-name-collisions.md`.

## Known gaps / not fixed in this PR

1. The other two reported defects — a phantom `type_removed` from `RecordType.name` disagreeing with `qualified_name` on opaque template patterns, and `enum_member_value_changed` firing twice for one member with distinct `finding_id`/`canonical_finding_id` — were investigated but not confidently reproduced through static analysis alone. `diff_helpers.TypeMap`/`type_map_key` (ADR-045) already keys old/new type matching by qualified identity with a collision-safe bare-name fallback, and `diff_filtering._dedup_enum_same_kind` already collapses same-`(kind, symbol)` enum findings, so the naive mechanisms I could check by reading the code don't explain the reported symptoms. Reproducing the actual root cause needs a live castxml/oneTBB (or equivalent) snapshot pair — castxml itself isn't installable in this environment, only clang — so it wasn't attempted.

2. **`classify_change_surface`'s type-level path (`surface.py`) has no qualified-identity awareness for typedefs, unlike `RecordType`/`EnumType`** (Codex review, fresh finding on this PR). `PublicSurface.all_types`/`.public_types` source their typedef entries straight from the bare, already-collapsing `AbiSnapshot.typedefs` dict (`for alias in snap.typedefs: surface.all_types.add(alias)`, `_walk_type_closure`'s `snap.typedefs.get(name)`), not from `typedefs_qualified` — independent of whatever `Change.symbol` `_diff_typedefs` emits. `RecordType`/`EnumType` got dedicated qualified-identity treatment here (`origin_by_qualified_key`, `ambiguous_type_names`, a qualified index augmenting `record_by_name`/`enum_by_name`) across what reads like several of its own prior review rounds; typedefs never did. Concretely: two typedefs sharing a bare name where one is genuinely public and the other private, with the private one changing, can have that change classified in-surface via the unrelated public one's reachability — a false BREAKING result for a private change. This is a **pre-existing** structural limitation of `PublicSurface`'s typedef indexing (independent of this PR's `symbol=` choice — passing the qualified alias there wouldn't fix it, since `all_types`/`public_types` themselves have no qualified typedef entries to match against), not something this PR introduces from nothing, but this PR's fix does make it easier to reach in practice — before, `AbiSnapshot.typedefs`' own bare-key collapsing meant at most one, arbitrary typedef finding ever reached this classification step for a given bare name; now up to N real findings do, each subject to the same bare-name-blind classification. A correct fix needs `typedefs_qualified` threaded through `_seed_public_roots`/`_walk_type_closure`/`PublicSurface` the same way `RecordType.qualified_name` already is — a real, separate feature, not a follow-up patch to `_diff_typedefs`. Left undone rather than attempted as a fourth reactive patch under continued review pressure in this same area, per this repo's own "known gaps over risky reactive patches" convention.

## Bug-fix test contract

- Bug class: snapshot fact collapsed onto a non-unique key (bare typedef alias), and a location-embedded type spelling leaking into a persisted identity/type field (clang backend), each fabricating spurious findings.
- Publicly observable failure: `compare()` reports `typedef_base_changed`/`typedef_removed` for a typedef that never itself changed, purely because an unrelated class gained/lost a same-named member typedef; on the clang backend, a field/parameter/variable/function whose type is a lambda closure used as a template argument embeds an absolute, checkout-dependent path in its recorded type, which would fabricate a spurious finding across two checkouts of the identical declaration.
- Regression test fails on base: yes — `tests/test_typedef_qualified_collision.py`'s cases, `tests/test_dumper_clang.py::test_qualtype_strips_anonymous_type_location_from_field_and_param_types`, and `tests/test_clang_header_backend_integration.py::test_clang_ast_strips_lambda_location_from_instantiated_param_type` all fail against the pre-fix code (confirmed by checking out the parent commit's `diff_types.py`/`diff_helpers.py`/`dumper_clang.py`).
- Negative control: `test_genuine_qualified_change_is_still_reported`/`test_genuine_qualified_removal_is_still_reported` confirm a real typedef change/removal is still reported; `test_legacy_bare_only_snapshot_is_unaffected` confirms the DWARF/pre-v25 fallback path is unchanged; `test_stdlib_qualified_typedef_churn_is_filtered_for_a_normal_library` (pre-existing, now re-verified) confirms the `std::`-prefix filter still fires correctly against the fully-qualified legacy typedef key; `test_qualified_diff_still_attributes_to_the_bare_referencing_function` confirms `affected_symbols` attribution survives for a namespaced typedef referenced (bare) by a real exported function.
- Real-dependency test: yes — `tests/test_clang_header_backend_integration.py::test_clang_ast_strips_lambda_location_from_instantiated_param_type` runs the **live** `clang -ast-dump=json` frontend (via `_clang_header_dump`) over a real header containing a function template instantiated with a lambda argument, and asserts the parsed `Param.type` no longer contains the tmp-checkout path — not a hand-constructed AST fixture standing in for clang's actual output shape.
- Public-surface test: yes — the typedef tests go through the real `compare()`/`AbiSnapshot` public API; the clang tests go through `_ClangAstParser.parse_types()`/`.parse_functions()`, the real extraction entry points, one of them fed by a genuine live-clang AST rather than a hand-built dict.
- Axes covered: bare-key collision vs. genuine qualified change vs. genuine qualified removal vs. legacy/no-qualified-twin fallback vs. the pre-existing `std::`-prefix filter vs. affected-symbols attribution (typedefs); fixture-level vs. live-clang-verified leak reproduction, field/param/variable/return-type coverage via the one shared `_qualtype()` choke point (clang lambda marker).
- General invariant: a snapshot fact that is unique per declaration must never be diffed through a representation that collapses distinct declarations onto one key; a location-embedded type spelling must never leak into a persisted/compared identity or type field, on any header backend; a Change's emitted `symbol` must match the spelling convention every downstream consumer (attribution, dedup) actually expects, even when internal matching uses a different, richer identity.
- Known unsupported cases: castxml's own `RecordType`/`EnumType` qualified_name construction was re-verified by reading the code and already strips correctly for that field (not independently reproduced against a live castxml binary, which isn't installable in this environment); the two undiagnosed defects and the `classify_change_surface` typedef-qualification gap noted above are explicitly out of scope for this PR; a lambda type reached only through `desugaredQualType` (behind a typedef/`decltype` alias) is not stripped, since `_qualtype()` never reads that key and no current consumer needs the desugared form.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create` equivalent) — touches `abicheck/**/*.py`
- [ ] Docs updated if user-visible behaviour changed — not applicable (internal diffing correctness fix, no CLI/API surface change)
- [x] `ruff check` / `mypy abicheck/` pass on the changed files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLi4JsEu2jkqUqjDoGAvDJ