### PR TITLE
fix: two SYMBOL_RENAMED_BATCH namespace-move roll-up defects

### DIFF
--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -436,6 +436,51 @@ def itanium_qualified_name(mangled: str) -> str | None:
     return "::".join(comps) if comps else None
 
 
+def component_embeds_template_args(component: str) -> bool:
+    """Whether *component* -- one entry from
+    :func:`itanium_scope_components`/:func:`qualified_name_scope_components`
+    -- embeds a template-argument list, rather than naming a bare
+    namespace/class/function segment.
+
+    Two representations to recognize, since the two producers keep a
+    component's template arguments in different forms:
+
+    * :func:`qualified_name_scope_components` (a demangled or already
+      pretty-printed spelling) keeps the human-readable ``<...>`` form, so a
+      literal ``<`` anywhere in *component* is sufficient.
+    * :func:`itanium_scope_components` keeps a directly-attached template
+      argument list RAW -- see :func:`_parse_source_name_component`'s own
+      docstring, "keep it raw so ``Box<int>`` and ``Box<float>`` stay
+      distinct" -- so ``Box<int>`` there is the component ``"BoxIiE"``,
+      containing no literal ``<`` at all (Codex review, fresh evidence: a
+      real Itanium-mangled ``concurrent_priority_queue<tbb::detail::d1::
+      graph_task *>`` component is ``"...QIPN3tbb6detail2d110graph_taskEE"``
+      -- exactly the shape this module's own namespace-move masking
+      primitive needs to recognize as template-bearing, not just the
+      qualified-name fallback's pretty-printed spelling). Detected by
+      scanning for a raw ``I...E`` block via the identical bracket-aware
+      parser :func:`_skip_template_args` uses, and requiring the match to
+      reach the *exact end* of *component*: :func:`_parse_source_name_component`
+      always appends a directly-attached template-argument list as the
+      final suffix of a component, so this is what tells a real template
+      block apart from an ordinary identifier that merely happens to
+      contain the letter ``"I"`` (e.g. a class named ``"Item"``) -- such an
+      identifier fails to parse as a balanced template-args block at all,
+      or parses to something short of the component's actual end.
+
+    Deliberately conservative like every other guard in this module: an
+    unrecognized shape returns ``False`` (not template-bearing) rather than
+    risking a false positive that would suppress a genuine namespace-move
+    finding.
+    """
+    if "<" in component:
+        return True
+    for i, ch in enumerate(component):
+        if ch == "I" and _skip_template_args(component, i) == len(component):
+            return True
+    return False
+
+
 def itanium_ctor_dtor_marker_span(mangled: str) -> tuple[int, int] | None:
     """``(start, end)`` indices of *mangled*'s own Itanium ctor/dtor code
     (``C1``/``C2``/``C3``/``D0``/``D1``/``D2``) -- the exact 2-character

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -184,17 +184,28 @@ def _itanium_strip_prefix(mangled: str) -> tuple[str, bool] | None:
     return s, nested
 
 
-def _parse_source_name_component(s: str, i: int) -> tuple[str | None, int]:
+def _parse_source_name_component(s: str, i: int) -> tuple[str | None, int, bool]:
     """Parse a length-prefixed source-name component (with optional template args
     and GNU ABI tags) starting at ``s[i]``.
 
-    Returns ``(name, next_index)`` where *name* includes any directly-attached
-    ``I…E`` template-argument list and ``B<tag>`` GNU ABI tags, or
-    ``(None, i)`` on any parse failure.
+    Returns ``(name, next_index, template_attached)`` where *name* includes
+    any directly-attached ``I…E`` template-argument list and ``B<tag>`` GNU
+    ABI tags, and *template_attached* is ``True`` exactly when a template-
+    argument list was consumed -- tracked structurally here, at the one
+    place that ever attaches one, rather than left for a caller to guess
+    back out of the assembled *name* text. Guessing from text is unsound:
+    ``component_embeds_template_args()``'s own text-based heuristic (kept
+    for the qualified-name/header-tier-fallback shape, which has no parser
+    to ask) misreads an ordinary identifier like ``"ICE"`` or ``"IWidgetE"``
+    as a balanced ``I...E`` template block purely by coincidental spelling
+    (Codex review, fresh evidence) -- a real false positive this structural
+    flag exists to avoid for the one shape (a real Itanium mangling) that
+    has a parser available to answer the question exactly. Returns
+    ``(None, i, False)`` on any parse failure.
     """
     name, i = _read_length_prefixed_name(s, i)
     if name is None:
-        return None, i
+        return None, i, False
     n = len(s)
     # GNU ABI tags (`B<source-name>`, e.g. the libstdc++ `cxx11` tag, or a
     # user `__attribute__((abi_tag(...)))`) attach to the unqualified name
@@ -230,10 +241,11 @@ def _parse_source_name_component(s: str, i: int) -> tuple[str | None, int]:
     if i < n and s[i] == "I":
         end = _skip_template_args(s, i)
         if end is None:
-            return None, i
+            return None, i, False
         name = name + s[i:end]
         i = end
-    return name, i
+        return name, i, True
+    return name, i, False
 
 
 def _parse_ctor_dtor_component(s: str, i: int) -> tuple[str | None, int]:
@@ -335,30 +347,35 @@ def _parse_non_source_name_component(s: str, i: int) -> tuple[str | None, int]:
 
 def _step_next_component(
     s: str, i: int, nested: bool
-) -> tuple[str | None, int, bool] | None:
+) -> tuple[str | None, int, bool, bool] | None:
     """Advance one component in the Itanium nested-name body ``s`` at position ``i``.
 
