### PR TITLE
fix: reject many-to-one namespace-move pairings, validate conversion-operator nesting

### DIFF
--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -781,6 +781,49 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     matching close -- regardless of what it looks like -- is treated as
     fully opaque interior, untouched by any other counter in this
     function.
+
+    Bracket (``[``/``]``) nesting is tracked as a FOURTH independent
+    counter, for the same reason: a subscript expression used inside a
+    non-type template argument (e.g. ``operator B<A[N > M]>()``, confirmed
+    to compile) carries a ``>`` that needs no parenthesization either --
+    ``]``, not ``>``, closes the subscript, so it carries none of the
+    top-level template-argument ambiguity a bare ``>`` would (Codex review,
+    fresh evidence). Treated exactly like a brace: once a bracket opens,
+    its entire interior is opaque, and this needs no heuristic either,
+    since ``[``/``]`` always balance unconditionally in valid C++ too.
+
+    Known, accepted limitation (Codex review, fresh evidence): the brace/
+    bracket "opaque interior" scan above is a raw character count, not a
+    real tokenizer -- it does not skip over string/char-literal content or
+    comments, so a brace, bracket, paren, or angle-bracket CHARACTER
+    embedded inside a string literal within a lambda body (e.g. ``operator
+    B<[]{ return sizeof("}"); }>()``, confirmed to compile and to be
+    pretty-printed verbatim by clang) desynchronizes the corresponding
+    counter and this function rejects otherwise-valid input. Closing this
+    for real needs an actual lexical scanner for the brace/bracket
+    interior -- string/char-literal quoting and escape-sequence handling
+    (including raw string literals, ``R"delim(...)delim"``, whose
+    terminator is itself data-dependent), plus line (``//``) and block
+    (``/* */``) comment recognition -- which is a materially different,
+    larger piece of work than "track one more independently-balancing
+    bracket kind" (the pattern every fix in this function's history above
+    has been). Deliberately not attempted here: this is the sixth
+    consecutive real-but-increasingly-exotic C++ grammar shape found in
+    this function across as many review rounds, and a string/char literal
+    containing bracket-like characters *inside a lambda body used as a
+    conversion-operator's own non-type template argument* is deep into
+    adversarially-constructed territory -- vanishingly unlikely to appear
+    in any real-world header this tool would actually be pointed at,
+    unlike every shape fixed above (each was a plain, if less common,
+    construct a real codebase could plausibly contain). Per this
+    codebase's own "known gaps over risky reactive patches" convention:
+    the input this function was built to defend against in the first
+    place is a genuinely MALFORMED synthetic key, and no valid, real-world
+    header-tier declaration this codebase has ever actually needed to
+    parse has required this. A caller reaching this gap gets the existing,
+    documented conservative fallback (``None``, no namespace-move pairing
+    for that one declaration) -- a missed roll-up for one input, not a
+    wrong one.
     """
     if not qualified:
         return None
@@ -788,6 +831,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     angle_depth = 0
     paren_depth = 0
     brace_depth = 0
+    bracket_depth = 0
     i = 0
     n = len(qualified)
     marker_idx = -1
@@ -803,13 +847,28 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
                 return None
             i += 1
             continue
-        if brace_depth > 0:
+        if ch == "[":
+            bracket_depth += 1
+            i += 1
+            continue
+        if ch == "]":
+            bracket_depth -= 1
+            if bracket_depth < 0:
+                return None
+            i += 1
+            continue
+        if brace_depth > 0 or bracket_depth > 0:
             # Opaque interior of a brace-delimited lambda body (a legal
             # C++20 non-type template argument, e.g. "B<[]{ return N > M;
-            # }>") -- a full statement grammar, unrelated to the enclosing
-            # template-argument-list's own bracket balance. See this
-            # function's own docstring for why braces need no whitespace
-            # heuristic, unlike angle brackets.
+            # }>") or a bracketed subscript expression (e.g. "B<A[N >
+            # M]>", confirmed to compile: a ">" nested inside "[...]" is
+            # unambiguous to the parser -- "]", not ">", closes the
+            # subscript, so it carries none of the top-level
+            # template-argument ambiguity a bare ">" would). Both are a
+            # full expression/statement grammar unrelated to the
+            # enclosing template-argument-list's own bracket balance. See
+            # this function's own docstring for why braces/brackets need
+            # no whitespace heuristic, unlike angle brackets.
             i += 1
             continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
@@ -844,7 +903,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
         ):
             marker_idx = i
         i += 1
-    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0:
+    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0 or bracket_depth != 0:
         return None
     if marker_idx != -1:
         head = qualified[:marker_idx]
@@ -865,6 +924,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     angle_depth = 0
     paren_depth = 0
     brace_depth = 0
+    bracket_depth = 0
     start = 0
     i = 0
     while i < n:
@@ -879,7 +939,17 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
                 return None
             i += 1
             continue
-        if brace_depth > 0:
+        if ch == "[":
+            bracket_depth += 1
+            i += 1
+            continue
+        if ch == "]":
+            bracket_depth -= 1
+            if bracket_depth < 0:
+                return None
+            i += 1
+            continue
+        if brace_depth > 0 or bracket_depth > 0:
             i += 1
             continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
@@ -912,7 +982,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             start = i
             continue
         i += 1
-    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0:
+    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0 or bracket_depth != 0:
         return None
     comps.append(qualified[start:])
     if any(not c for c in comps):
@@ -962,6 +1032,7 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
     depth = 0
     paren_depth = 0
     brace_depth = 0
+    bracket_depth = 0
     i = 0
     n = len(text)
     while i < n:
@@ -974,8 +1045,16 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
             brace_depth = max(0, brace_depth - 1)
             i += 1
             continue
-        if brace_depth > 0:
-            # Opaque lambda-body interior -- see
+        if ch == "[":
+            bracket_depth += 1
+            i += 1
+            continue
+        if ch == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+            i += 1
+            continue
+        if brace_depth > 0 or bracket_depth > 0:
+            # Opaque lambda-body/subscript interior -- see
             # qualified_name_scope_components's identical concern.
             i += 1
             continue

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -664,11 +664,32 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     malformed target like ``"api::C::operator old::X<"`` (CodeRabbit
     review, fresh evidence: the earlier revision broke out of the loop the
     moment the marker was found, so nothing past it was ever validated).
+
+    Angle-bracket (``<``/``>``) and paren (``(``/``)``) nesting are tracked
+    as two INDEPENDENT counters, not one shared ``depth`` -- a real,
+    demangled non-type template argument can legitimately contain a bare
+    ``<``/``>`` comparison, e.g. ``operator
+    std::integral_constant<bool, (sizeof(T) > 1)>`` for
+    ``std::integral_constant<bool, (sizeof(T) > 1)>`` (Codex review, fresh
+    evidence: an earlier revision used one shared counter for both bracket
+    kinds, so the comparison's ``>`` was miscounted as closing the
+    ``integral_constant<`` template, driving the counter negative and
+    rejecting a perfectly well-formed target). This is not a heuristic: the
+    C++ grammar itself requires such a comparison to be parenthesized
+    wherever it appears as a non-type template argument, specifically to
+    remove this exact ambiguity for any parser -- so a compiler's own
+    demangled/pretty-printed text is guaranteed to already carry the
+    disambiguating parens around it. A ``<``/``>`` character can therefore
+    only be a REAL template delimiter while no paren is currently open
+    (``paren_depth == 0``); while a paren is open, it is guaranteed by that
+    same grammar rule to be part of an expression, never a delimiter, so it
+    is left untouched rather than folded into a bracket-kind-blind counter.
     """
     if not qualified:
         return None
     marker = "::operator "
-    depth = 0
+    angle_depth = 0
+    paren_depth = 0
     i = 0
     n = len(qualified)
     marker_idx = -1
@@ -679,18 +700,27 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             if tok_len:
                 i += tok_len
                 continue
-        if ch in "<(":
-            depth += 1
-        elif ch in ">)":
-            depth -= 1
-            if depth < 0:
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth -= 1
+            if paren_depth < 0:
+                return None
+        elif ch == "<" and paren_depth == 0:
+            angle_depth += 1
+        elif ch == ">" and paren_depth == 0:
+            angle_depth -= 1
+            if angle_depth < 0:
                 return None
         elif (
-            depth == 0 and marker_idx == -1 and qualified[i : i + len(marker)] == marker
+            angle_depth == 0
+            and paren_depth == 0
+            and marker_idx == -1
+            and qualified[i : i + len(marker)] == marker
         ):
             marker_idx = i
         i += 1
-    if depth != 0:
+    if angle_depth != 0 or paren_depth != 0:
         return None
     if marker_idx != -1:
         head = qualified[:marker_idx]
@@ -708,7 +738,8 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
         # whole thing as one leaf rather than guessing at a split.
         return [qualified]
     comps: list[str] = []
-    depth = 0
+    angle_depth = 0
+    paren_depth = 0
     start = 0
     i = 0
     while i < n:
@@ -718,19 +749,25 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             if tok_len:
                 i += tok_len
                 continue
-        if ch in "<(":
-            depth += 1
-        elif ch in ">)":
-            depth -= 1
-            if depth < 0:
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth -= 1
+            if paren_depth < 0:
                 return None
-        elif depth == 0 and qualified[i : i + 2] == "::":
+        elif ch == "<" and paren_depth == 0:
+            angle_depth += 1
+        elif ch == ">" and paren_depth == 0:
+            angle_depth -= 1
+            if angle_depth < 0:
+                return None
+        elif angle_depth == 0 and paren_depth == 0 and qualified[i : i + 2] == "::":
             comps.append(qualified[start:i])
             i += 2
             start = i
             continue
         i += 1
-    if depth != 0:
+    if angle_depth != 0 or paren_depth != 0:
         return None
     comps.append(qualified[start:])
     if any(not c for c in comps):
