### PR TITLE
fix: delta-score legacy mutation survivors

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -168,7 +168,10 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # The full baseline has taken just over two hours on GitHub-hosted runners.
+    # Keep a hard ceiling, but leave enough headroom for the measurement to
+    # finish and produce a receipt rather than being cancelled at 120 minutes.
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v6
         with:

--- a/scripts/check_mutation_score.py
+++ b/scripts/check_mutation_score.py
@@ -147,6 +147,11 @@ def render_baseline(records: list[MutantRecord]) -> dict[str, object]:
     can see which mutants were accepted.
     """
     by_module = survivors_by_module(records)
+    functions: dict[str, dict[str, int]] = {}
+    for record in records:
+        if record.is_survivor:
+            functions.setdefault(record.module_path, {}).setdefault(record.function, 0)
+            functions[record.module_path][record.function] += 1
     return {
         "_comment": (
             "Per-module surviving-mutant baseline. Regenerate with "
@@ -156,7 +161,14 @@ def render_baseline(records: list[MutantRecord]) -> dict[str, object]:
         ),
         "total_survivors": sum(len(v) for v in by_module.values()),
         "modules": {
-            module: {"survivors": len(keys), "keys": keys}
+            module: {
+                "survivors": len(keys),
+                "keys": keys,
+                # Counts, rather than mutant keys: mutmut renumbers a function
+                # when it is edited. This is the baseline needed to score a
+                # changed legacy function for *new* survivors only.
+                "functions": functions.get(module, {}),
+            }
             for module, keys in by_module.items()
         },
     }
@@ -178,6 +190,32 @@ def load_baseline(path: Path) -> dict[str, int] | None:
             out[module] = entry["survivors"]
         elif isinstance(entry, int):
             out[module] = entry
+    return out
+
+
+def load_function_baseline(path: Path) -> dict[tuple[str, str], int]:
+    """Read per-function survivor counts from a current baseline document.
+
+    Old baselines intentionally yield no entries: treating their module total
+    as a function total would hide a regression in one function paid for by an
+    improvement in another.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    modules = doc.get("modules") if isinstance(doc, dict) else None
+    if not isinstance(modules, dict):
+        return {}
+    out: dict[tuple[str, str], int] = {}
+    for module, entry in modules.items():
+        funcs = entry.get("functions") if isinstance(entry, dict) else None
+        if not isinstance(funcs, dict):
+            continue
+        for function, survivors in funcs.items():
+            if isinstance(function, str) and isinstance(survivors, int):
+                out[(module, function)] = survivors
     return out
 
 
@@ -407,24 +445,32 @@ def _base_reader(base_ref: str) -> Callable[[str], str | None] | None:
 
 
 def check_diff_scoped(
-    records: list[MutantRecord], touched: dict[str, set[str]]
+    records: list[MutantRecord],
+    touched: dict[str, set[str]],
+    baseline: dict[tuple[str, str], int] | None = None,
 ) -> list[str]:
     """Survivors living in a function this branch changed.
 
-    Absolute: there is no baseline to be under. If you edited a function and a
-    mutation of it still passes the suite, the edit is not verified.
+    A function recorded in a baseline is delta-scored: existing survivor debt
+    must not make every edit impossible, but its count may not rise. Functions
+    without a recorded baseline remain absolute. Module-scope edits are scored
+    by the per-module drift gate below; mutmut has no module-scope mutant to
+    attribute precisely.
     """
+    baseline = baseline or {}
+    current: dict[tuple[str, str], list[str]] = {}
+    for r in records:
+        if r.is_survivor and r.function in touched.get(r.module_path, set()):
+            current.setdefault((r.module_path, r.function), []).append(r.key)
     failures = []
-    for r in sorted(records, key=lambda r: r.key):
-        if not r.is_survivor:
-            continue
-        module_touched = touched.get(r.module_path, set())
-        if MODULE_SCOPE in module_touched:
+    for (module, function), keys in sorted(current.items()):
+        was = baseline.get((module, function))
+        if was is None:
+            failures.extend(f"  {module}::{function}  [{key}]" for key in sorted(keys))
+        elif len(keys) > was:
             failures.append(
-                f"  {r.module_path}::{r.function}  [{r.key}]  (module-scope change)"
+                f"  {module}::{function}: {was} -> {len(keys)} (+{len(keys) - was})"
             )
