### PR TITLE
Fix namespace moves and batch renames in type/symbol matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5272,6 +5272,65 @@ Once a root command genuinely clears the bar above, pick the right home:
   emptying that test's own `headers` list, since its actual subject is
   `public_headers`/`public_header_dirs`'s own expansion, not `headers`'s.
 
+- **Lambda-closure churn survives at the *function* level after the type-level
+  fix — investigated, deliberately not patched (oneTBB flow-graph report,
+  fresh evidence).** `name_classification._ANONYMOUS_TYPE_MARKERS` did not
+  recognize clang's own closure spelling (`(lambda at <path>:<line>:<col>)`,
+  or the `(lambda:<file>:<line>:<col>)` form
+  `strip_anonymous_type_location` normalizes it to), so a template
+  instantiated over a closure —
+  `raii_guard<(lambda:task_group.h:522:26)>` — was treated as ordinary ABI
+  surface. That half is fixed: the marker list now covers it, and an
+  unrelated edit that merely shifts the lambda's line no longer produces a
+  `type_removed`/`type_added` pair. **Two residuals were reproduced and are
+  not closed.**
+
+  (1) *Function-level findings on closure-parameterized symbols.* A
+  destructor of that instantiation is still reported as a BREAKING
+  `func_removed` (plus `func_added` for the shifted spelling), and a public
+  function taking the closure-parameterized type by value still produces
+  `func_params_changed`/`template_param_type_changed`, because the
+  *mangled symbol* and the *parameter type spelling* both embed the
+  closure's source coordinates. Reproduced directly through `compare()`
+  with the two spellings differing only in the line number.
+  `is_non_abi_surface_type` is a *type*-name predicate and is not consulted
+  on either path, so the marker fix cannot reach them. **Demoting the
+  removal is not the fix, and the reason matters**: this codebase already
+  states the correct reading in `change_registry`'s own
+  `unnamed_type_in_public_abi` entry ("the Itanium mangling of unnamed
+  types is per-translation-unit and compiler-ordering dependent ... so
+  exporting one is an ABI time bomb: a rebuilt consumer can fail to resolve
+  the symbol"). A consumer *already linked* against the old numbering
+  really does fail at load when the numbering shifts — so the removal is a
+  genuine break, and softening it would hide a real one. That is the same
+  direction of error the linkage-blind-removal entry above was reverted
+  twice for. Nor is "strip `:<line>:<col>` before comparing two spellings"
+  a free win: `strip_anonymous_type_location`'s own docstring records why
+  the coordinates are kept (two unrelated lambdas in one header collapse to
+  one key, silently overwriting an entry in every name-keyed map that
+  consumes the spelling), and this pass has no real oneTBB snapshot to
+  check a narrower "normalize only for pairwise spelling comparison, never
+  for keys" variant against. What a correct fix needs is the annotation
+  route ADR-style precedent already establishes elsewhere in this file
+  ("Annotate; never remove"): correlate such a finding with the existing
+  `unnamed_type_in_public_abi` RISK signal so a reader can see *why* the
+  symbol churned, rather than removing it from `changes` or lowering its
+  verdict. That is a new correlation pass with its own identity question
+  (which finding covers which), not a marker-list edit.
+
+  (2) *A constructor key rendering a literal `?` parameter.* Traced to two
+  legitimate "type not recoverable" sentinels rather than to a formatting
+  bug: `dwarf_snapshot._process_param` returns `Param(type="?")` for a
+  `DW_TAG_formal_parameter` carrying no `DW_AT_type`, and
+  `dumper_castxml._type_name` returns `"?"` when a referenced type id does
+  not resolve in the XML (a closure class declared inside a function body
+  is exactly the shape that goes unemitted). Both are honest unknowns, and
+  which one produced the reported key cannot be determined without the
+  original snapshot, which this pass does not have. Guessing a
+  substitution here would replace a visible unknown with a fabricated
+  spelling, which is strictly worse; closing it needs the real artifact (or
+  a live castxml/DWARF repro of a closure-parameterized ctor) first.
+
 - Don't hand-edit `CHANGELOG.md`'s `## [Unreleased]` section directly — add a `changelog.d/` fragment instead (see Conventions above); CI enforces this
 - Don't modify `examples/` test cases without understanding the ground truth they encode
 - Don't add dependencies without strong justification (this is a lightweight tool)

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -425,13 +425,40 @@ def lookup_matched_type(own: TypeMap[Q], other: TypeMap[Q], t: Q) -> Q | None:
     short/leaf-name collision ``type_map_key`` was introduced to fix, this
     time through the compatibility fallback instead of naive bare matching
     (Codex review, PR #608, second round).
+
+    That unambiguity check is necessary but **not sufficient**, and the
+    missing half is what this function's second fix closes. The retry exists
+    for exactly one situation — *other* is a legacy side that never recorded
+    a qualified identity for this type — but it used to fire whenever the
+    qualified lookup missed, *including* when both sides carry full,
+    genuinely different qualified identities. A real namespace move
+    (oneTBB 2022's flow graph, ``tbb::detail::d1::graph`` ->
+    ``tbb::detail::d2::graph``: distinct types, distinct mangled vtable
+    symbols, no declaration in common) is precisely that shape: each side
+    holds exactly one type whose bare name is ``graph``, so both bare names
+    are "unambiguous" within their own snapshot, the retry hits the other
+    side's bare alias, and two unrelated types are diffed against each other
+    — manufacturing ``TYPE_SIZE_CHANGED`` / ``TYPE_FIELD_OFFSET_CHANGED`` /
+    ``TYPE_VTABLE_CHANGED`` for a pair that is really one removal plus one
+    addition. Unambiguity cannot see this: it answers "is this bare spelling
+    claimed once here", never "did the other side actually fail to record a
+    qualified name".
+
+    So the candidate the retry finds is accepted only when it is itself
+    *legacy-shaped* — its own matching key equals its bare declaration name,
+    i.e. it carries no distinct qualified identity of its own. That is
+    exactly the schema-evolution case the alias was introduced for and
+    nothing else: a side that DID record ``ns::Foo`` and simply does not
+    contain *t* is reported as a non-match, which is the truth.
     """
     key = type_map_key(t)
     found = other.get(key)
     if found is not None:
         return found
     if t.name != key and own.bare_name_is_unambiguous(t.name):
-        return other.get(t.name)
+        candidate = other.get(t.name)
+        if candidate is not None and type_map_key(candidate) == candidate.name:
+            return candidate
     return None
 
 

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -46,6 +46,7 @@ from .fact_provenance import (
     same_producer_backed_fact_qualified,
 )
 from .model import AbiSnapshot
+from .qualified_name_segments import strip_inline_abi_namespaces
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -444,12 +445,27 @@ def lookup_matched_type(own: TypeMap[Q], other: TypeMap[Q], t: Q) -> Q | None:
     claimed once here", never "did the other side actually fail to record a
     qualified name".
 
-    So the candidate the retry finds is accepted only when it is itself
-    *legacy-shaped* — its own matching key equals its bare declaration name,
-    i.e. it carries no distinct qualified identity of its own. That is
-    exactly the schema-evolution case the alias was introduced for and
-    nothing else: a side that DID record ``ns::Foo`` and simply does not
-    contain *t* is reported as a non-match, which is the truth.
+    So the candidate the retry finds is accepted in exactly two shapes:
+
+    * the candidate is *legacy-shaped* — its own matching key equals its bare
+      declaration name, i.e. it carries no distinct qualified identity. That
+      is the schema-evolution case the alias was introduced for.
+    * the two qualified identities are equal once *inline ABI-tag
+      namespaces* are stripped from both
+      (:func:`qualified_name_segments.strip_inline_abi_namespaces`) —
+      ``std::basic_string<...>`` vs. libstdc++'s dual-ABI
+      ``std::__cxx11::basic_string<...>``, or a versioned ``ns::v1::X``
+      vs. ``ns::X``. An inline namespace is transparent for name lookup, so
+      the two spellings name one entity and a real layout change between
+      them (the dual-ABI size change) is a mutation, not a removal plus an
+      addition. The stripping is deliberately narrow: only the version-shaped
+      (``v1``/``__1``) and named toolchain (``__cxx11``/``__ndk1``) tags
+      qualify, never an ordinary implementation namespace such as
+      ``detail``, ``impl`` or oneTBB's ``d1`` — renaming one of those really
+      does move every declaration inside it.
+
+    Anything else — a side that DID record ``ns::Foo`` and simply does not
+    contain *t* — is reported as a non-match, which is the truth.
     """
     key = type_map_key(t)
     found = other.get(key)
@@ -457,7 +473,12 @@ def lookup_matched_type(own: TypeMap[Q], other: TypeMap[Q], t: Q) -> Q | None:
         return found
     if t.name != key and own.bare_name_is_unambiguous(t.name):
         candidate = other.get(t.name)
-        if candidate is not None and type_map_key(candidate) == candidate.name:
+        if candidate is None:
+            return None
+        candidate_key = type_map_key(candidate)
+        if candidate_key == candidate.name or strip_inline_abi_namespaces(
+            key
+        ) == strip_inline_abi_namespaces(candidate_key):
             return candidate
     return None
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import bisect
 import re
 from collections.abc import Mapping
 from typing import Any
@@ -70,6 +69,10 @@ from .diff_symbols_renames import (  # noqa: F401  (public-surface re-exports)
     _unqualified_name as _unqualified_name,
     _unqualified_name_of as _unqualified_name_of,
     _unwrap_funcptr_declarator as _unwrap_funcptr_declarator,
+    emit_namespace_move_batches as emit_namespace_move_batches,
+    emit_prefix_batch_rename as emit_prefix_batch_rename,
+    find_namespace_move_groups as find_namespace_move_groups,
+    find_prefix_rename_pairs as find_prefix_rename_pairs,
 )
 from .diff_symbols_scalar import (  # noqa: F401  (public-surface re-exports)
     _abi_equivalent_scalar as _abi_equivalent_scalar,
@@ -1606,77 +1609,26 @@ def _diff_anon_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return changes
 
 
-def _find_rename_pairs(
-    removed: set[str],
-    added: set[str],
-    old_map: dict[str, Function],
-    new_map: dict[str, Function],
-) -> list[tuple[str, str]]:
-    """Return (old_name, new_name) pairs where new_name has a common prefix added to old_name.
-
-    The match condition is ``a_name.endswith(r_name)`` with ``a_name`` strictly
-    longer (a prefix was prepended). The old ``endswith("_" + r_name)`` branch
-    was redundant — any name ending with ``"_" + r_name`` already ends with
-    ``r_name``. To avoid the O(removed × added) cross-product, index the added
-    names *reversed* so the suffix test becomes a prefix lookup: a binary search
-    locates the contiguous block of reversed added names that start with the
-    reversed removed name. Both ``removed`` and the reversed index are iterated
-    in sorted order, so the result is deterministic.
-    """
-    rev_index = sorted(
-        (new_map[a_sym].name[::-1], new_map[a_sym].name) for a_sym in added
-    )
-    rev_keys = [k for k, _ in rev_index]
-    pairs: list[tuple[str, str]] = []
-    for r_sym in sorted(removed):
-        r_name = old_map[r_sym].name
-        rk = r_name[::-1]
-        i = bisect.bisect_left(rev_keys, rk)
-        while i < len(rev_keys) and rev_keys[i].startswith(rk):
-            a_name = rev_index[i][1]
-            if len(a_name) > len(r_name):
-                pairs.append((r_name, a_name))
-                break
-            i += 1
-    return pairs
-
-
-def _emit_batch_rename(rename_pairs: list[tuple[str, str]]) -> list[Change]:
-    """Emit a SYMBOL_RENAMED_BATCH change if all pairs share a single common prefix."""
-    if len(rename_pairs) < 2:
-        return []
-    prefixes = {
-        new_name[: new_name.rfind(old_name)] for old_name, new_name in rename_pairs
-    }
-    if len(prefixes) != 1:
-        return []
-    prefix = prefixes.pop()
-    pair_desc = ", ".join(f"{o} → {n}" for o, n in rename_pairs[:5])
-    if len(rename_pairs) > 5:
-        pair_desc += f", ... ({len(rename_pairs)} total)"
-    return [
-        make_change(
-            ChangeKind.SYMBOL_RENAMED_BATCH,
-            symbol=f"batch_rename:{prefix}*",
-            name=prefix,
-            detail=f"{len(rename_pairs)} symbols ({pair_desc})",
-            old_value=", ".join(o for o, _ in rename_pairs),
-            new_value=", ".join(n for _, n in rename_pairs),
-        )
-    ]
-
-
 @registry.detector("symbol_renames")
 def _diff_symbol_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect batch symbol renames (namespace refactoring).
 
-    When multiple symbols are removed and corresponding prefixed versions are
-    added (e.g. ``init`` → ``mylib_init``), this indicates a namespace
-    refactoring that breaks all existing consumers.
+    Two independent shapes, both rolled up into ``SYMBOL_RENAMED_BATCH`` and
+    both implemented in the leaf ``diff_symbols_renames`` module:
 
-    Heuristic: if 2+ removed symbols each have a matching added symbol where
-    the added name ends with the removed name (common prefix pattern), emit
-    a SYMBOL_RENAMED_BATCH change.
+    * a common *prefix* prepended to many leaf names (``init`` ->
+      ``mylib_init``) — :func:`find_prefix_rename_pairs`;
+    * a namespace *segment substitution* shared by many symbols
+      (``tbb::detail::d1::X`` -> ``tbb::detail::d2::X`` for every ``X``) —
+      :func:`find_namespace_move_groups`. A namespace move is neither a
+      prefix nor a suffix of the old name, so the prefix shape above cannot
+      see it and every moved symbol was reported as an unpaired
+      ``func_removed``/``func_added`` with nothing tying the two halves
+      together.
+
+    The roll-up is additive: the per-symbol removals stay, because a moved
+    symbol really is gone from the old name and a consumer linked against it
+    really does fail to resolve.
     """
     old_map = _public_functions(old)
     new_map = _public_functions(new)
@@ -1687,8 +1639,13 @@ def _diff_symbol_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if len(removed) < 2 or not added:
         return []
 
-    rename_pairs = _find_rename_pairs(removed, added, old_map, new_map)
-    return _emit_batch_rename(rename_pairs)
+    changes = emit_prefix_batch_rename(
+        find_prefix_rename_pairs(removed, added, old_map, new_map)
+    )
+    changes.extend(
+        emit_namespace_move_batches(find_namespace_move_groups(removed, added))
+    )
+    return changes
 
 
 @registry.detector("param_restrict")

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -23,8 +23,10 @@ The symbol-level public surface re-exports these names back from
 
 from __future__ import annotations
 
+import bisect
 import logging
 import re
+from collections.abc import Mapping
 from functools import lru_cache
 
 from .binary_fingerprint import (
@@ -36,10 +38,11 @@ from .checker_policy import ChangeKind
 from .checker_types import Change
 from .demangle import demangle, demangle_batch
 from .detector_registry import registry
+from .diff_cxx_rules import itanium_scope_components, msvc_scope_components
 from .diff_helpers import make_change
 from .elf_metadata import SymbolType
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
-from .model import AbiSnapshot, is_cxx_runtime_library
+from .model import AbiSnapshot, Function, is_cxx_runtime_library
 
 _log = logging.getLogger(__name__)
 
@@ -677,4 +680,236 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
             len(candidates),
         )
 
+    return changes
+
+
+# ── Batch rename / namespace-move roll-up (SYMBOL_RENAMED_BATCH) ──────────
+#
+# Moved here from ``diff_symbols`` (which sits at the 2000-line hard cap) so
+# both batch shapes live next to the rest of the rename machinery.
+
+
+def _is_destructor_leaf(name: str) -> bool:
+    """True when *name*'s own leaf component names a destructor.
+
+    Splitting on the *last* ``"::"`` is enough for this predicate: a
+    destructor's ``~`` is always the first character of the leaf component,
+    and any ``"::"`` inside a template argument only ever appears *before*
+    the leaf's ``~`` would, never between it and the end.
+    """
+    return name.rsplit("::", 1)[-1].startswith("~")
+
+
+def _prefix_ends_at_a_name_boundary(prefix: str) -> bool:
+    """True when *prefix* is a plausible *prepended* naming prefix.
+
+    A batch rename prepends a namespace or library prefix to an existing
+    leaf name, so the added text ends where a name legitimately starts: at a
+    scope separator (``ns::foo``) or an underscore (``mylib_foo``). Anything
+    else means the "prefix" cuts into the middle of an identifier or is a
+    declarator sigil rather than a name — the ``~`` of a destructor being the
+    case this rule exists for (``Wrapper`` -> ``~Wrapper`` is not a rename of
+    ``Wrapper``, it is a different declaration that happens to end with the
+    same spelling).
+    """
+    return prefix.endswith(("::", "_"))
+
+
+def find_prefix_rename_pairs(
+    removed: set[str],
+    added: set[str],
+    old_map: Mapping[str, Function],
+    new_map: Mapping[str, Function],
+) -> list[tuple[str, str]]:
+    """Return (old_name, new_name) pairs where new_name has a common prefix added to old_name.
+
+    The match condition is ``a_name.endswith(r_name)`` with ``a_name`` strictly
+    longer (a prefix was prepended). The old ``endswith("_" + r_name)`` branch
+    was redundant — any name ending with ``"_" + r_name`` already ends with
+    ``r_name``. To avoid the O(removed × added) cross-product, index the added
+    names *reversed* so the suffix test becomes a prefix lookup: a binary search
+    locates the contiguous block of reversed added names that start with the
+    reversed removed name. Both ``removed`` and the reversed index are iterated
+    in sorted order, so the result is deterministic.
+
+    Two gates keep the raw suffix test from manufacturing pairs out of
+    unrelated declarations that merely share a trailing spelling:
+
+    * the two names must agree on being a destructor
+      (:func:`_is_destructor_leaf`), and
+    * the prepended text must end at a name boundary
+      (:func:`_prefix_ends_at_a_name_boundary`).
+
+    Either one alone rejects the reported ``Wrapper`` -> ``~Wrapper`` /
+    ``graph`` -> ``~graph`` noise; both are kept because they state
+    independent facts. The destructor rule is about *what the two
+    declarations are* and holds no matter how the prefix is spelled (it also
+    rejects ``~Foo`` -> ``ns::Foo``, where the prefix is perfectly
+    well-formed); the boundary rule is about *where the added text stops*
+    and rejects mid-identifier cuts that have nothing to do with
+    destructors.
+    """
+    rev_index = sorted(
+        (new_map[a_sym].name[::-1], new_map[a_sym].name) for a_sym in added
+    )
+    rev_keys = [k for k, _ in rev_index]
+    pairs: list[tuple[str, str]] = []
+    for r_sym in sorted(removed):
+        r_name = old_map[r_sym].name
+        rk = r_name[::-1]
+        i = bisect.bisect_left(rev_keys, rk)
+        while i < len(rev_keys) and rev_keys[i].startswith(rk):
+            a_name = rev_index[i][1]
+            if len(a_name) > len(r_name):
+                prefix = a_name[: len(a_name) - len(r_name)]
+                if _is_destructor_leaf(a_name) == _is_destructor_leaf(
+                    r_name
+                ) and _prefix_ends_at_a_name_boundary(prefix):
+                    pairs.append((r_name, a_name))
+                break
+            i += 1
+    return pairs
+
+
+def emit_prefix_batch_rename(rename_pairs: list[tuple[str, str]]) -> list[Change]:
+    """Emit a SYMBOL_RENAMED_BATCH change if all pairs share a single common prefix."""
+    if len(rename_pairs) < 2:
+        return []
+    prefixes = {
+        new_name[: new_name.rfind(old_name)] for old_name, new_name in rename_pairs
+    }
+    if len(prefixes) != 1:
+        return []
+    prefix = prefixes.pop()
+    pair_desc = ", ".join(f"{o} → {n}" for o, n in rename_pairs[:5])
+    if len(rename_pairs) > 5:
+        pair_desc += f", ... ({len(rename_pairs)} total)"
+    return [
+        make_change(
+            ChangeKind.SYMBOL_RENAMED_BATCH,
+            symbol=f"batch_rename:{prefix}*",
+            name=prefix,
+            detail=f"{len(rename_pairs)} symbols ({pair_desc})",
+            old_value=", ".join(o for o, _ in rename_pairs),
+            new_value=", ".join(n for _, n in rename_pairs),
+        )
+    ]
+
+
+#: Sentinel standing in for the one scope component a candidate namespace
+#: substitution replaces. A real Itanium component can never contain a NUL,
+#: so it cannot collide with one.
+_MASKED = "\x00"
+
+
+def _scope_components(mangled: str) -> list[str] | None:
+    """Return *mangled*'s scope chain (namespaces + class path + leaf), or None.
+
+    Itanium first, MSVC second — the two prefixes (``_Z``/``__Z`` vs. ``?``)
+    are mutually exclusive, so trying both in order is unambiguous, and it is
+    the same order :func:`diff_cxx_rules.owner_class_of` already uses. A
+    component list shorter than two carries no namespace to substitute, so it
+    is reported as "no usable chain" rather than as a one-element chain.
+    """
+    comps = itanium_scope_components(mangled) or msvc_scope_components(mangled)
+    if comps is None or len(comps) < 2:
+        return None
+    return comps
+
+
+def find_namespace_move_groups(
+    removed: set[str],
+    added: set[str],
+) -> dict[tuple[str, str], list[tuple[str, str]]]:
+    """Group removed/added symbols by a *shared namespace-segment substitution*.
+
+    A namespace move (oneTBB 2022's flow graph: every ``tbb::detail::d1::X``
+    became ``tbb::detail::d2::X``) is neither a prefix nor a suffix of the old
+    name, so :func:`find_prefix_rename_pairs` structurally cannot see it —
+    every moved symbol was reported as an unpaired ``func_removed`` next to an
+    unpaired ``func_added`` with nothing recording that the two halves are the
+    same declaration under a new scope.
+
+    Matching is on the *mangled* names' parsed scope chains
+    (:func:`_scope_components`), not on demangled text: the chain is exactly
+    the sequence of namespace/class components plus the leaf, with ctor/dtor
+    markers already normalized, so "differs in exactly one component" is a
+    statement about scoping rather than about string spelling.
+
+    A pair is recorded when the two chains have the same length, differ at
+    exactly one position, and that position is **not** the leaf — a differing
+    leaf is a renamed *declaration*, which is a different claim from a moved
+    scope and is what the prefix shape above is for. Pairs are grouped by the
+    ``(old_segment, new_segment)`` substitution they support, so unrelated
+    coincidental one-component differences never accumulate into one group;
+    the caller requires a group to have at least two supporting pairs before
+    reporting anything.
+
+    Deliberately *not* keyed on the position index as well: the same rename
+    of a namespace can legitimately show up at different depths (a nested
+    class in one symbol, a free function in another), and requiring an equal
+    index would split one real move into several under-supported groups.
+
+    Returns ``{(old_segment, new_segment): [(old_qualified, new_qualified)]}``
+    with deterministic ordering (both sides iterated sorted).
+    """
+    added_index: dict[tuple[str, ...], list[tuple[str, list[str]]]] = {}
+    for a_sym in sorted(added):
+        comps = _scope_components(a_sym)
+        if comps is None:
+            continue
+        for i in range(len(comps) - 1):
+            masked = tuple(comps[:i]) + (_MASKED,) + tuple(comps[i + 1 :])
+            added_index.setdefault(masked, []).append((a_sym, comps))
+
+    groups: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    for r_sym in sorted(removed):
+        r_comps = _scope_components(r_sym)
+        if r_comps is None:
+            continue
+        seen_here: set[tuple[str, str]] = set()
+        for i in range(len(r_comps) - 1):
+            masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
+            for a_sym, a_comps in added_index.get(masked, ()):
+                key = (r_comps[i], a_comps[i])
+                if key[0] == key[1] or key in seen_here:
+                    continue
+                seen_here.add(key)
+                groups.setdefault(key, []).append(
+                    ("::".join(r_comps), "::".join(a_comps))
+                )
+    return groups
+
+
+def emit_namespace_move_batches(
+    groups: dict[tuple[str, str], list[tuple[str, str]]],
+) -> list[Change]:
+    """Emit one SYMBOL_RENAMED_BATCH per namespace substitution with 2+ pairs.
+
+    Ordered by support (most-supported substitution first, then by the
+    substitution itself) so the report is stable across runs and the dominant
+    move leads.
+    """
+    changes: list[Change] = []
+    for (old_seg, new_seg), pairs in sorted(
+        groups.items(), key=lambda kv: (-len(kv[1]), kv[0])
+    ):
+        if len(pairs) < 2:
+            continue
+        pair_desc = ", ".join(f"{o} → {n}" for o, n in pairs[:5])
+        if len(pairs) > 5:
+            pair_desc += f", ... ({len(pairs)} total)"
+        changes.append(
+            make_change(
+                ChangeKind.SYMBOL_RENAMED_BATCH,
+                symbol=f"batch_rename:{old_seg}→{new_seg}",
+                description=(
+                    "Batch symbol rename detected (namespace refactoring): "
+                    f"namespace segment '{old_seg}' → '{new_seg}' on "
+                    f"{len(pairs)} symbols ({pair_desc})"
+                ),
+                old_value=", ".join(o for o, _ in pairs),
+                new_value=", ".join(n for _, n in pairs),
+            )
+        )
     return changes

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -811,8 +811,10 @@ _SYMBOL_LEVEL_KIND_SLUGS = frozenset(
 #: entity-bearing" -- their ``Change.symbol`` is a version-node/requirement
 #: label (``diff_versioning.py``/``diff_platform_elf_symbols.py``: e.g.
 #: ``symbol=node`` where ``node`` is a string like ``"GLIBC_2.17"``) or a
-#: synthetic batch identifier (``diff_symbols.py``'s ``_emit_batch_rename``:
-#: ``symbol=f"batch_rename:{prefix}*"``), never a real exported function or
+#: synthetic batch identifier (``diff_symbols_renames.py``'s
+#: ``emit_prefix_batch_rename``/``emit_namespace_move_batches``:
+#: ``symbol=f"batch_rename:{prefix}*"`` and
+#: ``symbol=f"batch_rename:{old_segment}->{new_segment}"``), never a real exported function or
 #: variable name (Codex review: a version label or batch id that happens to
 #: resemble a mangling must not be promoted to CANONICAL and aliased
 #: alongside an actual function's mangled name). Verified per-kind against

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -434,6 +434,29 @@ STDLIB_TYPE_NAMESPACE_PREFIXES: tuple[str, ...] = (
 _ANONYMOUS_TYPE_MARKERS: tuple[str, ...] = (
     "<lambda",
     "{lambda",
+    # Clang's own closure spelling is ``(lambda at <path>:<line>:<col>)`` --
+    # and after :func:`strip_anonymous_type_location` normalizes it, simply
+    # ``(lambda:<file>:<line>:<col>)``. Neither form starts the marker with
+    # ``<`` or ``{``, so a template instantiation over a closure type
+    # (``raii_guard<(lambda:task_group.h:522:26)>``) matched none of the
+    # markers above and was treated as ordinary ABI surface -- even though
+    # the *same* module already parses this exact spelling one screen down
+    # (``_ANON_LOCATION_RE``), i.e. the omission was in this list, not in
+    # what the codebase knows about clang's spelling. The consequence is a
+    # type whose identity carries a source *line number*: an unrelated edit
+    # earlier in the header shifts it, and the shifted spelling reads as a
+    # whole type removed and a whole type added, at BREAKING severity, for a
+    # closure class that has no user-nameable identity to break in the first
+    # place. GCC/DWARF's ``{lambda(...)#1}`` spelling matched all along,
+    # which is why this only ever showed up on clang-derived spellings.
+    #
+    # Like its two siblings this is a substring test, so it also matches a
+    # type whose name merely *contains* the text (the documented
+    # ``Tag<"(lambda at a.hpp:1:2)">`` string-NTTP shape). That exposure is
+    # identical in kind to what ``<lambda``/``{lambda`` already carry, and
+    # errs toward excluding a synthetic-looking type rather than admitting a
+    # line-number-keyed one.
+    "(lambda",
     "(anonymous",
     "(unnamed",
     "<unnamed",

--- a/abicheck/qualified_name_segments.py
+++ b/abicheck/qualified_name_segments.py
@@ -140,3 +140,91 @@ def version_strip_segments(segs: list[str]) -> tuple[tuple[str, ...], int | None
         if v is not None:
             return tuple(segs[:i] + segs[i + 1 :]), v
     return tuple(segs), None
+
+
+#: Toolchain *ABI-tag* inline namespaces that are not version-number-shaped
+#: and therefore invisible to :func:`version_suffix`: libstdc++'s dual-ABI
+#: ``std::__cxx11`` and the Android NDK's ``std::__ndk1``. Both are inline
+#: namespaces — transparent for name lookup — so a declaration gaining or
+#: losing one is the *same* entity spelled two ways, exactly like the
+#: ``v1``/``__1`` family ``version_suffix`` already recognizes.
+_ABI_TAG_NS_RE = _re.compile(r"^__(?:cxx|ndk)\d+$")
+
+
+def is_inline_abi_namespace_segment(segment: str) -> bool:
+    """True when *segment* names an inline namespace used as an ABI tag.
+
+    Union of the version-number family (``v1``, ``__1``, ``_V2`` — see
+    :func:`version_suffix`) and the named toolchain tags (``__cxx11``,
+    ``__ndk1``). Deliberately not a general "looks like an implementation
+    detail" test: a segment such as ``detail``, ``impl`` or oneTBB's ``d1``
+    is an *ordinary* namespace whose rename is a real move of the
+    declarations inside it, so it must not be stripped.
+    """
+    return version_suffix(segment) is not None or bool(_ABI_TAG_NS_RE.match(segment))
+
+
+def strip_inline_abi_namespaces(qualified: str) -> tuple[str, ...]:
+    """Return *qualified*'s segments with every inline ABI-tag namespace removed.
+
+    Two spellings that reduce to the same tuple name the same entity through
+    a transparent inline namespace (``std::basic_string`` vs.
+    ``std::__cxx11::basic_string``); two that do not are genuinely different
+    scopes (``tbb::detail::d1::graph`` vs. ``tbb::detail::d2::graph``).
+
+    The leaf segment is never stripped, for the same reason
+    :func:`version_strip_segments` never scans it: a declaration may
+    legitimately *be* named ``v1``, and stripping its own name would collapse
+    it onto its enclosing scope.
+
+    Splitting keeps each segment's template arguments, unlike
+    :func:`segments`: two spellings that differ only inside an *enclosing*
+    segment's argument list (``ns::Outer<int>::Inner`` vs.
+    ``ns::Outer<float>::Inner``) name different entities, and dropping the
+    arguments would reduce both to the same tuple.
+    """
+    segs = raw_segments(qualified)
+    if len(segs) < 2:
+        return tuple(segs)
+    leaf = len(segs) - 1
+    return tuple(
+        s
+        for i, s in enumerate(segs)
+        if i == leaf or not is_inline_abi_namespace_segment(s)
+    )
+
+
+def raw_segments(qualified: str) -> list[str]:
+    """:func:`segments`, but keeping each segment's template arguments.
+
+    Splits on ``::`` at template-nesting depth zero only, so
+    ``ns::Map<std::pair<int, int>>::iterator`` yields three segments and the
+    ``::`` inside the argument list is not a separator.
+    """
+    if not qualified:
+        return []
+    if "::" not in qualified and "<" not in qualified:
+        return [qualified]
+    out: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    i = 0
+    n = len(qualified)
+    while i < n:
+        ch = qualified[i]
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            if depth > 0:
+                depth -= 1
+        elif depth == 0 and ch == ":" and i + 1 < n and qualified[i + 1] == ":":
+            if buf:
+                out.append("".join(buf).strip())
+                buf = []
+            i += 2
+            continue
+        buf.append(ch)
+        i += 1
+    if buf:
+        out.append("".join(buf).strip())
+    return [s for s in out if s]

--- a/changelog.d/20260824_211703_noreply_onetbb_enum_namespace_matching_xjm205.md
+++ b/changelog.d/20260824_211703_noreply_onetbb_enum_namespace_matching_xjm205.md
@@ -7,9 +7,12 @@
   `tbb::detail::d1::graph` → `tbb::detail::d2::graph`) paired two distinct
   types and produced phantom `type_size_changed` /
   `type_field_offset_changed` / `type_vtable_changed` findings instead of a
-  removal plus an addition. The bare-name retry now applies only to the
-  schema-evolution case it exists for — a side that genuinely never recorded
-  `qualified_name`.
+  removal plus an addition. The bare-name retry now applies only to the two
+  cases it exists for — a side that genuinely never recorded
+  `qualified_name`, and two spellings that differ only by an inline ABI-tag
+  namespace (`std::` vs. libstdc++'s dual-ABI `std::__cxx11::`, or a
+  versioned `ns::v1::`), which name one entity. An ordinary implementation
+  namespace (`detail`, `impl`, `d1`) is never treated as such a tag.
 
 - **A whole-namespace move is recognized as one `symbol_renamed_batch`** —
   the batch-rename detector only understood a *prepended prefix*, so a set

--- a/changelog.d/20260824_211703_noreply_onetbb_enum_namespace_matching_xjm205.md
+++ b/changelog.d/20260824_211703_noreply_onetbb_enum_namespace_matching_xjm205.md
@@ -1,0 +1,33 @@
+### Fixed
+
+- **Namespace moves no longer report as type mutations** — old/new type
+  matching (`diff_helpers.lookup_matched_type`) retried a failed
+  qualified-name lookup by bare declaration name even when *both* sides
+  recorded a qualified identity, so a real namespace move (oneTBB 2022's
+  `tbb::detail::d1::graph` → `tbb::detail::d2::graph`) paired two distinct
+  types and produced phantom `type_size_changed` /
+  `type_field_offset_changed` / `type_vtable_changed` findings instead of a
+  removal plus an addition. The bare-name retry now applies only to the
+  schema-evolution case it exists for — a side that genuinely never recorded
+  `qualified_name`.
+
+- **A whole-namespace move is recognized as one `symbol_renamed_batch`** —
+  the batch-rename detector only understood a *prepended prefix*, so a set
+  of symbols whose mangled names differ by one namespace scope component was
+  reported as N unpaired `func_removed` next to N unpaired `func_added` with
+  nothing linking the two halves. Generic over any shared segment
+  substitution; the per-symbol removals are still reported, since a consumer
+  linked against the old name really does fail to resolve.
+
+- **Destructors are no longer treated as renamed class names** — the same
+  detector paired `Wrapper` → `~Wrapper` and `graph` → `~graph`, reading the
+  `~` as an added prefix. A rename pair's two halves must now agree on being
+  a destructor, and the prepended text must end at a name boundary.
+
+- **Clang-spelled lambda closure types are classified as non-ABI-surface** —
+  `(lambda at <path>:<line>:<col>)` (and its normalized
+  `(lambda:<file>:<line>:<col>)` form) matched none of the anonymous-type
+  markers, so a template instantiated over a closure carried a source line
+  number in its ABI identity: an unrelated edit earlier in the header made
+  it read as a whole type removed plus a whole type added at BREAKING
+  severity. GCC/DWARF's `{lambda(...)#1}` spelling was unaffected.

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``SYMBOL_RENAMED_BATCH``: namespace-segment moves, and the destructor noise.
+
+Two independent fixes share this file because they are two halves of the same
+detector:
+
+* a whole set of symbols moving namespace (oneTBB 2022's
+  ``tbb::detail::d1::X`` -> ``tbb::detail::d2::X``) is now recognized as one
+  batch instead of N unpaired removals next to N unpaired additions;
+* the pre-existing prefix shape no longer treats ``Wrapper`` -> ``~Wrapper``
+  as "a ``~`` prefix was added to a symbol", which it never was.
+
+The grouping primitives are tested directly (per CLAUDE.md's "Primitive-level
+property tests" guidance) as well as through ``compare``.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings, strategies as st
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.diff_symbols_renames import (
+    emit_namespace_move_batches,
+    find_namespace_move_groups,
+    find_prefix_rename_pairs,
+)
+from abicheck.model import AbiSnapshot, Function, Visibility
+
+
+def _fn(name: str, mangled: str | None = None) -> Function:
+    return Function(
+        name=name,
+        mangled=mangled or name,
+        return_type="void",
+        visibility=Visibility.PUBLIC,
+    )
+
+
+def _snap(version: str, functions: list[Function]) -> AbiSnapshot:
+    return AbiSnapshot(library="libtbb.so", version=version, functions=functions)
+
+
+# The real shape: oneTBB moved its flow-graph implementation namespace from
+# ``tbb::detail::d1`` to ``tbb::detail::d2``, so every flow-graph symbol's
+# mangled name changed one length-prefixed scope component (``2d1`` -> ``2d2``).
+_D1 = [
+    "_ZN3tbb6detail2d15graph5resetEv",
+    "_ZN3tbb6detail2d15graph4waitEv",
+    "_ZN3tbb6detail2d15graphC1Ev",
+    "_ZN3tbb6detail2d15graphD1Ev",
+]
+_D2 = [m.replace("2d15graph", "2d25graph") for m in _D1]
+
+
+class TestNamespaceMoveIsRecognizedAsOneBatch:
+    def test_groups_the_whole_move_under_one_substitution(self) -> None:
+        groups = find_namespace_move_groups(set(_D1), set(_D2))
+        assert ("d1", "d2") in groups
+        assert len(groups[("d1", "d2")]) == len(_D1)
+
+    def test_emits_a_single_rolled_up_finding(self) -> None:
+        changes = emit_namespace_move_batches(
+            find_namespace_move_groups(set(_D1), set(_D2))
+        )
+        assert len(changes) == 1
+        assert changes[0].kind is ChangeKind.SYMBOL_RENAMED_BATCH
+        assert "d1" in changes[0].description and "d2" in changes[0].description
+
+    def test_reported_through_compare(self) -> None:
+        old = _snap("2021", [_fn(m, m) for m in _D1])
+        new = _snap("2022", [_fn(m, m) for m in _D2])
+        result = compare(old, new)
+        batch = [c for c in result.changes if c.kind is ChangeKind.SYMBOL_RENAMED_BATCH]
+        assert batch, "namespace move produced no batch roll-up"
+        assert batch[0].symbol.startswith("batch_rename:")
+        # The roll-up is additive: every moved symbol is still individually
+        # gone, and a consumer linked against the old name still fails.
+        assert any(c.kind is ChangeKind.FUNC_REMOVED for c in result.changes)
+
+    def test_leaf_only_difference_is_not_a_namespace_move(self) -> None:
+        """Two symbols differing only in the *declaration* name are a rename of
+        the declaration, not a move of its scope — the prefix shape's job."""
+        removed = {"_ZN3lib3foo3runEv", "_ZN3lib3foo4stopEv"}
+        added = {"_ZN3lib3foo5run2Ev", "_ZN3lib3foo5stop2Ev"}
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_one_supporting_pair_is_not_a_batch(self) -> None:
+        groups = find_namespace_move_groups({_D1[0]}, {_D2[0]})
+        assert emit_namespace_move_batches(groups) == []
+
+    def test_unrelated_removals_and_additions_produce_nothing(self) -> None:
+        removed = {"_ZN3lib1a1fEv", "_ZN3lib1b1gEv"}
+        added = {"_ZN4othr1c1hEv", "_ZN4othr1d1iEv"}
+        assert (
+            emit_namespace_move_batches(find_namespace_move_groups(removed, added))
+            == []
+        )
+
+
+class TestDestructorKeysAreNotRenameGroupMembers:
+    def test_dtor_is_not_a_prefixed_rename_of_its_class_name(self) -> None:
+        old = {"a": _fn("Wrapper"), "b": _fn("graph")}
+        new = {"x": _fn("~Wrapper"), "y": _fn("~graph")}
+        assert find_prefix_rename_pairs(set(old), set(new), old, new) == []
+
+    def test_no_batch_finding_for_dtor_vs_plain_name(self) -> None:
+        old = _snap(
+            "1", [_fn("Wrapper", "_ZN7WrapperC1Ev"), _fn("graph", "_ZN5graphC1Ev")]
+        )
+        new = _snap(
+            "2", [_fn("~Wrapper", "_ZN7WrapperD1Ev"), _fn("~graph", "_ZN5graphD1Ev")]
+        )
+        kinds = {c.kind for c in compare(old, new).changes}
+        assert ChangeKind.SYMBOL_RENAMED_BATCH not in kinds
+
+    def test_a_real_dtor_to_dtor_namespace_prefix_still_pairs(self) -> None:
+        """The rule is *destructor-ness must agree*, not "destructors are
+        excluded" — moving a set of destructors under a namespace is a real
+        batch rename."""
+        old = {"a": _fn("~Foo"), "b": _fn("~Bar")}
+        new = {"x": _fn("ns::~Foo"), "y": _fn("ns::~Bar")}
+        assert sorted(find_prefix_rename_pairs(set(old), set(new), old, new)) == [
+            ("~Bar", "ns::~Bar"),
+            ("~Foo", "ns::~Foo"),
+        ]
+
+    def test_ordinary_library_prefix_rename_still_detected(self) -> None:
+        old = _snap("1", [_fn("init"), _fn("process"), _fn("cleanup")])
+        new = _snap(
+            "2", [_fn("mylib_init"), _fn("mylib_process"), _fn("mylib_cleanup")]
+        )
+        kinds = {c.kind for c in compare(old, new).changes}
+        assert ChangeKind.SYMBOL_RENAMED_BATCH in kinds
+
+
+# ── Property-level contracts ──────────────────────────────────────────────
+
+_BASES = st.sampled_from(["Wrapper", "graph", "Foo", "task_group"])
+_PREFIXES = st.sampled_from(["", "~", "mylib_", "ns::", "ns::~", "X"])
+
+
+@settings(max_examples=300, deadline=None)
+@given(bases=st.lists(_BASES, min_size=1, max_size=4, unique=True), pre=_PREFIXES)
+def test_a_destructor_is_never_grouped_with_a_non_destructor(
+    bases: list[str], pre: str
+) -> None:
+    """The invariant issue 3 is about: whatever the spelling, the two halves of
+    a rename pair always agree on whether they name a destructor."""
+    old_map = {f"o{i}": _fn(b) for i, b in enumerate(bases)}
+    new_map = {f"n{i}": _fn(pre + b) for i, b in enumerate(bases)}
+    for old_name, new_name in find_prefix_rename_pairs(
+        set(old_map), set(new_map), old_map, new_map
+    ):
+        assert old_name.rsplit("::", 1)[-1].startswith("~") == new_name.rsplit("::", 1)[
+            -1
+        ].startswith("~")
+
+
+@settings(max_examples=200, deadline=None)
+@given(
+    old_seg=st.sampled_from(["d1", "v1", "detail"]),
+    new_seg=st.sampled_from(["d1", "v1", "d2", "v2", "impl"]),
+    leaves=st.lists(
+        st.sampled_from(["run", "stop", "reset", "wait"]),
+        min_size=1,
+        max_size=4,
+        unique=True,
+    ),
+)
+def test_a_namespace_move_group_never_mixes_leaves(
+    old_seg: str, new_seg: str, leaves: list[str]
+) -> None:
+    """Every pair inside one group shares its leaf declaration name and differs
+    only in the substituted scope component — a group that mixed leaves would
+    mean two unrelated declarations were reported as one move."""
+
+    def mangle(seg: str, leaf: str) -> str:
+        return f"_ZN3lib{len(seg)}{seg}{len(leaf)}{leaf}Ev"
+
+    removed = {mangle(old_seg, leaf) for leaf in leaves}
+    added = {mangle(new_seg, leaf) for leaf in leaves}
+    groups = find_namespace_move_groups(removed, added)
+    for (a, b), pairs in groups.items():
+        assert a != b
+        for old_q, new_q in pairs:
+            assert old_q.rsplit("::", 1)[-1] == new_q.rsplit("::", 1)[-1]
+            assert old_q.replace(f"::{a}::", f"::{b}::") == new_q
+
+
+@settings(max_examples=150, deadline=None)
+@given(
+    leaves=st.lists(
+        st.sampled_from(["run", "stop", "reset"]), min_size=1, max_size=3, unique=True
+    )
+)
+def test_an_unchanged_namespace_never_yields_a_group(leaves: list[str]) -> None:
+    """No substitution exists when nothing moved, so nothing is ever grouped —
+    a self-comparison must stay silent."""
+    syms = {f"_ZN3lib2d1{len(leaf)}{leaf}Ev" for leaf in leaves}
+    assert find_namespace_move_groups(syms, syms) == {}

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -885,7 +885,7 @@ class TestResolveChangeIdentity:
         assert identity.tier == IDENTITY_TIER_NORMALIZED
 
     def test_batch_rename_synthetic_id_is_not_canonical(self) -> None:
-        # diff_symbols.py's _emit_batch_rename stores a synthetic
+        # diff_symbols_renames.py's emit_prefix_batch_rename stores a synthetic
         # "batch_rename:<prefix>*" identifier, never a real symbol.
         change = Change(
             kind=ChangeKind.SYMBOL_RENAMED_BATCH,

--- a/tests/test_lambda_closure_type_classification.py
+++ b/tests/test_lambda_closure_type_classification.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Clang-spelled lambda closure types are not the library's own ABI surface.
+
+``_ANONYMOUS_TYPE_MARKERS`` recognized GCC/DWARF's ``{lambda(...)#1}`` and the
+``<lambda`` spelling but not clang's ``(lambda at <path>:<line>:<col>)`` — nor
+the ``(lambda:<file>:<line>:<col>)`` form
+:func:`strip_anonymous_type_location` normalizes it to. A template
+instantiated over a closure (``raii_guard<(lambda:task_group.h:522:26)>``)
+therefore carried a source *line number* in its ABI identity: an unrelated
+edit earlier in the header shifted it and the shifted spelling read as a whole
+type removed plus a whole type added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.model import AbiSnapshot, RecordType, TypeField
+from abicheck.name_classification import (
+    is_abi_surface_type_name,
+    is_non_abi_surface_type,
+    strip_anonymous_type_location,
+)
+
+# Every spelling a supported backend can produce for the same closure-
+# parameterized instantiation.
+_CLOSURE_SPELLINGS = [
+    # clang, raw
+    "tbb::detail::d1::raii_guard<(lambda at /src/tbb/task_group.h:522:26)>",
+    # clang, after strip_anonymous_type_location
+    "tbb::detail::d1::raii_guard<(lambda:task_group.h:522:26)>",
+    # GCC / DWARF
+    "tbb::detail::d1::raii_guard<{lambda()#1}>",
+    # castxml
+    "tbb::detail::d1::raii_guard<<lambda_1>>",
+]
+
+
+@pytest.mark.parametrize("spelling", _CLOSURE_SPELLINGS)
+def test_every_backend_spelling_is_off_surface(spelling: str) -> None:
+    assert is_non_abi_surface_type(spelling)
+    assert not is_abi_surface_type_name(spelling, exclude_stdlib=True)
+
+
+def test_normalized_clang_spelling_round_trips_through_the_stripper() -> None:
+    """The stripper and the classifier must agree: normalizing a raw clang
+    spelling must not turn an off-surface type into an on-surface one."""
+    raw = _CLOSURE_SPELLINGS[0]
+    stripped = strip_anonymous_type_location(raw)
+    assert stripped != raw
+    assert is_non_abi_surface_type(stripped)
+
+
+def test_an_ordinary_template_instantiation_stays_on_surface() -> None:
+    assert is_abi_surface_type_name(
+        "tbb::detail::d1::raii_guard<int>", exclude_stdlib=True
+    )
+
+
+def _snap(version: str, line: int) -> AbiSnapshot:
+    ty = f"tbb::detail::d1::raii_guard<(lambda:task_group.h:{line}:26)>"
+    return AbiSnapshot(
+        library="libtbb.so",
+        version=version,
+        types=[
+            RecordType(
+                name=ty,
+                kind="class",
+                size_bits=64,
+                fields=[TypeField(name="m_func", type="int", offset_bits=0)],
+            )
+        ],
+    )
+
+
+def test_lambda_location_churn_produces_no_type_level_findings() -> None:
+    """An unrelated edit shifts the lambda's line; nothing about the library's
+    own ABI surface changed, so no type-level finding may be emitted."""
+    result = compare(_snap("2021", 522), _snap("2022", 530))
+    type_kinds = {
+        ChangeKind.TYPE_ADDED,
+        ChangeKind.TYPE_REMOVED,
+        ChangeKind.TYPE_SIZE_CHANGED,
+    }
+    assert not ({c.kind for c in result.changes} & type_kinds)

--- a/tests/test_qualified_type_matching.py
+++ b/tests/test_qualified_type_matching.py
@@ -32,6 +32,7 @@ from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind
 from abicheck.diff_helpers import build_type_map, lookup_matched_type
 from abicheck.model import AbiSnapshot, EnumType, RecordType, TypeField
+from abicheck.qualified_name_segments import strip_inline_abi_namespaces
 
 
 def _rec(
@@ -102,10 +103,61 @@ class TestDistinctNamespacesNeverMatch:
         assert ChangeKind.TYPE_ADDED in kinds
 
     def test_enums_share_the_same_matching_primitive(self) -> None:
-        old = EnumType(name="reduction", qualified_name="ccl::v1::reduction")
-        new = EnumType(name="reduction", qualified_name="ccl::v2::reduction")
+        old = EnumType(name="reduction", qualified_name="ccl::detail::d1::reduction")
+        new = EnumType(name="reduction", qualified_name="ccl::detail::d2::reduction")
         old_map, new_map = build_type_map([old]), build_type_map([new])
         assert lookup_matched_type(old_map, new_map, old) is None
+
+    def test_an_enclosing_templates_arguments_are_not_dropped(self) -> None:
+        """The inline-namespace equivalence below splits on ``::`` keeping
+        template arguments: two nested types under different instantiations of
+        the same outer template are different types."""
+        old = _rec("Inner", "ns::Outer<int>::Inner")
+        new = _rec("Inner", "ns::Outer<float>::Inner")
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is None
+        )
+
+
+class TestInlineAbiTagNamespacesStillMatch:
+    """An inline namespace is transparent for name lookup, so a declaration
+    gaining or losing one is the same entity spelled two ways — the libstdc++
+    dual-ABI (``std::`` <-> ``std::__cxx11::``) case, where the layout really
+    does change and the correct finding is a mutation, not remove+add."""
+
+    _STR = "basic_string<char, std::char_traits<char>, std::allocator<char> >"
+
+    def test_dual_abi_spelling_matches(self) -> None:
+        old = _rec(self._STR, f"std::{self._STR}", size_bits=32)
+        new = _rec(self._STR, f"std::__cxx11::{self._STR}", size_bits=40)
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is new
+        )
+
+    def test_versioned_inline_namespace_matches(self) -> None:
+        old = _rec("Handle", "ns::v1::Handle")
+        new = _rec("Handle", "ns::Handle", size_bits=128)
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is new
+        )
+
+    def test_an_ordinary_implementation_namespace_is_not_an_abi_tag(self) -> None:
+        """``detail``/``impl``/``d1`` are ordinary namespaces: renaming one
+        really does move every declaration inside it."""
+        for old_ns, new_ns in (
+            ("ns::detail", "ns::impl"),
+            ("tbb::detail::d1", "tbb::detail::d2"),
+            ("ns::internal", "ns"),
+        ):
+            old = _rec("Handle", f"{old_ns}::Handle")
+            new = _rec("Handle", f"{new_ns}::Handle")
+            assert (
+                lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+                is None
+            ), f"{old_ns} -> {new_ns} must not match"
 
 
 class TestGenuineMutationsStillMatch:
@@ -167,7 +219,9 @@ class TestLegacySchemaCompatibilityIsPreserved:
 
 # ── Property-level contract of the matching primitive ─────────────────────
 
-_NS = st.sampled_from(["", "a", "b", "a::b", "x::y::z", "tbb::detail::d1"])
+_NS = st.sampled_from(
+    ["", "a", "b", "a::b", "x::y::z", "tbb::detail::d1", "a::v1", "a::__cxx11"]
+)
 _LEAF = st.sampled_from(["Foo", "graph", "Impl", "value_type"])
 
 
@@ -181,13 +235,16 @@ def test_a_match_never_crosses_two_recorded_qualified_identities(
     ns_old: str, ns_new: str, leaf: str
 ) -> None:
     """The invariant: when *both* sides recorded a qualified identity, a match
-    implies those identities are equal. A bare-name coincidence is never
+    implies those identities are equal *modulo inline ABI-tag namespaces*,
+    which are transparent for name lookup. A bare-name coincidence is never
     sufficient — which is exactly what the oneTBB namespace move exposed."""
     old = _rec(leaf, _qualified(ns_old, leaf))
     new = _rec(leaf, _qualified(ns_new, leaf))
     matched = lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
     if matched is not None and old.qualified_name and new.qualified_name:
-        assert old.qualified_name == new.qualified_name
+        assert strip_inline_abi_namespaces(
+            old.qualified_name
+        ) == strip_inline_abi_namespaces(new.qualified_name)
 
 
 @settings(max_examples=250, deadline=None)
@@ -222,3 +279,44 @@ def test_identical_snapshots_always_match_every_type_to_itself(
         matched = lookup_matched_type(own, other, t)
         assert matched is not None
         assert (matched.qualified_name or matched.name) == (t.qualified_name or t.name)
+
+
+# ── The stripping primitive's own contract ────────────────────────────────
+
+_SEGMENT = st.sampled_from(
+    ["ns", "detail", "d1", "impl", "v1", "__1", "_V2", "__cxx11", "__ndk1", "internal"]
+)
+
+
+@settings(max_examples=300, deadline=None)
+@given(segs=st.lists(_SEGMENT, min_size=1, max_size=5), leaf=_LEAF)
+def test_stripping_never_removes_the_leaf_and_is_idempotent(
+    segs: list[str], leaf: str
+) -> None:
+    """Two invariants of the primitive itself: the declaration's own name
+    always survives (a type may legitimately *be* named ``v1``), and stripping
+    an already-stripped name is a no-op."""
+    qualified = "::".join([*segs, leaf])
+    stripped = strip_inline_abi_namespaces(qualified)
+    assert stripped[-1] == leaf
+    assert strip_inline_abi_namespaces("::".join(stripped)) == stripped
+
+
+@settings(max_examples=300, deadline=None)
+@given(segs=st.lists(_SEGMENT, min_size=1, max_size=5), leaf=_LEAF)
+def test_only_abi_tag_segments_are_ever_removed(segs: list[str], leaf: str) -> None:
+    """Whatever is dropped is an ABI tag, and whatever is ordinary is kept in
+    its original relative order — an ordinary namespace rename must remain
+    visible."""
+    from abicheck.qualified_name_segments import is_inline_abi_namespace_segment
+
+    qualified = "::".join([*segs, leaf])
+    stripped = strip_inline_abi_namespaces(qualified)
+    assert list(stripped) == [
+        s for s in segs if not is_inline_abi_namespace_segment(s)
+    ] + [leaf]
+
+
+def test_a_single_segment_name_is_returned_unchanged() -> None:
+    assert strip_inline_abi_namespaces("v1") == ("v1",)
+    assert strip_inline_abi_namespaces("") == ()

--- a/tests/test_qualified_type_matching.py
+++ b/tests/test_qualified_type_matching.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Old/new type matching must not pair two *distinct* qualified identities.
+
+``diff_helpers.lookup_matched_type`` is the one primitive every RecordType/
+EnumType detector matches through, so it gets the "Primitive-level property
+tests" treatment CLAUDE.md prescribes: its contract stated as invariants over
+generated inputs, decoupled from any one detector's domain logic, alongside the
+concrete oneTBB-shaped regression that motivated it (``tbb::detail::d1::graph``
+vs. ``tbb::detail::d2::graph`` — same bare leaf, different namespace, different
+mangled vtable symbol, and emphatically not the same type).
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings, strategies as st
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.diff_helpers import build_type_map, lookup_matched_type
+from abicheck.model import AbiSnapshot, EnumType, RecordType, TypeField
+
+
+def _rec(
+    bare: str,
+    qualified: str | None = None,
+    *,
+    size_bits: int = 64,
+    fields: list[TypeField] | None = None,
+) -> RecordType:
+    return RecordType(
+        name=bare,
+        kind="class",
+        qualified_name=qualified,
+        size_bits=size_bits,
+        fields=fields or [],
+    )
+
+
+class TestDistinctNamespacesNeverMatch:
+    """(a) Two distinct types in different namespaces sharing a bare name."""
+
+    def test_onetbb_d1_to_d2_graph_is_not_a_match(self) -> None:
+        old = _rec("graph", "tbb::detail::d1::graph", size_bits=64)
+        new = _rec("graph", "tbb::detail::d2::graph", size_bits=128)
+        old_map, new_map = build_type_map([old]), build_type_map([new])
+        assert lookup_matched_type(old_map, new_map, old) is None
+        assert lookup_matched_type(new_map, old_map, new) is None
+
+    def test_namespace_move_reports_removal_and_addition_not_a_mutation(self) -> None:
+        """End-to-end: the phantom mutation findings are gone, and the truth
+        (one type removed, one added) is what is reported instead."""
+        old_snap = AbiSnapshot(
+            library="libtbb.so",
+            version="2021",
+            types=[
+                _rec(
+                    "graph",
+                    "tbb::detail::d1::graph",
+                    size_bits=64,
+                    fields=[TypeField(name="my_root_task", type="int*", offset_bits=0)],
+                ),
+                # A second, unrelated type so the old side is not a single-entry
+                # map (which would make the assertion trivially true).
+                _rec("task_group", "tbb::detail::d1::task_group", size_bits=32),
+            ],
+        )
+        new_snap = AbiSnapshot(
+            library="libtbb.so",
+            version="2022",
+            types=[
+                _rec(
+                    "graph",
+                    "tbb::detail::d2::graph",
+                    size_bits=192,
+                    fields=[
+                        TypeField(name="my_context", type="int*", offset_bits=0),
+                        TypeField(name="my_root_task", type="int*", offset_bits=64),
+                    ],
+                ),
+                _rec("task_group", "tbb::detail::d1::task_group", size_bits=32),
+            ],
+        )
+        kinds = {c.kind for c in compare(old_snap, new_snap).changes}
+        assert ChangeKind.TYPE_SIZE_CHANGED not in kinds
+        assert ChangeKind.TYPE_FIELD_OFFSET_CHANGED not in kinds
+        assert ChangeKind.TYPE_FIELD_ADDED not in kinds
+        assert ChangeKind.TYPE_REMOVED in kinds
+        assert ChangeKind.TYPE_ADDED in kinds
+
+    def test_enums_share_the_same_matching_primitive(self) -> None:
+        old = EnumType(name="reduction", qualified_name="ccl::v1::reduction")
+        new = EnumType(name="reduction", qualified_name="ccl::v2::reduction")
+        old_map, new_map = build_type_map([old]), build_type_map([new])
+        assert lookup_matched_type(old_map, new_map, old) is None
+
+
+class TestGenuineMutationsStillMatch:
+    """(b) A same-namespace mutation is still detected."""
+
+    def test_same_qualified_identity_matches(self) -> None:
+        old = _rec("graph", "tbb::detail::d1::graph", size_bits=64)
+        new = _rec("graph", "tbb::detail::d1::graph", size_bits=128)
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is new
+        )
+
+    def test_same_namespace_size_change_is_reported(self) -> None:
+        old_snap = AbiSnapshot(
+            library="lib.so",
+            version="1",
+            types=[_rec("graph", "tbb::detail::d1::graph", size_bits=64)],
+        )
+        new_snap = AbiSnapshot(
+            library="lib.so",
+            version="2",
+            types=[_rec("graph", "tbb::detail::d1::graph", size_bits=128)],
+        )
+        kinds = {c.kind for c in compare(old_snap, new_snap).changes}
+        assert ChangeKind.TYPE_SIZE_CHANGED in kinds
+
+
+class TestLegacySchemaCompatibilityIsPreserved:
+    """The bare-name alias exists for one reason only — a side that never
+    recorded ``qualified_name`` — and that reason still works, in both
+    directions."""
+
+    def test_new_side_is_legacy(self) -> None:
+        old = _rec("Foo", "ns::Foo")
+        new = _rec("Foo", None, size_bits=128)
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is new
+        )
+
+    def test_old_side_is_legacy(self) -> None:
+        old = _rec("Foo", None)
+        new = _rec("Foo", "ns::Foo", size_bits=128)
+        assert (
+            lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+            is new
+        )
+
+    def test_legacy_side_with_two_same_leaf_types_stays_ambiguous(self) -> None:
+        old_a = _rec("Foo", "ns1::Foo")
+        old_b = _rec("Foo", "ns2::Foo")
+        new = _rec("Foo", None)
+        own = build_type_map([old_a, old_b])
+        other = build_type_map([new])
+        assert lookup_matched_type(own, other, old_a) is None
+        assert lookup_matched_type(own, other, old_b) is None
+
+
+# ── Property-level contract of the matching primitive ─────────────────────
+
+_NS = st.sampled_from(["", "a", "b", "a::b", "x::y::z", "tbb::detail::d1"])
+_LEAF = st.sampled_from(["Foo", "graph", "Impl", "value_type"])
+
+
+def _qualified(ns: str, leaf: str) -> str | None:
+    return f"{ns}::{leaf}" if ns else None
+
+
+@settings(max_examples=250, deadline=None)
+@given(ns_old=_NS, ns_new=_NS, leaf=_LEAF)
+def test_a_match_never_crosses_two_recorded_qualified_identities(
+    ns_old: str, ns_new: str, leaf: str
+) -> None:
+    """The invariant: when *both* sides recorded a qualified identity, a match
+    implies those identities are equal. A bare-name coincidence is never
+    sufficient — which is exactly what the oneTBB namespace move exposed."""
+    old = _rec(leaf, _qualified(ns_old, leaf))
+    new = _rec(leaf, _qualified(ns_new, leaf))
+    matched = lookup_matched_type(build_type_map([old]), build_type_map([new]), old)
+    if matched is not None and old.qualified_name and new.qualified_name:
+        assert old.qualified_name == new.qualified_name
+
+
+@settings(max_examples=250, deadline=None)
+@given(ns_old=_NS, ns_new=_NS, leaf=_LEAF)
+def test_matching_is_symmetric(ns_old: str, ns_new: str, leaf: str) -> None:
+    """Probing old->new and new->old must agree: half the detectors walk the
+    old map and half walk the new one (``diff_layout`` probes from the new
+    side), so an asymmetric answer would make one detector see a mutation
+    where its sibling sees an add/remove pair."""
+    old = _rec(leaf, _qualified(ns_old, leaf))
+    new = _rec(leaf, _qualified(ns_new, leaf))
+    old_map, new_map = build_type_map([old]), build_type_map([new])
+    forward = lookup_matched_type(old_map, new_map, old) is not None
+    backward = lookup_matched_type(new_map, old_map, new) is not None
+    assert forward == backward
+
+
+@settings(max_examples=200, deadline=None)
+@given(
+    leaf=_LEAF,
+    namespaces=st.lists(_NS, min_size=1, max_size=4, unique=True),
+)
+def test_identical_snapshots_always_match_every_type_to_itself(
+    leaf: str, namespaces: list[str]
+) -> None:
+    """Reflexivity: comparing a snapshot's type set against itself must pair
+    every type with its own counterpart, however many share a bare leaf."""
+    types = [_rec(leaf, _qualified(ns, leaf)) for ns in namespaces]
+    own = build_type_map(types)
+    other = build_type_map([_rec(t.name, t.qualified_name) for t in types])
+    for t in own.values():
+        matched = lookup_matched_type(own, other, t)
+        assert matched is not None
+        assert (matched.qualified_name or matched.name) == (t.qualified_name or t.name)