@@ -758,15 +795,33 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
 
     Returns *text* unchanged when no top-level ``(`` is found (e.g. unbalanced
     nesting, or genuinely no parameter list) rather than guessing.
+
+    Angle-bracket depth is only tracked while no paren is currently open —
+    the identical concern :func:`qualified_name_scope_components` documents
+    for the same reason: a non-type template argument can legitimately
+    contain a parenthesized ``<``/``>`` comparison (``Holder<(A > B),
+    void(int)>``), and the C++ grammar itself guarantees such a comparison
+    is always parenthesized wherever it appears as a template argument. A
+    ``<``/``>`` seen while a paren is open is therefore guaranteed to be
+    part of that expression, never a real template delimiter, so folding it
+    into the angle-bracket counter would close the enclosing template one
+    character too early and let a later, still-nested ``(`` (a function-type
+    template argument's own parameter list, not the real trailing one) be
+    mistaken for the top-level split point.
     """
     depth = 0
+    paren_depth = 0
     for i, ch in enumerate(text):
-        if ch == "<":
+        if ch == "(":
+            if depth == 0 and paren_depth == 0:
+                return text[:i]
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif ch == "<" and paren_depth == 0:
             depth += 1
-        elif ch == ">":
+        elif ch == ">" and paren_depth == 0:
             depth = max(0, depth - 1)
-        elif ch == "(" and depth == 0:
-            return text[:i]
     return text
 
 

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -792,6 +792,23 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     its entire interior is opaque, and this needs no heuristic either,
     since ``[``/``]`` always balance unconditionally in valid C++ too.
 
+    A lambda's trailing-return-type arrow (``[]() -> bool { ... }``,
+    confirmed to compile and pretty-print verbatim as a non-type template
+    argument) needs its own check, unrelated to brace/bracket tracking:
+    the ``->`` sits in the lambda's OWN declarator, between its parameter
+    list and its body, so it is not inside any brace/bracket this function
+    already tracks as opaque. Unlike every other ``>`` case above, this
+    one needs no heuristic and no depth-awareness at all: by the C++
+    lexical grammar's own maximal-munch rule, a ``-`` immediately adjacent
+    to a ``>`` can ONLY ever tokenize as the single ``->`` token, never as
+    two separate ``-`` and ``>`` tokens -- if the source meant a
+    subtraction immediately followed by a separate closing ``>`` with
+    zero characters between them, the compiler's own lexer would already
+    have misread that as ``->`` too, so this exact adjacency cannot
+    represent two separate tokens in any valid, compiled C++ program
+    (Codex review, fresh evidence). A ``>`` immediately preceded by ``-``
+    is therefore always skipped as part of ``->``, unconditionally.
+
     Known, accepted limitation (Codex review, fresh evidence): the brace/
     bracket "opaque interior" scan above is a raw character count, not a
     real tokenizer -- it does not skip over string/char-literal content or
@@ -869,6 +886,22 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             # enclosing template-argument-list's own bracket balance. See
             # this function's own docstring for why braces/brackets need
             # no whitespace heuristic, unlike angle brackets.
+            i += 1
+            continue
+        if ch == ">" and i > 0 and qualified[i - 1] == "-":
+            # A lambda's trailing-return-type arrow ("[]() -> bool {...}",
+            # confirmed to compile as a non-type template argument and be
+            # pretty-printed verbatim) -- unlike the other ">" cases, this
+            # needs no heuristic or brace/bracket-depth awareness at all:
+            # by the C++ lexical grammar's own maximal-munch rule, a "-"
+            # character immediately adjacent to a ">" can ONLY ever
+            # tokenize as the single "->" token, never as two separate
+            # "-" and ">" tokens -- if the source meant a subtraction
+            # immediately followed by a separate closing ">" with zero
+            # characters between them, the compiler's own lexer would
+            # already have misread THAT as "->" too, so this adjacency
+            # cannot represent two separate tokens in any valid, compiled
+            # C++ program (Codex review, fresh evidence).
             i += 1
             continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
@@ -950,6 +983,12 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             i += 1
             continue
         if brace_depth > 0 or bracket_depth > 0:
+            i += 1
+            continue
+        if ch == ">" and i > 0 and qualified[i - 1] == "-":
+            # A lambda's trailing-return-type arrow -- see this function's
+            # own docstring / the sibling scan above for why this needs
+            # no heuristic at all.
             i += 1
             continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
@@ -1055,6 +1094,11 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
             continue
         if brace_depth > 0 or bracket_depth > 0:
             # Opaque lambda-body/subscript interior -- see
+            # qualified_name_scope_components's identical concern.
+            i += 1
+            continue
+        if ch == ">" and i > 0 and text[i - 1] == "-":
+            # A lambda's trailing-return-type arrow -- see
             # qualified_name_scope_components's identical concern.
             i += 1
             continue

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -608,6 +608,24 @@ def _operator_keyword_precedes(qualified: str, i: int) -> bool:
     )
 
 
+def _is_template_opening_angle(qualified: str, i: int) -> bool:
+    """Whether ``qualified[i] == "<"`` is a real template-opening delimiter,
+    as opposed to an unparenthesized ``<`` comparison in a dependent
+    non-type template argument.
+
+    Unlike ``>`` (see :func:`qualified_name_scope_components`'s own
+    docstring -- a bare ``>`` there is a genuine, unparenthesized-forbidden
+    compile error), a bare ``<`` comparison is legal C++ and a real
+    compiler's parser disambiguates it via name lookup, which this scanner
+    has no access to. Falls back to a spacing signal instead, confirmed
+    against real clang output: a template-opening ``<`` is always rendered
+    immediately after its name with no preceding space, while a binary
+    comparison operator is always rendered with a space on both sides
+    regardless of the original source's own spacing.
+    """
+    return i == 0 or not qualified[i - 1].isspace()
+
+
 def qualified_name_scope_components(qualified: str) -> list[str] | None:
     """Scope components of an already-demangled, ``::``-qualified name.
 
@@ -679,11 +697,41 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     wherever it appears as a non-type template argument, specifically to
     remove this exact ambiguity for any parser -- so a compiler's own
     demangled/pretty-printed text is guaranteed to already carry the
-    disambiguating parens around it. A ``<``/``>`` character can therefore
-    only be a REAL template delimiter while no paren is currently open
+    disambiguating parens around it. A ``>`` character can therefore only be
+    a REAL template-closing delimiter while no paren is currently open
     (``paren_depth == 0``); while a paren is open, it is guaranteed by that
     same grammar rule to be part of an expression, never a delimiter, so it
     is left untouched rather than folded into a bracket-kind-blind counter.
+
+    That grammar guarantee is ONE-SIDED, though: only a ``>``-bearing
+    expression must be parenthesized as a non-type template argument (a
+    bare, unparenthesized ``>`` there is a genuine, confirmed compile
+    error) -- an unparenthesized ``<`` comparison is perfectly legal and
+    unambiguous to a real parser, which disambiguates it via *name lookup*
+    (is the identifier immediately to its left a known template name?), not
+    via any textual rule this scanner could replicate. Confirmed directly
+    against real clang: ``template<int N, int M> struct C { operator
+    B<N < M>() const; };`` compiles cleanly, and clang's own AST dump
+    prints the *unparenthesized* comparison verbatim as ``operator B<N <
+    M>`` for the uninstantiated (template-parameter-dependent) member --
+    exactly the shape :func:`qualified_name_scope_components` receives from
+    this codebase's own castxml/clang-derived declaration names (Codex
+    review, fresh evidence: an earlier revision treated every ``<`` at
+    ``paren_depth == 0`` as a real template opener unconditionally, so this
+    exact input drove ``angle_depth`` one too high and never came back
+    down, rejecting valid input). Since a `<` cannot be soundly resolved by
+    grammar alone, a ``<`` at ``paren_depth == 0`` is instead treated as a
+    real template-opening delimiter only when it is NOT preceded by
+    whitespace -- confirmed, empirically, against real clang output: a
+    template-opening ``<`` is always rendered immediately after its name
+    with no space (``Other<D>``, ``B<N < M>``'s own leading ``<``), while a
+    binary comparison operator is always rendered with a space on both
+    sides (``N < M``) REGARDLESS of the source's own spacing (confirmed by
+    compiling the identical construct spelled ``N<M`` with no spaces at
+    all -- clang's pretty-printer still re-inserts them). This is not
+    airtight for arbitrary hand-crafted text, but it is sound for every
+    real input this function actually receives, which originates from a
+    compiler's own canonical printer, never from hand-written source.
     """
     if not qualified:
         return None
@@ -706,7 +754,9 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             paren_depth -= 1
             if paren_depth < 0:
                 return None
-        elif ch == "<" and paren_depth == 0:
+        elif (
+            ch == "<" and paren_depth == 0 and _is_template_opening_angle(qualified, i)
+        ):
             angle_depth += 1
         elif ch == ">" and paren_depth == 0:
             angle_depth -= 1
@@ -755,7 +805,9 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             paren_depth -= 1
             if paren_depth < 0:
                 return None
-        elif ch == "<" and paren_depth == 0:
+        elif (
+            ch == "<" and paren_depth == 0 and _is_template_opening_angle(qualified, i)
+        ):
             angle_depth += 1
         elif ch == ">" and paren_depth == 0:
             angle_depth -= 1
@@ -800,14 +852,19 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
     the identical concern :func:`qualified_name_scope_components` documents
     for the same reason: a non-type template argument can legitimately
     contain a parenthesized ``<``/``>`` comparison (``Holder<(A > B),
-    void(int)>``), and the C++ grammar itself guarantees such a comparison
-    is always parenthesized wherever it appears as a template argument. A
-    ``<``/``>`` seen while a paren is open is therefore guaranteed to be
-    part of that expression, never a real template delimiter, so folding it
-    into the angle-bracket counter would close the enclosing template one
-    character too early and let a later, still-nested ``(`` (a function-type
-    template argument's own parameter list, not the real trailing one) be
-    mistaken for the top-level split point.
+    void(int)>``), and the C++ grammar itself guarantees a ``>``-bearing
+    comparison must be parenthesized wherever it appears as a template
+    argument. A ``>`` seen while a paren is open is therefore guaranteed to
+    be part of that expression, never a real template delimiter, so folding
+    it into the angle-bracket counter would close the enclosing template
+    one character too early and let a later, still-nested ``(`` (a
+    function-type template argument's own parameter list, not the real
+    trailing one) be mistaken for the top-level split point. That grammar
+    guarantee does NOT cover ``<``, though -- an unparenthesized ``<``
+    comparison is legal C++ (e.g. a class template's own scope carrying an
+    uninstantiated ``Holder<N < M>``), so a ``<`` is only counted as a real
+    template opener via :func:`_is_template_opening_angle`'s spacing signal,
+    the same one :func:`qualified_name_scope_components` uses.
     """
     depth = 0
     paren_depth = 0
@@ -818,7 +875,7 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
             paren_depth += 1
         elif ch == ")":
             paren_depth = max(0, paren_depth - 1)
-        elif ch == "<" and paren_depth == 0:
+        elif ch == "<" and paren_depth == 0 and _is_template_opening_angle(text, i):
             depth += 1
         elif ch == ">" and paren_depth == 0:
             depth = max(0, depth - 1)

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -626,6 +626,37 @@ def _is_template_opening_angle(qualified: str, i: int) -> bool:
     return i == 0 or not qualified[i - 1].isspace()
 
 
+#: Multi-character ``<``-led expression-operator tokens (as opposed to a
+#: lone ``<``, which needs :func:`_is_template_opening_angle`'s spacing
+#: signal). Longest-first so ``<<=`` matches before ``<<``.
+_LESS_THAN_LED_OPERATOR_TOKENS = ("<<=", "<=>", "<<", "<=")
+
+
+def _less_than_led_operator_token_len(qualified: str, i: int) -> int:
+    """Length of a multi-character ``<``-led expression-operator token
+    (``<<=``, ``<=>``, ``<<``, ``<=``) at ``qualified[i:]``, or 0.
+
+    Unlike a lone ``<`` (see :func:`_is_template_opening_angle`), ANY
+    multi-character ``<``-led token is structurally guaranteed to be a
+    real operator, never two adjacent template-opening delimiters: a
+    template-argument-list can never begin with a bare ``<`` or ``=`` (no
+    expression or type-id starts with either), so two consecutive ``<``
+    characters, or a ``<`` immediately followed by ``=``, cannot be two
+    independent delimiters -- they can only be this operator's own
+    spelling. Confirmed against real clang: ``operator B<N << M>``
+    compiles and is pretty-printed verbatim for an uninstantiated member
+    (Codex review, fresh evidence -- the second ``<`` of ``<<`` is not
+    preceded by whitespace, so :func:`_is_template_opening_angle`'s
+    per-character spacing signal alone misclassified it as a template
+    opener). No whitespace check needed here, unlike the lone-``<`` case:
+    the grammar guarantee is unconditional.
+    """
+    for tok in _LESS_THAN_LED_OPERATOR_TOKENS:
+        if qualified.startswith(tok, i):
+            return len(tok)
+    return 0
+
+
 def qualified_name_scope_components(qualified: str) -> list[str] | None:
     """Scope components of an already-demangled, ``::``-qualified name.
 
@@ -748,6 +779,11 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             if tok_len:
                 i += tok_len
                 continue
+        if ch == "<":
+            lt_tok_len = _less_than_led_operator_token_len(qualified, i)
+            if lt_tok_len:
+                i += lt_tok_len
+                continue
         if ch == "(":
             paren_depth += 1
         elif ch == ")":
@@ -798,6 +834,11 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             tok_len = _operator_angle_token_len(qualified, i)
             if tok_len:
                 i += tok_len
+                continue
+        if ch == "<":
+            lt_tok_len = _less_than_led_operator_token_len(qualified, i)
+            if lt_tok_len:
+                i += lt_tok_len
                 continue
         if ch == "(":
             paren_depth += 1
@@ -868,7 +909,15 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
     """
     depth = 0
     paren_depth = 0
-    for i, ch in enumerate(text):
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "<":
+            lt_tok_len = _less_than_led_operator_token_len(text, i)
+            if lt_tok_len:
+                i += lt_tok_len
+                continue
         if ch == "(":
             if depth == 0 and paren_depth == 0:
                 return text[:i]
@@ -879,6 +928,7 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
             depth += 1
         elif ch == ">" and paren_depth == 0:
             depth = max(0, depth - 1)
+        i += 1
     return text
 
 

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -603,7 +603,9 @@ def _operator_keyword_precedes(qualified: str, i: int) -> bool:
     if qualified[i - 8 : i] != "operator":
         return False
     before = i - 8
-    return before == 0 or not (qualified[before - 1].isalnum() or qualified[before - 1] == "_")
+    return before == 0 or not (
+        qualified[before - 1].isalnum() or qualified[before - 1] == "_"
+    )
 
 
 def qualified_name_scope_components(qualified: str) -> list[str] | None:
@@ -654,7 +656,14 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     top-level ``"::"``, e.g. ``"::foo"`` or ``"foo::::bar"``), or unbalanced
     bracket/paren nesting, rather than silently dropping or fabricating a
     component, mirroring the "return ``None``, let the caller fall back"
-    contract the mangled-name parsers above use.
+    contract the mangled-name parsers above use. That conservatism applies
+    to the WHOLE string, including a conversion operator's own target past
+    the ``"::operator "`` marker -- the scan below keeps tracking depth
+    through the opaque leaf and rejects the whole input if it ends
+    unbalanced, rather than stopping at the marker and silently accepting a
+    malformed target like ``"api::C::operator old::X<"`` (CodeRabbit
+    review, fresh evidence: the earlier revision broke out of the loop the
+    moment the marker was found, so nothing past it was ever validated).
     """
     if not qualified:
         return None
@@ -676,10 +685,13 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             depth -= 1
             if depth < 0:
                 return None
-        elif depth == 0 and qualified[i : i + len(marker)] == marker:
+        elif (
+            depth == 0 and marker_idx == -1 and qualified[i : i + len(marker)] == marker
+        ):
             marker_idx = i
-            break
         i += 1
+    if depth != 0:
+        return None
     if marker_idx != -1:
         head = qualified[:marker_idx]
         leaf = qualified[marker_idx + 2 :]  # keep the "operator ..." target whole

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -763,17 +763,55 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     airtight for arbitrary hand-crafted text, but it is sound for every
     real input this function actually receives, which originates from a
     compiler's own canonical printer, never from hand-written source.
+
+    Brace (``{``/``}``) nesting is tracked as a THIRD independent counter,
+    for a different reason than the ``<``/``>``/``(``/``)`` cases above:
+    C++20 allows a captureless lambda closure as a non-type template
+    argument, and its body is a full, self-contained statement grammar --
+    a ``>``/``<`` inside it is not required to be parenthesized the way a
+    bare comparison directly in the template-argument-list is, because it
+    is not at that grammar production at all. Confirmed directly against
+    real clang: ``operator B<[]{ return N > M; }>()`` (a lambda-typed
+    conversion target) compiles under ``-std=c++20`` and is pretty-printed
+    verbatim, unparenthesized comparison included, sometimes spanning
+    multiple lines (Codex review, fresh evidence). Unlike the angle-bracket
+    cases, this needs no heuristic at all: braces always balance
+    unconditionally in valid C++ (no ambiguity like ``<``/``>`` ever
+    applies to them), so once a brace opens, every character up to its
+    matching close -- regardless of what it looks like -- is treated as
+    fully opaque interior, untouched by any other counter in this
+    function.
     """
     if not qualified:
         return None
     marker = "::operator "
     angle_depth = 0
     paren_depth = 0
+    brace_depth = 0
     i = 0
     n = len(qualified)
     marker_idx = -1
     while i < n:
         ch = qualified[i]
+        if ch == "{":
+            brace_depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            brace_depth -= 1
+            if brace_depth < 0:
+                return None
+            i += 1
+            continue
+        if brace_depth > 0:
+            # Opaque interior of a brace-delimited lambda body (a legal
+            # C++20 non-type template argument, e.g. "B<[]{ return N > M;
+            # }>") -- a full statement grammar, unrelated to the enclosing
+            # template-argument-list's own bracket balance. See this
+            # function's own docstring for why braces need no whitespace
+            # heuristic, unlike angle brackets.
+            i += 1
+            continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
             tok_len = _operator_angle_token_len(qualified, i)
             if tok_len:
@@ -806,7 +844,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
         ):
             marker_idx = i
         i += 1
-    if angle_depth != 0 or paren_depth != 0:
+    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0:
         return None
     if marker_idx != -1:
         head = qualified[:marker_idx]
@@ -826,10 +864,24 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
     comps: list[str] = []
     angle_depth = 0
     paren_depth = 0
+    brace_depth = 0
     start = 0
     i = 0
     while i < n:
         ch = qualified[i]
+        if ch == "{":
+            brace_depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            brace_depth -= 1
+            if brace_depth < 0:
+                return None
+            i += 1
+            continue
+        if brace_depth > 0:
+            i += 1
+            continue
         if ch in "<>" and _operator_keyword_precedes(qualified, i):
             tok_len = _operator_angle_token_len(qualified, i)
             if tok_len:
@@ -860,7 +912,7 @@ def qualified_name_scope_components(qualified: str) -> list[str] | None:
             start = i
             continue
         i += 1
-    if angle_depth != 0 or paren_depth != 0:
+    if angle_depth != 0 or paren_depth != 0 or brace_depth != 0:
         return None
     comps.append(qualified[start:])
     if any(not c for c in comps):
@@ -909,10 +961,24 @@ def strip_trailing_top_level_parameter_list(text: str) -> str:
     """
     depth = 0
     paren_depth = 0
+    brace_depth = 0
     i = 0
     n = len(text)
     while i < n:
         ch = text[i]
+        if ch == "{":
+            brace_depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            brace_depth = max(0, brace_depth - 1)
+            i += 1
+            continue
+        if brace_depth > 0:
+            # Opaque lambda-body interior -- see
+            # qualified_name_scope_components's identical concern.
+            i += 1
+            continue
         if ch == "<":
             lt_tok_len = _less_than_led_operator_token_len(text, i)
             if lt_tok_len:

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -938,22 +938,29 @@ def find_namespace_move_groups(
             added_index.setdefault(masked, []).append((a_sym, comps))
 
     groups: dict[tuple[str, str], list[tuple[str, str]]] = {}
-    # Tracks which (old_qualified, new_qualified) pairs have already been
-    # recorded per substitution key, so the SAME declaration reported under
-    # two different `removed` string identities (a real mangled symbol and
-    # a header-tier synthetic key that normalize to the identical
-    # scope-component list -- see the co-matching comment below) is only
-    # ever counted once toward the 2+-pairs support threshold
-    # (Codex review, fresh evidence: without this, one moved declaration
-    # reported both ways produced two identical list entries, passing
-    # emit_namespace_move_batches' threshold and reporting a false
-    # BREAKING batch for what was really a single symbol).
-    recorded_pairs: dict[tuple[str, str], set[tuple[str, str]]] = {}
+
+    # Phase 1: for every (removed symbol, masking position) pair, resolve at
+    # most one unambiguous-on-the-target-side candidate (the existing
+    # one-to-many rejection below), and record which OLD segment value it
+    # came from under that masked context. This also builds
+    # `masked_to_old_segments`, the reciprocal (many-to-one) signal Phase 2
+    # needs: a masked context claimed by more than one distinct old segment
+    # value means several different removed namespaces are each proposing
+    # themselves as the source of the SAME added symbol -- e.g. removed
+    # old1::{f,g}/old2::{f,g} vs. added only new::{f,g}: `old1::f` and
+    # `old2::f` masked at their differing position both resolve to the
+    # single candidate `new::f` (no one-to-many ambiguity on the target
+    # side at all), yet there is no evidence which of old1/old2 actually
+    # moved -- the other was simply deleted. Without this check both
+    # `old1 -> new` and `old2 -> new` would independently clear the 2+-pair
+    # threshold and emit two contradictory SYMBOL_RENAMED_BATCH findings
+    # (Codex review, fresh evidence).
+    entries: list[tuple[tuple[str, ...], list[str], int, list[str]]] = []
+    masked_to_old_segments: dict[tuple[str, ...], set[str]] = {}
     for r_sym in sorted(removed):
         r_comps = _scope_components(r_sym)
         if r_comps is None:
             continue
-        seen_here: set[tuple[str, str]] = set()
         for i in range(len(r_comps) - 1):
             masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
             candidates = added_index.get(masked, [])
@@ -992,17 +999,43 @@ def find_namespace_move_groups(
             distinct_targets = {a_comps[i] for _a_sym, a_comps in candidates}
             if len(distinct_targets) != 1:
                 continue
-            a_sym, a_comps = candidates[0]
-            key = (r_comps[i], a_comps[i])
-            if key[0] == key[1] or key in seen_here:
+            _a_sym, a_comps = candidates[0]
+            if r_comps[i] == a_comps[i]:
                 continue
-            seen_here.add(key)
-            pair = ("::".join(r_comps), "::".join(a_comps))
-            already_recorded = recorded_pairs.setdefault(key, set())
-            if pair in already_recorded:
-                continue
-            already_recorded.add(pair)
-            groups.setdefault(key, []).append(pair)
+            masked_to_old_segments.setdefault(masked, set()).add(r_comps[i])
+            entries.append((masked, r_comps, i, a_comps))
+
+    # Phase 2: record only the entries whose masked context was claimed by
+    # exactly one distinct old segment value -- i.e. reject the reciprocal
+    # many-to-one collision Phase 1 detected, then apply the pre-existing
+    # per-symbol/per-key/per-pair dedup exactly as before.
+    seen_here: dict[str, set[tuple[str, str]]] = {}
+    # Tracks which (old_qualified, new_qualified) pairs have already been
+    # recorded per substitution key, so the SAME declaration reported under
+    # two different `removed` string identities (a real mangled symbol and
+    # a header-tier synthetic key that normalize to the identical
+    # scope-component list -- see the co-matching comment above) is only
+    # ever counted once toward the 2+-pairs support threshold
+    # (Codex review, fresh evidence: without this, one moved declaration
+    # reported both ways produced two identical list entries, passing
+    # emit_namespace_move_batches' threshold and reporting a false
+    # BREAKING batch for what was really a single symbol).
+    recorded_pairs: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    for masked, r_comps, i, a_comps in entries:
+        if len(masked_to_old_segments[masked]) != 1:
+            continue
+        key = (r_comps[i], a_comps[i])
+        symbol_id = "::".join(r_comps)
+        symbol_seen = seen_here.setdefault(symbol_id, set())
+        if key in symbol_seen:
+            continue
+        symbol_seen.add(key)
+        pair = (symbol_id, "::".join(a_comps))
+        already_recorded = recorded_pairs.setdefault(key, set())
+        if pair in already_recorded:
+            continue
+        already_recorded.add(pair)
+        groups.setdefault(key, []).append(pair)
     return groups
 
 

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -927,6 +927,39 @@ def find_namespace_move_groups(
 
     Returns ``{(old_segment, new_segment): [(old_qualified, new_qualified)]}``
     with deterministic ordering (both sides iterated sorted).
+
+    Known, accepted limitation (Codex review, fresh evidence): matching is
+    on the *scope chain only* -- :func:`_scope_components` deliberately
+    discards a function's own parameter-type signature, since two overloads
+    of the same declaration share an identical scope chain and are not
+    "different declarations" for this detector's purpose. This means the
+    reciprocal many-to-one rejection above cannot distinguish a genuine
+    collision (two unrelated old namespaces both proposing themselves as
+    the source of the identical target, e.g. ``old1::f``/``old2::f`` both
+    matching a single ``new::f``) from a legitimate consolidation where two
+    old namespaces contribute *different overloads* of the same name to one
+    new namespace (``old1::f(int)``/``old2::f(double)`` both genuinely
+    moving into ``new::{f(int), f(double)}``) -- both shapes look identical
+    once the parameter types are stripped, so the rejection fires on the
+    overload-consolidation case too, even though the mangled symbols
+    themselves *do* carry the disambiguating parameter-type suffix that
+    would resolve it. This is not a new gap this function's many-to-one
+    check introduced: the whole primitive was already signature-blind
+    before that check existed (a pre-existing overload pair collapses to
+    one identical ``pair`` string via the same ``_scope_components`` chain,
+    and the pre-existing one-to-many check has the mirror-image blind spot
+    from the other side) -- the new check simply makes an already-ambiguous
+    shape resolve to REJECT (no roll-up; the individual
+    ``func_removed``/``func_added`` findings are still reported
+    individually) rather than to arbitrarily ACCEPT one specific pairing
+    that might be wrong, which is the same false-negative-over-false-
+    positive default this module's other ambiguity guards already use (see
+    the many-to-many/local-ambiguity comments above). A correct fix needs
+    real parameter-signature matching threaded through the whole primitive
+    (``_scope_components``, ``added_index``, candidate resolution, and the
+    ``(old_segment, new_segment)`` key itself) -- a genuine redesign of a
+    primitive several other things in this module already depend on being
+    signature-blind, not a scoped patch to the many-to-one check alone.
     """
     added_index: dict[tuple[str, ...], list[tuple[str, list[str]]]] = {}
     for a_sym in sorted(added):

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -990,6 +990,7 @@ def find_namespace_move_groups(
     # (Codex review, fresh evidence).
     entries: list[tuple[tuple[str, ...], list[str], int, list[str]]] = []
     masked_to_old_segments: dict[tuple[str, ...], set[str]] = {}
+    added_id_to_keys: dict[str, set[tuple[str, str]]] = {}
     for r_sym in sorted(removed):
         r_comps = _scope_components(r_sym)
         if r_comps is None:
@@ -1037,11 +1038,32 @@ def find_namespace_move_groups(
                 continue
             masked_to_old_segments.setdefault(masked, set()).add(r_comps[i])
             entries.append((masked, r_comps, i, a_comps))
+            # Reject an ambiguous substitution ACROSS masking positions too
+            # (Codex review, fresh evidence): the check above only catches
+            # two old segments competing for the SAME masked context (same
+            # position), but the identical added declaration can just as
+            # well be claimed by two removed symbols differing at
+            # DIFFERENT positions -- e.g. removed `p1::old::{f,g}` and
+            # `new::p2::{f,g}` vs. added only `new::old::{f,g}`:
+            # `p1::old::f` (masking position 0) and `new::p2::f` (masking
+            # position 1) both resolve to the SAME added `new::old::f`, so
+            # their masked contexts differ and the position-scoped check
+            # above sees no collision at all, yet the same added
+            # declaration cannot simultaneously be evidence for both
+            # `p1 -> new` AND `p2 -> old`. Tracked by the added
+            # declaration's own identity (its full "::"-joined scope
+            # chain) rather than by masked context, since that identity is
+            # exactly the one thing both positions' candidates share.
+            added_id_to_keys.setdefault("::".join(a_comps), set()).add(
+                (r_comps[i], a_comps[i])
+            )
 
     # Phase 2: record only the entries whose masked context was claimed by
-    # exactly one distinct old segment value -- i.e. reject the reciprocal
-    # many-to-one collision Phase 1 detected, then apply the pre-existing
-    # per-symbol/per-key/per-pair dedup exactly as before.
+    # exactly one distinct old segment value (the position-scoped
+    # many-to-one rejection) AND whose added declaration was claimed by
+    # exactly one distinct substitution key (the cross-position rejection)
+    # -- then apply the pre-existing per-symbol/per-key/per-pair dedup
+    # exactly as before.
     seen_here: dict[str, set[tuple[str, str]]] = {}
     # Tracks which (old_qualified, new_qualified) pairs have already been
     # recorded per substitution key, so the SAME declaration reported under
@@ -1056,6 +1078,9 @@ def find_namespace_move_groups(
     recorded_pairs: dict[tuple[str, str], set[tuple[str, str]]] = {}
     for masked, r_comps, i, a_comps in entries:
         if len(masked_to_old_segments[masked]) != 1:
+            continue
+        added_id = "::".join(a_comps)
+        if len(added_id_to_keys[added_id]) != 1:
             continue
         key = (r_comps[i], a_comps[i])
         symbol_id = "::".join(r_comps)

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -1040,55 +1040,53 @@ def find_namespace_move_groups(
 
     # Phase 1b: build the two cross-position collision signals Phase 2 below
     # needs -- deliberately a separate pass over `entries`, not folded into
-    # the loop above, and deliberately built from two DIFFERENT entry sets
-    # (Codex review, fresh evidence, two rounds): an earlier revision built
-    # BOTH signals from the SAME entry set, and either choice of that one
-    # set was wrong for a different reason.
+    # the loop above, and deliberately built from the FULL, UNFILTERED
+    # `entries` list for BOTH signals (Codex review, fresh evidence, three
+    # rounds -- the middle round's "fix" is worth recording since its
+    # failure mode is the interesting part).
     #
-    # Building both from the FULL, unfiltered `entries` list let a same
-    # -position collision on ONE removed symbol's entry (already correctly
-    # rejected on its own by `masked_to_old_segments`) leak into
-    # `removed_id_to_added_symbols` for an UNRELATED removed symbol sharing
-    # that same masked context, wrongly making that unrelated symbol look
-    # self-contradictory (see the "spurious same-position collision must
-    # not taint a symbol's own clean, different-position candidacy" test
-    # below: `ns::old::f`'s legitimate `ns -> new` move, evidenced cleanly
-    # via one masking position, was wrongly rejected purely because its
-    # OTHER masking position happened to collide with an unrelated `p1`/`p2`
-    # pair at that position's masked context).
+    # Round 1 built both from the full, unfiltered list, same as here.
+    # Round 2 found that this let `ns::old::f`'s legitimate `ns -> new`
+    # move -- evidenced cleanly via ONE masking position -- get wrongly
+    # rejected purely because its OTHER masking position happened to
+    # collide with an unrelated `p1`/`p2` pair at THAT position's masked
+    # context, and "fixed" it by filtering `removed_id_to_added_symbols` to
+    # only entries surviving `masked_to_old_segments` -- i.e. by preferring
+    # whichever of a removed symbol's two candidacies happened to be
+    # locally clean at its own masked context.
     #
-    # Building both from ONLY the entries that survive
-    # `masked_to_old_segments` instead (the fix attempted for the above)
-    # broke the ORIGINAL many-to-one-across-positions case this dict exists
-    # for: when a removed symbol's own entry is invalidated by a same
-    # -position collision with an UNRELATED third symbol, that entry's
-    # candidacy on a given added declaration is still real evidence that
-    # the added declaration is CONTESTED (a different removed symbol's
-    # independent, valid entry cannot be treated as its sole, uncontested
-    # source just because its rival's own entry additionally happens to
-    # collide with something else at the SAME masked context) -- see
-    # `TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings`'s
-    # own reported collision, reproduced again here alongside `ns`: `p1`'s
-    # only candidacy on `new::old::f` still contests that target even
-    # though `p1`'s SPECIFIC entry is separately invalidated by the
-    # unrelated `ns` collision at that same masked context.
+    # Round 3 found that "fix" itself unsound, with the EXACT MIRROR-IMAGE
+    # shape: removed `ns::old::{f,g}` and `ns::q::{f,g}`, added
+    # `new::old::{f,g}` and `ns::new::{f,g}`. `ns::old::f` again has two
+    # raw candidacies -- position 0 (masking `ns`) cleanly, uniquely
+    # matches `new::old::f`; position 1 (masking `old`) matches
+    # `ns::new::f`, but COLLIDES with `ns::q::f` there (real,
+    # unconfirmable ambiguity: was it `old` or `q` that became `new`?).
+    # Round 2's filter discarded the colliding position-1 entry and kept
+    # the clean position-0 one, letting `ns::old -> new::old` survive
+    # uncontested -- but a colliding masked context proves the SPECIFIC
+    # claimant (old vs. q) is unconfirmable, not that the ALTERNATE
+    # explanation (`old -> new`, competing with `ns -> new`) is
+    # impossible. `ns::old::f`'s true fate is exactly as uncertain as it
+    # was without `ns::q` in the picture at all -- an unrelated third
+    # symbol colliding with ONE of two live hypotheses cannot make the
+    # OTHER hypothesis newly confirmed. Round 2's own justifying scenario
+    # (`ns`/`p1`/`p2`) is the identical shape from the other position, and
+    # is -- by the same reasoning -- equally unconfirmable: `ns::old::f`
+    # there ALSO has two live, unconfirmed candidacies (`ns -> new`,
+    # contested with `p1`; `old -> new`, clean), and preferring the clean
+    # one over the contested one is exactly the same unsound "resolve
+    # ambiguity by picking whichever half of it happens to look cleaner"
+    # move, just with the collision on the other side.
     #
-    # The two questions are genuinely asymmetric, which is why they need
-    # two different entry sets:
-    #  - "is this ADDED declaration contested by more than one distinct
-    #    removed identity" (`added_id_to_removed_symbols`) is a question
-    #    about the target, answerable from EVERY raw candidacy regardless
-    #    of whether that candidacy is independently valid -- a same
-    #    -position-colliding candidacy is still a real, structurally
-    #    possible alternative explanation contesting the target, so it
-    #    still counts.
-    #  - "does this REMOVED symbol resolve to more than one distinct added
-    #    declaration" (`removed_id_to_added_symbols`) should only weigh a
-    #    removed symbol's OWN candidacies that are not already known
-    #    -spurious for an unrelated reason (a same-position collision with
-    #    a THIRD symbol) -- otherwise a removed symbol's one clean,
-    #    unambiguous candidacy gets wrongly discredited by its OWN
-    #    unrelated, already-rejected candidacy at a different position.
+    # So both signals are built from every raw candidacy, without regard
+    # to whether that specific candidacy's own masked context is itself
+    # ambiguous -- deliberately more conservative than round 2 (a removed
+    # symbol with any second raw candidacy, confirmed-contested or not, is
+    # treated as genuinely undecidable and reported nowhere), matching this
+    # function's own stated false-negative-over-false-positive default
+    # (see the local-ambiguity comment above) rather than trying to be
+    # clever about which half of an ambiguity to trust.
     #
     # `added_id_to_removed_symbols`: reject an ambiguous substitution
     # ACROSS masking positions (Codex review, fresh evidence): the
@@ -1139,17 +1137,15 @@ def find_namespace_move_groups(
     # for both at once. Tracked the mirror-image way: per removed symbol's
     # own "::"-joined identity, the set of distinct added declarations'
     # "::"-joined identities it was resolved to across every masking
-    # position whose OWN masked context is not itself already known
-    # -ambiguous (see the asymmetry note above for why this differs from
-    # `added_id_to_removed_symbols`, which uses every raw candidacy).
+    # position -- every raw candidacy, same as `added_id_to_removed_symbols`
+    # (see the round-3 note above for why filtering either dict by
+    # `masked_to_old_segments` is unsound).
     added_id_to_removed_symbols: dict[str, set[str]] = {}
     removed_id_to_added_symbols: dict[str, set[str]] = {}
-    for masked, r_comps, i, a_comps in entries:
+    for _masked, r_comps, _i, a_comps in entries:
         added_id = "::".join(a_comps)
         symbol_id = "::".join(r_comps)
         added_id_to_removed_symbols.setdefault(added_id, set()).add(symbol_id)
-        if len(masked_to_old_segments[masked]) != 1:
-            continue
         removed_id_to_added_symbols.setdefault(symbol_id, set()).add(added_id)
 
     # Phase 2: record only the entries whose masked context was claimed by

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -990,7 +990,7 @@ def find_namespace_move_groups(
     # (Codex review, fresh evidence).
     entries: list[tuple[tuple[str, ...], list[str], int, list[str]]] = []
     masked_to_old_segments: dict[tuple[str, ...], set[str]] = {}
-    added_id_to_keys: dict[str, set[tuple[str, str]]] = {}
+    added_id_to_removed_symbols: dict[str, set[str]] = {}
     for r_sym in sorted(removed):
         r_comps = _scope_components(r_sym)
         if r_comps is None:
@@ -1050,20 +1050,40 @@ def find_namespace_move_groups(
             # their masked contexts differ and the position-scoped check
             # above sees no collision at all, yet the same added
             # declaration cannot simultaneously be evidence for both
-            # `p1 -> new` AND `p2 -> old`. Tracked by the added
-            # declaration's own identity (its full "::"-joined scope
-            # chain) rather than by masked context, since that identity is
-            # exactly the one thing both positions' candidates share.
-            added_id_to_keys.setdefault("::".join(a_comps), set()).add(
-                (r_comps[i], a_comps[i])
+            # `p1 -> new` AND `p2 -> old`.
+            #
+            # Tracked by DISTINCT CLAIMING REMOVED-SYMBOL IDENTITY, not by
+            # distinct substitution KEY (Codex review, fresh evidence: an
+            # earlier revision tracked distinct `(old_segment, new_segment)`
+            # key text instead, which is insufficient -- removing
+            # `old::new::f` and `new::old::f` while adding only
+            # `new::new::f` has BOTH claims spell the identical key
+            # `('old', 'new')` (`old::new::f` masked at position 0 gives
+            # `old -> new`; `new::old::f` masked at position 1 also gives
+            # `old -> new`), so a key-text set collapses them to size one
+            # and the guard wrongly accepted both, even though they are two
+            # genuinely different removed originals both claiming the same
+            # single added declaration as their target -- an added
+            # declaration can only actually be the result of one historical
+            # move). Keyed by the added declaration's own identity (its
+            # full "::"-joined scope chain), tracking the set of distinct
+            # claiming removed symbols' own "::"-joined identities: two
+            # different string spellings of the SAME removed declaration
+            # (a real mangled symbol and a header-tier synthetic key for
+            # the same move -- see the co-matching comment above, which is
+            # about the ADDED side, but the identical principle applies
+            # here) normalize to the same joined identity and so still
+            # count as one claimant, not two.
+            added_id_to_removed_symbols.setdefault("::".join(a_comps), set()).add(
+                "::".join(r_comps)
             )
 
     # Phase 2: record only the entries whose masked context was claimed by
     # exactly one distinct old segment value (the position-scoped
     # many-to-one rejection) AND whose added declaration was claimed by
-    # exactly one distinct substitution key (the cross-position rejection)
-    # -- then apply the pre-existing per-symbol/per-key/per-pair dedup
-    # exactly as before.
+    # exactly one distinct removed-symbol identity (the cross-position
+    # rejection) -- then apply the pre-existing per-symbol/per-key/per-pair
+    # dedup exactly as before.
     seen_here: dict[str, set[tuple[str, str]]] = {}
     # Tracks which (old_qualified, new_qualified) pairs have already been
     # recorded per substitution key, so the SAME declaration reported under
@@ -1080,10 +1100,10 @@ def find_namespace_move_groups(
         if len(masked_to_old_segments[masked]) != 1:
             continue
         added_id = "::".join(a_comps)
-        if len(added_id_to_keys[added_id]) != 1:
+        symbol_id = "::".join(r_comps)
+        if len(added_id_to_removed_symbols[added_id]) != 1:
             continue
         key = (r_comps[i], a_comps[i])
-        symbol_id = "::".join(r_comps)
         symbol_seen = seen_here.setdefault(symbol_id, set())
         if key in symbol_seen:
             continue

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -990,7 +990,6 @@ def find_namespace_move_groups(
     # (Codex review, fresh evidence).
     entries: list[tuple[tuple[str, ...], list[str], int, list[str]]] = []
     masked_to_old_segments: dict[tuple[str, ...], set[str]] = {}
-    added_id_to_removed_symbols: dict[str, set[str]] = {}
     for r_sym in sorted(removed):
         r_comps = _scope_components(r_sym)
         if r_comps is None:
@@ -1038,52 +1037,130 @@ def find_namespace_move_groups(
                 continue
             masked_to_old_segments.setdefault(masked, set()).add(r_comps[i])
             entries.append((masked, r_comps, i, a_comps))
-            # Reject an ambiguous substitution ACROSS masking positions too
-            # (Codex review, fresh evidence): the check above only catches
-            # two old segments competing for the SAME masked context (same
-            # position), but the identical added declaration can just as
-            # well be claimed by two removed symbols differing at
-            # DIFFERENT positions -- e.g. removed `p1::old::{f,g}` and
-            # `new::p2::{f,g}` vs. added only `new::old::{f,g}`:
-            # `p1::old::f` (masking position 0) and `new::p2::f` (masking
-            # position 1) both resolve to the SAME added `new::old::f`, so
-            # their masked contexts differ and the position-scoped check
-            # above sees no collision at all, yet the same added
-            # declaration cannot simultaneously be evidence for both
-            # `p1 -> new` AND `p2 -> old`.
-            #
-            # Tracked by DISTINCT CLAIMING REMOVED-SYMBOL IDENTITY, not by
-            # distinct substitution KEY (Codex review, fresh evidence: an
-            # earlier revision tracked distinct `(old_segment, new_segment)`
-            # key text instead, which is insufficient -- removing
-            # `old::new::f` and `new::old::f` while adding only
-            # `new::new::f` has BOTH claims spell the identical key
-            # `('old', 'new')` (`old::new::f` masked at position 0 gives
-            # `old -> new`; `new::old::f` masked at position 1 also gives
-            # `old -> new`), so a key-text set collapses them to size one
-            # and the guard wrongly accepted both, even though they are two
-            # genuinely different removed originals both claiming the same
-            # single added declaration as their target -- an added
-            # declaration can only actually be the result of one historical
-            # move). Keyed by the added declaration's own identity (its
-            # full "::"-joined scope chain), tracking the set of distinct
-            # claiming removed symbols' own "::"-joined identities: two
-            # different string spellings of the SAME removed declaration
-            # (a real mangled symbol and a header-tier synthetic key for
-            # the same move -- see the co-matching comment above, which is
-            # about the ADDED side, but the identical principle applies
-            # here) normalize to the same joined identity and so still
-            # count as one claimant, not two.
-            added_id_to_removed_symbols.setdefault("::".join(a_comps), set()).add(
-                "::".join(r_comps)
-            )
+
+    # Phase 1b: build the two cross-position collision signals Phase 2 below
+    # needs -- deliberately a separate pass over `entries`, not folded into
+    # the loop above, and deliberately built from two DIFFERENT entry sets
+    # (Codex review, fresh evidence, two rounds): an earlier revision built
+    # BOTH signals from the SAME entry set, and either choice of that one
+    # set was wrong for a different reason.
+    #
+    # Building both from the FULL, unfiltered `entries` list let a same
+    # -position collision on ONE removed symbol's entry (already correctly
+    # rejected on its own by `masked_to_old_segments`) leak into
+    # `removed_id_to_added_symbols` for an UNRELATED removed symbol sharing
+    # that same masked context, wrongly making that unrelated symbol look
+    # self-contradictory (see the "spurious same-position collision must
+    # not taint a symbol's own clean, different-position candidacy" test
+    # below: `ns::old::f`'s legitimate `ns -> new` move, evidenced cleanly
+    # via one masking position, was wrongly rejected purely because its
+    # OTHER masking position happened to collide with an unrelated `p1`/`p2`
+    # pair at that position's masked context).
+    #
+    # Building both from ONLY the entries that survive
+    # `masked_to_old_segments` instead (the fix attempted for the above)
+    # broke the ORIGINAL many-to-one-across-positions case this dict exists
+    # for: when a removed symbol's own entry is invalidated by a same
+    # -position collision with an UNRELATED third symbol, that entry's
+    # candidacy on a given added declaration is still real evidence that
+    # the added declaration is CONTESTED (a different removed symbol's
+    # independent, valid entry cannot be treated as its sole, uncontested
+    # source just because its rival's own entry additionally happens to
+    # collide with something else at the SAME masked context) -- see
+    # `TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings`'s
+    # own reported collision, reproduced again here alongside `ns`: `p1`'s
+    # only candidacy on `new::old::f` still contests that target even
+    # though `p1`'s SPECIFIC entry is separately invalidated by the
+    # unrelated `ns` collision at that same masked context.
+    #
+    # The two questions are genuinely asymmetric, which is why they need
+    # two different entry sets:
+    #  - "is this ADDED declaration contested by more than one distinct
+    #    removed identity" (`added_id_to_removed_symbols`) is a question
+    #    about the target, answerable from EVERY raw candidacy regardless
+    #    of whether that candidacy is independently valid -- a same
+    #    -position-colliding candidacy is still a real, structurally
+    #    possible alternative explanation contesting the target, so it
+    #    still counts.
+    #  - "does this REMOVED symbol resolve to more than one distinct added
+    #    declaration" (`removed_id_to_added_symbols`) should only weigh a
+    #    removed symbol's OWN candidacies that are not already known
+    #    -spurious for an unrelated reason (a same-position collision with
+    #    a THIRD symbol) -- otherwise a removed symbol's one clean,
+    #    unambiguous candidacy gets wrongly discredited by its OWN
+    #    unrelated, already-rejected candidacy at a different position.
+    #
+    # `added_id_to_removed_symbols`: reject an ambiguous substitution
+    # ACROSS masking positions (Codex review, fresh evidence): the
+    # position-scoped check above only catches two old segments competing
+    # for the SAME masked context (same position), but the identical added
+    # declaration can just as well be claimed by two removed symbols
+    # differing at DIFFERENT positions -- e.g. removed `p1::old::{f,g}`
+    # and `new::p2::{f,g}` vs. added only `new::old::{f,g}`:
+    # `p1::old::f` (masking position 0) and `new::p2::f` (masking
+    # position 1) both resolve to the SAME added `new::old::f`, so their
+    # masked contexts differ and the position-scoped check above sees no
+    # collision at all, yet the same added declaration cannot
+    # simultaneously be evidence for both `p1 -> new` AND `p2 -> old`.
+    #
+    # Tracked by DISTINCT CLAIMING REMOVED-SYMBOL IDENTITY, not by distinct
+    # substitution KEY (Codex review, fresh evidence: an earlier revision
+    # tracked distinct `(old_segment, new_segment)` key text instead, which
+    # is insufficient -- removing `old::new::f` and `new::old::f` while
+    # adding only `new::new::f` has BOTH claims spell the identical key
+    # `('old', 'new')` (`old::new::f` masked at position 0 gives
+    # `old -> new`; `new::old::f` masked at position 1 also gives
+    # `old -> new`), so a key-text set collapses them to size one and the
+    # guard wrongly accepted both, even though they are two genuinely
+    # different removed originals both claiming the same single added
+    # declaration as their target -- an added declaration can only
+    # actually be the result of one historical move). Keyed by the added
+    # declaration's own identity (its full "::"-joined scope chain),
+    # tracking the set of distinct claiming removed symbols' own
+    # "::"-joined identities: two different string spellings of the SAME
+    # removed declaration (a real mangled symbol and a header-tier
+    # synthetic key for the same move -- see the co-matching comment above,
+    # which is about the ADDED side, but the identical principle applies
+    # here) normalize to the same joined identity and so still count as
+    # one claimant, not two.
+    #
+    # `removed_id_to_added_symbols`: reject the SYMMETRIC cross-position
+    # ambiguity too (Codex review, fresh evidence): the check just above
+    # catches several removed symbols converging on one added declaration;
+    # it says nothing about the reverse -- the SAME removed symbol matching
+    # DIFFERENT added declarations at its different masking positions. E.g.
+    # removed `p1::old::{f,g}` with added `new::old::{f,g}` AND
+    # `p1::new::{f,g}`: `p1::old::f` masked at position 0 (masking `p1`)
+    # matches `new::old::f` (implying `p1 -> new`), while the SAME
+    # `p1::old::f` masked at position 1 (masking `old`) matches
+    # `p1::new::f` (implying `old -> new`) -- two mutually exclusive
+    # substitutions, each independently unambiguous by every check above,
+    # both backed by the identical removed symbol as if it were evidence
+    # for both at once. Tracked the mirror-image way: per removed symbol's
+    # own "::"-joined identity, the set of distinct added declarations'
+    # "::"-joined identities it was resolved to across every masking
+    # position whose OWN masked context is not itself already known
+    # -ambiguous (see the asymmetry note above for why this differs from
+    # `added_id_to_removed_symbols`, which uses every raw candidacy).
+    added_id_to_removed_symbols: dict[str, set[str]] = {}
+    removed_id_to_added_symbols: dict[str, set[str]] = {}
+    for masked, r_comps, i, a_comps in entries:
+        added_id = "::".join(a_comps)
+        symbol_id = "::".join(r_comps)
+        added_id_to_removed_symbols.setdefault(added_id, set()).add(symbol_id)
+        if len(masked_to_old_segments[masked]) != 1:
+            continue
+        removed_id_to_added_symbols.setdefault(symbol_id, set()).add(added_id)
 
     # Phase 2: record only the entries whose masked context was claimed by
     # exactly one distinct old segment value (the position-scoped
-    # many-to-one rejection) AND whose added declaration was claimed by
+    # many-to-one rejection), whose added declaration was claimed by
     # exactly one distinct removed-symbol identity (the cross-position
-    # rejection) -- then apply the pre-existing per-symbol/per-key/per-pair
-    # dedup exactly as before.
+    # many-to-one rejection), AND whose removed symbol was itself resolved
+    # to exactly one distinct added declaration across all its masking
+    # positions (the symmetric cross-position one-to-many rejection) --
+    # then apply the pre-existing per-symbol/per-key/per-pair dedup exactly
+    # as before.
     seen_here: dict[str, set[tuple[str, str]]] = {}
     # Tracks which (old_qualified, new_qualified) pairs have already been
     # recorded per substitution key, so the SAME declaration reported under
@@ -1102,6 +1179,8 @@ def find_namespace_move_groups(
         added_id = "::".join(a_comps)
         symbol_id = "::".join(r_comps)
         if len(added_id_to_removed_symbols[added_id]) != 1:
+            continue
+        if len(removed_id_to_added_symbols[symbol_id]) != 1:
             continue
         key = (r_comps[i], a_comps[i])
         symbol_seen = seen_here.setdefault(symbol_id, set())

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -990,13 +990,44 @@ def find_namespace_move_groups(
     # (Codex review, fresh evidence).
     entries: list[tuple[tuple[str, ...], list[str], int, list[str]]] = []
     masked_to_old_segments: dict[tuple[str, ...], set[str]] = {}
+    # `added_id_to_removed_symbols`/`removed_id_to_added_symbols`: the two
+    # cross-position collision signals Phase 2 below needs, built from
+    # EVERY raw candidacy below -- including one a masking position's own
+    # LOCAL one-to-many check (a few lines down) is about to discard
+    # entirely from `entries` (Codex review, fresh evidence: an earlier
+    # revision built these two dicts only from `entries`, i.e. only from
+    # candidacies that already survived the local filter -- removed
+    # `p1::old::{f,g}` and `new::p2::{f,g}`, added `new::old::{f,g}` and
+    # `x::old::{f,g}`: `p1::old::f` masked at position 0 matches BOTH
+    # `new::old::f` and `x::old::f`, so the local one-to-many check
+    # discards that entry before it ever reaches `entries` -- but
+    # discarding it as unusable EVIDENCE FOR A SPECIFIC PAIRING does not
+    # mean `new::old::f` stops being a real, live alternative explanation
+    # for `p1::old::f`. `new::p2::f` (masking position 1) then matched
+    # `new::old::f` uniquely and, with `p1::old::f`'s own claim invisible
+    # to the tracking built only from `entries`, appeared uncontested --
+    # wrongly emitting a `p2 -> old` batch even though `p1::old::f` is
+    # just as plausibly `new::old::f`'s real source). Built here, in the
+    # SAME loop that computes `candidates`, before the local filter runs,
+    # so every raw candidacy -- ambiguous-at-its-own-position or not --
+    # counts as evidence contesting/claiming its target, matching this
+    # function's own stated false-negative-over-false-positive default.
+    added_id_to_removed_symbols: dict[str, set[str]] = {}
+    removed_id_to_added_symbols: dict[str, set[str]] = {}
     for r_sym in sorted(removed):
         r_comps = _scope_components(r_sym)
         if r_comps is None:
             continue
+        symbol_id = "::".join(r_comps)
         for i in range(len(r_comps) - 1):
             masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
             candidates = added_index.get(masked, [])
+            for _cand_sym, cand_comps in candidates:
+                if r_comps[i] == cand_comps[i]:
+                    continue
+                cand_id = "::".join(cand_comps)
+                added_id_to_removed_symbols.setdefault(cand_id, set()).add(symbol_id)
+                removed_id_to_added_symbols.setdefault(symbol_id, set()).add(cand_id)
             # Reject an AMBIGUOUS substitution at the source (Codex review,
             # fresh evidence): when the SAME masked context (this removed
             # symbol's scope chain with position `i` blanked out) matches
@@ -1038,115 +1069,45 @@ def find_namespace_move_groups(
             masked_to_old_segments.setdefault(masked, set()).add(r_comps[i])
             entries.append((masked, r_comps, i, a_comps))
 
-    # Phase 1b: build the two cross-position collision signals Phase 2 below
-    # needs -- deliberately a separate pass over `entries`, not folded into
-    # the loop above, and deliberately built from the FULL, UNFILTERED
-    # `entries` list for BOTH signals (Codex review, fresh evidence, three
-    # rounds -- the middle round's "fix" is worth recording since its
-    # failure mode is the interesting part).
+    # `added_id_to_removed_symbols`/`removed_id_to_added_symbols` were
+    # already fully built above, alongside `entries` -- from every raw
+    # candidacy at every masking position, independent of whether that
+    # position's own local one-to-many check passed. See the comment on
+    # their declaration above for the full history of why this
+    # construction is the sound one: three review rounds each found a
+    # different way of scoping these two dicts to be unsound --
+    # building them only from `entries` (missing evidence discarded by the
+    # LOCAL one-to-many filter before it ever reached `entries`), filtering
+    # by `masked_to_old_segments` (preferring whichever of a removed
+    # symbol's two candidacies happened to be locally clean over one that's
+    # merely contested, when a collision proves the contested claimant
+    # unconfirmable, not the alternate explanation impossible) -- and the
+    # construction above, from every raw candidacy with no filtering at
+    # all, is what survived all three.
     #
-    # Round 1 built both from the full, unfiltered list, same as here.
-    # Round 2 found that this let `ns::old::f`'s legitimate `ns -> new`
-    # move -- evidenced cleanly via ONE masking position -- get wrongly
-    # rejected purely because its OTHER masking position happened to
-    # collide with an unrelated `p1`/`p2` pair at THAT position's masked
-    # context, and "fixed" it by filtering `removed_id_to_added_symbols` to
-    # only entries surviving `masked_to_old_segments` -- i.e. by preferring
-    # whichever of a removed symbol's two candidacies happened to be
-    # locally clean at its own masked context.
+    # `added_id_to_removed_symbols` answers: is this added declaration
+    # claimed by more than one distinct removed identity, whether they
+    # collide at the SAME masking position (already caught by
+    # `masked_to_old_segments` above) or at DIFFERENT ones (e.g. removed
+    # `p1::old::{f,g}` and `new::p2::{f,g}` vs. added only
+    # `new::old::{f,g}` -- masking positions 0 and 1 respectively, masked
+    # contexts differ, so `masked_to_old_segments` alone sees no collision,
+    # yet the same added declaration cannot simultaneously be evidence for
+    # both `p1 -> new` and `p2 -> old`). Tracked by distinct CLAIMING
+    # REMOVED-SYMBOL IDENTITY, not by distinct substitution key text --
+    # removing `old::new::f` and `new::old::f` while adding only
+    # `new::new::f` has both claims spell the identical key `('old',
+    # 'new')`, so a key-text set would collapse them to size one even
+    # though they are two genuinely different removed originals.
     #
-    # Round 3 found that "fix" itself unsound, with the EXACT MIRROR-IMAGE
-    # shape: removed `ns::old::{f,g}` and `ns::q::{f,g}`, added
-    # `new::old::{f,g}` and `ns::new::{f,g}`. `ns::old::f` again has two
-    # raw candidacies -- position 0 (masking `ns`) cleanly, uniquely
-    # matches `new::old::f`; position 1 (masking `old`) matches
-    # `ns::new::f`, but COLLIDES with `ns::q::f` there (real,
-    # unconfirmable ambiguity: was it `old` or `q` that became `new`?).
-    # Round 2's filter discarded the colliding position-1 entry and kept
-    # the clean position-0 one, letting `ns::old -> new::old` survive
-    # uncontested -- but a colliding masked context proves the SPECIFIC
-    # claimant (old vs. q) is unconfirmable, not that the ALTERNATE
-    # explanation (`old -> new`, competing with `ns -> new`) is
-    # impossible. `ns::old::f`'s true fate is exactly as uncertain as it
-    # was without `ns::q` in the picture at all -- an unrelated third
-    # symbol colliding with ONE of two live hypotheses cannot make the
-    # OTHER hypothesis newly confirmed. Round 2's own justifying scenario
-    # (`ns`/`p1`/`p2`) is the identical shape from the other position, and
-    # is -- by the same reasoning -- equally unconfirmable: `ns::old::f`
-    # there ALSO has two live, unconfirmed candidacies (`ns -> new`,
-    # contested with `p1`; `old -> new`, clean), and preferring the clean
-    # one over the contested one is exactly the same unsound "resolve
-    # ambiguity by picking whichever half of it happens to look cleaner"
-    # move, just with the collision on the other side.
-    #
-    # So both signals are built from every raw candidacy, without regard
-    # to whether that specific candidacy's own masked context is itself
-    # ambiguous -- deliberately more conservative than round 2 (a removed
-    # symbol with any second raw candidacy, confirmed-contested or not, is
-    # treated as genuinely undecidable and reported nowhere), matching this
-    # function's own stated false-negative-over-false-positive default
-    # (see the local-ambiguity comment above) rather than trying to be
-    # clever about which half of an ambiguity to trust.
-    #
-    # `added_id_to_removed_symbols`: reject an ambiguous substitution
-    # ACROSS masking positions (Codex review, fresh evidence): the
-    # position-scoped check above only catches two old segments competing
-    # for the SAME masked context (same position), but the identical added
-    # declaration can just as well be claimed by two removed symbols
-    # differing at DIFFERENT positions -- e.g. removed `p1::old::{f,g}`
-    # and `new::p2::{f,g}` vs. added only `new::old::{f,g}`:
-    # `p1::old::f` (masking position 0) and `new::p2::f` (masking
-    # position 1) both resolve to the SAME added `new::old::f`, so their
-    # masked contexts differ and the position-scoped check above sees no
-    # collision at all, yet the same added declaration cannot
-    # simultaneously be evidence for both `p1 -> new` AND `p2 -> old`.
-    #
-    # Tracked by DISTINCT CLAIMING REMOVED-SYMBOL IDENTITY, not by distinct
-    # substitution KEY (Codex review, fresh evidence: an earlier revision
-    # tracked distinct `(old_segment, new_segment)` key text instead, which
-    # is insufficient -- removing `old::new::f` and `new::old::f` while
-    # adding only `new::new::f` has BOTH claims spell the identical key
-    # `('old', 'new')` (`old::new::f` masked at position 0 gives
-    # `old -> new`; `new::old::f` masked at position 1 also gives
-    # `old -> new`), so a key-text set collapses them to size one and the
-    # guard wrongly accepted both, even though they are two genuinely
-    # different removed originals both claiming the same single added
-    # declaration as their target -- an added declaration can only
-    # actually be the result of one historical move). Keyed by the added
-    # declaration's own identity (its full "::"-joined scope chain),
-    # tracking the set of distinct claiming removed symbols' own
-    # "::"-joined identities: two different string spellings of the SAME
-    # removed declaration (a real mangled symbol and a header-tier
-    # synthetic key for the same move -- see the co-matching comment above,
-    # which is about the ADDED side, but the identical principle applies
-    # here) normalize to the same joined identity and so still count as
-    # one claimant, not two.
-    #
-    # `removed_id_to_added_symbols`: reject the SYMMETRIC cross-position
-    # ambiguity too (Codex review, fresh evidence): the check just above
-    # catches several removed symbols converging on one added declaration;
-    # it says nothing about the reverse -- the SAME removed symbol matching
-    # DIFFERENT added declarations at its different masking positions. E.g.
-    # removed `p1::old::{f,g}` with added `new::old::{f,g}` AND
-    # `p1::new::{f,g}`: `p1::old::f` masked at position 0 (masking `p1`)
-    # matches `new::old::f` (implying `p1 -> new`), while the SAME
-    # `p1::old::f` masked at position 1 (masking `old`) matches
-    # `p1::new::f` (implying `old -> new`) -- two mutually exclusive
-    # substitutions, each independently unambiguous by every check above,
-    # both backed by the identical removed symbol as if it were evidence
-    # for both at once. Tracked the mirror-image way: per removed symbol's
-    # own "::"-joined identity, the set of distinct added declarations'
-    # "::"-joined identities it was resolved to across every masking
-    # position -- every raw candidacy, same as `added_id_to_removed_symbols`
-    # (see the round-3 note above for why filtering either dict by
-    # `masked_to_old_segments` is unsound).
-    added_id_to_removed_symbols: dict[str, set[str]] = {}
-    removed_id_to_added_symbols: dict[str, set[str]] = {}
-    for _masked, r_comps, _i, a_comps in entries:
-        added_id = "::".join(a_comps)
-        symbol_id = "::".join(r_comps)
-        added_id_to_removed_symbols.setdefault(added_id, set()).add(symbol_id)
-        removed_id_to_added_symbols.setdefault(symbol_id, set()).add(added_id)
+    # `removed_id_to_added_symbols` answers the symmetric question: does
+    # this removed symbol resolve to more than one distinct added
+    # declaration across its masking positions -- e.g. removed
+    # `p1::old::{f,g}` with added `new::old::{f,g}` AND `p1::new::{f,g}`,
+    # where `p1::old::f` matches `new::old::f` (masking position 0,
+    # implying `p1 -> new`) and ALSO matches `p1::new::f` (masking
+    # position 1, implying `old -> new`) -- two mutually exclusive
+    # substitutions, both backed by the identical removed symbol.
 
     # Phase 2: record only the entries whose masked context was claimed by
     # exactly one distinct old segment value (the position-scoped

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -132,6 +132,18 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   function's own stated false-negative-over-false-positive default: a
   removed symbol with any second raw candidacy at all — confirmed-contested
   or not — is now treated as genuinely undecidable and reported nowhere.
+  A fourth round found one more gap in the SAME construction: a candidacy
+  a removed symbol's own masking position discarded via the pre-existing
+  LOCAL one-to-many check (that position's masked context matching more
+  than one distinct added target) never entered the shared `entries` list
+  at all, so it never contributed to either cross-position tracking dict
+  either — even though discarding it as unusable evidence for one specific
+  pairing doesn't mean the added declaration it ambiguously matched stops
+  being a real, live alternative explanation for a DIFFERENT removed
+  symbol's own claim on it. Fixed by moving both tracking dicts' construction
+  earlier, into the same loop that computes each masking position's raw
+  candidate list, so every raw candidacy is registered before the local
+  one-to-many filter ever discards it.
 - **Cross-tier enum findings now dedupe correctly.** The L2 header-tier
   enum detector (`diff_types._diff_enums`, bare `EnumType.name`) and the L1
   DWARF-tier detector (`diff_platform._diff_enum_layouts`, fully-qualified

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -121,8 +121,17 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   (a same-position collision on one removed symbol's entry either leaked
   into an unrelated symbol's own clean, different-position candidacy and
   wrongly discredited it, or — filtered the other way — lost real evidence
-  that a target is contested); the two checks are now built from
-  deliberately different entry sets to avoid both failure modes.
+  that a target is contested). A third round found that "filtering the
+  other way" fix was itself unsound in the mirror-image shape: a removed
+  symbol whose one candidacy is contested by an unrelated third symbol
+  (unconfirmable, not disproven) had its OTHER, merely-locally-clean
+  candidacy wrongly treated as confirmed and reported — the identical
+  unsound "resolve ambiguity by preferring whichever half looks cleaner"
+  move, just with the collision on the other position. Both tracking dicts
+  are now built from every raw candidacy, unfiltered, matching this
+  function's own stated false-negative-over-false-positive default: a
+  removed symbol with any second raw candidacy at all — confirmed-contested
+  or not — is now treated as genuinely undecidable and reported nowhere.
 - **Cross-tier enum findings now dedupe correctly.** The L2 header-tier
   enum detector (`diff_types._diff_enums`, bare `EnumType.name`) and the L1
   DWARF-tier detector (`diff_platform._diff_enum_layouts`, fully-qualified

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -52,7 +52,21 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   pretty-print verbatim). Once a brace opens, every character up to its
   matching close is now treated as fully opaque — unlike the angle-bracket
   cases, this needs no heuristic at all, since braces always balance
-  unconditionally in valid C++.
+  unconditionally in valid C++. Bracket (`[`/`]`) nesting is now tracked
+  the same way, for the same reason: a subscript expression as (or within)
+  a non-type template argument (`operator B<A[N > M]>`, confirmed to
+  compile) carries a `>` needing no parenthesization either, since `]` —
+  not `>` — closes it. Both fixes are string/character-count-based, not a
+  real tokenizer: a string/char literal inside a lambda body containing a
+  brace/bracket/paren/angle-bracket character can still desynchronize the
+  count, and closing that would need real lexical scanning (quoting,
+  escape sequences, raw string literals, comments) — documented as a
+  known, accepted limitation in `qualified_name_scope_components`'s own
+  docstring rather than attempted, since it is a materially larger piece
+  of work than the bounded fixes above and the shape it would guard
+  against (a string literal inside a lambda body used as a conversion
+  operator's own non-type template argument) is far into
+  adversarially-constructed territory rather than real-world C++.
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -34,7 +34,16 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   argument, so a real template-opening `<` is now distinguished from a
   comparison via the same spacing convention every compiler pretty-printer
   uses (a template opener is never preceded by whitespace; a binary
-  operator always is, on both sides).
+  operator always is, on both sides). A multi-character `<`-led expression
+  operator (`<<`, `<=`, `<<=`, `<=>`, e.g. `operator B<N << M>`) is now
+  also correctly accepted — the per-character spacing signal alone
+  misclassified the second `<` of `<<` (preceded by the first `<`, not
+  whitespace) as its own template opener; these tokens are now recognized
+  and skipped atomically before either character is considered
+  individually, which is structurally sound with no whitespace check
+  needed (a template-argument-list can never begin with a bare `<` or
+  `=`, so two adjacent `<`s, or a `<` immediately followed by `=`, can
+  only be this operator's own spelling).
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -109,7 +109,20 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   removed-symbol identities* per added declaration instead of key text —
   an added declaration can only actually be the result of one historical
   move, regardless of whether two different claims happen to describe that
-  move with the same substitution text.
+  move with the same substitution text. A symmetric gap was found and
+  closed too: the same removed symbol can resolve to *different* added
+  declarations at its different masking positions (removing
+  `p1::old::{f,g}` while adding `new::old::{f,g}` and `p1::new::{f,g}`
+  makes each removed symbol match both `p1 -> new` and `old -> new`,
+  mutually exclusive substitutions, simultaneously) — now tracked the
+  mirror-image way, per removed symbol's own identity, the set of distinct
+  added declarations it resolves to. Building both directions' tracking
+  from the same entry set turned out to be unsound either way it was tried
+  (a same-position collision on one removed symbol's entry either leaked
+  into an unrelated symbol's own clean, different-position candidacy and
+  wrongly discredited it, or — filtered the other way — lost real evidence
+  that a target is contested); the two checks are now built from
+  deliberately different entry sets to avoid both failure modes.
 - **Cross-tier enum findings now dedupe correctly.** The L2 header-tier
   enum detector (`diff_types._diff_enums`, bare `EnumType.name`) and the L1
   DWARF-tier detector (`diff_platform._diff_enum_layouts`, fully-qualified

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -66,7 +66,15 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   of work than the bounded fixes above and the shape it would guard
   against (a string literal inside a lambda body used as a conversion
   operator's own non-type template argument) is far into
-  adversarially-constructed territory rather than real-world C++.
+  adversarially-constructed territory rather than real-world C++. A
+  lambda's trailing-return-type arrow (`[]() -> bool { ... }`, confirmed
+  to compile and pretty-print verbatim as a non-type template argument) is
+  now also correctly accepted — the `>` in `->` sits in the lambda's own
+  declarator, not inside any brace/bracket the earlier fixes already
+  track as opaque, so it needs its own check. Unlike every other `>` case
+  here, this one needs no heuristic at all: a `-` immediately adjacent to
+  a `>` can only ever tokenize as the single `->` token by the C++
+  lexical grammar's own maximal-munch rule, never as two separate tokens.
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -86,6 +86,20 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   table, mirroring `diff_versioning.demote_internal_version_node_findings`.
   A genuinely-exported symbol, or a castxml-synthesized ctor/dtor key
   (never a real export by construction), is left untouched.
+- **`find_namespace_move_groups` now also rejects a many-to-one collision
+  spanning DIFFERENT masking positions**, not just the same one. The
+  existing many-to-one guard only caught two removed segment values
+  competing for the identical masked context at the SAME component
+  position; when `p1::old::{f,g}` (differing from the sole added
+  `new::old::{f,g}` at position 0) and `new::p2::{f,g}` (differing from the
+  same added declaration at position 1) are both removed, their masked
+  contexts differ, so the position-scoped check saw no collision and both
+  `p1 -> new` and `p2 -> old` independently cleared the 2+-pairs threshold
+  as contradictory `SYMBOL_RENAMED_BATCH` findings over the identical
+  added symbols. Fixed by also tracking, per added declaration's own full
+  scope-chain identity, the distinct `(old_segment, new_segment)`
+  substitution keys it has been claimed under, and rejecting any entry
+  whose added declaration was claimed under more than one.
 - **Cross-tier enum findings now dedupe correctly.** The L2 header-tier
   enum detector (`diff_types._diff_enums`, bare `EnumType.name`) and the L1
   DWARF-tier detector (`diff_platform._diff_enum_layouts`, fully-qualified

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -11,7 +11,15 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `~Qualified::Name`) or a plain qualified display name never joined the
   batch roll-up — leaving most of a real move's findings unpaired. A new
   qualified-name fallback (`diff_cxx_rules.qualified_name_scope_components`)
-  closes the gap generically for any such key.
+  closes the gap generically for any such key. `find_namespace_move_groups`
+  also now rejects an ambiguous pairing in either direction: one removed
+  symbol matching several distinct added targets (one-to-many), and several
+  distinct removed namespaces converging on the identical added target
+  (many-to-one, e.g. `old1::{f,g}`/`old2::{f,g}` removed with only
+  `new::{f,g}` added) — and no longer double-counts the same declaration
+  toward the roll-up's 2+-pairs threshold when it's reported under two
+  different string identities (a real mangled symbol and a header-tier
+  synthetic key for the same move).
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -19,7 +19,14 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `new::{f,g}` added) — and no longer double-counts the same declaration
   toward the roll-up's 2+-pairs threshold when it's reported under two
   different string identities (a real mangled symbol and a header-tier
-  synthetic key for the same move).
+  synthetic key for the same move). `qualified_name_scope_components`'s
+  balanced-nesting check (and `strip_trailing_top_level_parameter_list`'s
+  identical concern) now track angle-bracket and paren nesting as two
+  independent counters rather than one shared depth — a real, demangled
+  non-type template argument can legitimately contain a parenthesized
+  `<`/`>` comparison (`operator std::integral_constant<bool, (sizeof(T) >
+  1)>`), which a single shared counter miscounted as closing the enclosing
+  template and rejected as malformed.
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -43,7 +43,16 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   individually, which is structurally sound with no whitespace check
   needed (a template-argument-list can never begin with a bare `<` or
   `=`, so two adjacent `<`s, or a `<` immediately followed by `=`, can
-  only be this operator's own spelling).
+  only be this operator's own spelling). Brace (`{`/`}`) nesting is now
+  also tracked as a third independent counter: C++20 allows a captureless
+  lambda closure as a non-type template argument, and its body is a full,
+  self-contained statement grammar where a `<`/`>` comparison needs no
+  parenthesization the way one directly in the template-argument-list
+  does (`operator B<[]{ return N > M; }>`, confirmed to compile and
+  pretty-print verbatim). Once a brace opens, every character up to its
+  matching close is now treated as fully opaque — unlike the angle-bracket
+  cases, this needs no heuristic at all, since braces always balance
+  unconditionally in valid C++.
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -26,7 +26,15 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   non-type template argument can legitimately contain a parenthesized
   `<`/`>` comparison (`operator std::integral_constant<bool, (sizeof(T) >
   1)>`), which a single shared counter miscounted as closing the enclosing
-  template and rejected as malformed.
+  template and rejected as malformed. A bare, unparenthesized `<`
+  comparison (e.g. `operator B<N < M>`, legal C++ and confirmed produced
+  verbatim by clang's own AST dump for an uninstantiated class template
+  member) is also now correctly accepted — unlike `>`, C++'s grammar does
+  not require a `<` comparison to be parenthesized as a non-type template
+  argument, so a real template-opening `<` is now distinguished from a
+  comparison via the same spacing convention every compiler pretty-printer
+  uses (a template opener is never preceded by whitespace; a binary
+  operator always is, on both sides).
 - **A lambda-closure-parameterized function-level finding is now demoted
   when confirmed never exported on either side.** A `func_removed`/
   `func_params_changed`/`template_param_type_changed`/

--- a/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
+++ b/changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md
@@ -99,7 +99,17 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   added symbols. Fixed by also tracking, per added declaration's own full
   scope-chain identity, the distinct `(old_segment, new_segment)`
   substitution keys it has been claimed under, and rejecting any entry
-  whose added declaration was claimed under more than one.
+  whose added declaration was claimed under more than one. That guard was
+  itself refined once more: tracking distinct *substitution key text*
+  under-rejected a further collision where two genuinely different removed
+  originals happen to spell the identical `(old_segment, new_segment)`
+  text from different masking positions (removing `old::new::f` and
+  `new::old::f` while adding only `new::new::f`: both claims spell
+  `old -> new`). Fixed by tracking the set of distinct *claiming
+  removed-symbol identities* per added declaration instead of key text —
+  an added declaration can only actually be the result of one historical
+  move, regardless of whether two different claims happen to describe that
+  move with the same substitution text.
 - **Cross-tier enum findings now dedupe correctly.** The L2 header-tier
   enum detector (`diff_types._diff_enums`, bare `EnumType.name`) and the L1
   DWARF-tier detector (`diff_platform._diff_enum_layouts`, fully-qualified

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1266,3 +1266,22 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings:
         assert ("old", "new") in groups
         assert ("p1", "new") not in groups
         assert ("p2", "old") not in groups
+
+    def test_cross_position_collision_sharing_identical_key_text_is_rejected(
+        self,
+    ) -> None:
+        """Codex review, fresh evidence: the fix above tracked distinct
+        claiming removed-symbol identities per added declaration -- an
+        earlier revision tracked distinct ``(old_segment, new_segment)``
+        KEY TEXT instead, which is insufficient. Removing ``old::new::f``
+        and ``new::old::f`` while adding only ``new::new::f`` has BOTH
+        claims spell the identical key ``('old', 'new')`` (``old::new::f``
+        masked at position 0 gives ``old -> new``; ``new::old::f`` masked
+        at position 1 also gives ``old -> new``), so a key-text-only guard
+        wrongly saw one distinct key and accepted both -- even though they
+        are two genuinely different removed originals both claiming the
+        SAME single added declaration as their target, which cannot
+        actually be the result of two different historical moves at once."""
+        removed = {"_ZN3old3new1fEv", "_ZN3new3old1fEv"}
+        added = {"_ZN3new3new1fEv"}
+        assert find_namespace_move_groups(removed, added) == {}

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -748,6 +748,81 @@ class TestStripTrailingTopLevelParameterListAcceptsLeftShiftExpressionOperators:
         )
 
 
+class TestQualifiedNameScopeComponentsAcceptsLambdaBodyTemplateArguments:
+    """Codex review, fresh evidence: C++20 allows a captureless lambda
+    closure as a non-type template argument, and its BODY is a full,
+    self-contained statement grammar -- a comparison inside it is not
+    required to be parenthesized the way a bare comparison directly in the
+    template-argument-list is, since it isn't at that grammar production at
+    all. Confirmed directly against real clang: ``operator B<[]{ return N
+    > M; }>() const`` (a lambda-typed conversion target) compiles under
+    ``-std=c++20`` and is pretty-printed verbatim, unparenthesized
+    comparison included, sometimes spanning multiple lines. An earlier
+    revision treated every ``>`` at ``paren_depth == 0`` as a real
+    template-closing delimiter unconditionally, so this comparison's ``>``
+    closed the outer template early and the real closing ``>`` drove the
+    counter negative, rejecting valid input."""
+
+    def test_lambda_body_comparison_target_is_accepted(self) -> None:
+        target = "operator B<[]{ return N > M; }>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_multi_line_lambda_body_target_confirmed_against_real_clang_output(
+        self,
+    ) -> None:
+        """The exact spelling confirmed by ``clang -ast-dump`` for
+        ``operator B<[]{ return N > M; }>()`` under ``-std=c++20`` --
+        clang's pretty-printer wraps the lambda body across lines."""
+        target = "operator B<[] {\n    return N > M;\n}>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_a_real_nested_template_after_a_lambda_body_sibling_is_still_recognized(
+        self,
+    ) -> None:
+        target = "operator Foo<[]{ return N > M; }, Other<C>>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_still_rejects_genuinely_unbalanced_braces(self) -> None:
+        assert (
+            qualified_name_scope_components("api::C::operator B<[]{ return N > M; >")
+            is None
+        )
+
+    def test_still_rejects_genuinely_unbalanced_nesting_after_a_closed_lambda_body(
+        self,
+    ) -> None:
+        assert (
+            qualified_name_scope_components("api::C::operator B<[]{ return N > M; }")
+            is None
+        )
+
+
+class TestStripTrailingTopLevelParameterListAcceptsLambdaBodyTemplateArguments:
+    """The identical brace-tracking fix, applied to
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking."""
+
+    def test_lambda_body_scope_splits_correctly(self) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list(
+                "ns::Holder<[]{ return N > M; }>(int)"
+            )
+            == "ns::Holder<[]{ return N > M; }>"
+        )
+
+
 class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
     """The identical bracket-kind-blind depth bug as the class above, in
     :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1285,3 +1285,70 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings:
         removed = {"_ZN3old3new1fEv", "_ZN3new3old1fEv"}
         added = {"_ZN3new3new1fEv"}
         assert find_namespace_move_groups(removed, added) == {}
+
+
+class TestFindNamespaceMoveGroupsRejectsCrossPositionOneToManyPairings:
+    """Codex review, fresh evidence: the previous fixes catch several
+    removed symbols converging on one added declaration; they say nothing
+    about the SYMMETRIC shape -- the SAME removed symbol resolving to
+    DIFFERENT added declarations at its different masking positions.
+    Removing ``p1::old::{f,g}`` while adding ``new::old::{f,g}`` AND
+    ``p1::new::{f,g}`` makes each removed symbol match TWO candidates: at
+    masking position 0 (hiding ``p1``) it matches ``new::old::{f,g}``
+    (implying ``p1 -> new``); at masking position 1 (hiding ``old``) it
+    matches ``p1::new::{f,g}`` (implying ``old -> new``). Both
+    substitutions are individually unambiguous by every other check, yet
+    the identical removed symbol is being counted as evidence for two
+    mutually exclusive moves at once."""
+
+    def test_one_removed_symbol_matching_two_targets_across_positions_is_rejected(
+        self,
+    ) -> None:
+        removed = {"_ZN2p13old1fEv", "_ZN2p13old1gEv"}
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN2p13new1fEv",
+            "_ZN2p13new1gEv",
+        }
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_unrelated_same_position_collision_does_not_taint_a_clean_move(
+        self,
+    ) -> None:
+        """Regression for a real bug in an earlier revision of this fix:
+        building the cross-position tracking dicts from the SAME entry set
+        for both directions let a same-position collision on `p1`'s own
+        entry (correctly rejected on its own by the position-scoped
+        many-to-one guard) leak into the SYMMETRIC (removed-side) check for
+        the UNRELATED `ns::old::f`/`ns::old::g`, which happens to share the
+        bare masked context ``('*', 'old', 'f')``/``('*', 'old', 'g')``
+        with `p1::old::f`/`p1::old::g` purely by coincidental bare-name
+        reuse. `ns::old -> ns::new` is a real, cleanly-evidenced move via
+        its OWN, collision-free masking position and must survive; `p1`'s
+        and `p2`'s contradictory claims on `new::old::{f,g}` (the
+        cross-position many-to-one shape from the previous test class)
+        must still both be rejected."""
+        removed = {
+            "_ZN2p13old1fEv",
+            "_ZN2p13old1gEv",
+            "_ZN3new2p21fEv",
+            "_ZN3new2p21gEv",
+            "_ZN2ns3old1fEv",
+            "_ZN2ns3old1gEv",
+        }
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN2ns3new1fEv",
+            "_ZN2ns3new1gEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert groups == {
+            ("old", "new"): [
+                ("ns::old::f", "ns::new::f"),
+                ("ns::old::g", "ns::new::g"),
+            ]
+        }
+        assert ("p1", "new") not in groups
+        assert ("p2", "old") not in groups

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -611,6 +611,69 @@ class TestQualifiedNameScopeComponentsAcceptsExpressionBearingTargets:
         ]
 
 
+class TestQualifiedNameScopeComponentsAcceptsUnparenthesizedLessThan:
+    """Codex review, fresh evidence: unlike ``>``, a bare, UNPARENTHESIZED
+    ``<`` comparison as a non-type template argument is legal C++ -- a real
+    parser disambiguates it via name lookup (is the identifier immediately
+    to its left a known template name?), which this text-only scanner has
+    no access to. Confirmed directly against real clang: ``template<int N,
+    int M> struct C { operator B<N < M>() const; };`` compiles cleanly, and
+    clang's own AST dump prints the unparenthesized comparison verbatim as
+    ``operator B<N < M>`` for the uninstantiated member -- exactly the
+    shape this function receives from this codebase's own castxml/clang-
+    derived declaration names. An earlier revision treated every ``<`` at
+    ``paren_depth == 0`` as a real template opener unconditionally, driving
+    ``angle_depth`` one too high with nothing to bring it back down,
+    rejecting this valid input."""
+
+    def test_unparenthesized_less_than_comparison_target_is_accepted(self) -> None:
+        target = "operator B<N < M>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_unparenthesized_less_than_in_an_ordinary_qualified_name_splits_correctly(
+        self,
+    ) -> None:
+        assert qualified_name_scope_components("ns::B<N < M>::method") == [
+            "ns",
+            "B<N < M>",
+            "method",
+        ]
+
+    def test_a_real_template_open_immediately_after_a_name_is_still_recognized(
+        self,
+    ) -> None:
+        """The spacing signal must not become blind to genuine nested
+        templates -- a real template-opening ``<`` (no preceding space)
+        alongside an unparenthesized comparison in a sibling argument."""
+        target = "operator Holder<N < M, Other<C>>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_still_rejects_genuinely_unbalanced_nesting_alongside_the_comparison(
+        self,
+    ) -> None:
+        assert qualified_name_scope_components("api::C::operator B<N < M") is None
+
+
+class TestStripTrailingTopLevelParameterListAcceptsUnparenthesizedLessThan:
+    """The identical spacing-based fix, applied to
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking."""
+
+    def test_unparenthesized_less_than_scope_splits_correctly(self) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list("ns::Holder<N < M>(int)")
+            == "ns::Holder<N < M>"
+        )
+
+
 class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
     """The identical bracket-kind-blind depth bug as the class above, in
     :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -674,6 +674,80 @@ class TestStripTrailingTopLevelParameterListAcceptsUnparenthesizedLessThan:
         )
 
 
+class TestQualifiedNameScopeComponentsAcceptsLeftShiftExpressionOperators:
+    """Codex review, fresh evidence: a lone ``<`` was correctly distinguished
+    from a template opener via the spacing signal
+    (:func:`_is_template_opening_angle`), but that signal examines each
+    character independently -- the SECOND ``<`` of a genuine ``<<``
+    left-shift expression operator (e.g. ``operator B<N << M>``) is
+    preceded by the FIRST ``<``, not whitespace, so it was still
+    misclassified as a template opener. Confirmed directly against real
+    clang: ``template<int N, int M> struct C { operator B<N << M>() const;
+    };`` compiles cleanly, and clang's AST dump prints the comparison
+    verbatim as ``operator B<N << M>``. Fixed by tokenizing multi-character
+    ``<``-led expression operators (``<<``, ``<=``, ``<<=``, ``<=>``)
+    atomically via :func:`_less_than_led_operator_token_len` BEFORE
+    considering either character individually -- structurally sound
+    without any whitespace signal, since a template-argument-list can
+    never begin with a bare ``<`` or ``=``, so two adjacent ``<``
+    characters (or a ``<`` immediately followed by ``=``) can only ever be
+    this operator's own spelling, never two independent delimiters."""
+
+    def test_left_shift_comparison_target_is_accepted(self) -> None:
+        target = "operator B<N << M>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_less_than_or_equal_comparison_target_is_accepted(self) -> None:
+        """A second multi-character `<`-led token, confirmed against real
+        clang (``operator B<N <= M>`` compiles and prints verbatim)."""
+        target = "operator B<N <= M>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_left_shift_in_an_ordinary_qualified_name_splits_correctly(self) -> None:
+        assert qualified_name_scope_components("ns::B<N << M>::method") == [
+            "ns",
+            "B<N << M>",
+            "method",
+        ]
+
+    def test_a_real_nested_template_after_a_left_shift_sibling_is_still_recognized(
+        self,
+    ) -> None:
+        """The multi-char-token skip must not desynchronize angle-bracket
+        tracking for a genuinely nested template argument that follows."""
+        target = "operator Foo<N << M, Other<C>>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_still_rejects_genuinely_unbalanced_nesting_alongside_left_shift(
+        self,
+    ) -> None:
+        assert qualified_name_scope_components("api::C::operator B<N << M") is None
+
+
+class TestStripTrailingTopLevelParameterListAcceptsLeftShiftExpressionOperators:
+    """The identical multi-character-token fix, applied to
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking."""
+
+    def test_left_shift_scope_splits_correctly(self) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list("ns::Holder<N << M>(int)")
+            == "ns::Holder<N << M>"
+        )
+
+
 class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
     """The identical bracket-kind-blind depth bug as the class above, in
     :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -538,6 +538,99 @@ class TestQualifiedNameScopeComponentsKeepsConversionTargetsWhole:
         assert groups == {}
 
 
+class TestQualifiedNameScopeComponentsAcceptsExpressionBearingTargets:
+    """Codex review, fresh evidence: an earlier revision of the balanced-
+    nesting check (added to close the malformed-target gap above) used one
+    shared depth counter for both ``<``/``>`` and ``(``/``)`` -- but a real,
+    demangled non-type template argument can legitimately contain a bare
+    ``<``/``>`` comparison, e.g. ``operator
+    std::integral_constant<bool, (sizeof(T) > 1)>``. The comparison's own
+    ``>`` was miscounted as closing the ``integral_constant<`` template,
+    driving the counter negative and rejecting perfectly well-formed input.
+    C++'s own grammar requires such a comparison to be parenthesized
+    wherever it appears as a template argument specifically to remove this
+    ambiguity, so a compiler's pretty-printed text always carries the
+    disambiguating parens -- angle-bracket and paren nesting are now
+    tracked as two independent counters, and a ``<``/``>`` is only ever
+    treated as a real template delimiter while no paren is open."""
+
+    def test_comparison_inside_a_non_type_template_argument_is_accepted(self) -> None:
+        target = "operator std::integral_constant<bool, (sizeof(T) > 1)>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_less_than_comparison_inside_a_non_type_template_argument_is_accepted(
+        self,
+    ) -> None:
+        target = "operator Array<bool, (N < M)>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_nested_template_argument_alongside_a_parenthesized_comparison_is_accepted(
+        self,
+    ) -> None:
+        """A comparison AND a genuinely nested template argument in the same
+        argument list -- the paren-open/close bracket the comparison sits in
+        must not desynchronize the angle-bracket counter for the sibling
+        template argument that follows it."""
+        target = "operator Holder<(A > B), Other<C>>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_still_rejects_genuinely_unbalanced_nesting_alongside_a_comparison(
+        self,
+    ) -> None:
+        """The two-counter fix must not become blind to real malformation --
+        an unclosed template past a parenthesized comparison is still
+        rejected."""
+        assert (
+            qualified_name_scope_components("api::C::operator Holder<(A > B), Other<C>")
+            is None
+        )
+
+    def test_ordinary_qualified_name_with_a_comparison_template_argument_splits_correctly(
+        self,
+    ) -> None:
+        """The same fix applies to the main top-level ``"::"`` split loop,
+        not just the conversion-operator scan -- a plain (non-conversion-
+        operator) qualified name can carry the identical non-type template
+        argument shape anywhere in its scope chain."""
+        assert qualified_name_scope_components("ns::Array<bool, (N > M)>::method") == [
+            "ns",
+            "Array<bool, (N > M)>",
+            "method",
+        ]
+
+
+class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
+    """The identical bracket-kind-blind depth bug as the class above, in
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking: a comparison inside a parenthesized non-type template
+    argument, followed by a genuinely nested function-type template
+    argument, could make the counter close the enclosing template one
+    character early and mistake the nested function type's own parameter
+    list for the real, top-level one."""
+
+    def test_comparison_alongside_a_nested_function_type_argument_splits_correctly(
+        self,
+    ) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list(
+                "ns::Holder<(A > B), int(int)>(really)"
+            )
+            == "ns::Holder<(A > B), int(int)>"
+        )
+
+
 class TestStripTrailingTopLevelParameterList:
     """CodeRabbit review, fresh evidence: a synthesized ctor key's
     parameter-list suffix (``__abicheck_ctor__<scope>(<params>)``) was

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1236,12 +1236,26 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings:
         added = {"_ZN3new3old1fEv", "_ZN3new3old1gEv"}
         assert find_namespace_move_groups(removed, added) == {}
 
-    def test_an_unambiguous_group_survives_alongside_a_cross_position_collision(
+    def test_ns_symbol_sharing_the_collision_at_one_position_is_also_rejected(
         self,
     ) -> None:
-        """The rejection must be scoped to the colliding added declarations,
-        not collateral-damage a real, resolvable move sharing no segment
-        with it."""
+        """Codex review, fresh evidence (round 3): an earlier revision of
+        this fix treated `ns::old::f`/`ns::old::g` as an unambiguous
+        "unrelated" survivor here, on the reasoning that its OWN masking
+        position (masking `old`, matching `ns::new::f`) is collision-free
+        even though its OTHER position (masking `ns`, matching
+        `new::old::f`) collides with `p1`/`p2` there. That reasoning is
+        unsound: `ns::old::f` genuinely has TWO live, structurally possible
+        fates here -- `ns -> new` (contested with `p1`, unconfirmable) or
+        `old -> new` (its own, otherwise-clean candidacy) -- and a
+        collision at one position proves the CONTESTED half is
+        unconfirmable, not that the OTHER half is thereby confirmed.
+        `ns::old::f`'s fate is exactly as undecided as `p1::old::f`'s or
+        `new::p2::f`'s, so nothing here should be reported at all -- see
+        `test_an_unambiguous_move_with_no_second_candidacy_still_survives`
+        below for what a GENUINELY unambiguous unrelated move (only one
+        candidacy total, not merely one collision-free position) looks
+        like, and that it does still survive alongside this rejection."""
         removed = {
             "_ZN2p13old1fEv",
             "_ZN2p13old1gEv",
@@ -1256,14 +1270,43 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings:
             "_ZN2ns3new1fEv",
             "_ZN2ns3new1gEv",
         }
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_an_unambiguous_move_with_no_second_candidacy_still_survives(
+        self,
+    ) -> None:
+        """The rejection must be scoped to a removed symbol that genuinely
+        has more than one raw candidacy, not collateral-damage a real,
+        resolvable move that has only ONE candidacy in total (no second
+        masking position produces any candidate at all) -- unlike
+        `ns::old::f` above, whose own second position DOES produce a
+        (contested) candidate."""
+        removed = {
+            "_ZN2p13old1fEv",
+            "_ZN2p13old1gEv",
+            "_ZN3new2p21fEv",
+            "_ZN3new2p21gEv",
+            "_ZN2ns3old1fEv",
+            "_ZN2ns3old1gEv",
+            "_ZN2a34old31hEv",
+            "_ZN2a34old31iEv",
+        }
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN2ns3new1fEv",
+            "_ZN2ns3new1gEv",
+            "_ZN2a34new31hEv",
+            "_ZN2a34new31iEv",
+        }
         groups = find_namespace_move_groups(removed, added)
         assert groups == {
-            ("old", "new"): [
-                ("ns::old::f", "ns::new::f"),
-                ("ns::old::g", "ns::new::g"),
+            ("old3", "new3"): [
+                ("a3::old3::h", "a3::new3::h"),
+                ("a3::old3::i", "a3::new3::i"),
             ]
         }
-        assert ("old", "new") in groups
+        assert ("old", "new") not in groups
         assert ("p1", "new") not in groups
         assert ("p2", "old") not in groups
 
@@ -1313,22 +1356,22 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionOneToManyPairings:
         }
         assert find_namespace_move_groups(removed, added) == {}
 
-    def test_unrelated_same_position_collision_does_not_taint_a_clean_move(
+    def test_unrelated_same_position_collision_also_rejects_the_shared_symbol(
         self,
     ) -> None:
-        """Regression for a real bug in an earlier revision of this fix:
-        building the cross-position tracking dicts from the SAME entry set
-        for both directions let a same-position collision on `p1`'s own
-        entry (correctly rejected on its own by the position-scoped
-        many-to-one guard) leak into the SYMMETRIC (removed-side) check for
-        the UNRELATED `ns::old::f`/`ns::old::g`, which happens to share the
-        bare masked context ``('*', 'old', 'f')``/``('*', 'old', 'g')``
-        with `p1::old::f`/`p1::old::g` purely by coincidental bare-name
-        reuse. `ns::old -> ns::new` is a real, cleanly-evidenced move via
-        its OWN, collision-free masking position and must survive; `p1`'s
-        and `p2`'s contradictory claims on `new::old::{f,g}` (the
-        cross-position many-to-one shape from the previous test class)
-        must still both be rejected."""
+        """This is the identical scenario as
+        `TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings.
+        test_ns_symbol_sharing_the_collision_at_one_position_is_also_rejected`
+        above, pinned here too since it's the concrete counterexample that
+        proved an earlier revision of THIS class's own guard unsound (see
+        the round-3 note on `removed_id_to_added_symbols`'s construction):
+        `ns::old::f`/`ns::old::g` genuinely have two live candidacies here
+        (`ns -> new`, contested with `p1`/`p2`; `old -> new`, its own
+        otherwise-clean candidacy) and must be rejected entirely, not
+        merely have the contested half discarded in favor of the clean
+        half. See `TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings.
+        test_an_unambiguous_move_with_no_second_candidacy_still_survives`
+        for what a genuinely single-candidacy unrelated move looks like."""
         removed = {
             "_ZN2p13old1fEv",
             "_ZN2p13old1gEv",
@@ -1343,12 +1386,40 @@ class TestFindNamespaceMoveGroupsRejectsCrossPositionOneToManyPairings:
             "_ZN2ns3new1fEv",
             "_ZN2ns3new1gEv",
         }
-        groups = find_namespace_move_groups(removed, added)
-        assert groups == {
-            ("old", "new"): [
-                ("ns::old::f", "ns::new::f"),
-                ("ns::old::g", "ns::new::g"),
-            ]
+        assert find_namespace_move_groups(removed, added) == {}
+
+
+class TestFindNamespaceMoveGroupsRejectsContestedAlternateCandidacies:
+    """Codex review, fresh evidence (round 3) -- the mirror image of
+    `TestFindNamespaceMoveGroupsRejectsCrossPositionOneToManyPairings`'s own
+    counterexample, found on review of that fix. A removed symbol with two
+    raw candidacies must be rejected even when only ONE of its two
+    candidacies is itself independently ambiguous (contested by an
+    unrelated third symbol at that position) -- the OTHER, locally-clean
+    candidacy is not thereby confirmed; it remains merely one of two
+    unconfirmed hypotheses. Removing ``ns::old::{f,g}`` and ``ns::q::{f,g}``
+    while adding ``new::old::{f,g}`` and ``ns::new::{f,g}``: `ns::old::f`
+    matches `new::old::f` cleanly via one masking position (implying
+    `ns -> new`) and matches `ns::new::f` via its other masking position
+    (implying `old -> new`), but that second candidacy collides with
+    `ns::q::f`'s own identical claim on `ns::new::f` (was it `old` or `q`
+    that became `new`?). An earlier revision of this fix discarded the
+    colliding candidacy and let the clean one survive uncontested, emitting
+    a false `ns -> new` batch backed only by `ns::old::f`/`ns::old::g`."""
+
+    def test_alternate_candidacy_contested_by_a_third_symbol_is_still_rejected(
+        self,
+    ) -> None:
+        removed = {
+            "_ZN2ns3old1fEv",
+            "_ZN2ns3old1gEv",
+            "_ZN2ns1q1fEv",
+            "_ZN2ns1q1gEv",
         }
-        assert ("p1", "new") not in groups
-        assert ("p2", "old") not in groups
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN2ns3new1fEv",
+            "_ZN2ns3new1gEv",
+        }
+        assert find_namespace_move_groups(removed, added) == {}

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1423,3 +1423,38 @@ class TestFindNamespaceMoveGroupsRejectsContestedAlternateCandidacies:
             "_ZN2ns3new1gEv",
         }
         assert find_namespace_move_groups(removed, added) == {}
+
+
+class TestFindNamespaceMoveGroupsRetainsLocallyAmbiguousCandidatesGlobally:
+    """Codex review, fresh evidence (round 4) -- a candidacy discarded by
+    the LOCAL one-to-many check (a removed symbol's masked context matching
+    more than one distinct added target AT THAT POSITION) never entered
+    `entries` at all, so it never contributed to the global
+    `added_id_to_removed_symbols`/`removed_id_to_added_symbols` collision
+    tracking either -- even though discarding it as unusable evidence for
+    ONE SPECIFIC pairing does not mean the added declaration it ambiguously
+    matched stops being a real, live alternative explanation. Removing
+    ``p1::old::{f,g}`` and ``new::p2::{f,g}`` while adding
+    ``new::old::{f,g}`` and ``x::old::{f,g}``: `p1::old::f` masked at
+    position 0 matches BOTH `new::old::f` and `x::old::f` (locally
+    ambiguous, discarded from `entries`), so `new::p2::f` (masking position
+    1, matching `new::old::f` uniquely) appeared uncontested and emitted a
+    false `p2 -> old` batch, even though `p1::old::f` is just as plausibly
+    `new::old::f`'s real source."""
+
+    def test_locally_discarded_candidacy_still_contests_its_target(
+        self,
+    ) -> None:
+        removed = {
+            "_ZN2p13old1fEv",
+            "_ZN2p13old1gEv",
+            "_ZN3new2p21fEv",
+            "_ZN3new2p21gEv",
+        }
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN1x3old1fEv",
+            "_ZN1x3old1gEv",
+        }
+        assert find_namespace_move_groups(removed, added) == {}

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -490,6 +490,26 @@ class TestQualifiedNameScopeComponentsKeepsConversionTargetsWhole:
     def test_bare_conversion_operator_with_no_owner_has_no_scope(self) -> None:
         assert qualified_name_scope_components("operator old::X") == ["operator old::X"]
 
+    def test_malformed_target_with_unclosed_template_is_rejected(self) -> None:
+        """CodeRabbit review, fresh evidence: an earlier revision stopped
+        scanning the instant the ``"::operator "`` marker was found, so
+        nothing past it was ever validated for balanced nesting -- a
+        malformed target like ``operator old::X<`` (an unclosed template
+        argument) was silently accepted instead of rejected."""
+        assert qualified_name_scope_components("api::C::operator old::X<") is None
+
+    def test_malformed_target_with_stray_closing_paren_is_rejected(self) -> None:
+        assert qualified_name_scope_components("api::C::operator old::X)") is None
+
+    def test_well_formed_template_target_is_still_accepted(self) -> None:
+        """The balance check must not reject a genuinely well-formed
+        target that merely contains its own template arguments."""
+        assert qualified_name_scope_components("api::C::operator Foo<int>") == [
+            "api",
+            "C",
+            "operator Foo<int>",
+        ]
+
     def test_two_conversion_operator_removals_and_additions_still_pair_correctly(
         self,
     ) -> None:

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1205,3 +1205,64 @@ class TestFindNamespaceMoveGroupsRejectsManyToOnePairings:
             ("p2::old2::h", "p2::new::h"),
             ("p2::old2::i", "p2::new::i"),
         ]
+
+
+class TestFindNamespaceMoveGroupsRejectsCrossPositionManyToOnePairings:
+    """Codex review, fresh evidence: the position-scoped many-to-one guard
+    above (``TestFindNamespaceMoveGroupsRejectsManyToOnePairings``) only
+    catches two old segment values competing for the SAME masked context --
+    i.e. differing at the SAME component position. When removed candidates
+    differ from the same added symbol at DIFFERENT positions, their masked
+    contexts differ too, so that check sees no collision and both
+    contradictory pairings survive. Concretely: removing ``p1::old::{f,g}``
+    (masking position 0 -> candidate ``new::old::{f,g}``) and
+    ``new::p2::{f,g}`` (masking position 1 -> the SAME candidate
+    ``new::old::{f,g}``) while adding only ``new::old::{f,g}`` lets both
+    ``p1 -> new`` and ``p2 -> old`` independently clear the 2+-pairs
+    threshold, over the identical added declarations -- the same added
+    symbol cannot simultaneously be evidence that ``p1`` moved to ``new``
+    (with ``old`` unchanged) AND that ``p2`` moved to ``old`` (with ``new``
+    unchanged)."""
+
+    def test_cross_position_collision_on_one_added_declaration_is_rejected(
+        self,
+    ) -> None:
+        removed = {
+            "_ZN2p13old1fEv",
+            "_ZN2p13old1gEv",
+            "_ZN3new2p21fEv",
+            "_ZN3new2p21gEv",
+        }
+        added = {"_ZN3new3old1fEv", "_ZN3new3old1gEv"}
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_an_unambiguous_group_survives_alongside_a_cross_position_collision(
+        self,
+    ) -> None:
+        """The rejection must be scoped to the colliding added declarations,
+        not collateral-damage a real, resolvable move sharing no segment
+        with it."""
+        removed = {
+            "_ZN2p13old1fEv",
+            "_ZN2p13old1gEv",
+            "_ZN3new2p21fEv",
+            "_ZN3new2p21gEv",
+            "_ZN2ns3old1fEv",
+            "_ZN2ns3old1gEv",
+        }
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN2ns3new1fEv",
+            "_ZN2ns3new1gEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert groups == {
+            ("old", "new"): [
+                ("ns::old::f", "ns::new::f"),
+                ("ns::old::g", "ns::new::g"),
+            ]
+        }
+        assert ("old", "new") in groups
+        assert ("p1", "new") not in groups
+        assert ("p2", "old") not in groups

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -823,6 +823,65 @@ class TestStripTrailingTopLevelParameterListAcceptsLambdaBodyTemplateArguments:
         )
 
 
+class TestQualifiedNameScopeComponentsAcceptsSubscriptTemplateArguments:
+    """Codex review, fresh evidence: a subscript expression used as (or
+    within) a non-type template argument carries a ``>`` that needs no
+    parenthesization either -- ``]``, not ``>``, closes the subscript, so
+    it carries none of the top-level template-argument ambiguity a bare
+    ``>`` would. Confirmed directly against real clang:
+    ``operator B<A[N > M]>()`` compiles cleanly (with ``constexpr int
+    A[10]``) and is pretty-printed verbatim. An earlier revision treated
+    every ``>`` at ``paren_depth == 0`` as a real template-closing
+    delimiter unconditionally, so the comparison's own ``>`` closed the
+    outer template early and the real closing ``>`` drove the counter
+    negative, rejecting valid input."""
+
+    def test_subscript_comparison_target_is_accepted(self) -> None:
+        target = "operator B<A[N > M]>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_subscript_in_an_ordinary_qualified_name_splits_correctly(self) -> None:
+        assert qualified_name_scope_components("ns::B<A[N > M]>::method") == [
+            "ns",
+            "B<A[N > M]>",
+            "method",
+        ]
+
+    def test_a_real_nested_template_after_a_subscript_sibling_is_still_recognized(
+        self,
+    ) -> None:
+        target = "operator Foo<A[N > M], Other<C>>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_still_rejects_genuinely_unbalanced_brackets(self) -> None:
+        assert qualified_name_scope_components("api::C::operator B<A[N > M>") is None
+
+    def test_still_rejects_genuinely_unbalanced_nesting_after_a_closed_subscript(
+        self,
+    ) -> None:
+        assert qualified_name_scope_components("api::C::operator B<A[N > M]") is None
+
+
+class TestStripTrailingTopLevelParameterListAcceptsSubscriptTemplateArguments:
+    """The identical bracket-tracking fix, applied to
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking."""
+
+    def test_subscript_scope_splits_correctly(self) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list("ns::Holder<A[N > M]>(int)")
+            == "ns::Holder<A[N > M]>"
+        )
+
+
 class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
     """The identical bracket-kind-blind depth bug as the class above, in
     :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -145,8 +145,18 @@ class TestNamespaceMoveIsRecognizedAsOneBatch:
         still be reported -- rejecting the ambiguous segments must not
         collateral-damage a real, resolvable move that shares no segment
         with them."""
-        removed = set(_D1) | {"_ZN4old11fEv", "_ZN4old11gEv", "_ZN4old21fEv", "_ZN4old21gEv"}
-        added = set(_D2) | {"_ZN4new11fEv", "_ZN4new11gEv", "_ZN4new21fEv", "_ZN4new21gEv"}
+        removed = set(_D1) | {
+            "_ZN4old11fEv",
+            "_ZN4old11gEv",
+            "_ZN4old21fEv",
+            "_ZN4old21gEv",
+        }
+        added = set(_D2) | {
+            "_ZN4new11fEv",
+            "_ZN4new11gEv",
+            "_ZN4new21fEv",
+            "_ZN4new21gEv",
+        }
         groups = find_namespace_move_groups(removed, added)
         assert ("d1", "d2") in groups
         assert len(groups[("d1", "d2")]) == len(_D1)
@@ -216,9 +226,7 @@ class TestHeaderTierKeysAlsoJoinTheNamespaceMove:
         return ``{}`` before the qualified-name fallback (neither
         ``itanium_scope_components`` nor ``msvc_scope_components`` recognizes
         either key shape)."""
-        groups = find_namespace_move_groups(
-            set(_D1_HEADER_TIER), set(_D2_HEADER_TIER)
-        )
+        groups = find_namespace_move_groups(set(_D1_HEADER_TIER), set(_D2_HEADER_TIER))
         assert ("d1", "d2") in groups
         assert len(groups[("d1", "d2")]) == 2
 
@@ -244,12 +252,10 @@ class TestHeaderTierKeysAlsoJoinTheNamespaceMove:
         assert ("d1", "d2") in groups
         pairs = dict(groups[("d1", "d2")])
         assert (
-            pairs["tbb::detail::d1::graph::{ctor}"]
-            == "tbb::detail::d2::graph::{ctor}"
+            pairs["tbb::detail::d1::graph::{ctor}"] == "tbb::detail::d2::graph::{ctor}"
         )
         assert (
-            pairs["tbb::detail::d1::graph::{dtor}"]
-            == "tbb::detail::d2::graph::{dtor}"
+            pairs["tbb::detail::d1::graph::{dtor}"] == "tbb::detail::d2::graph::{dtor}"
         )
         assert len(groups[("d1", "d2")]) == len(_D1)
 
@@ -257,9 +263,7 @@ class TestHeaderTierKeysAlsoJoinTheNamespaceMove:
         old = _snap("2021", [_fn("graph", m) for m in _D1_HEADER_TIER])
         new = _snap("2022", [_fn("graph", m) for m in _D2_HEADER_TIER])
         result = compare(old, new)
-        batch = [
-            c for c in result.changes if c.kind is ChangeKind.SYMBOL_RENAMED_BATCH
-        ]
+        batch = [c for c in result.changes if c.kind is ChangeKind.SYMBOL_RENAMED_BATCH]
         assert batch, "namespace move via header-tier keys produced no batch roll-up"
 
     def test_qualified_function_name_without_any_mangling_also_pairs(self) -> None:
@@ -484,9 +488,7 @@ class TestQualifiedNameScopeComponentsKeepsConversionTargetsWhole:
         ]
 
     def test_bare_conversion_operator_with_no_owner_has_no_scope(self) -> None:
-        assert qualified_name_scope_components("operator old::X") == [
-            "operator old::X"
-        ]
+        assert qualified_name_scope_components("operator old::X") == ["operator old::X"]
 
     def test_two_conversion_operator_removals_and_additions_still_pair_correctly(
         self,
@@ -675,3 +677,82 @@ class TestFindNamespaceMoveGroupsCountsEachDeclarationOnce:
         # Below the 2-pairs threshold -- a single declaration reported
         # twice must not manufacture a batch finding on its own.
         assert emit_namespace_move_batches(groups) == []
+
+
+class TestFindNamespaceMoveGroupsRejectsManyToOnePairings:
+    """Codex review, fresh evidence: the one-to-many ambiguity guard (see
+    ``test_ambiguous_many_to_many_pairing_is_rejected`` above) checks
+    whether a REMOVED symbol's masked context matches more than one added
+    candidate, but says nothing about the RECIPROCAL shape -- more than one
+    DISTINCT removed segment value converging on the identical masked
+    context. When ``old1::{f,g}`` and ``old2::{f,g}`` are both removed
+    while only ``new::{f,g}`` is added, each removed symbol's masked lookup
+    has exactly one candidate (``new::f``/``new::g``), so the one-to-many
+    check alone accepts BOTH ``old1 -> new`` and ``old2 -> new`` and each
+    independently clears the 2+-pairs threshold -- two contradictory
+    SYMBOL_RENAMED_BATCH findings for evidence that cannot say which of
+    old1/old2 actually moved (the other was simply deleted)."""
+
+    def test_two_old_namespaces_converging_on_one_new_namespace_is_rejected(
+        self,
+    ) -> None:
+        removed = {
+            "_ZN4old11fEv",
+            "_ZN4old11gEv",
+            "_ZN4old21fEv",
+            "_ZN4old21gEv",
+        }
+        added = {"_ZN3new1fEv", "_ZN3new1gEv"}
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_an_unambiguous_group_survives_alongside_an_unrelated_many_to_one_one(
+        self,
+    ) -> None:
+        """The rejection must be scoped to the colliding masked context,
+        not collateral-damage a real, resolvable move sharing no segment
+        with it."""
+        removed = set(_D1) | {
+            "_ZN4old11fEv",
+            "_ZN4old11gEv",
+            "_ZN4old21fEv",
+            "_ZN4old21gEv",
+        }
+        added = set(_D2) | {"_ZN3new1fEv", "_ZN3new1gEv"}
+        groups = find_namespace_move_groups(removed, added)
+        assert ("d1", "d2") in groups
+        assert len(groups[("d1", "d2")]) == len(_D1)
+        assert ("old1", "new") not in groups
+        assert ("old2", "new") not in groups
+
+    def test_independent_moves_reusing_a_bare_target_name_are_not_rejected(
+        self,
+    ) -> None:
+        """Two genuinely independent, unambiguous moves that happen to
+        reuse the same bare TARGET segment name in different scopes
+        (``p1::old1::{f,g} -> p1::new::{f,g}`` alongside the unrelated
+        ``p2::old2::{h,i} -> p2::new::{h,i}``) must still both be
+        reported: each masked context is scoped by its own unmasked
+        siblings (``p1`` vs. ``p2``), so the two moves never collide on
+        the same masked key even though both target a segment spelled
+        ``new``."""
+        removed = {
+            "_ZN2p14old11fEv",
+            "_ZN2p14old11gEv",
+            "_ZN2p24old21hEv",
+            "_ZN2p24old21iEv",
+        }
+        added = {
+            "_ZN2p13new1fEv",
+            "_ZN2p13new1gEv",
+            "_ZN2p23new1hEv",
+            "_ZN2p23new1iEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert groups[("old1", "new")] == [
+            ("p1::old1::f", "p1::new::f"),
+            ("p1::old1::g", "p1::new::g"),
+        ]
+        assert groups[("old2", "new")] == [
+            ("p2::old2::h", "p2::new::h"),
+            ("p2::old2::i", "p2::new::i"),
+        ]

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -882,6 +882,71 @@ class TestStripTrailingTopLevelParameterListAcceptsSubscriptTemplateArguments:
         )
 
 
+class TestQualifiedNameScopeComponentsAcceptsLambdaTrailingReturnArrows:
+    """Codex review, fresh evidence: a lambda's trailing-return-type arrow
+    (``[]() -> bool { ... }``) sits in the lambda's OWN declarator, between
+    its parameter list and its body -- not inside any brace/bracket the
+    earlier fixes already track as opaque. Confirmed directly against real
+    clang: ``operator B<[]() -> bool { return N > 0; }>()`` compiles under
+    ``-std=c++20`` and is pretty-printed verbatim. Unlike every other ``>``
+    case, this needs no heuristic at all: by the C++ lexical grammar's own
+    maximal-munch rule, a ``-`` immediately adjacent to a ``>`` can only
+    ever tokenize as the single ``->`` token, never as two separate
+    tokens."""
+
+    def test_lambda_trailing_return_arrow_target_is_accepted(self) -> None:
+        target = "operator B<[]() -> bool { return N > 0; }>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_multi_line_trailing_return_arrow_confirmed_against_real_clang_output(
+        self,
+    ) -> None:
+        """The exact spelling confirmed by ``clang -ast-dump`` for
+        ``operator B<[]() -> bool { return N > 0; }>()`` under
+        ``-std=c++20``."""
+        target = "operator B<[]() -> bool {\n    return N > 0;\n}>"
+        assert qualified_name_scope_components(f"api::C::{target}") == [
+            "api",
+            "C",
+            target,
+        ]
+
+    def test_trailing_return_arrow_in_an_ordinary_qualified_name_splits_correctly(
+        self,
+    ) -> None:
+        assert qualified_name_scope_components(
+            "ns::B<[]() -> bool { return N > 0; }>::method"
+        ) == ["ns", "B<[]() -> bool { return N > 0; }>", "method"]
+
+    def test_still_rejects_genuinely_unbalanced_nesting_alongside_the_arrow(
+        self,
+    ) -> None:
+        assert (
+            qualified_name_scope_components(
+                "api::C::operator B<[]() -> bool { return N > 0; }"
+            )
+            is None
+        )
+
+
+class TestStripTrailingTopLevelParameterListAcceptsLambdaTrailingReturnArrows:
+    """The identical arrow-token fix, applied to
+    :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket
+    tracking."""
+
+    def test_lambda_trailing_return_arrow_scope_splits_correctly(self) -> None:
+        assert (
+            strip_trailing_top_level_parameter_list(
+                "ns::Holder<[]() -> bool { return N > 0; }>(int)"
+            )
+            == "ns::Holder<[]() -> bool { return N > 0; }>"
+        )
+
+
 class TestStripTrailingTopLevelParameterListAcceptsExpressionBearingScopes:
     """The identical bracket-kind-blind depth bug as the class above, in
     :func:`strip_trailing_top_level_parameter_list`'s own angle-bracket


### PR DESCRIPTION
## Summary

Two follow-up fixes for review findings raised on #854 (`find_namespace_move_groups`/`qualified_name_scope_components`) after that PR had already merged, so they land here as a fresh PR on top of `main` rather than being folded into the merged history.

## Changes

- **`abicheck/diff_symbols_renames.py`: reject many-to-one namespace-move pairings.** `find_namespace_move_groups` already rejected one-to-many ambiguity (a removed symbol's masked scope context matching several distinct added candidates), but had no reciprocal check for the many-to-one shape: several distinct removed namespaces converging on the identical masked context. When `old1::{f,g}` and `old2::{f,g}` are both removed while only `new::{f,g}` is added, each removed symbol's masked lookup has exactly one candidate, so the existing guard accepted both `old1 -> new` and `old2 -> new` — each independently clearing the 2+-pairs threshold and emitting two contradictory `SYMBOL_RENAMED_BATCH` findings for evidence that cannot say which of `old1`/`old2` actually moved (the other was simply deleted). Restructured into two phases: phase 1 resolves each `(removed symbol, masking position)` to at most one target-unambiguous candidate and records which old segment value it came from per masked context; phase 2 rejects any masked context claimed by more than one distinct old segment before applying the pre-existing per-symbol/per-key/per-pair dedup.
- **`abicheck/diff_cxx_rules.py`: validate the conversion-operator target for balanced nesting.** `qualified_name_scope_components` broke out of its scanning loop the instant it found the `"::operator "` marker, so nothing past it was ever validated for balanced angle-bracket/paren nesting — a malformed conversion target like `"api::C::operator old::X<"` (unclosed template argument) or `"api::C::operator old::X)"` (stray closing paren) was silently accepted instead of rejected, violating the function's own documented "unbalanced nesting returns `None`" contract. Fixed by recording the marker's position on first sight without breaking, so the scan continues tracking depth through the whole string (including the opaque conversion-target leaf) and the existing `depth != 0 -> None` check now covers it too.

## Bug-fix test contract

- Bug class: Two independent gaps in the namespace-move/qualified-name-parsing primitives added in #854 — a missing reciprocal ambiguity check in the grouping loop, and an early-exit that skipped validation of the remainder of a malformed input.
- Publicly observable failure: `compare()` on real-world evidence with two removed namespaces sharing a leaf set converging on one added namespace could emit two contradictory `SYMBOL_RENAMED_BATCH` findings claiming different sources for the same move; a malformed synthetic/qualified symbol key with unbalanced template/paren nesting could silently be accepted as a real scope chain and feed a false namespace-move pairing instead of being rejected.
- Regression test fails on base: Yes — both new test classes' positive cases (`TestFindNamespaceMoveGroupsRejectsManyToOnePairings`, and the new malformed-conversion-target cases in `TestQualifiedNameScopeComponentsKeepsConversionTargetsWhole`) fail against `main` (i.e. against #854 as merged, before these two commits).
- Negative control: Yes — each fix has a companion test proving the negative case is untouched: an unrelated, genuinely unambiguous move survives the many-to-one rejection (`test_an_unambiguous_group_survives_alongside_an_unrelated_many_to_one_one`); two independent moves reusing the same bare *target* segment name in different scopes are still both reported (`test_independent_moves_reusing_a_bare_target_name_are_not_rejected`); a well-formed templated conversion target (`"operator Foo<int>"`) is confirmed still accepted.
- Public-surface test: Both fixes are exercised directly through the public primitives (`find_namespace_move_groups`, `qualified_name_scope_components`) that `compare()`'s namespace-move detector calls, per this repo's "Primitive-level property tests" convention — not only through a private helper.
- Axes covered: Both fixes are pure-Python string/structure logic with no platform, backend, or evidence-tier dependency (they operate on already-extracted mangled/qualified symbol strings, identically regardless of ELF/PE/Mach-O or castxml/clang/DWARF origin), so there is one axis here and it's fully covered by the direct primitive-level tests.
- General invariant: `find_namespace_move_groups` now rejects ambiguity in both directions (one-to-many *and* many-to-one) before recording any pairing, so a substitution group is only ever reported when the evidence is genuinely unambiguous in both directions. `qualified_name_scope_components` now validates nesting balance across the *entire* input, including any text past a recognized marker, so "returns `None` on unbalanced nesting" holds unconditionally rather than only for the pre-marker prefix.

## Checklist

- [x] Tests added for new behaviour
- [x] Changelog fragment updated (`changelog.d/20260824_234408_noreply_intelligent_hawking_je2phy.md`, the same fragment #854 added, per this repo's "one fragment per user-visible change area, kept updated as the PR evolves" pattern)
- [x] Docs updated if user-visible behaviour changed — N/A, no user-facing CLI/doc surface changed
- [x] `ruff check`/`ruff format --check`/`mypy` clean on touched files
- [x] Targeted test suite green (`tests/test_batch_rename_namespace_move.py`, `tests/test_enum_cross_tier_dedup.py`, `tests/test_lambda_closure_function_demotion.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ name parsing for templates, operators, comparisons, nested lambdas, and conversion types.
  * Corrected namespace-move detection to reject contradictory or ambiguous mappings.
  * Improved handling of header symbols, destructor names, enum findings, and duplicate declarations.
  * Reduced incorrect findings for internal lambda-generated symbols.

* **Tests**
  * Added extensive coverage for complex C++ expressions, namespace moves, symbol identities, and duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->