-        elif r.function in module_touched:
-            failures.append(f"  {r.module_path}::{r.function}  [{r.key}]")
     return failures
 
 
@@ -679,6 +725,7 @@ def main(argv: list[str] | None = None) -> int:
 
     exit_code = 0
     baseline_modules = load_baseline(Path(args.baseline_file))
+    function_baseline = load_function_baseline(Path(args.baseline_file))
     total_baseline = args.baseline if args.baseline is not None else SURVIVOR_BASELINE
     #: Is there a *drift* reference — the only thing that can answer "did the
     #: survivor set grow", for any function, changed or not?
@@ -844,7 +891,7 @@ def main(argv: list[str] | None = None) -> int:
             # survivors — so this is set before the pass/fail split, not
             # inside the "no survivors" arm.
             gated = True
-        failures = check_diff_scoped(records, touched)
+        failures = check_diff_scoped(records, touched, function_baseline)
         if failures:
             print(
                 "ERROR: surviving mutants in functions this branch changed — a "

--- a/scripts/check_mutation_score.py
+++ b/scripts/check_mutation_score.py
@@ -107,6 +107,11 @@ SURVIVOR_BASELINE: int | None = None
 #: Default per-module baseline, committed alongside the code.
 DEFAULT_BASELINE_FILE = REPO_ROOT / "mutation-baseline.json"
 
+# Must match the 240-minute GitHub Actions job limit in mutation.yml.  The
+# subprocess cap formerly stayed at 7,200 seconds, silently aborting the run
+# at 120 minutes even after the job itself was given more time.
+MUTMUT_RUN_TIMEOUT_SECONDS = 14_400
+
 #: ``@@ -old,cnt +new,cnt @@`` — we only need the new-side range.
 _HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
@@ -126,7 +131,7 @@ def _run_mutmut(cmd: list[str]) -> tuple[str, int]:
     and let the gate pass on stale results (Codex review).
     """
     proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-        cmd, capture_output=True, text=True, timeout=7200
+        cmd, capture_output=True, text=True, timeout=MUTMUT_RUN_TIMEOUT_SECONDS
     )
     return proc.stdout + proc.stderr, proc.returncode
 

--- a/tests/test_mutation_score_gate.py
+++ b/tests/test_mutation_score_gate.py
@@ -67,6 +67,15 @@ def test_parse_survivors_returns_none_when_unmeasurable(text: str) -> None:
     assert gate.parse_survivors(text) is None
 
 
+def test_mutmut_subprocess_timeout_matches_the_workflow_ceiling() -> None:
+    """The Python cap must not pre-empt the GitHub Actions job deadline."""
+    workflow = (
+        Path(__file__).resolve().parent.parent / ".github" / "workflows" / "mutation.yml"
+    ).read_text(encoding="utf-8")
+    assert "timeout-minutes: 240" in workflow
+    assert gate.MUTMUT_RUN_TIMEOUT_SECONDS == 240 * 60
+
+
 def test_stats_without_a_survivor_count_are_not_a_completion_witness(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_mutation_score_gate.py
+++ b/tests/test_mutation_score_gate.py
@@ -433,6 +433,31 @@ def test_diff_scoped_fails_on_a_survivor_in_a_changed_function(
     assert "abicheck/diff_types.py::alpha" in capsys.readouterr().out
 
 
+def test_diff_scoped_allows_recorded_legacy_survivors_but_rejects_delta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A baseline makes a legacy function a delta gate, not a permanent ban."""
+    diff, baseline = _diff_scoped_env(tmp_path, monkeypatch)
+    Path(baseline).write_text(
+        json.dumps(
+            {"modules": {"abicheck/diff_types.py": {
+                "survivors": 10, "keys": [], "functions": {"alpha": 1}
+            }}},
+        ),
+        encoding="utf-8",
+    )
+    one = _write(tmp_path, "one.txt", "    abicheck.diff_types.x_alpha__mutmut_1: survived\n")
+    two = _write(
+        tmp_path, "two.txt",
+        "    abicheck.diff_types.x_alpha__mutmut_1: survived\n"
+        "    abicheck.diff_types.x_alpha__mutmut_2: survived\n",
+    )
+    common = ["--baseline-file", baseline, "--diff-scoped", "--diff-file", diff]
+    assert gate.main(["--results-file", one, *common]) == 0
+    assert gate.main(["--results-file", two, *common]) == 1
+    assert "alpha: 1 -> 2" in capsys.readouterr().out
+
+
 #: A diff that touches only a test file — the shape a PR takes when it weakens
 #: or deletes assertions without editing the detector.
 _TEST_ONLY_DIFF = """diff --git a/tests/test_diff_types.py b/tests/test_diff_types.py
@@ -1497,12 +1522,14 @@ def test_an_unresolvable_base_ref_fails_the_diff_scoped_gate(
     assert "diff-scoped OK" not in out
 
 
-def test_a_module_scope_change_gates_every_survivor_in_that_module(
+def test_a_module_scope_change_uses_per_module_drift_not_absolute_debt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A top-level policy table can change what any function in the module
-    does, so a module-scope edit gates the module's survivors rather than
-    matching none of them."""
+    """Module scope has no precise mutant attribution, so baseline drift gates it.
+
+    Historical survivors must not permanently prohibit a constant/table edit;
+    a raised module total is still rejected by the ordinary baseline gate.
+    """
     (tmp_path / "abicheck").mkdir()
     (tmp_path / "abicheck" / "diff_types.py").write_text(
         "_KINDS = frozenset({'a'})\n\n\ndef untouched():\n    return _KINDS\n",
@@ -1528,5 +1555,5 @@ def test_a_module_scope_change_gates_every_survivor_in_that_module(
             diff,
         ]
     )
-    assert rc == 1
-    assert "module-scope change" in capsys.readouterr().out
+    assert rc == 0
+    assert "per-module baseline OK" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Make the diff-scoped mutation gate distinguish legacy survivor debt from a regression introduced by the PR.

## Motivation

A change within a legacy function with pre-existing mutmut survivors was an unconditional PR failure. A module-scope change (for example `SCHEMA_VERSION`) likewise attributed every survivor in the module to the PR, even when the survivor existed on `main`.

## Changes

- Store per-function survivor counts in `mutation-baseline.json`.
- For a changed function recorded in the baseline, fail only if its survivor count increases.
- Keep an absolute zero-survivor requirement for functions absent from the baseline.
- Use existing per-module drift rather than absolute function debt for module-scope edits.
- Align the `check_mutation_score.py` subprocess deadline with the 240-minute GitHub Actions job ceiling.

## Bug-fix test contract

- Bug class: Diff-scoped mutation attribution conflated historical survivors with mutations introduced by a changed legacy function or a module-scope declaration.
- Publicly observable failure: A PR with no new surviving mutants failed CI solely because `main` already had survivors in the edited function or module.
- Regression test fails on base: `test_diff_scoped_allows_recorded_legacy_survivors_but_rejects_delta` requires the new per-function baseline field and delta comparison; base fails its expected pass/fail outcomes.
- Negative control: A changed function absent from the baseline still fails on any survivor; a recorded function still fails when its count rises from 1 to 2.
- Public-surface test: `scripts/check_mutation_score.py` is exercised through `gate.main(...)`, the CI entry point invoked by `.github/workflows/mutation.yml`.
- Axes covered: Changed legacy function with stable debt, changed legacy function with increased debt, newly unbaselined function, and module-scope constant/table edit.
- General invariant: Existing baseline debt cannot hide a survivor-count increase; unbaselined production code remains an absolute mutation gate.
- Malicious fixture + side-effect absence: N/A — this only extends the bounded GitHub-hosted mutation measurement deadline; it adds no untrusted-input path and does not change CI permissions, commands, or side effects.

## Verification

- `python -m pytest tests/test_mutation_score_gate.py tests/test_mutation_results.py -q` — 138 passed, 1 skipped
- `git diff --check`