-    Returns ``(label, next_i, done)`` on success:
+    Returns ``(label, next_i, done, template_attached)`` on success:
 
     - *label* is the parsed component string, or ``None`` when the position
       holds the nested-name ``E`` terminator (no component to append, just stop).
     - *next_i* is the index to continue from.
     - *done* is ``True`` when the caller should stop iterating (``E`` reached
       for a nested name, or a free-function's single component was consumed).
+    - *template_attached* is ``True`` exactly when this step consumed a
+      directly-attached template-argument list -- structurally known only for
+      a source-name component (see :func:`_parse_source_name_component`);
+      always ``False`` for a ctor/dtor/operator component, none of which can
+      carry one.
 
-    Returns ``None`` (not a 3-tuple) when the component cannot be parsed at all
+    Returns ``None`` (not a 4-tuple) when the component cannot be parsed at all
     (an unrecognized/vendor operator, substitution, truncated source name) so
     the caller propagates failure by returning ``None`` from its own scope.
     """
     c = s[i]
     if nested and c == "E":
         # Normal terminator of the ``N…E`` nested-name wrapper; no component.
-        return None, i + 1, True
+        return None, i + 1, True, False
     if c in _ASCII_DIGITS:
-        name, new_i = _parse_source_name_component(s, i)
+        name, new_i, template_attached = _parse_source_name_component(s, i)
         if name is None:
             return None  # malformed source name — propagate failure
-        return name, new_i, not nested
+        return name, new_i, not nested, template_attached
     label, new_i = _parse_non_source_name_component(s, i)
     if label is None:
         return None  # conversion operator / substitution / vendor — not modelled
@@ -367,8 +384,56 @@ def _step_next_component(
         # target type follows immediately and is deliberately not parsed
         # (see _parse_operator_component) so stop right here regardless of
         # nesting, rather than attempt to step into that unparsed type.
-        return label, new_i, True
-    return label, new_i, not nested
+        return label, new_i, True, False
+    return label, new_i, not nested, False
+
+
+def itanium_scope_components_with_template_positions(
+    mangled: str,
+) -> tuple[list[str], frozenset[int]] | None:
+    """Like :func:`itanium_scope_components`, but also reports exactly which
+    component indices carry a directly-attached template-argument list.
+
+    Tracked structurally at parse time -- from :func:`_step_next_component`'s
+    (in turn :func:`_parse_source_name_component`'s) own knowledge of
+    whether it consumed an ``I…E`` block -- rather than guessed back out of
+    the assembled component text by a caller. See
+    :func:`_parse_source_name_component`'s own docstring for why the
+    structural signal matters: a text-based guess (``component_embeds_
+    template_args()``, kept for the qualified-name/header-tier-fallback
+    shape, which has no parser to ask) misreads an ordinary identifier like
+    ``"ICE"`` as a balanced template block purely by coincidental spelling.
+
+    Returns ``None`` under the identical conditions
+    :func:`itanium_scope_components` does (see its own docstring); the
+    ``list[str]`` half of a successful result is byte-for-byte the same
+    list that function returns for the same input.
+    """
+    prefix = _itanium_strip_prefix(mangled)
+    if prefix is None:
+        return None
+    s, nested = prefix
+    components: list[str] = []
+    template_positions: set[int] = set()
+    i = 0
+    n = len(s)
+    if s[i : i + 2] == "St":
+        components.append("std")
+        i += 2
+    while i < n:
+        step = _step_next_component(s, i, nested)
+        if step is None:
+            return None  # unmodelled or malformed component
+        label, i, done, template_attached = step
+        if label is not None:
+            if template_attached:
+                template_positions.add(len(components))
+            components.append(label)
+        if done:
+            break
+    if not components:
+        return None
+    return components, frozenset(template_positions)
 
 
 def itanium_scope_components(mangled: str) -> list[str] | None:
@@ -408,26 +473,8 @@ def itanium_scope_components(mangled: str) -> list[str] | None:
     other substitutions, non-Itanium or unmangled names) so callers fall
     back.
     """
-    prefix = _itanium_strip_prefix(mangled)
-    if prefix is None:
-        return None
-    s, nested = prefix
-    components: list[str] = []
-    i = 0
-    n = len(s)
-    if s[i : i + 2] == "St":
-        components.append("std")
-        i += 2
-    while i < n:
-        step = _step_next_component(s, i, nested)
-        if step is None:
-            return None  # unmodelled or malformed component
-        label, i, done = step
-        if label is not None:
-            components.append(label)
-        if done:
-            break
-    return components or None
+    result = itanium_scope_components_with_template_positions(mangled)
+    return result[0] if result is not None else None
 
 
 def itanium_qualified_name(mangled: str) -> str | None:
@@ -438,47 +485,43 @@ def itanium_qualified_name(mangled: str) -> str | None:
 
 def component_embeds_template_args(component: str) -> bool:
     """Whether *component* -- one entry from
-    :func:`itanium_scope_components`/:func:`qualified_name_scope_components`
-    -- embeds a template-argument list, rather than naming a bare
-    namespace/class/function segment.
+    :func:`qualified_name_scope_components` (a demangled or already
+    pretty-printed spelling) -- embeds a template-argument list, rather than
+    naming a bare namespace/class/function segment.
 
-    Two representations to recognize, since the two producers keep a
-    component's template arguments in different forms:
+    A pretty-printed spelling keeps the human-readable ``<...>`` form (e.g.
+    ``"Box<int>"``), so a literal ``<`` anywhere in *component* is a sound,
+    exact signal for this shape: no ordinary C++ identifier can contain
+    ``<``.
 
-    * :func:`qualified_name_scope_components` (a demangled or already
-      pretty-printed spelling) keeps the human-readable ``<...>`` form, so a
-      literal ``<`` anywhere in *component* is sufficient.
-    * :func:`itanium_scope_components` keeps a directly-attached template
-      argument list RAW -- see :func:`_parse_source_name_component`'s own
-      docstring, "keep it raw so ``Box<int>`` and ``Box<float>`` stay
-      distinct" -- so ``Box<int>`` there is the component ``"BoxIiE"``,
-      containing no literal ``<`` at all (Codex review, fresh evidence: a
-      real Itanium-mangled ``concurrent_priority_queue<tbb::detail::d1::
-      graph_task *>`` component is ``"...QIPN3tbb6detail2d110graph_taskEE"``
-      -- exactly the shape this module's own namespace-move masking
-      primitive needs to recognize as template-bearing, not just the
-      qualified-name fallback's pretty-printed spelling). Detected by
-      scanning for a raw ``I...E`` block via the identical bracket-aware
-      parser :func:`_skip_template_args` uses, and requiring the match to
-      reach the *exact end* of *component*: :func:`_parse_source_name_component`
-      always appends a directly-attached template-argument list as the
-      final suffix of a component, so this is what tells a real template
-      block apart from an ordinary identifier that merely happens to
-      contain the letter ``"I"`` (e.g. a class named ``"Item"``) -- such an
-      identifier fails to parse as a balanced template-args block at all,
-      or parses to something short of the component's actual end.
+    This is deliberately a TEXT-ONLY heuristic and is NOT used for an
+    Itanium-mangled component: :func:`itanium_scope_components` keeps a
+    directly-attached template-argument list RAW -- see
+    :func:`_parse_source_name_component`'s own docstring, "keep it raw so
+    ``Box<int>`` and ``Box<float>`` stay distinct" -- so ``Box<int>`` there
+    is the component ``"BoxIiE"``, containing no literal ``<`` at all, and a
+    naive scan for a raw ``I...E`` block is unsound: an ordinary identifier
+    like ``"ICE"`` or ``"IWidgetE"`` parses as a balanced template-args
+    block purely by coincidental spelling (Codex review, fresh evidence --
+    this function itself carried exactly that guessing branch until this
+    fix, and it produced a real false positive: a genuine namespace move of
+    a class spelled e.g. ``ICE`` -> ``ACE`` was silently skipped). The sound
+    answer for an Itanium mangling is the STRUCTURAL one,
+    :func:`itanium_scope_components_with_template_positions`, which knows
+    at parse time -- from :func:`_parse_source_name_component`'s own
+    return value -- whether a template-argument list was actually consumed,
+    rather than guessing it back out of the assembled text. Every caller of
+    *this* function must therefore route an Itanium-mangled component
+    through that structural answer instead (see
+    :mod:`diff_symbols_renames`'s ``_scope_components``, this function's
+    only production consumer).
 
     Deliberately conservative like every other guard in this module: an
     unrecognized shape returns ``False`` (not template-bearing) rather than
     risking a false positive that would suppress a genuine namespace-move
     finding.
     """
-    if "<" in component:
-        return True
-    for i, ch in enumerate(component):
-        if ch == "I" and _skip_template_args(component, i) == len(component):
-            return True
-    return False
+    return "<" in component
 
 
 def itanium_ctor_dtor_marker_span(mangled: str) -> tuple[int, int] | None:
@@ -531,7 +574,7 @@ def itanium_ctor_dtor_marker_span(mangled: str) -> tuple[int, int] | None:
         if c == "E":
             return None  # nested name closed with no ctor/dtor component found
         if c in _ASCII_DIGITS:
-            _name, new_i = _parse_source_name_component(s, i)
+            _name, new_i, _template_attached = _parse_source_name_component(s, i)
             if new_i == i:
                 return None  # malformed source name
             i = new_i

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -39,6 +39,7 @@ from .checker_types import Change
 from .demangle import demangle, demangle_batch
 from .detector_registry import registry
 from .diff_cxx_rules import (
+    component_embeds_template_args,
     itanium_scope_components,
     msvc_scope_components,
     qualified_name_scope_components,
@@ -983,8 +984,16 @@ def find_namespace_move_groups(
             # this primitive reasons about scope chains, not about a
             # component's internal template structure, so a templated
             # component is simply excluded from ever being *the* differing
-            # position (oneTBB report, fresh evidence).
-            if "<" in comps[i]:
+            # position (oneTBB report, fresh evidence). Recognizes both the
+            # qualified-name-fallback's pretty-printed ``<...>`` spelling AND
+            # a real Itanium mangled symbol's RAW, un-demangled template-args
+            # encoding (``itanium_scope_components`` keeps it raw so distinct
+            # specializations stay distinct -- see
+            # ``component_embeds_template_args``'s own docstring; a naive
+            # ``"<" in comps[i]`` check alone never fires for the real,
+            # mangled-symbol production case this guard exists for -- Codex
+            # review, fresh evidence).
+            if component_embeds_template_args(comps[i]):
                 continue
             masked = tuple(comps[:i]) + (_MASKED,) + tuple(comps[i + 1 :])
             added_index.setdefault(masked, []).append((a_sym, comps))
@@ -1040,9 +1049,10 @@ def find_namespace_move_groups(
         symbol_id = "::".join(r_comps)
         for i in range(len(r_comps) - 1):
             # Mirrors the identical skip in the `added_index` build above: a
-            # templated component can never be treated as *the* differing
-            # namespace/class segment.
-            if "<" in r_comps[i]:
+            # templated component (pretty-printed or raw-Itanium-encoded)
+            # can never be treated as *the* differing namespace/class
+            # segment.
+            if component_embeds_template_args(r_comps[i]):
                 continue
             masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
             candidates = added_index.get(masked, [])

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -967,6 +967,25 @@ def find_namespace_move_groups(
         if comps is None:
             continue
         for i in range(len(comps) - 1):
+            # A component that itself carries a template-argument list is not
+            # a bare namespace/class segment -- it is an instantiation whose
+            # *spelling* can differ between old and new purely because one of
+            # its template arguments names a declaration that moved (e.g.
+            # ``concurrent_priority_queue<tbb::detail::d1::graph_task *, ...>``
+            # vs. ``...d2::graph_task...``, where the enclosing scope of
+            # ``concurrent_priority_queue`` itself never changed). Treating
+            # such a component as "the segment that changed" fabricates a
+            # spurious, redundant substitution group keyed on the whole
+            # instantiation text instead of on the real namespace segment --
+            # which the un-instantiated symbol that actually names the moved
+            # type already supplies evidence for. See
+            # ``_scope_components``'s own "signature-blind" caveat above:
+            # this primitive reasons about scope chains, not about a
+            # component's internal template structure, so a templated
+            # component is simply excluded from ever being *the* differing
+            # position (oneTBB report, fresh evidence).
+            if "<" in comps[i]:
+                continue
             masked = tuple(comps[:i]) + (_MASKED,) + tuple(comps[i + 1 :])
             added_index.setdefault(masked, []).append((a_sym, comps))
 
@@ -1020,6 +1039,11 @@ def find_namespace_move_groups(
             continue
         symbol_id = "::".join(r_comps)
         for i in range(len(r_comps) - 1):
+            # Mirrors the identical skip in the `added_index` build above: a
+            # templated component can never be treated as *the* differing
+            # namespace/class segment.
+            if "<" in r_comps[i]:
+                continue
             masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
             candidates = added_index.get(masked, [])
             for _cand_sym, cand_comps in candidates:
@@ -1153,10 +1177,53 @@ def find_namespace_move_groups(
     return groups
 
 
+def _declaring_entity(qualified: str) -> str:
+    """Collapse a synthesized ``{ctor}``/``{dtor}`` leaf marker so both
+    facets of one class -- its constructor and its destructor -- count as
+    the SAME declaring entity for support-counting purposes.
+
+    Every class, real or coincidentally paired, contributes exactly a
+    ``{ctor}`` pair and a ``{dtor}`` pair once *any* one-component
+    substitution happens to line its removed and added mangled names up
+    (see :func:`emit_namespace_move_batches`) -- so two such pairs are not
+    two independent pieces of evidence, they are one class counted twice.
+    An ordinary (non-ctor/dtor) leaf is returned unchanged: two distinct
+    member functions of the same class are still two distinct declarations.
+    """
+    for suffix in ("::{ctor}", "::{dtor}"):
+        if qualified.endswith(suffix):
+            return qualified[: -len(suffix)]
+    return qualified
+
+
 def emit_namespace_move_batches(
     groups: dict[tuple[str, str], list[tuple[str, str]]],
 ) -> list[Change]:
-    """Emit one SYMBOL_RENAMED_BATCH per namespace substitution with 2+ pairs.
+    """Emit one SYMBOL_RENAMED_BATCH per namespace substitution supported by
+    2+ pairs from 2+ *distinct declaring entities*.
+
+    ``len(pairs) >= 2`` alone gives zero protection at class granularity: an
+    unrelated deleted class and an unrelated added class that happen to
+    share an enclosing scope always contribute exactly two pairs -- the
+    class's compiler-generated constructor and destructor -- to whatever
+    substitution key their names happen to mask into, regardless of
+    whether the class actually moved namespaces or was simply deleted while
+    an unrelated, differently-named class was simultaneously added in the
+    same scope. Neither :func:`find_namespace_move_groups`'s per-position
+    ambiguity guards catches this: there is exactly one candidate per
+    masked context (so ``distinct_targets`` never fires), and the ctor/dtor
+    pairs are recorded under different leaves (so the header-tier
+    double-counting guard's ``recorded_pairs`` dedup never collapses them
+    either) -- the two pairs are both genuine, unambiguous matches, they
+    are just not *independent* evidence of a scope move (oneCCL report,
+    fresh evidence: ``broadcastExt_attr`` deleted and an unrelated
+    ``window`` added in the same enclosing scope reported a fabricated
+    ``broadcastExt_attr`` -> ``window`` "namespace segment" rename).
+    Requiring support from 2+ distinct declaring entities (via
+    :func:`_declaring_entity`, which folds a class's own ctor/dtor pair
+    down to one entity) closes this at the class-count level without
+    touching :func:`find_namespace_move_groups`'s ambiguity logic, which
+    is unaffected by this exact shape.
 
     Ordered by support (most-supported substitution first, then by the
     substitution itself) so the report is stable across runs and the dominant
@@ -1167,6 +1234,8 @@ def emit_namespace_move_batches(
         groups.items(), key=lambda kv: (-len(kv[1]), kv[0])
     ):
         if len(pairs) < 2:
+            continue
+        if len({_declaring_entity(old) for old, _new in pairs}) < 2:
             continue
         pair_desc = ", ".join(f"{o} → {n}" for o, n in pairs[:5])
         if len(pairs) > 5:

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -40,7 +40,7 @@ from .demangle import demangle, demangle_batch
 from .detector_registry import registry
 from .diff_cxx_rules import (
     component_embeds_template_args,
-    itanium_scope_components,
+    itanium_scope_components_with_template_positions,
     msvc_scope_components,
     qualified_name_scope_components,
     strip_trailing_top_level_parameter_list,
@@ -869,8 +869,8 @@ def _qualified_key_scope_components(key: str) -> list[str] | None:
     return qualified_name_scope_components(key)
 
 
-def _scope_components(mangled: str) -> list[str] | None:
-    """Return *mangled*'s scope chain (namespaces + class path + leaf), or None.
+def _scope_components(mangled: str) -> tuple[list[str], frozenset[int]] | None:
+    """Return (*mangled*'s scope chain, template-bearing component indices), or None.
 
     Itanium first, MSVC second — the two prefixes (``_Z``/``__Z`` vs. ``?``)
     are mutually exclusive, so trying both in order is unambiguous, and it is
@@ -882,15 +882,38 @@ def _scope_components(mangled: str) -> list[str] | None:
     namespace to substitute, so it is reported as "no usable chain" rather
     than as a one-element chain, regardless of which of the three parsers
     produced it.
+
+    The second element identifies which components embed a template-
+    argument list, so a caller can exclude them from ever being treated as
+    a bare namespace/class segment (see the two masking loops in
+    :func:`find_namespace_move_groups`). For an Itanium mangling this is
+    the *exact* structural answer from
+    :func:`diff_cxx_rules.itanium_scope_components_with_template_positions`
+    — not a guess back out of the assembled text, which is unsound (Codex
+    review, fresh evidence: a text-based heuristic misreads an ordinary
+    identifier like ``"ICE"`` as a template block by coincidental
+    spelling). For MSVC this is always empty:
+    :func:`diff_cxx_rules.msvc_scope_components` already rejects the whole
+    symbol outright when any component starts with the template marker
+    ``?$``, so a template-bearing MSVC component never reaches here. Only
+    the qualified-name/header-tier-fallback shape has no parser to ask, so
+    it falls back to :func:`diff_cxx_rules.component_embeds_template_args`'s
+    text-based ``<...>`` check — exact for that shape, since a pretty-
+    printed spelling never coincidentally contains a raw Itanium encoding.
     """
-    comps = (
-        itanium_scope_components(mangled)
-        or msvc_scope_components(mangled)
-        or _qualified_key_scope_components(mangled)
+    itanium = itanium_scope_components_with_template_positions(mangled)
+    if itanium is not None:
+        comps, template_positions = itanium
+        return (comps, template_positions) if len(comps) >= 2 else None
+    fallback = msvc_scope_components(mangled) or _qualified_key_scope_components(
+        mangled
     )
-    if comps is None or len(comps) < 2:
+    if fallback is None or len(fallback) < 2:
         return None
-    return comps
+    fallback_template_positions = frozenset(
+        i for i, c in enumerate(fallback) if component_embeds_template_args(c)
+    )
+    return fallback, fallback_template_positions
 
 
 def find_namespace_move_groups(
@@ -964,9 +987,10 @@ def find_namespace_move_groups(
     """
     added_index: dict[tuple[str, ...], list[tuple[str, list[str]]]] = {}
     for a_sym in sorted(added):
-        comps = _scope_components(a_sym)
-        if comps is None:
+        resolved = _scope_components(a_sym)
+        if resolved is None:
             continue
+        comps, template_positions = resolved
         for i in range(len(comps) - 1):
             # A component that itself carries a template-argument list is not
             # a bare namespace/class segment -- it is an instantiation whose
@@ -980,20 +1004,15 @@ def find_namespace_move_groups(
             # instantiation text instead of on the real namespace segment --
             # which the un-instantiated symbol that actually names the moved
             # type already supplies evidence for. See
-            # ``_scope_components``'s own "signature-blind" caveat above:
-            # this primitive reasons about scope chains, not about a
-            # component's internal template structure, so a templated
-            # component is simply excluded from ever being *the* differing
-            # position (oneTBB report, fresh evidence). Recognizes both the
-            # qualified-name-fallback's pretty-printed ``<...>`` spelling AND
-            # a real Itanium mangled symbol's RAW, un-demangled template-args
-            # encoding (``itanium_scope_components`` keeps it raw so distinct
-            # specializations stay distinct -- see
-            # ``component_embeds_template_args``'s own docstring; a naive
-            # ``"<" in comps[i]`` check alone never fires for the real,
-            # mangled-symbol production case this guard exists for -- Codex
-            # review, fresh evidence).
-            if component_embeds_template_args(comps[i]):
+            # ``_scope_components``'s own docstring: for a real Itanium
+            # mangling *i* is checked against the EXACT structural answer
+            # (``template_positions``), never guessed back out of the
+            # assembled text -- a text-based guess is unsound (Codex review,
+            # fresh evidence: ordinary identifiers like ``"ICE"`` coincide
+            # with a balanced raw template-args spelling), which is exactly
+            # why this primitive reasons about scope chains via a per-
+            # position flag rather than re-deriving it here.
+            if i in template_positions:
                 continue
             masked = tuple(comps[:i]) + (_MASKED,) + tuple(comps[i + 1 :])
             added_index.setdefault(masked, []).append((a_sym, comps))
@@ -1043,16 +1062,17 @@ def find_namespace_move_groups(
     added_id_to_removed_symbols: dict[str, set[str]] = {}
     removed_id_to_added_symbols: dict[str, set[str]] = {}
     for r_sym in sorted(removed):
-        r_comps = _scope_components(r_sym)
-        if r_comps is None:
+        r_resolved = _scope_components(r_sym)
+        if r_resolved is None:
             continue
+        r_comps, r_template_positions = r_resolved
         symbol_id = "::".join(r_comps)
         for i in range(len(r_comps) - 1):
             # Mirrors the identical skip in the `added_index` build above: a
-            # templated component (pretty-printed or raw-Itanium-encoded)
-            # can never be treated as *the* differing namespace/class
-            # segment.
-            if component_embeds_template_args(r_comps[i]):
+            # templated component (pretty-printed, or the exact structural
+            # answer for a raw-Itanium-encoded one) can never be treated as
+            # *the* differing namespace/class segment.
+            if i in r_template_positions:
                 continue
             masked = tuple(r_comps[:i]) + (_MASKED,) + tuple(r_comps[i + 1 :])
             candidates = added_index.get(masked, [])

--- a/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
+++ b/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
@@ -22,9 +22,16 @@
   `concurrent_priority_queue<tbb::detail::d1::graph_task *, ...>` vs. the
   `...d2...` spelling, alongside the real `d1` → `d2` group the actual move
   is already reported under). Fixed by never treating a template-bearing
-  component as the differing scope position — a new
-  `diff_cxx_rules.component_embeds_template_args` recognizes both a
-  pretty-printed `<...>` spelling *and* a real Itanium-mangled symbol's raw,
-  un-demangled template-argument encoding (`itanium_scope_components` keeps
-  it raw, so a literal `<` alone never fires for the actual production
-  case this fix exists for).
+  component as the differing scope position. A pretty-printed `<...>`
+  spelling (the qualified-name/header-tier-fallback shape) is recognized by
+  `diff_cxx_rules.component_embeds_template_args`'s literal `<` check; a
+  real Itanium-mangled symbol's raw, un-demangled template-argument
+  encoding (`itanium_scope_components` keeps it raw, so a literal `<` never
+  appears there at all) is recognized by the new, structural
+  `diff_cxx_rules.itanium_scope_components_with_template_positions` instead
+  — tracked at parse time from whether a template-argument list was
+  actually consumed, not guessed back out of the assembled component text
+  (an earlier revision of this fix used a text-based guess for both shapes,
+  which misread an ordinary identifier like `ICE` as a template block by
+  coincidental spelling and silently excluded a real move of a class named
+  that from detection).

--- a/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
+++ b/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
@@ -21,5 +21,10 @@
   redundant "namespace segment" rename (reported against real oneTBB data:
   `concurrent_priority_queue<tbb::detail::d1::graph_task *, ...>` vs. the
   `...d2...` spelling, alongside the real `d1` → `d2` group the actual move
-  is already reported under). Fixed by never treating a component
-  containing `<` as the differing scope position.
+  is already reported under). Fixed by never treating a template-bearing
+  component as the differing scope position — a new
+  `diff_cxx_rules.component_embeds_template_args` recognizes both a
+  pretty-printed `<...>` spelling *and* a real Itanium-mangled symbol's raw,
+  un-demangled template-argument encoding (`itanium_scope_components` keeps
+  it raw, so a literal `<` alone never fires for the actual production
+  case this fix exists for).

--- a/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
+++ b/changelog.d/1787300000_claude_namespace_move_batch_two_defects.md
@@ -1,0 +1,25 @@
+### Fixed
+
+- **`SYMBOL_RENAMED_BATCH`'s namespace-move roll-up fabricated a batch rename
+  for two unrelated classes, and mislabeled a template-argument substitution
+  as a namespace move.** (1) `emit_namespace_move_batches` required only
+  `len(pairs) >= 2` before reporting a substitution, but any unrelated
+  deleted class and unrelated added class sharing an enclosing scope always
+  contribute exactly two pairs — the class's own compiler-generated
+  `{ctor}`/`{dtor}` — to whatever one-component substitution their scope
+  chains happen to mask into, regardless of whether the class actually
+  moved namespaces (reported against real oneCCL data: an unrelated deleted
+  `broadcastExt_attr` and added `window` fabricated a `broadcastExt_attr`
+  → `window` "namespace segment" rename). Fixed by requiring support from
+  2+ *distinct declaring entities*, collapsing a class's own ctor/dtor pair
+  to one entity, so ctor+dtor of a single class is no longer sufficient
+  evidence on its own. (2) `find_namespace_move_groups` could treat a
+  template-parameterized scope component (one containing `<...>`) as the
+  segment that changed, even when the component's *own* enclosing scope
+  never moved and only a template argument nested inside it named a type
+  that did — mislabeling a template-argument substitution as its own,
+  redundant "namespace segment" rename (reported against real oneTBB data:
+  `concurrent_priority_queue<tbb::detail::d1::graph_task *, ...>` vs. the
+  `...d2...` spelling, alongside the real `d1` → `d2` group the actual move
+  is already reported under). Fixed by never treating a component
+  containing `<` as the differing scope position.

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -37,6 +37,7 @@ from abicheck.checker_policy import ChangeKind
 from abicheck.diff_cxx_rules import (
     component_embeds_template_args,
     itanium_scope_components,
+    itanium_scope_components_with_template_positions,
     qualified_name_scope_components,
     strip_trailing_top_level_parameter_list,
 )
@@ -1610,8 +1611,11 @@ class TestFindNamespaceMoveGroupsIgnoresTemplateArgumentSubstitutions:
 
 
 class TestComponentEmbedsTemplateArgs:
-    """Direct primitive-level tests for the shared predicate the fix above
-    relies on (CLAUDE.md's "Primitive-level property tests" guidance)."""
+    """Direct primitive-level tests for the qualified-name/header-tier-
+    fallback predicate (CLAUDE.md's "Primitive-level property tests"
+    guidance). Text-only, and deliberately NOT used for an Itanium-mangled
+    component -- see ``TestItaniumScopeComponentsWithTemplatePositions``
+    below for that shape's own, structural predicate."""
 
     def test_recognizes_pretty_printed_form(self) -> None:
         assert component_embeds_template_args("Box<int>") is True
@@ -1622,25 +1626,89 @@ class TestComponentEmbedsTemplateArgs:
             is True
         )
 
-    def test_recognizes_raw_itanium_form(self) -> None:
-        assert component_embeds_template_args("BoxIiE") is True
-        assert (
-            component_embeds_template_args(
-                "concurrent_priority_queueIPN3tbb6detail2d110graph_taskEE"
-            )
-            is True
-        )
-
     def test_plain_identifiers_are_not_template_bearing(self) -> None:
         assert component_embeds_template_args("graph_task") is False
         assert component_embeds_template_args("run") is False
-
-    def test_a_bare_leading_i_is_not_mistaken_for_a_template_marker(self) -> None:
-        """An ordinary identifier that happens to start with 'I' (a common
-        interface-naming convention) must not be misread as an opened,
-        unterminated template-args block."""
         assert component_embeds_template_args("Item") is False
-        assert component_embeds_template_args("IWidget") is False
+        assert component_embeds_template_args("ICE") is False
+
+
+class TestItaniumScopeComponentsWithTemplatePositions:
+    """Direct primitive-level tests for the structural (parse-time, not
+    text-guessed) template-position signal a real Itanium mangling uses.
+    CodeRabbit/Codex review, fresh evidence: this predicate exists
+    specifically because a text-based guess over the assembled raw
+    component (the shape ``component_embeds_template_args`` briefly also
+    attempted for this case, then reverted) is unsound -- an ordinary
+    identifier like ``"ICE"`` parses as a balanced raw ``I...E`` template
+    block purely by coincidental spelling, which would silently exclude a
+    genuine namespace move of a class named ``ICE`` from ever being
+    detected."""
+
+    def test_recognizes_a_real_template_instantiation(self) -> None:
+        # `tbb::detail::d1::concurrent_priority_queue<tbb::detail::d1::graph_task *>::graph_task_ptr` (ctor)
+        mangled = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d110graph_taskEEC1Ev"
+        result = itanium_scope_components_with_template_positions(mangled)
+        assert result is not None
+        comps, template_positions = result
+        assert comps == [
+            "tbb",
+            "detail",
+            "d1",
+            "concurrent_priority_queueIPN3tbb6detail2d110graph_taskEE",
+            "{ctor}",
+        ]
+        assert template_positions == frozenset({3})
+
+    def test_does_not_misread_a_coincidentally_ice_shaped_identifier(self) -> None:
+        """The exact regression this predicate exists to close: a real class
+        literally named ``ICE`` moving namespace must not have its own
+        component excluded from masking -- unlike the text-based guess this
+        function replaces for the Itanium shape."""
+        mangled = "_ZN2ns3ICE1fEv"
+        result = itanium_scope_components_with_template_positions(mangled)
+        assert result is not None
+        comps, template_positions = result
+        assert comps == ["ns", "ICE", "f"]
+        assert template_positions == frozenset()
+
+    def test_plain_symbols_have_no_template_positions(self) -> None:
+        result = itanium_scope_components_with_template_positions(
+            "_ZN3tbb6detail2d110graph_task3runEv"
+        )
+        assert result is not None
+        comps, template_positions = result
+        assert comps == ["tbb", "detail", "d1", "graph_task", "run"]
+        assert template_positions == frozenset()
+
+    def test_matches_the_plain_scope_components_list(self) -> None:
+        """The list half of a successful result must be identical to what
+        ``itanium_scope_components`` (the pre-existing, template-position-
+        blind function) returns for the same input."""
+        mangled = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d110graph_taskEEC1Ev"
+        result = itanium_scope_components_with_template_positions(mangled)
+        assert result is not None
+        assert result[0] == itanium_scope_components(mangled)
+
+
+class TestFindNamespaceMoveGroupsDoesNotSkipACoincidentallyTemplateShapedName:
+    """End-to-end regression for the same fix, through the real detector
+    entry points -- not just the primitive."""
+
+    def test_a_real_move_of_a_class_named_ice_is_still_detected(self) -> None:
+        removed = {
+            "_ZN2ns3ICE1fEv",
+            "_ZN2ns3ICE1gEv",
+        }
+        added = {
+            "_ZN2ns3ACE1fEv",
+            "_ZN2ns3ACE1gEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert ("ICE", "ACE") in groups
+        assert len(groups[("ICE", "ACE")]) == 2
+        changes = emit_namespace_move_batches(groups)
+        assert len(changes) == 1
 
 
 class TestFindNamespaceMoveGroupsIgnoresRawMangledTemplateArguments:

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -1690,6 +1690,24 @@ class TestItaniumScopeComponentsWithTemplatePositions:
         assert result is not None
         assert result[0] == itanium_scope_components(mangled)
 
+    def test_an_unbalanced_directly_attached_template_args_list_returns_none(
+        self,
+    ) -> None:
+        """A class name followed by an opened but never-closed ``I`` template-
+        args list (no matching ``E`` anywhere) must degrade to ``None`` --
+        the same "unparseable, let the caller fall back" contract every
+        other malformed-input branch in this module uses -- rather than
+        raising or fabricating a component."""
+        assert itanium_scope_components_with_template_positions("_ZN3FooI") is None
+        assert itanium_scope_components("_ZN3FooI") is None
+
+    def test_an_empty_nested_name_body_returns_none(self) -> None:
+        """``N…E`` immediately closed with no component in between (no
+        ``std::`` prefix, nothing parsed before the terminator) must
+        degrade to ``None`` rather than an empty, unusable component list."""
+        assert itanium_scope_components_with_template_positions("_ZNEi") is None
+        assert itanium_scope_components("_ZNEi") is None
+
 
 class TestFindNamespaceMoveGroupsDoesNotSkipACoincidentallyTemplateShapedName:
     """End-to-end regression for the same fix, through the real detector

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -35,6 +35,8 @@ from hypothesis import given, settings, strategies as st
 from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind
 from abicheck.diff_cxx_rules import (
+    component_embeds_template_args,
+    itanium_scope_components,
     qualified_name_scope_components,
     strip_trailing_top_level_parameter_list,
 )
@@ -1599,6 +1601,99 @@ class TestFindNamespaceMoveGroupsIgnoresTemplateArgumentSubstitutions:
             "tbb::detail::d2::graph_task::wait",
             f"__abicheck_ctor__tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}()",
             f"~tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert set(groups) == {("d1", "d2")}
+        assert len(groups[("d1", "d2")]) == 2
+        changes = emit_namespace_move_batches(groups)
+        assert len(changes) == 1
+
+
+class TestComponentEmbedsTemplateArgs:
+    """Direct primitive-level tests for the shared predicate the fix above
+    relies on (CLAUDE.md's "Primitive-level property tests" guidance)."""
+
+    def test_recognizes_pretty_printed_form(self) -> None:
+        assert component_embeds_template_args("Box<int>") is True
+        assert (
+            component_embeds_template_args(
+                "concurrent_priority_queue<tbb::detail::d1::graph_task *>"
+            )
+            is True
+        )
+
+    def test_recognizes_raw_itanium_form(self) -> None:
+        assert component_embeds_template_args("BoxIiE") is True
+        assert (
+            component_embeds_template_args(
+                "concurrent_priority_queueIPN3tbb6detail2d110graph_taskEE"
+            )
+            is True
+        )
+
+    def test_plain_identifiers_are_not_template_bearing(self) -> None:
+        assert component_embeds_template_args("graph_task") is False
+        assert component_embeds_template_args("run") is False
+
+    def test_a_bare_leading_i_is_not_mistaken_for_a_template_marker(self) -> None:
+        """An ordinary identifier that happens to start with 'I' (a common
+        interface-naming convention) must not be misread as an opened,
+        unterminated template-args block."""
+        assert component_embeds_template_args("Item") is False
+        assert component_embeds_template_args("IWidget") is False
+
+
+class TestFindNamespaceMoveGroupsIgnoresRawMangledTemplateArguments:
+    """Codex review, fresh evidence, on the fix above: a REAL Itanium-mangled
+    symbol keeps a directly-attached template-argument list RAW (see
+    ``itanium_scope_components``'s own docstring -- ``Box<int>`` mangles to
+    the component ``"BoxIiE"``, with no literal ``<`` anywhere), so a naive
+    ``"<" in comps[i]`` check never fires for the real, mangled-symbol
+    production case this whole fix exists for -- only for the qualified-
+    name/header-tier-fallback spelling the sibling test class above uses.
+    These tests reproduce the exact reported shape through real mangled
+    symbols: ``tbb::detail::d1::concurrent_priority_queue<tbb::detail::d1::
+    graph_task *>`` (ctor/dtor mangled with a raw ``I...E`` template-args
+    block naming ``tbb::detail::d1::graph_task``) whose OWN enclosing scope
+    (``tbb::detail::d1::concurrent_priority_queue``) never moved, alongside
+    the real ``d1`` -> ``d2`` move of ``graph_task`` itself."""
+
+    # `tbb::detail::d1::concurrent_priority_queue<tbb::detail::d1::graph_task *>`
+    # ctor/dtor, and the `d2`-instantiated sibling -- hand-mangled (not from a
+    # real compiler) but structurally well-formed Itanium encodings, verified
+    # to parse via `itanium_scope_components` before being used here.
+    _OLD_CTOR = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d110graph_taskEEC1Ev"
+    _NEW_CTOR = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d210graph_taskEEC1Ev"
+    _OLD_DTOR = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d110graph_taskEED1Ev"
+    _NEW_DTOR = "_ZN3tbb6detail2d125concurrent_priority_queueIPN3tbb6detail2d210graph_taskEED1Ev"
+
+    def test_component_is_recognized_as_template_bearing(self) -> None:
+        """Sanity check on the primitive itself: the raw Itanium component
+        differs between old and new (it embeds ``d1``/``d2``), so without the
+        fix it would be a candidate differing position."""
+        old_comps = itanium_scope_components(self._OLD_CTOR)
+        new_comps = itanium_scope_components(self._NEW_CTOR)
+        assert old_comps is not None and new_comps is not None
+        assert old_comps[3] != new_comps[3]
+        assert "<" not in old_comps[3]  # the raw shape, not the pretty one
+
+    def test_template_argument_substitution_alone_yields_no_group(self) -> None:
+        removed = {self._OLD_CTOR, self._OLD_DTOR}
+        added = {self._NEW_CTOR, self._NEW_DTOR}
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_does_not_duplicate_the_real_move_it_is_redundant_with(self) -> None:
+        removed = {
+            "_ZN3tbb6detail2d110graph_task3runEv",
+            "_ZN3tbb6detail2d110graph_task4waitEv",
+            self._OLD_CTOR,
+            self._OLD_DTOR,
+        }
+        added = {
+            "_ZN3tbb6detail2d210graph_task3runEv",
+            "_ZN3tbb6detail2d210graph_task4waitEv",
+            self._NEW_CTOR,
+            self._NEW_DTOR,
         }
         groups = find_namespace_move_groups(removed, added)
         assert set(groups) == {("d1", "d2")}

--- a/tests/test_batch_rename_namespace_move.py
+++ b/tests/test_batch_rename_namespace_move.py
@@ -260,8 +260,17 @@ class TestHeaderTierKeysAlsoJoinTheNamespaceMove:
         assert len(groups[("d1", "d2")]) == len(_D1)
 
     def test_reported_through_compare_with_header_tier_keys_only(self) -> None:
-        old = _snap("2021", [_fn("graph", m) for m in _D1_HEADER_TIER])
-        new = _snap("2022", [_fn("graph", m) for m in _D2_HEADER_TIER])
+        # A class's own ctor+dtor pair alone is deliberately *not* enough
+        # support (see `TestEmitNamespaceMoveBatchesRequiresTwoDistinctEntities`
+        # below) -- it is one declaring entity, indistinguishable from an
+        # unrelated deleted-class/added-class coincidence. A second,
+        # independent header-tier declaration (a plain qualified free-form
+        # member name, the third shape this fallback covers) is what makes
+        # this a genuine multi-entity move.
+        old_keys = [*_D1_HEADER_TIER, "tbb::detail::d1::graph::reset"]
+        new_keys = [*_D2_HEADER_TIER, "tbb::detail::d2::graph::reset"]
+        old = _snap("2021", [_fn("graph", m) for m in old_keys])
+        new = _snap("2022", [_fn("graph", m) for m in new_keys])
         result = compare(old, new)
         batch = [c for c in result.changes if c.kind is ChangeKind.SYMBOL_RENAMED_BATCH]
         assert batch, "namespace move via header-tier keys produced no batch roll-up"
@@ -1458,3 +1467,141 @@ class TestFindNamespaceMoveGroupsRetainsLocallyAmbiguousCandidatesGlobally:
             "_ZN1x3old1gEv",
         }
         assert find_namespace_move_groups(removed, added) == {}
+
+
+class TestEmitNamespaceMoveBatchesRequiresTwoDistinctEntities:
+    """Reported false positive (oneCCL, fresh evidence): an unrelated class
+    deleted in one scope and an unrelated, differently-named class added in
+    the SAME scope always contributes exactly two pairs -- its own
+    compiler-generated ``{ctor}``/``{dtor}`` -- to whatever one-component
+    substitution their scope chains happen to mask into, regardless of
+    whether the class actually moved. ``len(pairs) >= 2`` alone treats that
+    as sufficient support; it is not, because a ctor and a dtor of the same
+    class are never independent evidence -- they always travel together for
+    ANY class, moved or not."""
+
+    def test_one_deleted_class_and_one_unrelated_added_class_is_not_a_batch(
+        self,
+    ) -> None:
+        removed = {
+            "__abicheck_ctor__ccl::v1::broadcastExt_attr()",
+            "~ccl::v1::broadcastExt_attr",
+        }
+        added = {
+            "__abicheck_ctor__ccl::v1::window()",
+            "~ccl::v1::window",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        # The grouping primitive itself still sees two genuine, unambiguous
+        # pairs -- the fix belongs at the batch-emission threshold, not here.
+        assert groups == {
+            ("broadcastExt_attr", "window"): [
+                (
+                    "ccl::v1::broadcastExt_attr::{ctor}",
+                    "ccl::v1::window::{ctor}",
+                ),
+                (
+                    "ccl::v1::broadcastExt_attr::{dtor}",
+                    "ccl::v1::window::{dtor}",
+                ),
+            ]
+        }
+        assert emit_namespace_move_batches(groups) == []
+
+    def test_a_real_move_of_two_distinct_classes_still_reports(self) -> None:
+        """The guard is "one entity's ctor+dtor alone is not enough", not
+        "ctor/dtor pairs never count" -- two DIFFERENT classes each moving
+        namespace, evidenced only by their ctor/dtor pairs, is genuine
+        multi-entity support and must still be reported."""
+        removed = {
+            "__abicheck_ctor__ccl::v1::Foo()",
+            "~ccl::v1::Foo",
+            "__abicheck_ctor__ccl::v1::Bar()",
+            "~ccl::v1::Bar",
+        }
+        added = {
+            "__abicheck_ctor__ccl::v2::Foo()",
+            "~ccl::v2::Foo",
+            "__abicheck_ctor__ccl::v2::Bar()",
+            "~ccl::v2::Bar",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        changes = emit_namespace_move_batches(groups)
+        assert len(changes) == 1
+        assert changes[0].kind is ChangeKind.SYMBOL_RENAMED_BATCH
+        assert "v1" in changes[0].description and "v2" in changes[0].description
+
+    def test_reported_through_compare(self) -> None:
+        """The false positive reproduced end to end: an unrelated class
+        deletion + addition in the same scope must never surface as
+        SYMBOL_RENAMED_BATCH."""
+        old = _snap(
+            "13.1",
+            [
+                _fn(
+                    "broadcastExt_attr",
+                    "__abicheck_ctor__ccl::v1::broadcastExt_attr()",
+                ),
+                _fn("~broadcastExt_attr", "~ccl::v1::broadcastExt_attr"),
+            ],
+        )
+        new = _snap(
+            "14.0",
+            [
+                _fn("window", "__abicheck_ctor__ccl::v1::window()"),
+                _fn("~window", "~ccl::v1::window"),
+            ],
+        )
+        kinds = {c.kind for c in compare(old, new).changes}
+        assert ChangeKind.SYMBOL_RENAMED_BATCH not in kinds
+
+
+class TestFindNamespaceMoveGroupsIgnoresTemplateArgumentSubstitutions:
+    """Reported mislabel (oneTBB, fresh evidence): a template class whose OWN
+    enclosing scope never changed, but whose spelling embeds a template
+    argument naming a type that DID move namespace (e.g.
+    ``concurrent_priority_queue<tbb::detail::d1::graph_task *>`` ->
+    ``concurrent_priority_queue<tbb::detail::d2::graph_task *>``), must not
+    be reported as its own "namespace segment" substitution -- the whole
+    templated spelling is not a namespace segment, and the real move is
+    already reported through ``graph_task``'s own (non-templated) symbols."""
+
+    _OLD_ARG = "tbb::detail::d1::graph_task"
+    _NEW_ARG = "tbb::detail::d2::graph_task"
+    _TEMPLATE = "concurrent_priority_queue<{}::graph_task *>"
+
+    def test_template_argument_substitution_alone_yields_no_group(self) -> None:
+        """With no OTHER evidence of a `d1` -> `d2` move at all, the
+        templated ctor/dtor pair must produce nothing -- not even a group
+        keyed on the whole instantiation text."""
+        removed = {
+            f"__abicheck_ctor__tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d1')}()",
+            f"~tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d1')}",
+        }
+        added = {
+            f"__abicheck_ctor__tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}()",
+            f"~tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}",
+        }
+        assert find_namespace_move_groups(removed, added) == {}
+
+    def test_does_not_duplicate_the_real_move_it_is_redundant_with(self) -> None:
+        """The real ``d1`` -> ``d2`` move (evidenced by ``graph_task``'s own
+        symbols) must still be reported, and reported EXACTLY ONCE -- not
+        alongside a second, spurious group keyed on the templated spelling."""
+        removed = {
+            "tbb::detail::d1::graph_task::run",
+            "tbb::detail::d1::graph_task::wait",
+            f"__abicheck_ctor__tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d1')}()",
+            f"~tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d1')}",
+        }
+        added = {
+            "tbb::detail::d2::graph_task::run",
+            "tbb::detail::d2::graph_task::wait",
+            f"__abicheck_ctor__tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}()",
+            f"~tbb::detail::d1::{self._TEMPLATE.format('tbb::detail::d2')}",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert set(groups) == {("d1", "d2")}
+        assert len(groups[("d1", "d2")]) == 2
+        changes = emit_namespace_move_batches(groups)
+        assert len(changes) == 1


### PR DESCRIPTION
## Summary

Fix two false-finding defects in `SYMBOL_RENAMED_BATCH`'s namespace-move roll-up (`find_namespace_move_groups`/`emit_namespace_move_batches`), both reported against real production data (oneCCL, oneTBB).

## Motivation

Two independent defects introduced by the namespace-move roll-up were reported:

**A. False positive (oneCCL):** an unrelated deleted class (`broadcastExt_attr`, removed 13.1→14.0) and an unrelated added class (`window`, added 17.2→2022.0.0) in the same enclosing scope produced a fabricated BREAKING `symbol_renamed_batch` claiming `broadcastExt_attr` was renamed to `window`. Root cause: `emit_namespace_move_batches` required only `len(pairs) >= 2`, and any class's own compiler-generated `{ctor}`+`{dtor}` are always exactly two pairs — structurally guaranteed for *any* deleted class + added class sharing a scope, moved or not. Neither `find_namespace_move_groups`'s `distinct_targets` guard (one candidate per masked context) nor its `recorded_pairs` dedup (different leaves) catches this shape.

**B. Mislabel (oneTBB):** `concurrent_priority_queue<tbb::detail::d1::graph_task *, …>` → `…d2…` was reported as its own "namespace segment" rename, redundant with the real `d1`→`d2` group. The template class's own enclosing scope never moved — only a template argument nested inside it (`graph_task`) named a type that did — but the masking primitive treated the whole templated spelling as an atomic scope segment.

## Changes

- `emit_namespace_move_batches` now requires support from **2+ distinct declaring entities**, not merely 2+ pairs — a new `_declaring_entity` helper collapses a class's own `{ctor}`/`{dtor}` pair to one entity, so a single class's ctor+dtor is no longer sufficient evidence on its own. Two distinct classes moving namespace, evidenced only by their ctor/dtor pairs, still reports correctly.
- `find_namespace_move_groups` now skips any masking position whose component contains `<` (a template-argument list) in both the added-side index build and the removed-side masking loop, so a template-parameterized component is never treated as *the* differing namespace/class segment.
- Both fixes are scoped precisely to the threshold/masking logic; `find_namespace_move_groups`'s existing ambiguity guards (`distinct_targets`, `masked_to_old_segments`, `recorded_pairs`) are untouched.
- Widened the one pre-existing test that relied on the now-disallowed single-class-ctor/dtor-only shape (`test_reported_through_compare_with_header_tier_keys_only`) with a second, independent header-tier declaration, so it still demonstrates the intended capability under the corrected threshold.

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: A too-weak support threshold (`len(pairs) >= 2`, satisfied by any class's own ctor+dtor pair) and a masking primitive that doesn't distinguish a template-parameterized scope component from an ordinary namespace/class segment, together producing a fabricated and a mislabeled/redundant `SYMBOL_RENAMED_BATCH` finding.
- Publicly observable failure: `abicheck compare` reports a BREAKING `symbol_renamed_batch` finding claiming an unrelated deleted class was renamed to an unrelated added class (A), and a second, redundant `symbol_renamed_batch` keyed on a template-instantiation spelling whose own enclosing scope never moved (B).
- Regression test fails on base: Yes, confirmed by running the new tests against the pre-fix `diff_symbols_renames.py` (`git show HEAD~1:...` restored, new tests run) — 4 of the 5 new tests fail on base: `TestEmitNamespaceMoveBatchesRequiresTwoDistinctEntities::test_one_deleted_class_and_one_unrelated_added_class_is_not_a_batch`, `::test_reported_through_compare`, `TestFindNamespaceMoveGroupsIgnoresTemplateArgumentSubstitutions::test_template_argument_substitution_alone_yields_no_group`, `::test_does_not_duplicate_the_real_move_it_is_redundant_with`. All 5 pass with the fix.
- Negative control: `TestEmitNamespaceMoveBatchesRequiresTwoDistinctEntities::test_a_real_move_of_two_distinct_classes_still_reports` proves the guard is "one entity's ctor+dtor alone is not enough," not "ctor/dtor pairs never count" — two genuinely different classes each moving namespace, evidenced only by ctor/dtor pairs, still reports. `TestFindNamespaceMoveGroupsIgnoresTemplateArgumentSubstitutions::test_does_not_duplicate_the_real_move_it_is_redundant_with` proves the real `d1`→`d2` move (via `graph_task`'s own non-templated symbols) is still reported exactly once when a template-argument-only pair is also present.
- Public-surface test: Yes — `TestEmitNamespaceMoveBatchesRequiresTwoDistinctEntities::test_reported_through_compare` drives the fix through `compare()` end to end (the actual public entry point), asserting `SYMBOL_RENAMED_BATCH` is absent from the reported change kinds.
- Axes covered: (1) single-entity ctor/dtor-only coincidence (rejected), (2) multi-entity ctor/dtor-only genuine move (still accepted), (3) template-argument-only substitution with no other evidence (yields no group at all), (4) template-argument-only pair coexisting with the real, independently-evidenced move (real group reported once, no duplicate/redundant group).
- General invariant: A `SYMBOL_RENAMED_BATCH` substitution must be supported by 2+ *independent declaring entities* (a class's compiler-generated ctor/dtor pair is one entity, not two), and the differing scope position used to key a substitution must be a plain namespace/class segment, never a component that itself carries a template-argument list.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — `changelog.d/1787300000_claude_namespace_move_batch_two_defects.md`
- [ ] Docs updated if user-visible behaviour changed (internal detector-logic fix; no user-facing docs reference this shape)
- [x] `ruff check`/`ruff format --check`/`mypy` pass locally on touched files
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RAnNiQW4P54sz6pEkCKqZJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved namespace-move detection to avoid false positives involving template-parameterized scopes.
  - Prevented constructor/destructor pairs from incorrectly triggering batch rename findings.
  - Batch namespace rename reports now require evidence from at least two distinct declaring entities.

- **Tests**
  - Added coverage for template substitutions, constructor/destructor-only cases, and multi-entity namespace moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->