--- a/tests/test_typedef_bare_symbol_disambiguation.py
+++ b/tests/test_typedef_bare_symbol_disambiguation.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Several same-bare-name typedef removals stay individually distinguishable.
+
+``Change.symbol`` for a typedef is deliberately bare (a header-mode dumper
+spells a *reference* to a typedef bare in a signature, and
+``diff_filtering._enrich_affected_symbols`` matches on that) — so the
+qualified spelling has to reach the reader some other way. This pins the whole
+chain that makes five ``value_type`` removals tellable apart: the description,
+the generic ``(kind, description)`` dedup that would otherwise collapse them,
+and the canonical finding id downstream consumers key on.
+"""
+
+from __future__ import annotations
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.finding_identity import report_canonical_finding_id
+from abicheck.model import AbiSnapshot
+
+_OWNERS = [
+    "tbb::detail::d1::concurrent_vector",
+    "tbb::detail::d1::concurrent_queue",
+    "tbb::detail::d1::concurrent_map",
+    "tbb::detail::d2::concurrent_vector",
+    "tbb::detail::d2::concurrent_queue",
+]
+
+
+def _old() -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtbb.so",
+        version="2021",
+        typedefs={"value_type": "int"},
+        typedefs_qualified={f"{owner}::value_type": "int" for owner in _OWNERS},
+    )
+
+
+def _new() -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtbb.so", version="2022", typedefs={}, typedefs_qualified={}
+    )
+
+
+def _removals() -> list[object]:
+    return [
+        c
+        for c in compare(_old(), _new()).changes
+        if c.kind is ChangeKind.TYPEDEF_REMOVED
+    ]
+
+
+def test_every_qualified_declaration_is_reported_once() -> None:
+    removals = _removals()
+    assert len(removals) == len(_OWNERS)
+
+
+def test_symbol_stays_bare_for_affected_symbol_attribution() -> None:
+    assert {c.symbol for c in _removals()} == {"value_type"}  # type: ignore[attr-defined]
+
+
+def test_descriptions_disambiguate_by_qualified_owner() -> None:
+    descriptions = {c.description for c in _removals()}  # type: ignore[attr-defined]
+    assert len(descriptions) == len(_OWNERS)
+    for owner in _OWNERS:
+        assert any(f"{owner}::value_type" in d for d in descriptions)
+
+
+def test_canonical_finding_ids_are_distinct() -> None:
+    ids = {report_canonical_finding_id(c) for c in _removals()}
+    assert len(ids) == len(_OWNERS)


### PR DESCRIPTION
## Summary

Fix two related ABI matching bugs: (1) namespace moves are no longer incorrectly reported as type mutations, and (2) whole-namespace symbol moves are now recognized as a single batch rename instead of N unpaired removals/additions.

## Motivation

oneTBB 2022 moved its flow-graph implementation from `tbb::detail::d1` to `tbb::detail::d2`, creating two distinct types with the same bare name (`graph`). The old type matching logic would incorrectly pair these unrelated types and report phantom mutations (`TYPE_SIZE_CHANGED`, `TYPE_FIELD_OFFSET_CHANGED`) instead of correctly identifying one removal and one addition. Similarly, the batch-rename detector only recognized prepended prefixes, missing namespace-segment substitutions entirely.

## Changes

- **Type matching (`diff_helpers.lookup_matched_type`)**: The bare-name fallback retry now only applies when one side genuinely lacks a qualified identity, or when both sides differ only by inline ABI-tag namespaces (e.g., `std::` vs. `std::__cxx11::`). Ordinary implementation namespaces (`detail`, `impl`, `d1`) are no longer treated as transparent.

- **Qualified name handling (`qualified_name_segments.py`)**: Added `strip_inline_abi_namespaces()`/`raw_segments()`, plus `inline_abi_namespaces_equivalent()` — plain stripped-tuple equality is unsound on its own because two *different* explicit version tags (`v1` vs `v2`) both strip to the same tuple; the new function requires elision (one side omits the tag) or an identical tag on both sides, and rejects two different tags present on both sides.

- **Batch rename detection (`diff_symbols_renames.py`)**:
  - Moved `find_prefix_rename_pairs()` and `emit_prefix_batch_rename()` from `diff_symbols.py` with added destructor-matching guards to prevent false pairings like `Wrapper` → `~Wrapper`. The scan no longer stops at the first candidate regardless of validity — it keeps scanning past a boundary-rejected candidate for a later valid one.
  - Added `find_namespace_move_groups()` and `emit_namespace_move_batches()` to detect and roll up namespace-segment substitutions in mangled names. Matching requires the parsed scope chain **and** the mangled signature remainder (parameter types/cv-qualifiers) to agree, since the scope chain alone can't distinguish overloads (`f(int)`/`f(long)` both parse to `["f"]`); an added symbol is consumed by at most one removed symbol.

- **Signature-aware mangled-name parsing (`diff_cxx_rules.py`)**: Added `itanium_scope_components_with_signature()`/`msvc_scope_components_with_signature()`, returning the raw mangled remainder immediately after the parsed scope chain, so callers can disambiguate overloads that share a scope chain.

- **Lambda closure classification (`name_classification.py`)**: Extended `_ANONYMOUS_TYPE_MARKERS` to recognize clang's closure spelling `(lambda:...)` so closure-parameterized template instantiations are no longer treated as ABI surface.

- **Test coverage**: Added comprehensive property-based tests using Hypothesis to verify matching invariants, batch rename logic, overload disambiguation, and lambda closure handling.

## Bug-fix test contract

- **Bug class**: Type matching incorrectly paired distinct namespaces (including distinct version tags); batch rename detector missed namespace moves, could conflate distinct overloads under one batch, and could give up scanning before reaching a valid rename candidate.
- **Publicly observable failure**: `compare()` reports phantom type mutations for namespace moves; namespace-wide symbol moves appear as N unpaired removals/additions instead of one batch; two distinct overloads could be miscounted as one batch move; a valid prefix rename could be silently dropped when an invalid same-suffix candidate sorted first.
- **Regression test fails on base**: `test_onetbb_d1_to_d2_graph_is_not_a_match()`, `test_namespace_move_reports_removal_and_addition_not_a_mutation()`, `test_namespace_move_is_recognized_as_one_batch()`, `test_two_different_version_tags_do_not_match()`, `test_two_removed_overloads_do_not_both_claim_one_unrelated_addition()`, `test_a_rejected_candidate_does_not_stop_the_scan_for_a_later_one()`
- **Negative control**: `test_same_qualified_identity_matches()` verifies genuine mutations still pair correctly; `test_dual_abi_spelling_matches()`/`test_versioned_inline_namespace_matches()` confirm inline ABI tags and version elision still work; `test_matching_signature_still_pairs()` confirms a real overload move still batches.
- **Public-surface test**: End-to-end `compare()` tests verify the full pipeline produces correct findings.
- **Axes covered**: Distinct namespaces, inline ABI tags, version-number namespaces (elided vs. two different explicit tags), destructor vs. non-destructor, overload signature remainders, mangled scope chains, legacy schema compatibility.
- **General invariant**: When both sides record qualified identities, a match implies those identities are equivalent modulo inline-ABI-tag elision (never modulo a genuine tag *mismatch*); matching is symmetric; identical snapshots match every type to itself; a namespace-move pair additionally requires equal signature remainders and consumes each added symbol at most once.
- **Must-merge / must-not-merge pair**: Must-merge — `ns::v1::Handle` (tag present) vs. `ns::Handle` (tag elided) name the same entity and must match (`test_versioned_inline_namespace_matches`, `test_eliding_a_version_tag_is_always_equivalent`). Must-not-merge — `ns::v1::Handle` vs. `ns::v2::Handle` (a tag present on *both* sides with different values, i.e. a real version bump) must **not** match even though both strip to the identical `ns::Handle` (`test_two_different_version_tags_do_not_match`, `test_two_present_version_tags_equivalent_only_when_equal`). The equivalent pair for the batch-rename side: `v1::f(int)`→`v2::f(int)` must merge into one batch (`test_matching_signature_still_pairs`), while `v1::f(int)`/`v1::f(long)` against an unrelated `v2::f(float)` must not (`test_two_removed_overloads_do_not_both_claim_one_unrelated_addition`) — collapsing on scope chain alone is exactly what let two distinct overloads count as one move.

## Checklist

- [x] Tests added for new behaviour (4 new test files, 50+ test cases, including the must-merge/must-not-merge pairs above)
- [x] Changelog fragment added
- [x] No new mypy or ruff errors

https://claude.ai/code/session_01TYDrjVEgKrnvrLVsFzvn1S