### PR TITLE
feat(g38): verify declared vs. captured bundle-variant fingerprints

### DIFF
--- a/abicheck/bundle_variants_config.py
+++ b/abicheck/bundle_variants_config.py
@@ -45,6 +45,21 @@ raw ``dict`` (whatever a caller's own YAML/JSON loader produced for the
 the schema/validation half of "a declarative ``bundle_variants:`` config
 block" this plan phase asks for, with the discovery half left as the
 documented, scoped gap the plan doc's own Phase 13 status note names.
+
+**Declared-vs-captured fingerprint verification (G38 Phase 13 follow-up).**
+:func:`run_bundle_variant_pairing` can now optionally verify a captured
+``BundleFacts.variant_fingerprint`` against what the declared
+:class:`BundleVariantSpec` for that same name would itself compute
+(``verify_fingerprints=True``) -- closing the gap this module's own
+docstring used to leave open. It stays opt-in, default ``False``: every
+*existing* caller (including this module's own test suite, which
+deliberately pairs specs against hand-picked sentinel fingerprints that
+have nothing to do with any real coordinates) is unaffected, and a facts
+file carrying the ``DEFAULT_VARIANT_FINGERPRINT`` sentinel -- what every
+capture ``--bundle-facts-out`` produces today, since no real capture
+pipeline can be told a variant name yet (see above) -- is never treated as
+a mismatch either way, since there is nothing for it to be verified
+against.
 """
 
 from __future__ import annotations
@@ -200,6 +215,8 @@ def run_bundle_variant_pairing(
     specs: dict[str, BundleVariantSpec],
     old_facts_by_variant: dict[str, BundleFacts],
     new_facts_by_variant: dict[str, BundleFacts],
+    *,
+    verify_fingerprints: bool = False,
 ) -> BundleVariantPairingResult:
     """Pair real, captured per-variant `BundleFacts` by fingerprint and apply
     each variant's declared `required:` gating.
@@ -214,17 +231,46 @@ def run_bundle_variant_pairing(
     fingerprints it was actually given -- the `required:` gate only ever
     escalates a real `OLD_ONLY` outcome `pair_variants` produced.
 
-    Deliberately does **not** verify a captured `BundleFacts.variant_
-    fingerprint` against what `specs[name].fingerprint()` would compute for
-    that same name -- a real capture pipeline (this plan's Phase 2
-    `--bundle-facts-out`) has no way to be told a variant name today (see
-    this module's own file docstring: `.abicheck.yml` discovery is not
-    wired), so there is no real producer yet whose output this check could
-    validate against without risking false-positive mismatches on
-    hand-constructed input. Left as a documented gap alongside the config-
-    discovery one.
+    *verify_fingerprints* (default `False`): when `True`, additionally
+    checks -- for every name present in both `specs` and one of the two
+    facts maps -- that the captured `BundleFacts.variant_fingerprint`
+    equals what `specs[name].fingerprint()` itself computes for the same
+    declared coordinates, raising `BundleVariantsConfigError` on a real
+    mismatch (a `name` key paired with the wrong file is exactly the class
+    of silent misconfiguration this check exists to catch: pairing would
+    otherwise proceed using whichever fingerprint the facts file actually
+    carries, silently ignoring that it disagrees with what was declared for
+    that name). A facts file carrying `DEFAULT_VARIANT_FINGERPRINT` -- what
+    every `--bundle-facts-out` capture produces today, since no real capture
+    pipeline can be told a variant name yet (see this module's own file
+    docstring) -- is never flagged as a mismatch, since it was never
+    captured against any declared coordinates to verify against. Default is
+    `False` because every *existing* caller (this module's own test suite
+    included) pairs specs against arbitrary sentinel fingerprints that have
+    nothing to do with any real coordinates -- turning this on
+    unconditionally would make every such caller a hard error.
     """
+    from .bundle_facts import DEFAULT_VARIANT_FINGERPRINT
     from .bundle_multibuild import coverage_regression_findings, pair_variants
+
+    if verify_fingerprints:
+        for facts_by_variant in (old_facts_by_variant, new_facts_by_variant):
+            for name, facts in facts_by_variant.items():
+                spec = specs.get(name)
+                if spec is None:
+                    continue
+                actual = facts.variant_fingerprint
+                if actual == DEFAULT_VARIANT_FINGERPRINT:
+                    continue
+                expected = spec.fingerprint()
+                if actual != expected:
+                    raise BundleVariantsConfigError(
+                        f"bundle_variants.{name}: declared identity "
+                        f"coordinates fingerprint to {expected!r}, but the "
+                        f"captured BundleFacts file's own variant_"
+                        f"fingerprint is {actual!r} -- this looks like the "
+                        f"wrong file was assigned to variant {name!r}"
+                    )
 
     comparisons = pair_variants(old_facts_by_variant, new_facts_by_variant)
     findings = coverage_regression_findings(comparisons)

--- a/changelog.d/20260825_090000_claude_g38_variant_fingerprint_verification.md
+++ b/changelog.d/20260825_090000_claude_g38_variant_fingerprint_verification.md
@@ -1,0 +1,26 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **G38 Phase 13: `run_bundle_variant_pairing()` can now verify a captured
+  variant's fingerprint against its declared coordinates.**
+
+  `abicheck.bundle_variants_config.run_bundle_variant_pairing()` gained an
+  opt-in `verify_fingerprints: bool = False` parameter. When `True`, a
+  variant name present in both a declared `bundle_variants:` spec and one of
+  the captured `BundleFacts` maps whose own, non-default
+  `variant_fingerprint` disagrees with what the declared coordinates would
+  themselves fingerprint to raises `BundleVariantsConfigError` — catching
+  the wrong `BundleFacts` file being assigned to the wrong declared variant
+  name, a silent misconfiguration `pair_variants()` alone can't detect since
+  it pairs purely by whatever fingerprint a file happens to carry. A file
+  still carrying the `DEFAULT_VARIANT_FINGERPRINT` sentinel — what every
+  `--bundle-facts-out` capture produces today, since no real capture
+  pipeline can be told a variant name yet — is never flagged, since it
+  wasn't captured against any declared coordinates to verify against.
+  Default `False` keeps every pre-existing caller unaffected. Closes the
+  narrower, non-CLI-blocked half of the G38 plan's Phase 13 "Known gap"
+  note; the CLI/`.abicheck.yml` surface itself remains open (see the plan
+  doc).

--- a/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
+++ b/docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md
@@ -1762,12 +1762,29 @@ bundle_variants_config.py`'s own module docstrings record this same table
 (re-measured at the time each was written) so a future contributor who
 splits one of these files has a concrete, checkable pointer to what should
 consume the room it frees, rather than rediscovering this constraint from
-scratch. Until then: `bundle_variants_config.py` also does not verify a
-captured `BundleFacts.variant_fingerprint` against what a declared spec's
-own `.fingerprint()` would compute for the same name — documented in that
-module's own `run_bundle_variant_pairing()` docstring as a second,
-narrower gap that a real config-discovery producer should close alongside
-the CLI wiring itself, once one exists.
+scratch.
+
+**Fixed (Phase 13 follow-up, second pass):** `bundle_variants_config.py`'s
+own narrower, non-CLI-blocked gap — that it never verified a captured
+`BundleFacts.variant_fingerprint` against what a declared spec's own
+`.fingerprint()` would compute for the same name — is closed.
+`run_bundle_variant_pairing()` gained an opt-in `verify_fingerprints: bool
+= False` parameter: when `True`, a name present in both `specs` and one of
+the facts maps whose captured, *non-default* `variant_fingerprint`
+disagrees with `specs[name].fingerprint()` raises
+`BundleVariantsConfigError` (the wrong file assigned to the wrong declared
+variant name), while a facts file still carrying the
+`DEFAULT_VARIANT_FINGERPRINT` sentinel — what every `--bundle-facts-out`
+capture produces today, since no real capture pipeline can be told a
+variant name yet — is never flagged, since it was never captured against
+any declared coordinates to verify against. Default `False` so every
+pre-existing caller (this module's own test suite included, which pairs
+specs against arbitrary sentinel fingerprints unrelated to any real
+coordinates) is unaffected. This does not need the CLI/`BuildConfig`
+wiring above — it is a pure addition to the already-shipped Python-API
+`run_bundle_variant_pairing()` function — so it was safe to close
+independently of the still-open CLI-surface gap. See
+`tests/test_bundle_variants_config.py::TestRunBundleVariantPairingVerifyFingerprints`.
 
 The original multi-binary performance problem (repeated header/AST
 extraction across sibling DSOs sharing one source tree) is explicitly out

--- a/tests/test_bundle_variants_config.py
+++ b/tests/test_bundle_variants_config.py
@@ -208,6 +208,71 @@ class TestRunBundleVariantPairing:
         assert result.missing_required_variants == []
 
 
+class TestRunBundleVariantPairingVerifyFingerprints:
+    def test_disabled_by_default_ignores_mismatched_fingerprints(self) -> None:
+        # No coordinates declared -> spec.fingerprint() == "default", but
+        # the facts below carry an unrelated sentinel -- with verification
+        # off (the default), this must not raise.
+        specs = parse_bundle_variants_config({"cpu": {"required": False}})
+        old = {"cpu": _facts("fp-cpu", ("libcore.so",))}
+        new = {"cpu": _facts("fp-cpu", ("libcore.so",))}
+
+        result = run_bundle_variant_pairing(specs, old, new)
+
+        assert result.findings == []
+
+    def test_matching_fingerprint_passes_verification(self) -> None:
+        from abicheck.bundle_multibuild import variant_fingerprint
+
+        spec_raw = {
+            "cpu": {"target_triple": "x86_64-linux-gnu", "compiler_family": "gcc"}
+        }
+        specs = parse_bundle_variants_config(spec_raw)
+        fp = variant_fingerprint(
+            target_triple="x86_64-linux-gnu", compiler_family="gcc"
+        )
+        old = {"cpu": _facts(fp, ("libcore.so",))}
+        new = {"cpu": _facts(fp, ("libcore.so",))}
+
+        result = run_bundle_variant_pairing(
+            specs, old, new, verify_fingerprints=True
+        )
+
+        assert result.findings == []
+
+    def test_mismatched_fingerprint_raises(self) -> None:
+        specs = parse_bundle_variants_config(
+            {"cpu": {"target_triple": "x86_64-linux-gnu", "compiler_family": "gcc"}}
+        )
+        old = {"cpu": _facts("wrong-fingerprint", ("libcore.so",))}
+        new: dict[str, BundleFacts] = {}
+
+        with pytest.raises(BundleVariantsConfigError, match="bundle_variants.cpu"):
+            run_bundle_variant_pairing(specs, old, new, verify_fingerprints=True)
+
+    def test_default_sentinel_fingerprint_never_flagged(self) -> None:
+        from abicheck.bundle_facts import DEFAULT_VARIANT_FINGERPRINT
+
+        specs = parse_bundle_variants_config(
+            {"cpu": {"target_triple": "x86_64-linux-gnu", "compiler_family": "gcc"}}
+        )
+        old = {"cpu": _facts(DEFAULT_VARIANT_FINGERPRINT, ("libcore.so",))}
+        new: dict[str, BundleFacts] = {}
+
+        # No raise: an un-variant-tagged capture has nothing to verify
+        # against, so it degrades to the un-verified pairing behavior.
+        result = run_bundle_variant_pairing(specs, old, new, verify_fingerprints=True)
+        assert len(result.findings) == 1
+
+    def test_undeclared_variant_skips_verification(self) -> None:
+        old = {"undeclared": _facts("fp-x", ("libcore.so",))}
+        new: dict[str, BundleFacts] = {}
+
+        result = run_bundle_variant_pairing({}, old, new, verify_fingerprints=True)
+
+        assert len(result.findings) == 1
+
+
 class TestLoadBundleFactsByVariant:
     def test_loads_each_named_path(self, tmp_path: Path) -> None:
         cpu_path = tmp_path / "cpu.bundlefacts.json"


### PR DESCRIPTION
## Summary

Closes the narrower, non-CLI-blocked half of the G38 plan's Phase 13 "Known gap": `run_bundle_variant_pairing()` can now verify a captured bundle variant's fingerprint against its declared `bundle_variants:` coordinates.

## Motivation

`docs/contribute/plans/g38-bundle-facts-model-and-multibuild-comparability.md`'s Phase 13 section documented two gaps: (1) no CLI/`.abicheck.yml` surface — blocked by several files sitting within two lines of (or already at) the AI-readiness 2000-line hard cap, and (2) `run_bundle_variant_pairing()` never verified a captured `BundleFacts.variant_fingerprint` against what the declared `BundleVariantSpec` for that same name would itself compute. Gap (1) genuinely needs a separate file-split refactor first and stays open. Gap (2) is self-contained in `bundle_variants_config.py` (not at the cap) and is closed here.

## Changes

- `run_bundle_variant_pairing()` gains an opt-in `verify_fingerprints: bool = False` parameter. When `True`, a variant name present in both a declared spec and a captured `BundleFacts` map whose own, non-default `variant_fingerprint` disagrees with the declared coordinates' own fingerprint raises `BundleVariantsConfigError` — catching a facts file assigned to the wrong declared variant name, which plain fingerprint-based pairing alone can't detect.
- A facts file still carrying `DEFAULT_VARIANT_FINGERPRINT` (what every `--bundle-facts-out` capture produces today, since no producer can be told a variant name yet) is never flagged — there's nothing to verify it against.
- Default `False` keeps every pre-existing caller (including this module's own test suite, which pairs specs against arbitrary sentinel fingerprints) unaffected.
- Updated `bundle_variants_config.py`'s module/function docstrings and the G38 plan doc's Phase 13 status note.
- New tests in `tests/test_bundle_variants_config.py::TestRunBundleVariantPairingVerifyFingerprints` (matching fingerprint passes, mismatch raises, default sentinel is never flagged, disabled-by-default behavior, undeclared variant skips verification).
- Changelog fragment added.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (G38 plan doc status note)
- [x] `mypy abicheck/` clean, `ruff check` clean
- [x] `python scripts/check_ai_readiness.py` — 0 errors (no new warnings from touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014S2ZLzx6j9kU5URRwc8s3Q)_