### PR TITLE
Introduce immutable ReportDocument and route JSON renderers through it

### DIFF
--- a/abicheck/report/document.py
+++ b/abicheck/report/document.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable, format-neutral report document contracts.
+
+``ReportDocument`` is the ownership boundary between report construction and
+format-specific rendering.  It deliberately stores JSON-shaped values rather
+than a ``DiffResult``: renderers cannot mutate workflow state or recover facts
+by running policy a second time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TypeAlias, Union
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+FrozenJSON: TypeAlias = Union[JSONScalar, tuple["FrozenJSON", ...], "FrozenObject"]
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenObject:
+    """An ordered, immutable JSON object."""
+
+    items: tuple[tuple[str, FrozenJSON], ...]
+
+
+def _freeze(value: object) -> FrozenJSON:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return FrozenObject(
+            tuple((str(key), _freeze(item)) for key, item in value.items())
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    raise TypeError(f"report value is not JSON-compatible: {type(value).__name__}")
+
+
+def _thaw(value: FrozenJSON) -> object:
+    if isinstance(value, FrozenObject):
+        return {key: _thaw(item) for key, item in value.items}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ReportDocument:
+    """A completed report whose contents cannot be changed by a renderer.
+
+    ``from_mapping`` takes a defensive immutable snapshot.  ``to_mapping``
+    returns a fresh mutable projection for serializers that require ordinary
+    ``dict`` and ``list`` instances.
+    """
+
+    root: FrozenObject
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> ReportDocument:
+        frozen = _freeze(value)
+        if not isinstance(frozen, FrozenObject):  # pragma: no cover - type guard
+            raise TypeError("a report document must have an object root")
+        return cls(frozen)
+
+    def to_mapping(self) -> dict[str, object]:
+        return {key: _thaw(value) for key, value in self.root.items}

--- a/abicheck/report/render_json.py
+++ b/abicheck/report/render_json.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure JSON projection for canonical report documents."""
+
+from __future__ import annotations
+
+import json
+
+from .document import ReportDocument
+
+
+def render_json(document: ReportDocument, *, indent: int | None = 2) -> str:
+    """Serialize *document* without deriving or changing report facts."""
+
+    return json.dumps(document.to_mapping(), indent=indent)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -39,13 +39,13 @@ from .checker_policy import (
 )
 from .checker_types import validate_check_id, validate_evidence_depth
 from .impact import assess_change
+from .report.document import ReportDocument
+from .report.render_json import render_json
 from .report_model import VERDICT_TO_SEVERITY_LABEL as _VERDICT_TO_SEVERITY_LABEL
 from .report_summary import build_summary, surface_breakdown
 from .reporter_contract_blocks import add_contract_context as _add_contract_context
 
-# Markdown rendering + the shared --show-only filter and verdict-label maps now
-# live in the leaf module reporter_markdown (it imports nothing from here). Kept
-# importable under their historical names so the public API is unchanged.
+# Markdown rendering is a leaf; names stay importable here for compatibility.
 from .reporter_markdown import (
     _ADDITION_ICON as _ADDITION_ICON,
     _BREAKING_ICON as _BREAKING_ICON,
@@ -226,7 +226,7 @@ def to_stat_json(
     # summary. `compare` rejects `--stat --use-cases` outright rather than
     # dropping the manifest silently; this keeps the same promise for a
     # direct caller of the renderer (Codex review).
-    return json.dumps(d, indent=indent)
+    return render_json(ReportDocument.from_mapping(d), indent=indent)
 
 
 def _add_surface_scope(d: dict[str, object], result: DiffResult) -> None:
@@ -557,7 +557,7 @@ def _to_json_leaf(
     scope = _scope_dict(result)
     if scope is not None:
         d["scope"] = scope
-    return json.dumps(d, indent=indent)
+    return render_json(ReportDocument.from_mapping(d), indent=indent)
 
 
 def _add_entries_to_root_causes(
@@ -763,7 +763,7 @@ def _to_json_root_cause(
     scope = _scope_dict(result)
     if scope is not None:
         d["scope"] = scope
-    return json.dumps(d, indent=indent)
+    return render_json(ReportDocument.from_mapping(d), indent=indent)
 
 
 def _metadata_dict(meta: object | None) -> dict[str, object] | None:
@@ -1207,7 +1207,7 @@ def to_json(
     _add_confidence_evidence(d, result)
     _add_policy_overrides(d, result)
     _add_trailing_fields(d, result, show_impact, show_only)
-    return json.dumps(d, indent=indent)
+    return render_json(ReportDocument.from_mapping(d), indent=indent)
 
 
 _VERDICT_TO_RECOMMENDED_ACTION: dict[Verdict, str] = {

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -1,7 +1,7 @@
 # ADR-061: Responsibility-Package Architecture and Flat-Namespace Migration
 
 **Date:** 2026-08-24
-**Status:** Accepted — Phases 0-1 implemented; Phases 2-5 remain incremental.
+**Status:** Accepted — Phases 0-1 implemented; Phase 2 in progress; Phases 3-5 remain incremental.
 **Decision maker:** abicheck maintainers
 
 ## Context
@@ -625,6 +625,12 @@ new owner; no reverse facade import or duplicated aggregation decision
 exists; the relevant debt entries shrink or disappear.
 
 ### Phase 2 — establish the canonical report document
+
+Implementation status: the immutable, JSON-shaped ``ReportDocument`` and its
+pure JSON projection are established, and all native JSON report modes (full,
+stat, leaf, and root-cause) now cross that boundary. Markdown, HTML, SARIF, and
+JUnit remain explicit follow-up slices; this partial status must not be read as
+the phase acceptance criteria having been met.
 
 1. Define immutable `ReportDocument` contracts from existing report-model
    behavior rather than inventing a second schema.

--- a/tests/unit/report/test_document.py
+++ b/tests/unit/report/test_document.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from abicheck.checker import compare
+from abicheck.model import AbiSnapshot
+from abicheck.report.document import FrozenObject, ReportDocument
+from abicheck.report.render_json import render_json
+from abicheck.reporter import to_json, to_stat_json
+
+
+def test_document_takes_an_immutable_defensive_snapshot() -> None:
+    source: dict[str, object] = {"summary": {"breaking": 1}, "changes": ["a"]}
+    document = ReportDocument.from_mapping(source)
+
+    source["changes"] = []
+    source_summary = source["summary"]
+    assert isinstance(source_summary, dict)
+    source_summary["breaking"] = 0
+
+    assert document.to_mapping() == {
+        "summary": {"breaking": 1},
+        "changes": ["a"],
+    }
+    with pytest.raises(FrozenInstanceError):
+        document.root = FrozenObject(())  # type: ignore[misc]
+
+
+def test_projections_cannot_mutate_the_document() -> None:
+    document = ReportDocument.from_mapping({"changes": [{"kind": "removed"}]})
+    first = document.to_mapping()
+    changes = first["changes"]
+    assert isinstance(changes, list)
+    changes.clear()
+
+    assert document.to_mapping() == {"changes": [{"kind": "removed"}]}
+
+
+def test_json_projection_preserves_order_and_shape() -> None:
+    document = ReportDocument.from_mapping(
+        {"report_schema_version": "2.41", "summary": {"total_changes": 0}}
+    )
+
+    assert json.loads(render_json(document, indent=2)) == document.to_mapping()
+
+
+def test_document_rejects_non_json_values() -> None:
+    with pytest.raises(TypeError, match="not JSON-compatible"):
+        ReportDocument.from_mapping({"bad": object()})
+
+
+@pytest.mark.parametrize("report_mode", ["full", "leaf", "root-cause"])
+def test_every_native_json_mode_crosses_document_boundary(
+    monkeypatch: pytest.MonkeyPatch, report_mode: str
+) -> None:
+    result = compare(AbiSnapshot("lib.so", "1"), AbiSnapshot("lib.so", "2"))
+    calls = 0
+    original = ReportDocument.from_mapping
+
+    def recording_builder(value: dict[str, object]) -> ReportDocument:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(ReportDocument, "from_mapping", staticmethod(recording_builder))
+
+    assert json.loads(to_json(result, report_mode=report_mode))["changes"] == []
+    assert calls == 1
+
+
+def test_stat_json_crosses_document_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = compare(AbiSnapshot("lib.so", "1"), AbiSnapshot("lib.so", "2"))
+    calls = 0
+    original = ReportDocument.from_mapping
+
+    def recording_builder(value: dict[str, object]) -> ReportDocument:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(ReportDocument, "from_mapping", staticmethod(recording_builder))
+
+    assert "changes" not in json.loads(to_stat_json(result))
+    assert calls == 1


### PR DESCRIPTION
### Motivation

- Establish a canonical, immutable, JSON-shaped document boundary so renderers cannot mutate workflow state and to centralize JSON projection as part of Phase 2 of the architecture ADR. 
- Replace ad-hoc `json.dumps` usage with a single projection step to ensure parity and make future format-specific renderers (Markdown/HTML/SARIF/JUnit) follow the same contract.

### Description

- Add `abicheck/report/document.py` introducing `ReportDocument`, `FrozenObject`, and `_freeze`/`_thaw` logic to take an immutable defensive snapshot of JSON-shaped mappings. 
- Add `abicheck/report/render_json.py` providing `render_json(document, *, indent)` to serialize a `ReportDocument` without re-evaluating or mutating report facts. 
- Update `abicheck/reporter.py` to build a `ReportDocument` via `ReportDocument.from_mapping(...)` and emit JSON through `render_json(...)` in the native JSON code paths (full, leaf, root-cause, and stat), replacing direct `json.dumps(...)` calls. 
- Update ADR documentation `docs/contribute/adr/061-responsibility-package-architecture.md` to reflect Phase 2 progress and add unit tests in `tests/unit/report/test_document.py` that exercise immutability, projection safety, JSON equality, rejection of non-JSON values, and that native JSON modes cross the document boundary.

### Testing

- Ran the new unit tests `pytest tests/unit/report/test_document.py`, which assert defensive snapshot behavior, projection immutability, `render_json` parity, non-JSON rejection, and that JSON renderers call `ReportDocument.from_mapping`, and they all passed.  
- Existing JSON-producing code paths were exercised by those tests to verify replacement of `json.dumps` with the `ReportDocument` boundary, and no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ddfeb42d8832b9bac1317a2ecd784)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent, format-neutral report document layer for native JSON reports.
  - JSON report output can now be rendered with configurable indentation while preserving the existing report structure.
  - Report data is validated for JSON compatibility before serialization.

- **Documentation**
  - Updated the package architecture roadmap to reflect progress on immutable report documents and JSON projection.

- **Bug Fixes**
  - Improved consistency across all native and statistical JSON reporting paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->