### PR TITLE
fix: forward header_backend/compile and per-library overrides in the G38 bundle-facts driver

### DIFF
--- a/abicheck/bundle_side_input.py
+++ b/abicheck/bundle_side_input.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     from .bundle_manifest import InstantiationManifest
     from .bundle_models import BundleDiffResult, BundleSignatureEvidence, BundleSnapshot
     from .checker_types import DiffResult
+    from .compile_context import CompileContext
     from .model import AbiSnapshot
 
 
@@ -219,6 +220,11 @@ def compare_release_against_bundle_facts(
     *,
     headers: list[Path] | None = None,
     includes: list[Path] | None = None,
+    header_backend: str = "auto",
+    compile: CompileContext | None = None,
+    per_library_headers: dict[str, list[Path]] | None = None,
+    per_library_includes: dict[str, list[Path]] | None = None,
+    per_library_compile: dict[str, CompileContext] | None = None,
     new_version: str = "",
     lang: str = "c++",
     include_private_dso: bool = False,
@@ -253,13 +259,45 @@ def compare_release_against_bundle_facts(
     accounting, which stays a CLI-only concern.
 
     Only the ELF-only per-library evidence a bundle comparison actually
-    needs is resolved (no debug-info package resolution, no PDB, no header
-    scoping beyond *headers*/*includes* applied uniformly to every matched
-    library) -- the plan's own Phase 2 status note names exactly this
-    narrowing ("most of compare's ~40 release-fan-out flags ... lose their
-    old-side meaning once the old side is already a resolved snapshot") as
-    why this is a genuinely smaller surface than ``compare_release_cmd``,
-    not an oversight.
+    needs is resolved (no debug-info package resolution, no PDB) -- the
+    plan's own Phase 2 status note names exactly this narrowing ("most of
+    compare's ~40 release-fan-out flags ... lose their old-side meaning
+    once the old side is already a resolved snapshot") as why this is a
+    genuinely smaller surface than ``compare_release_cmd``, not an
+    oversight.
+
+    *header_backend*/*compile* forward straight to ``service.resolve_input``
+    (both were previously silently dropped: this driver called
+    ``resolve_input`` without either kwarg, so a header-scoped NEW side always
+    resolved under ``header_backend="auto"`` -- which, absent a real castxml
+    on the host, means ``resolve_input`` picks castxml anyway and dies on a
+    clang/icpx-only host rather than falling back). A caller with a
+    resolved, working ``CompileContext`` (compiler binding, frontend,
+    extra flags -- e.g. a SYCL/DPC++ host that needs
+    ``CompileContext(gcc_path="icpx", frontend="clang", ...)``) can now pass
+    it directly instead of monkeypatching this module.
+
+    *headers*/*includes*/*compile* are the **uniform** fallback applied to
+    every matched library -- correct only when every library in the bundle
+    shares one header tree and one compile configuration, which does not
+    hold for a mixed-toolchain release (e.g. oneDAL's ``daal``/``oneapi::dal``
+    libraries built as plain C++ alongside a ``dpc`` library built
+    ``-fsycl``/``icpx``): resolving *every* library with the same
+    ``headers``/``includes``/``compile`` in that case parses each library's
+    headers under whichever single configuration was supplied, which is
+    correct for at most one of them. *per_library_headers*/
+    *per_library_includes*/*per_library_compile* are optional
+    ``{canonical_name: ...}`` overrides, consulted before the uniform
+    fallback for each matched library -- a library with no entry in a given
+    per-library map still falls back to that map's uniform sibling
+    (*headers*/*includes*/*compile* respectively), so a caller only needs to
+    override the libraries that actually differ. A comparison run entirely
+    with the uniform fallback (no per-library overrides) remains a **cost
+    proof**, not a **correctness proof**, for a mixed-toolchain bundle: it
+    demonstrates the driver runs to completion in reasonable time/memory,
+    not that every library was parsed under its own real compile
+    configuration -- use the per-library maps once any library's headers
+    need flags another library's don't.
 
     *include_dependencies* (default ``False``) mirrors ``--include-system-
     declarations``'s own Click default (``cli_options.
@@ -305,12 +343,23 @@ def compare_release_against_bundle_facts(
         new_path = new_map.get(key)
         if new_path is None:
             continue
+        # Per-library overrides win over the uniform fallback -- a library
+        # absent from a given override map still falls back to that map's
+        # own uniform sibling (headers/includes/compile respectively), so a
+        # caller only needs to name the libraries that actually differ. See
+        # the docstring above for why a uniform-only invocation is a cost
+        # proof, not a correctness proof, for a mixed-toolchain bundle.
+        lib_headers = (per_library_headers or {}).get(key, headers)
+        lib_includes = (per_library_includes or {}).get(key, includes)
+        lib_compile = (per_library_compile or {}).get(key, compile)
         new_snapshot = service.resolve_input(
             new_path,
-            headers=headers,
-            includes=includes,
+            headers=lib_headers,
+            includes=lib_includes,
             version=new_version,
             lang=lang,
+            header_backend=header_backend,
+            compile=lib_compile,
             include_dependencies=include_dependencies,
         )
         diff = service.compare_snapshots(old_snapshot, new_snapshot, policy=policy)

--- a/changelog.d/20260824_220000_claude_g38_assessment_updates.md
+++ b/changelog.d/20260824_220000_claude_g38_assessment_updates.md
@@ -1,0 +1,40 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 Phase 13 driver: `compare_release_against_bundle_facts()` now
+  forwards `header_backend`/`compile`, and accepts per-library header/
+  compile overrides.**
+
+  Two gaps surfaced by an external validation pass against `compare_release_
+  against_bundle_facts()` (the Phase 13 stored-vs-live bundle driver,
+  `abicheck/bundle_side_input.py`), both real and both fixed:
+
+  1. The driver's `service.resolve_input()` call for the NEW side never
+     passed `header_backend`/`compile` at all, so a header-scoped
+     comparison always resolved under `header_backend="auto"` with no
+     `CompileContext` — on a host with no working castxml (a clang/icpx-only
+     host), that dies rather than falling back to a caller's own resolved
+     compiler binding/frontend. Both are now forwarded straight through.
+  2. `headers`/`includes`/`compile` applied uniformly to every matched
+     library, which is only correct when every library in the bundle shares
+     one header tree and one compile configuration — not true for a
+     mixed-toolchain release (e.g. a plain-C++ library alongside a
+     `-fsycl`/`icpx` one). New optional `per_library_headers`/
+     `per_library_includes`/`per_library_compile` `{canonical_name: ...}`
+     maps are consulted before the uniform fallback per matched library, so
+     only the libraries that actually differ need an override. A run using
+     only the uniform fallback remains a **cost proof** (the driver
+     completes in reasonable time/memory), not a **correctness proof**, for
+     a mixed-toolchain bundle — documented explicitly on the function.
+
+  The third gap from the same assessment — no CLI/`.abicheck.yml` surface
+  for this driver — remains the already-documented, deliberate Phase 13
+  "Known gap": every file that would host the dispatch is within two lines
+  of the AI-readiness 2000-line hard cap (see the G38 plan doc's Phase 13
+  section). Adoption still needs a committed Python step
+  (`compare_release_against_bundle_facts(...)`), not a bare
+  `uses: abicheck/abicheck@sha` Action input, until one of those files is
+  split.

--- a/changelog.d/20260824_220000_claude_g38_assessment_updates.md
+++ b/changelog.d/20260824_220000_claude_g38_assessment_updates.md
@@ -8,9 +8,9 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   forwards `header_backend`/`compile`, and accepts per-library header/
   compile overrides.**
 
-  Two gaps surfaced by an external validation pass against `compare_release_
-  against_bundle_facts()` (the Phase 13 stored-vs-live bundle driver,
-  `abicheck/bundle_side_input.py`), both real and both fixed:
+  Two gaps surfaced by an external validation pass against
+  `compare_release_against_bundle_facts()` (the Phase 13 stored-vs-live
+  bundle driver, `abicheck/bundle_side_input.py`), both real and both fixed:
 
   1. The driver's `service.resolve_input()` call for the NEW side never
      passed `header_backend`/`compile` at all, so a header-scoped

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1777,6 +1777,68 @@ per-binary extraction cost. That remains its own, separately-scoped
 initiative (shared/content-addressed evidence storage, memory-aware
 scan scheduling), not additional G38 phase surface.
 
+### Phase 13 follow-up — real-world assessment of the driver, two of three gaps closed
+
+A follow-up assessment, exercising `compare_release_against_bundle_facts()`
+against a real, mixed-toolchain oneDAL-shaped release (a `-fsycl`/`icpx`
+`dpc` library alongside plain-C++ `daal`/`oneapi::dal` libraries sharing one
+umbrella header tree), reported three gaps. All three are now small and
+precisely specified rather than architectural — two are fixed, the third
+remains the already-documented Known-gap above:
+
+1. **No CLI surface.** Unchanged from the "Known gap" note above: adoption
+   still needs a committed Python step calling
+   `compare_release_against_bundle_facts(...)` directly, not
+   `uses: abicheck/abicheck@sha` with a bare CLI flag — every file that
+   would host the dispatch is still within two lines of (or already at)
+   the 2000-line hard cap.
+2. **Fixed.** The driver's `service.resolve_input()` call never forwarded
+   `header_backend`/`compile`, so a header-scoped NEW side always resolved
+   under the library's own `header_backend="auto"` default — absent a real
+   castxml on the host, `resolve_input` still picks castxml first and dies
+   in seconds on a clang/icpx-only host rather than falling back. The
+   assessment's own monkeypatch injecting
+   `CompileContext(gcc_path="icpx", gcc_option_tokens=("-fsycl",
+   "-DONEDAL_DATA_PARALLEL", "-std=c++17"), frontend="clang")` directly into
+   `service.resolve_input` is what produced its one successful (35-minute,
+   10.2 GB peak RSS) header-scoped run — proof the fix works, not a
+   supported way to reach it. Both kwargs are now real, forwarded
+   parameters on `compare_release_against_bundle_facts()` itself; no
+   monkeypatch needed.
+3. **Fixed, additively.** `headers`/`includes`/`compile` applied uniformly
+   to every matched library — correct only when every library in the
+   bundle shares one header tree and one compile configuration, which does
+   not hold for oneDAL's own mix (plain C++ `daal`/`oneapi::dal` alongside
+   `-fsycl`/`icpx` `dpc`): the assessment's header-scoped run in practice
+   parsed the `daal` library's headers under the `dpc` library's own
+   SYCL/DPC++ flags, since there was no way to say otherwise. That run is
+   therefore correctly characterized as a **cost proof** (the driver
+   completes end to end in bounded time/memory against a real multi-library
+   release) rather than a **correctness proof** (every library's headers
+   parsed under its own real compile configuration) — the two are
+   different claims, and only the former was actually demonstrated. New
+   optional `per_library_headers`/`per_library_includes`/
+   `per_library_compile` `{canonical_name: ...}` maps are now consulted
+   before the uniform fallback per matched library, so a caller can give
+   `dpc` its own SYCL flags while `daal`/`oneapi::dal` fall back to the
+   plain-C++ uniform default (or vice versa) — a library absent from a
+   given override map still falls back to that map's own uniform sibling,
+   so only the libraries that actually differ need naming. The function's
+   own docstring states the cost-proof-vs-correctness-proof distinction
+   explicitly, so a future caller running with only the uniform fallback
+   against a mixed-toolchain bundle cannot mistake the resulting exit code
+   for a per-library-correct comparison.
+
+Regression coverage for both fixes:
+`tests/test_bundle_side_input.py::TestCompareReleaseAgainstBundleFactsResolutionUnit::
+test_header_backend_and_compile_are_forwarded` (pins that both kwargs reach
+`service.resolve_input` unchanged, replacing the need for the assessment's
+own monkeypatch) and
+`::test_per_library_overrides_win_over_the_uniform_fallback` (a two-library
+fixture confirming a `per_library_*` entry for one library doesn't leak onto
+a library absent from that same map, which still receives the uniform
+`headers`/`compile` default).
+
 ---
 
 ## Out of scope

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1829,15 +1829,14 @@ remains the already-documented Known-gap above:
    against a mixed-toolchain bundle cannot mistake the resulting exit code
    for a per-library-correct comparison.
 
-Regression coverage for both fixes:
-`tests/test_bundle_side_input.py::TestCompareReleaseAgainstBundleFactsResolutionUnit::
-test_header_backend_and_compile_are_forwarded` (pins that both kwargs reach
+Regression coverage for both fixes, in
+`tests/test_bundle_side_input.py::TestCompareReleaseAgainstBundleFactsResolutionUnit`:
+`test_header_backend_and_compile_are_forwarded` (pins that both kwargs reach
 `service.resolve_input` unchanged, replacing the need for the assessment's
-own monkeypatch) and
-`::test_per_library_overrides_win_over_the_uniform_fallback` (a two-library
-fixture confirming a `per_library_*` entry for one library doesn't leak onto
-a library absent from that same map, which still receives the uniform
-`headers`/`compile` default).
+own monkeypatch) and `test_per_library_overrides_win_over_the_uniform_fallback`
+(a two-library fixture confirming a `per_library_*` entry for one library
+doesn't leak onto a library absent from that same map, which still receives
+the uniform `headers`/`compile` default).
 
 ---
 

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -534,20 +534,26 @@ class TestCompareReleaseAgainstBundleFactsResolutionUnit:
         )
 
         uniform_headers = [Path("/include/common")]
+        uniform_includes = [Path("/include/common/sys")]
         dpc_headers = [Path("/include/dpc")]
+        dpc_includes = [Path("/include/dpc/sys")]
         dpc_ctx = CompileContext(gcc_path="icpx", frontend="clang")
 
         compare_release_against_bundle_facts(
             facts_path,
             new_dir,
             headers=uniform_headers,
+            includes=uniform_includes,
             per_library_headers={"libdpc.so": dpc_headers},
+            per_library_includes={"libdpc.so": dpc_includes},
             per_library_compile={"libdpc.so": dpc_ctx},
         )
 
         assert captured_kwargs[core_so]["headers"] == uniform_headers
+        assert captured_kwargs[core_so]["includes"] == uniform_includes
         assert captured_kwargs[core_so]["compile"] is None
         assert captured_kwargs[dpc_so]["headers"] == dpc_headers
+        assert captured_kwargs[dpc_so]["includes"] == dpc_includes
         assert captured_kwargs[dpc_so]["compile"] is dpc_ctx
 
 

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -429,6 +429,127 @@ class TestCompareReleaseAgainstBundleFactsResolutionUnit:
 
         assert resolved_paths == [v10]
 
+    def test_header_backend_and_compile_are_forwarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prior to this fix, ``header_backend``/``compile`` were silently
+        dropped -- the NEW side always resolved under
+        ``header_backend="auto"`` with no ``CompileContext``, so a
+        header-scoped comparison on a host with no working castxml (a
+        clang/icpx-only host) died rather than using the caller's own
+        resolved compiler binding/frontend."""
+        import abicheck.package as package_mod
+        import abicheck.service as service_mod
+        from abicheck.compile_context import CompileContext
+
+        facts_path = self._old_facts(tmp_path)
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        new_so = new_dir / "libcore.so"
+        new_so.write_bytes(b"")
+
+        monkeypatch.setattr(
+            package_mod,
+            "discover_shared_libraries",
+            lambda d, include_private=False: [new_so],
+        )
+        captured_kwargs: dict[str, object] = {}
+
+        def _fake_resolve_input(path, **kwargs):
+            captured_kwargs.update(kwargs)
+            return AbiSnapshot(
+                library="libcore.so",
+                version="new",
+                elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            )
+
+        monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+        monkeypatch.setattr(
+            service_mod,
+            "compare_snapshots",
+            lambda old, new, policy: _diff("libcore.so", verdict=Verdict.NO_CHANGE),
+        )
+
+        ctx = CompileContext(
+            gcc_path="icpx",
+            gcc_option_tokens=("-fsycl", "-DONEDAL_DATA_PARALLEL", "-std=c++17"),
+            frontend="clang",
+        )
+        compare_release_against_bundle_facts(
+            facts_path, new_dir, header_backend="clang", compile=ctx
+        )
+
+        assert captured_kwargs["header_backend"] == "clang"
+        assert captured_kwargs["compile"] is ctx
+
+    def test_per_library_overrides_win_over_the_uniform_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``headers``/``includes``/``compile`` apply uniformly to every
+        matched library by default -- correct only when every library in the
+        bundle shares one header tree/compile configuration, which does not
+        hold for a mixed-toolchain release (e.g. a plain-C++ library
+        alongside a ``-fsycl``/``icpx`` one). A per-library override for one
+        library must not leak onto a library with no entry in that map, which
+        must keep falling back to the uniform default."""
+        import abicheck.package as package_mod
+        import abicheck.service as service_mod
+        from abicheck.compile_context import CompileContext
+
+        metadata = {
+            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+            "libdpc.so": _meta(soname="libdpc.so", exports=["dpc_fn"]),
+        }
+        facts = capture_bundle_facts(_per_library_snapshots(metadata))
+        facts_path = tmp_path / "old.bundlefacts.json"
+        save_bundle_facts(facts, facts_path)
+
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        core_so = new_dir / "libcore.so"
+        dpc_so = new_dir / "libdpc.so"
+        core_so.write_bytes(b"")
+        dpc_so.write_bytes(b"")
+
+        monkeypatch.setattr(
+            package_mod,
+            "discover_shared_libraries",
+            lambda d, include_private=False: [core_so, dpc_so],
+        )
+        captured_kwargs: dict[Path, dict[str, object]] = {}
+
+        def _fake_resolve_input(path, **kwargs):
+            captured_kwargs[path] = kwargs
+            return AbiSnapshot(
+                library=path.name,
+                version="new",
+                elf=_meta(soname=path.name, exports=["fn"]),
+            )
+
+        monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+        monkeypatch.setattr(
+            service_mod,
+            "compare_snapshots",
+            lambda old, new, policy: _diff(new.library, verdict=Verdict.NO_CHANGE),
+        )
+
+        uniform_headers = [Path("/include/common")]
+        dpc_headers = [Path("/include/dpc")]
+        dpc_ctx = CompileContext(gcc_path="icpx", frontend="clang")
+
+        compare_release_against_bundle_facts(
+            facts_path,
+            new_dir,
+            headers=uniform_headers,
+            per_library_headers={"libdpc.so": dpc_headers},
+            per_library_compile={"libdpc.so": dpc_ctx},
+        )
+
+        assert captured_kwargs[core_so]["headers"] == uniform_headers
+        assert captured_kwargs[core_so]["compile"] is None
+        assert captured_kwargs[dpc_so]["headers"] == dpc_headers
+        assert captured_kwargs[dpc_so]["compile"] is dpc_ctx
+
 
 # ---------------------------------------------------------------------------
 # compare_release_against_bundle_facts -- real compiled binaries


### PR DESCRIPTION
## Summary

A real-world assessment of `compare_release_against_bundle_facts()` (G38 Phase 13's stored-vs-live bundle driver, `abicheck/bundle_side_input.py`) against a mixed-toolchain oneDAL-shaped release reported three gaps. Two are now fixed; the third remains an already-documented, deliberate known gap.

1. **No CLI surface.** Unchanged — `cli_compare_release.py` and its siblings are within two lines of the 2000-line AI-readiness hard cap, so a Click option can't land without splitting one of them first (its own dedicated pass). Adoption still needs a committed Python step calling `compare_release_against_bundle_facts(...)` directly, not a bare `uses: abicheck/abicheck@sha` Action input.
2. **Fixed.** The driver's `service.resolve_input()` call never forwarded `header_backend`/`compile`, so a header-scoped NEW side always resolved under `header_backend="auto"` — absent a working castxml on the host, that dies rather than falling back to the caller's own resolved compiler binding/frontend. Both are now real, forwarded parameters.
3. **Fixed, additively.** `headers`/`includes`/`compile` applied uniformly to every matched library, which is wrong for a mixed-toolchain release (e.g. a plain-C++ library alongside a `-fsycl`/`icpx` one) — the reported header-scoped run parsed the plain-C++ `daal` library under the `dpc` library's own SYCL/DPC++ flags, since there was no way to say otherwise. New optional `per_library_headers`/`per_library_includes`/`per_library_compile` `{canonical_name: ...}` maps are consulted before the uniform fallback per matched library. The function's docstring now states explicitly that a uniform-only run is a **cost proof** (completes end to end), not a **correctness proof** (every library parsed under its own real configuration), for a mixed-toolchain bundle.

## Motivation

An external validation pass exercised the Phase 13 stored-facts driver against a real, mixed-toolchain release and reported two silent-fallback/scoping gaps that would otherwise force every caller onto a hand-written monkeypatch to work around.

## Changes

- `abicheck/bundle_side_input.py`: `compare_release_against_bundle_facts()` gains `header_backend`, `compile`, `per_library_headers`, `per_library_includes`, `per_library_compile` parameters, all forwarded/merged correctly per matched library.
- `tests/test_bundle_side_input.py`: two new regression tests pinning both fixes.
- `docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md`: records the assessment and what was/wasn't fixed.
- `changelog.d/`: new fragment.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A Tier-2 driver silently dropping caller-supplied resolution parameters (`header_backend`/`compile`) instead of forwarding them to `service.resolve_input`, plus a single resolution-parameter value applied uniformly across a heterogeneous collection (per-library `headers`/`includes`/`compile`) where the underlying primitive already supports per-item configuration.
- Publicly observable failure: A caller of `compare_release_against_bundle_facts()` passing `header_backend`/`compile` saw them silently ignored — on a host with no working castxml, the header-scoped NEW-side resolution died under the forced `header_backend="auto"` default regardless of what the caller passed, with no way to reach a working clang/icpx frontend short of monkeypatching `service.resolve_input` directly. Separately, a mixed-toolchain bundle (one library needing `-fsycl`/`icpx` flags, others plain C++) had every library's headers parsed under the same single `headers`/`includes`/`compile` value, so at most one library in the bundle could be resolved correctly.
- Regression test fails on base: Yes — `test_header_backend_and_compile_are_forwarded` and `test_per_library_overrides_win_over_the_uniform_fallback` in `tests/test_bundle_side_input.py` both fail on `main` (`captured_kwargs["header_backend"]`/`["compile"]` were previously absent from the call, and `per_library_headers`/`per_library_compile` were not accepted parameters at all, raising `TypeError`).
- Negative control: `test_per_library_overrides_win_over_the_uniform_fallback` asserts the *other* library (absent from the per-library override maps) still receives the uniform `headers`/`compile` fallback unchanged (`captured_kwargs[core_so]["headers"] == uniform_headers`, `captured_kwargs[core_so]["compile"] is None`) — an override for one library must not leak onto a library with no entry.
- Public-surface test: Both new tests exercise `compare_release_against_bundle_facts()` itself (the public Python-API entry point this driver exists to be), not an internal helper — mocking only `service.resolve_input`/`service.compare_snapshots` at the boundary this function is documented to route through.
- Axes covered: Python-API surface only (this function has no CLI/Action surface per the still-open gap #1 above); mocked-resolution unit tests (no compiler/castxml dependency, matching the existing `TestCompareReleaseAgainstBundleFactsResolutionUnit` class's own stated rationale for why the threading behavior doesn't need a real toolchain to verify).
- General invariant: `compare_release_against_bundle_facts()` now forwards every `service.resolve_input` parameter it accepts (`header_backend`, `compile`) unmodified for every matched library, and resolves each library's `headers`/`includes`/`compile` from that library's own `per_library_*` override when present, falling back to the shared uniform value only when absent — holds for any number of matched libraries and any subset carrying overrides, not just the two-library case the tests exercise.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed
- [ ] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved release-versus-bundle comparisons for projects using different compilers or frontends.
  * Added support for library-specific header, include, and compilation settings, with reliable fallback behavior.
  * Ensured selected compilation and header-resolution settings are consistently applied during comparison.

* **Documentation**
  * Clarified the distinction between cost validation and mixed-toolchain correctness validation.
  * Documented current command-line and configuration integration limitations.

* **Tests**
  * Added coverage for header backend forwarding and per-library setting overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->