### PR TITLE
fix: demote lambda-closure ctor/dtor findings via binary export evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5364,17 +5364,19 @@ Once a root command genuinely clears the bar above, pick the right home:
   of a closure-parameterized instantiation permanently un-demotable,
   which is exactly the residual (1) describes and exactly what the oneTBB
   report reproduced: 5 breaking `func_removed` findings, all on synthetic
-  ctor/dtor keys naming `tbb::detail::raii_guard<(lambda:task_group.h:
-  522:26)>`/`try_call_proxy<...>`/`task_arena_function<...>`/
+  ctor/dtor keys naming
+  `tbb::detail::raii_guard<(lambda:task_group.h:522:26)>`/
+  `try_call_proxy<...>`/`task_arena_function<...>`/
   `delegated_function<...>`, paired 1:1 with 5 compatible `func_added`
   findings differing only in the lambda's line number.
 
   Fixed by asking the binary a question the synthetic key's *text* can
   answer honestly, even though the key itself is not a real symbol: is
   the owning class/class-template exported under ANY instantiation at
-  all, on either side? `finding_identity_ctor_dtor.
-  synthetic_ctor_dtor_template_base_name` recovers the owning scope from
-  the key (that same module's own `synthetic_ctor_scope` for a ctor key's
+  all, on either side?
+  `finding_identity_ctor_dtor.synthetic_ctor_dtor_template_base_name`
+  recovers the owning scope from the key (that same module's own
+  `synthetic_ctor_scope` for a ctor key's
   depth-aware `scope(params)` split; a plain prefix strip for a dtor key),
   reduces it to the bare, template-argument-stripped template name via
   `type_reachability._bare_type_name` plus a top-level `<` scan
@@ -5425,6 +5427,24 @@ Once a root command genuinely clears the bar above, pick the right home:
   `TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported` for both
   directions, verified against the exact class names from the oneTBB
   report.
+
+  **A review round on the same fix found a real gap in the substring
+  search itself, not in the demotion logic around it.** Six `std::` names
+  (`allocator`, `basic_string`, `basic_istream`, `basic_ostream`,
+  `basic_iostream`) carry a *fixed, mandatory* Itanium ABI substitution
+  (`Sa`/`Sb`/`Si`/`So`/`Sd`, C++ Itanium ABI §5.1.2) — the mangler always
+  emits the abbreviation instead of the literal source-name, even on the
+  first occurrence in a symbol. A real `std::allocator<int>::allocator()`
+  mangles to `_ZNSaIiEC1Ev`, never to anything containing the literal
+  substring `"9allocator"` — so a synthetic `std::allocator<(lambda:...)>`
+  finding's literal-token search would read that class as "never
+  exported" regardless of the truth, silently demoting a genuine removal.
+  Fixed with `finding_identity_ctor_dtor.itanium_standard_substitution_
+  token`, checked alongside the literal token whenever the owning class's
+  qualified name is exactly one of the six; see
+  `tests/test_lambda_closure_function_demotion.py`'s
+  `TestStdAllocatorSyntheticKeyNotFalselyDemoted` for the exact
+  counterexample from review, reproduced and fixed.
 
   Two related residuals from the same report, deliberately not addressed
   here: the *type-level* churn among these same symbols (the compatible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5345,6 +5345,83 @@ Once a root command genuinely clears the bar above, pick the right home:
   verdict. That is a new correlation pass with its own identity question
   (which finding covers which), not a marker-list edit.
 
+  **Update: the ctor/dtor half of (1) is now closed via binary evidence,
+  not annotation.** A later report against real oneTBB 2021.13.0 →
+  2022.3.0 binaries reproduced exactly this shape at scale:
+  `demote_lambda_closure_unexported_findings` (`diff_templates.py`) had
+  already been added to demote a `FUNC_PARAMS_CHANGED`/
+  `TEMPLATE_PARAM_TYPE_CHANGED`/`TEMPLATE_RETURN_TYPE_CHANGED` finding
+  whose reported symbol is confirmed absent from BOTH sides' real ELF
+  exported symbol table (never escalates; fails closed when no ELF
+  evidence exists on either side) — but it deliberately excluded every
+  castxml-synthesized ctor/dtor key
+  (`dumper_castxml.is_synthetic_ctor_key`/`is_synthetic_dtor_key`), on the
+  correct-as-far-as-it-went grounds that such a key is *never* itself a
+  real exported symbol (castxml synthesizes it specifically because it
+  could not produce one), so a membership check against the key text
+  would always read "confirmed absent" — vacuously, not because anything
+  was actually verified. That exclusion left every destructor/constructor
+  of a closure-parameterized instantiation permanently un-demotable,
+  which is exactly the residual (1) describes and exactly what the oneTBB
+  report reproduced: 5 breaking `func_removed` findings, all on synthetic
+  ctor/dtor keys naming `tbb::detail::raii_guard<(lambda:task_group.h:
+  522:26)>`/`try_call_proxy<...>`/`task_arena_function<...>`/
+  `delegated_function<...>`, paired 1:1 with 5 compatible `func_added`
+  findings differing only in the lambda's line number.
+
+  Fixed by asking the binary a question the synthetic key's *text* can
+  answer honestly, even though the key itself is not a real symbol: is
+  the owning class/class-template exported under ANY instantiation at
+  all, on either side? `_synthetic_ctor_dtor_template_base_name` recovers
+  the owning scope from the key (`finding_identity_ctor_dtor.
+  synthetic_ctor_scope` for a ctor key's depth-aware `scope(params)`
+  split; a plain prefix strip for a dtor key), reduces it to the bare,
+  template-argument-stripped template name via `type_reachability.
+  _bare_type_name` plus a top-level `<` scan (`raii_guard<(lambda:...)>`
+  → `raii_guard`), and `_itanium_source_name_token` renders that name as
+  its Itanium `<source-name>` encoding (`"raii_guard"` → `"10raii_guard"`)
+  — a literal substring every real mangled symbol naming that class as a
+  scope component must contain (Itanium C++ ABI §5.1.1), checked directly
+  against the raw exported names with no external demangler invoked, the
+  same "structural, not textual" preference `diff_cxx_rules.
+  itanium_scope_components` already established for this codebase. A
+  template with zero exported members under any instantiation on either
+  side is demoted (`Verdict.COMPATIBLE_WITH_RISK`,
+  `modulation_rule="lambda_closure_never_exported"`, same ADR-025 hook,
+  never removed); a template that *does* export some other instantiation
+  is left exactly as severe as the detector made it, since this check
+  cannot rule out that the specific closure-parameterized instantiation
+  was the one a consumer actually linked against.
+
+  Deliberately narrower than reconstructing the *exact* per-instantiation
+  mangling: the real Itanium mangling of a closure-type template argument
+  uses the compiler's own unnamed-type encoding (`Ul<parameter-types>E_`),
+  never castxml's `(lambda:file:line:col)` spelling, so there is no way to
+  derive the precise mangled substring for one specific instantiation from
+  the snapshot text alone — checking the template's own name is the safe,
+  strictly more conservative substitute this function's whole design
+  (fail closed, never escalate) already calls for. See
+  `tests/test_lambda_closure_function_demotion.py`'s
+  `TestSyntheticCtorDtorKeysDemotedWhenTemplateNeverExported`/
+  `TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported` for both
+  directions, verified against the exact class names from the oneTBB
+  report.
+
+  Two related residuals from the same report, deliberately not addressed
+  here: the *type-level* churn among these same symbols (the compatible
+  `func_added`/risk `declaration_renamed` findings the same 5 removals
+  pair with, and 7 further `declaration_renamed` findings elsewhere in the
+  same report) is pure noise from the lambda's identity embedding its
+  source `line:col` rather than an ordinal position — closing that needs
+  changing how a closure is *identified*, a materially larger change to
+  `name_classification`/the castxml and clang backends' own closure
+  naming than this fix's binary-evidence check, and is not attempted
+  here. And a public-surface filter gap (ELF-only, mangled-only symbols
+  such as `std::once_flag::_Prepare_execution<lambda>`'s internal guard
+  thunks, which `surface.py` cannot scope-classify because it never
+  demangles) is a separate detector, not this one, and is likewise not
+  addressed here.
+
   (2) *A constructor key rendering a literal `?` parameter.* Traced to two
   legitimate "type not recoverable" sentinels rather than to a formatting
   bug: `dwarf_snapshot._process_param` returns `Param(type="?")` for a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5372,21 +5372,40 @@ Once a root command genuinely clears the bar above, pick the right home:
   Fixed by asking the binary a question the synthetic key's *text* can
   answer honestly, even though the key itself is not a real symbol: is
   the owning class/class-template exported under ANY instantiation at
-  all, on either side? `_synthetic_ctor_dtor_template_base_name` recovers
-  the owning scope from the key (`finding_identity_ctor_dtor.
-  synthetic_ctor_scope` for a ctor key's depth-aware `scope(params)`
-  split; a plain prefix strip for a dtor key), reduces it to the bare,
-  template-argument-stripped template name via `type_reachability.
-  _bare_type_name` plus a top-level `<` scan (`raii_guard<(lambda:...)>`
-  → `raii_guard`), and `_itanium_source_name_token` renders that name as
-  its Itanium `<source-name>` encoding (`"raii_guard"` → `"10raii_guard"`)
-  — a literal substring every real mangled symbol naming that class as a
-  scope component must contain (Itanium C++ ABI §5.1.1), checked directly
-  against the raw exported names with no external demangler invoked, the
-  same "structural, not textual" preference `diff_cxx_rules.
-  itanium_scope_components` already established for this codebase. A
-  template with zero exported members under any instantiation on either
-  side is demoted (`Verdict.COMPATIBLE_WITH_RISK`,
+  all, on either side? `finding_identity_ctor_dtor.
+  synthetic_ctor_dtor_template_base_name` recovers the owning scope from
+  the key (that same module's own `synthetic_ctor_scope` for a ctor key's
+  depth-aware `scope(params)` split; a plain prefix strip for a dtor key),
+  reduces it to the bare, template-argument-stripped template name via
+  `type_reachability._bare_type_name` plus a top-level `<` scan
+  (`raii_guard<(lambda:...)>` → `raii_guard`), and
+  `finding_identity_ctor_dtor.itanium_source_name_token` renders that name
+  as its Itanium `<source-name>` encoding (`"raii_guard"` → `"10raii_guard"`,
+  keyed on the identifier's encoded UTF-8 **byte** length rather than its
+  Python character count, so a non-ASCII class name still produces the
+  correct token) — a literal substring every real mangled symbol naming
+  that class as a scope component must contain (Itanium C++ ABI §5.1.1),
+  checked directly against the raw exported names with no external
+  demangler invoked, the same "structural, not textual" preference
+  `diff_cxx_rules.itanium_scope_components` already established for this
+  codebase. Both helpers live in `finding_identity_ctor_dtor.py`, not
+  `diff_templates.py` itself (which only keeps the classification/
+  modulation entry point, `demote_lambda_closure_unexported_findings`):
+  `diff_templates.py` is one of ADR-061's `debt.yaml`-tracked
+  no-growth-baselined legacy files, `finding_identity_ctor_dtor.py` already
+  owns every other castxml synthetic-ctor/dtor-key helper and had headroom
+  under the flat 800-line production limit, and a brand-new flat `diff_*`
+  sibling module is explicitly rejected by `scripts/check_architecture.py`'s
+  `frozen_root_families` list (confirmed by trying it — `[frozen-root-family]`
+  and `[root-module]` findings) — while a real `policy/` package migration
+  for just this one function was investigated and found to cascade into
+  `unclassified-import` findings for every one of its ~8 currently-flat,
+  not-yet-layer-classified dependencies (`checker_policy`, `diff_symbols`,
+  `dumper_castxml`, `elf_symbol_filter`, `type_reachability`,
+  `name_classification`, ...), which is its own separate, much larger
+  ADR-061 migration slice, not a follow-up to this fix. A template with
+  zero exported members under any instantiation on either side is demoted
+  (`Verdict.COMPATIBLE_WITH_RISK`,
   `modulation_rule="lambda_closure_never_exported"`, same ADR-025 hook,
   never removed); a template that *does* export some other instantiation
   is left exactly as severe as the detector made it, since this check

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -1238,17 +1238,10 @@ _LAMBDA_CLOSURE_DEMOTABLE_KINDS: frozenset[ChangeKind] = frozenset(
 
 
 def _change_mentions_lambda_closure(change: Change) -> bool:
-    """Whether *change*'s own recorded text embeds a lambda-closure marker.
-
-    Checks every field a producer could have put the closure's spelling
-    into: ``symbol`` (a castxml-synthesized ctor/dtor key embeds the
-    owning class's full qualified name, closure spelling included —
-    ``dumper_castxml.SYNTHETIC_CTOR_KEY_PREFIX``/``is_synthetic_dtor_key``),
-    and ``old_value``/``new_value`` (a parameter or return-type spelling for
-    ``FUNC_PARAMS_CHANGED``/``TEMPLATE_PARAM_TYPE_CHANGED``/
-    ``TEMPLATE_RETURN_TYPE_CHANGED``, see :func:`_check_params_change`/
-    :func:`_diff_template_inner_types` in their respective modules).
-    """
+    """Whether *change*'s own recorded text embeds a lambda-closure marker
+    (``symbol``, ``old_value``, or ``new_value`` -- every field a producer
+    could have put a castxml synthetic ctor/dtor key or parameter/return
+    spelling into)."""
     from .name_classification import contains_anonymous_type_marker
 
     return (
@@ -1256,74 +1249,6 @@ def _change_mentions_lambda_closure(change: Change) -> bool:
         or contains_anonymous_type_marker(change.old_value)
         or contains_anonymous_type_marker(change.new_value)
     )
-
-
-def _synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
-    """The bare (namespace- and template-argument-stripped) name of the
-    class/class-template a castxml synthetic ctor/dtor key
-    (``dumper_castxml.SYNTHETIC_CTOR_KEY_PREFIX``/``is_synthetic_dtor_key``)
-    names as its owner, or ``None`` if *symbol* is not such a key or its
-    scope cannot be recovered.
-
-    This answers "was this class template ever exported under ANY
-    instantiation", not "was THIS EXACT instantiation (lambda-closure
-    argument included) exported": the real, per-instantiation Itanium
-    mangling of a closure-type template argument uses the compiler's own
-    unnamed-type encoding (``Ul<parameter-types>E_``), never castxml's
-    ``(lambda:file:line:col)`` spelling, so there is no way to reconstruct
-    the exact mangled substring for one specific instantiation from the
-    snapshot text alone. Checking the template's own bare name instead is
-    a safe, strictly more conservative substitute for
-    :func:`demote_lambda_closure_unexported_findings`'s purposes: a class
-    template with zero exported members under *any* instantiation, on
-    either side, cannot have been linked against by any consumer under
-    this instantiation either — while a template that *does* export some
-    other instantiation correctly leaves the demotion unconfirmed (fails
-    closed) rather than risking a false negative on the one that matters.
-    """
-    from .dumper_castxml import (
-        _SYNTHETIC_DTOR_KEY_PREFIX,
-        is_synthetic_ctor_key,
-        is_synthetic_dtor_key,
-    )
-    from .finding_identity_ctor_dtor import synthetic_ctor_scope
-    from .type_reachability import _bare_type_name
-
-    if is_synthetic_ctor_key(symbol):
-        scope = synthetic_ctor_scope(symbol)
-    elif is_synthetic_dtor_key(symbol):
-        scope = symbol[len(_SYNTHETIC_DTOR_KEY_PREFIX) :]
-    else:
-        return None
-    if not scope:
-        return None
-    bare = _bare_type_name(scope)
-    depth = 0
-    for i, ch in enumerate(bare):
-        if ch == "<":
-            if depth == 0:
-                base = bare[:i]
-                return base or None
-            depth += 1
-        elif ch == ">":
-            depth = max(0, depth - 1)
-    return bare or None
-
-
-def _itanium_source_name_token(name: str) -> str:
-    """The Itanium ``<source-name>`` encoding of a plain identifier: its
-    decimal length immediately followed by the identifier text, e.g.
-    ``"raii_guard"`` → ``"10raii_guard"``.
-
-    Every real Itanium-mangled symbol naming *name* as a namespace/class/
-    template component embeds this exact substring (Itanium C++ ABI
-    §5.1.1), so a substring search for it is a dependency-free way to ask
-    "does any real exported symbol reference this identifier" without
-    invoking an external demangler — the same "structural, not textual"
-    preference this codebase's mangled-name parsers (``diff_cxx_rules.
-    itanium_scope_components`` and friends) already follow.
-    """
-    return f"{len(name)}{name}"
 
 
 def demote_lambda_closure_unexported_findings(
@@ -1335,82 +1260,61 @@ def demote_lambda_closure_unexported_findings(
     never actually exported/defined in EITHER binary's real symbol table.
 
     A template instantiated over a local lambda's closure type has no
-    user-nameable identity: no consumer source can ever spell the type, so
-    the marker-list fix (``name_classification._ANONYMOUS_TYPE_MARKERS``)
-    already stops such a *type* from being treated as ABI surface — an
-    unrelated edit that merely shifts the lambda's source line must not
-    manufacture a spurious ``type_removed``/``type_added`` pair for it.
+    user-nameable identity, so the marker-list fix
+    (``name_classification._ANONYMOUS_TYPE_MARKERS``) already stops such a
+    *type* from being treated as ABI surface — an unrelated edit that merely
+    shifts the lambda's source line must not manufacture a spurious
+    ``type_removed``/``type_added`` pair for it. That fix does not reach
+    *function*-level findings (a destructor of such an instantiation, or a
+    function taking the closure-parameterized type by value): the mangled
+    symbol and/or parameter-type spelling embed the closure's source
+    coordinates directly (see AGENTS.md's "Lambda-closure churn survives at
+    the function level" entry for the full investigation).
 
-    That fix does not reach *function*-level findings: a destructor of such
-    an instantiation (reported ``FUNC_REMOVED``/``FUNC_REMOVED`` next to a
-    same-shaped ``FUNC_ADDED``), or a function taking the closure-
-    parameterized type by value (``FUNC_PARAMS_CHANGED``/
-    ``TEMPLATE_PARAM_TYPE_CHANGED``/``TEMPLATE_RETURN_TYPE_CHANGED``), still
-    fires purely from the closure's embedded source coordinates shifting —
-    because the mangled symbol and/or the parameter-type spelling embed
-    those coordinates directly (see AGENTS.md's "Lambda-closure churn
-    survives at the function level" entry for the full investigation).
-
-    Broadly demoting every such finding was considered and rejected there:
-    a symbol that a consumer's *already-compiled binary* linked against by
-    exact spelling can genuinely break on renumbering, even though no new
-    consumer could ever *write source* against it. What makes that risk
-    real is that the symbol was actually **exported** — an already-linked
-    consumer can only have resolved a name the dynamic linker actually
-    offered. So this demotes only when the finding's own symbol is
-    confirmed absent from BOTH sides' real ELF exported symbol table
-    (:func:`elf_symbol_filter.exported_symbol_names`, the same ``.dynsym``
-    evidence :func:`_public_functions <abicheck.diff_symbols._public_functions>`
-    narrows against) — never from DWARF/header evidence alone, which is
-    exactly the axis :func:`detect_missing_instantiations` above answers a
-    *different* question from (an instantiation genuinely present in the
-    old export table and genuinely gone from the new one, i.e. a real
-    break).
+    Broadly demoting every such finding was considered and rejected there: a
+    symbol an already-compiled consumer linked against by exact spelling can
+    genuinely break on renumbering, even though no new consumer could ever
+    *write source* against it. So this demotes only when the finding's own
+    symbol is confirmed absent from BOTH sides' real ELF exported symbol
+    table (:func:`elf_symbol_filter.exported_symbol_names`) — never from
+    DWARF/header evidence alone, the different question
+    :func:`detect_missing_instantiations` above answers (an instantiation
+    present in the old export table and gone from the new one).
 
     A castxml-synthesized ctor/dtor key
     (``dumper_castxml.is_synthetic_ctor_key``/``is_synthetic_dtor_key``) is
-    itself *never* a real exported symbol by construction (see
-    ``dumper_castxml._function_mangled_name``'s own comment) — castxml
-    synthesizes the key precisely because it could not produce a real
-    mangled name for this constructor/destructor overload, typically
-    because one of its (or its enclosing template's) arguments is an
-    unnameable local lambda closure type. A bare membership check of the
-    key text itself against the export tables would therefore always
-    report "confirmed absent" regardless of whether the real,
-    castxml-omitted mangled symbol was actually exported — a vacuous,
-    unsafe confirmation this function must not act on. Rather than skip
-    every such finding outright (which left every ctor/dtor of a
-    closure-parameterized instantiation permanently undemoted — see
-    AGENTS.md's "Lambda-closure churn survives at the function level"
-    entry, item 1), this asks the binary a question the key text itself
-    *can* answer honestly: is the owning class/class-template exported
-    under *any* instantiation at all, on either side
-    (:func:`_synthetic_ctor_dtor_template_base_name` +
-    :func:`_itanium_source_name_token`)? A class template with zero
-    exported members under any instantiation cannot have been linked
-    against under this instantiation either — while a template that does
-    export some other instantiation correctly leaves the demotion
-    unconfirmed, since this check cannot rule out that the *specific*
-    closure-parameterized instantiation was the one exported.
+    itself *never* a real exported symbol by construction — castxml
+    synthesizes it because it could not produce a real mangled name for this
+    overload, typically because one of its (or its enclosing template's)
+    arguments is an unnameable local lambda closure type. A bare membership
+    check of the key text would therefore always read "confirmed absent"
+    vacuously, so instead this asks whether the owning class/class-template
+    is exported under *any* instantiation at all, on either side
+    (``finding_identity_ctor_dtor.synthetic_ctor_dtor_template_base_name`` +
+    ``itanium_source_name_token``, a dependency-free Itanium ``<source-name>``
+    substring match against the raw exported symbols). Zero exported members
+    under any instantiation means no consumer could have linked against this
+    one either; some other instantiation being exported leaves the demotion
+    unconfirmed, since it can't rule out that the specific closure-
+    parameterized instantiation was the one exported (see AGENTS.md's
+    "Lambda-closure churn survives at the function level" entry, item 1).
 
     Like :func:`abicheck.diff_versioning.demote_internal_version_node_findings`,
-    this uses the per-finding ``effective_verdict`` modulation hook
-    (ADR-025) rather than removing anything from *changes* — the finding
-    stays fully visible, annotated with why it no longer drives the
-    verdict, matching this codebase's "annotate, never remove" precedent
-    (see AGENTS.md's ``LAYOUT_UNVERIFIABLE``/vtable entry). Conservative in
-    both directions: only already-BREAKING/API_BREAK findings are touched
-    (never escalates), findings already carrying a prior
-    ``effective_verdict`` are left untouched, and "no ELF symbol table on
-    one or both sides" is treated as "not confirmed" (fails closed) rather
-    than as evidence of absence.
-
-    Mutates and returns ``changes``.
+    this uses the per-finding ``effective_verdict`` modulation hook (ADR-025)
+    rather than removing anything from *changes* (annotate, never remove).
+    Conservative: only already-BREAKING/API_BREAK findings are touched
+    (never escalates), a prior ``effective_verdict`` is left untouched, and
+    missing ELF evidence on either side fails closed. Mutates and returns
+    ``changes``.
     """
     from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS, Verdict
     from .diff_symbols import _public_functions
     from .dumper_castxml import is_synthetic_ctor_key, is_synthetic_dtor_key
     from .elf_symbol_filter import FUNCTION_SYMBOL_TYPES, exported_symbol_names
+    from .finding_identity_ctor_dtor import (
+        itanium_source_name_token,
+        synthetic_ctor_dtor_template_base_name,
+    )
 
     old_elf = getattr(old, "elf", None)
     new_elf = getattr(new, "elf", None)
@@ -1425,17 +1329,11 @@ def demote_lambda_closure_unexported_findings(
         return changes
     old_exported = exported_symbol_names(old_elf, FUNCTION_SYMBOL_TYPES)
     new_exported = exported_symbol_names(new_elf, FUNCTION_SYMBOL_TYPES)
-    # `change.symbol` is the dict *key* the detector matched functions
-    # through -- for a function retained only via `_public_functions`'s own
-    # bare-name export fallback (a guessed/incomplete mangling that never
-    # equals the real export), that key can differ from the function's
-    # actual accepted export spelling, `Function.name` (Codex review, fresh
-    # evidence: the fallback exists specifically because castxml/DWARF can
-    # under-mangle a name that the real ELF export table still carries
-    # correctly). Checking `symbol` alone can therefore declare a subject
-    # "confirmed absent" even though the SAME function is genuinely exported
-    # under its `.name` spelling and a real consumer could have bound it --
-    # resolve both accepted spellings before ever claiming absence.
+    # `change.symbol` (the detector's match key) can differ from a function's
+    # real accepted export spelling, `Function.name` -- `_public_functions`'s
+    # own bare-name export fallback exists because castxml/DWARF can
+    # under-mangle a name the real ELF table still carries correctly, so both
+    # spellings must be checked before ever claiming absence.
     old_map = _public_functions(old)
     new_map = _public_functions(new)
 
@@ -1452,21 +1350,17 @@ def demote_lambda_closure_unexported_findings(
         if not _change_mentions_lambda_closure(change):
             continue
         if is_synthetic_ctor_key(symbol) or is_synthetic_dtor_key(symbol):
-            base_name = _synthetic_ctor_dtor_template_base_name(symbol)
+            base_name = synthetic_ctor_dtor_template_base_name(symbol)
             if base_name is None:
                 # Scope could not be recovered from the key text -- fail
                 # closed, same as an evidence gap elsewhere in this function.
                 continue
-            token = _itanium_source_name_token(base_name)
+            token = itanium_source_name_token(base_name)
             if any(token in exported for exported in old_exported) or any(
                 token in exported for exported in new_exported
             ):
-                # The owning class/class-template is exported under SOME
-                # instantiation on at least one side -- this check cannot
-                # rule out that the specific closure-parameterized
-                # instantiation was the one a consumer actually linked
-                # against, so the finding stays exactly as severe as the
-                # detector made it.
+                # Exported under SOME instantiation on at least one side --
+                # can't rule out it was this one, so stays as severe as made.
                 continue
             change.effective_verdict = Verdict.COMPATIBLE_WITH_RISK
             change.modulation_reason = (
@@ -1487,11 +1381,8 @@ def demote_lambda_closure_unexported_findings(
         if new_fn is not None:
             candidate_spellings.add(new_fn.name)
         if candidate_spellings & (old_exported | new_exported):
-            # Genuinely exported on at least one side, under either the
-            # dict-key spelling or the matched function's own accepted
-            # export alias: an already-linked consumer could really have
-            # resolved this exact spelling, so the finding stays exactly as
-            # severe as the detector made it.
+            # Genuinely exported under the key or the matched function's own
+            # export alias: stays exactly as severe as the detector made it.
             continue
         change.effective_verdict = Verdict.COMPATIBLE_WITH_RISK
         change.modulation_reason = (

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -1313,6 +1313,7 @@ def demote_lambda_closure_unexported_findings(
     from .elf_symbol_filter import FUNCTION_SYMBOL_TYPES, exported_symbol_names
     from .finding_identity_ctor_dtor import (
         itanium_source_name_token,
+        itanium_standard_substitution_token,
         synthetic_ctor_dtor_template_base_name,
     )
 
@@ -1352,12 +1353,17 @@ def demote_lambda_closure_unexported_findings(
         if is_synthetic_ctor_key(symbol) or is_synthetic_dtor_key(symbol):
             base_name = synthetic_ctor_dtor_template_base_name(symbol)
             if base_name is None:
-                # Scope could not be recovered from the key text -- fail
-                # closed, same as an evidence gap elsewhere in this function.
-                continue
-            token = itanium_source_name_token(base_name)
-            if any(token in exported for exported in old_exported) or any(
-                token in exported for exported in new_exported
+                continue  # scope unrecoverable -- fail closed
+            # A std:: owner may mangle via a fixed Itanium substitution
+            # instead of its literal source-name -- see
+            # itanium_standard_substitution_token's own docstring.
+            tokens = {itanium_source_name_token(base_name)}
+            std_token = itanium_standard_substitution_token(symbol)
+            if std_token is not None:
+                tokens.add(std_token)
+            if any(
+                any(token in exported for token in tokens)
+                for exported in (*old_exported, *new_exported)
             ):
                 # Exported under SOME instantiation on at least one side --
                 # can't rule out it was this one, so stays as severe as made.

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -1258,6 +1258,74 @@ def _change_mentions_lambda_closure(change: Change) -> bool:
     )
 
 
+def _synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
+    """The bare (namespace- and template-argument-stripped) name of the
+    class/class-template a castxml synthetic ctor/dtor key
+    (``dumper_castxml.SYNTHETIC_CTOR_KEY_PREFIX``/``is_synthetic_dtor_key``)
+    names as its owner, or ``None`` if *symbol* is not such a key or its
+    scope cannot be recovered.
+
+    This answers "was this class template ever exported under ANY
+    instantiation", not "was THIS EXACT instantiation (lambda-closure
+    argument included) exported": the real, per-instantiation Itanium
+    mangling of a closure-type template argument uses the compiler's own
+    unnamed-type encoding (``Ul<parameter-types>E_``), never castxml's
+    ``(lambda:file:line:col)`` spelling, so there is no way to reconstruct
+    the exact mangled substring for one specific instantiation from the
+    snapshot text alone. Checking the template's own bare name instead is
+    a safe, strictly more conservative substitute for
+    :func:`demote_lambda_closure_unexported_findings`'s purposes: a class
+    template with zero exported members under *any* instantiation, on
+    either side, cannot have been linked against by any consumer under
+    this instantiation either — while a template that *does* export some
+    other instantiation correctly leaves the demotion unconfirmed (fails
+    closed) rather than risking a false negative on the one that matters.
+    """
+    from .dumper_castxml import (
+        _SYNTHETIC_DTOR_KEY_PREFIX,
+        is_synthetic_ctor_key,
+        is_synthetic_dtor_key,
+    )
+    from .finding_identity_ctor_dtor import synthetic_ctor_scope
+    from .type_reachability import _bare_type_name
+
+    if is_synthetic_ctor_key(symbol):
+        scope = synthetic_ctor_scope(symbol)
+    elif is_synthetic_dtor_key(symbol):
+        scope = symbol[len(_SYNTHETIC_DTOR_KEY_PREFIX) :]
+    else:
+        return None
+    if not scope:
+        return None
+    bare = _bare_type_name(scope)
+    depth = 0
+    for i, ch in enumerate(bare):
+        if ch == "<":
+            if depth == 0:
+                base = bare[:i]
+                return base or None
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+    return bare or None
+
+
+def _itanium_source_name_token(name: str) -> str:
+    """The Itanium ``<source-name>`` encoding of a plain identifier: its
+    decimal length immediately followed by the identifier text, e.g.
+    ``"raii_guard"`` → ``"10raii_guard"``.
+
+    Every real Itanium-mangled symbol naming *name* as a namespace/class/
+    template component embeds this exact substring (Itanium C++ ABI
+    §5.1.1), so a substring search for it is a dependency-free way to ask
+    "does any real exported symbol reference this identifier" without
+    invoking an external demangler — the same "structural, not textual"
+    preference this codebase's mangled-name parsers (``diff_cxx_rules.
+    itanium_scope_components`` and friends) already follow.
+    """
+    return f"{len(name)}{name}"
+
+
 def demote_lambda_closure_unexported_findings(
     changes: list[Change],
     old: AbiSnapshot,
@@ -1301,18 +1369,29 @@ def demote_lambda_closure_unexported_findings(
 
     A castxml-synthesized ctor/dtor key
     (``dumper_castxml.is_synthetic_ctor_key``/``is_synthetic_dtor_key``) is
-    deliberately excluded even when it embeds the marker: such a key is
-    *never* a real exported symbol by construction (see
-    ``dumper_castxml._function_mangled_name``'s own comment), so a bare
-    membership check against it would always report "confirmed absent"
-    regardless of whether the real, castxml-omitted mangled symbol was
-    actually exported — a vacuous, unsafe confirmation this function must
-    not act on. Demotion is therefore reachable only for a finding whose
-    ``symbol`` is a real (possibly still-changing) mangled/exported name,
-    which in practice is the ``FUNC_PARAMS_CHANGED``/
-    ``TEMPLATE_PARAM_TYPE_CHANGED``/``TEMPLATE_RETURN_TYPE_CHANGED`` shape
-    (the same function persists — same mangled key both sides — only its
-    recorded parameter/return spelling shifted).
+    itself *never* a real exported symbol by construction (see
+    ``dumper_castxml._function_mangled_name``'s own comment) — castxml
+    synthesizes the key precisely because it could not produce a real
+    mangled name for this constructor/destructor overload, typically
+    because one of its (or its enclosing template's) arguments is an
+    unnameable local lambda closure type. A bare membership check of the
+    key text itself against the export tables would therefore always
+    report "confirmed absent" regardless of whether the real,
+    castxml-omitted mangled symbol was actually exported — a vacuous,
+    unsafe confirmation this function must not act on. Rather than skip
+    every such finding outright (which left every ctor/dtor of a
+    closure-parameterized instantiation permanently undemoted — see
+    AGENTS.md's "Lambda-closure churn survives at the function level"
+    entry, item 1), this asks the binary a question the key text itself
+    *can* answer honestly: is the owning class/class-template exported
+    under *any* instantiation at all, on either side
+    (:func:`_synthetic_ctor_dtor_template_base_name` +
+    :func:`_itanium_source_name_token`)? A class template with zero
+    exported members under any instantiation cannot have been linked
+    against under this instantiation either — while a template that does
+    export some other instantiation correctly leaves the demotion
+    unconfirmed, since this check cannot rule out that the *specific*
+    closure-parameterized instantiation was the one exported.
 
     Like :func:`abicheck.diff_versioning.demote_internal_version_node_findings`,
     this uses the per-finding ``effective_verdict`` modulation hook
@@ -1370,11 +1449,35 @@ def demote_lambda_closure_unexported_findings(
         symbol = change.symbol or ""
         if not symbol:
             continue
-        if is_synthetic_ctor_key(symbol) or is_synthetic_dtor_key(symbol):
-            # Never a real export by construction -- absence here is
-            # vacuous, not confirmed. See the docstring above.
-            continue
         if not _change_mentions_lambda_closure(change):
+            continue
+        if is_synthetic_ctor_key(symbol) or is_synthetic_dtor_key(symbol):
+            base_name = _synthetic_ctor_dtor_template_base_name(symbol)
+            if base_name is None:
+                # Scope could not be recovered from the key text -- fail
+                # closed, same as an evidence gap elsewhere in this function.
+                continue
+            token = _itanium_source_name_token(base_name)
+            if any(token in exported for exported in old_exported) or any(
+                token in exported for exported in new_exported
+            ):
+                # The owning class/class-template is exported under SOME
+                # instantiation on at least one side -- this check cannot
+                # rule out that the specific closure-parameterized
+                # instantiation was the one a consumer actually linked
+                # against, so the finding stays exactly as severe as the
+                # detector made it.
+                continue
+            change.effective_verdict = Verdict.COMPATIBLE_WITH_RISK
+            change.modulation_reason = (
+                "subject is a constructor/destructor of a template "
+                "instantiated over a local lambda closure type, and the "
+                "owning class/class-template is confirmed absent from both "
+                "the old and new binary's exported symbol table under any "
+                "instantiation -- no consumer, past or present, could have "
+                "linked against it"
+            )
+            change.modulation_rule = "lambda_closure_never_exported"
             continue
         candidate_spellings = {symbol}
         old_fn = old_map.get(symbol)

--- a/abicheck/finding_identity_ctor_dtor.py
+++ b/abicheck/finding_identity_ctor_dtor.py
@@ -326,16 +326,14 @@ def synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
     if not scope:
         return None
     bare = _bare_type_name(scope)
-    depth = 0
-    for i, ch in enumerate(bare):
-        if ch == "<":
-            if depth == 0:
-                base = bare[:i]
-                return base or None
-            depth += 1
-        elif ch == ">":
-            depth = max(0, depth - 1)
-    return bare or None
+    # Only the OUTERMOST template-argument list's opening bracket matters --
+    # once found, everything from it onward (nested brackets included) is
+    # dropped in one slice, so no depth tracking is needed here (unlike
+    # `_bare_type_name`'s own namespace-suffix splitting, which must find
+    # every "::" at depth zero, not just the first "<").
+    idx = bare.find("<")
+    base = bare[:idx] if idx != -1 else bare
+    return base or None
 
 
 def itanium_source_name_token(name: str) -> str:

--- a/abicheck/finding_identity_ctor_dtor.py
+++ b/abicheck/finding_identity_ctor_dtor.py
@@ -302,6 +302,21 @@ def synthetic_ctor_scope(mangled: str) -> str | None:
     return split[0] if split is not None else None
 
 
+def _synthetic_ctor_dtor_scope(symbol: str) -> str | None:
+    """The raw (possibly namespace/template-qualified) scope embedded in a
+    castxml synthetic ctor/dtor key, or ``None`` if *symbol* is not such a
+    key or the scope cannot be recovered. Shared by
+    :func:`synthetic_ctor_dtor_template_base_name` and
+    :func:`itanium_standard_substitution_token`.
+    """
+    if is_synthetic_ctor_key(symbol):
+        return synthetic_ctor_scope(symbol)
+    if is_synthetic_dtor_key(symbol):
+        scope = symbol[len(_SYNTHETIC_DTOR_KEY_PREFIX) :]
+        return scope or None
+    return None
+
+
 def synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
     """The bare (namespace- and template-argument-stripped) name of the
     class/class-template a castxml synthetic ctor/dtor key names as its
@@ -317,12 +332,7 @@ def synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
     mangled substring for one specific instantiation can't be reconstructed
     from the snapshot text alone).
     """
-    if is_synthetic_ctor_key(symbol):
-        scope = synthetic_ctor_scope(symbol)
-    elif is_synthetic_dtor_key(symbol):
-        scope = symbol[len(_SYNTHETIC_DTOR_KEY_PREFIX) :]
-    else:
-        return None
+    scope = _synthetic_ctor_dtor_scope(symbol)
     if not scope:
         return None
     bare = _bare_type_name(scope)
@@ -334,6 +344,53 @@ def synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
     idx = bare.find("<")
     base = bare[:idx] if idx != -1 else bare
     return base or None
+
+
+#: The Itanium C++ ABI (section 5.1.2) reserves a fixed, mandatory
+#: 2-character substitution for these six ``std::`` component names --
+#: the mangler ALWAYS emits the abbreviation instead of spelling out the
+#: source-name, even on the very first occurrence in a symbol (unlike an
+#: ordinary repeated-component substitution, which is optional and only
+#: ever applies to a name already spelled out earlier in the SAME symbol).
+#: `"basic_string"` deliberately maps to the *name* substitution `Sb`, not
+#: the additional, narrower full-type substitution `Ss` (`std::string`
+#: with its exact default template arguments) -- `Sb` is what a
+#: differently-parameterized `std::basic_string<...>` instantiation uses.
+_ITANIUM_STD_NAME_SUBSTITUTIONS: dict[str, str] = {
+    "allocator": "Sa",
+    "basic_string": "Sb",
+    "basic_istream": "Si",
+    "basic_ostream": "So",
+    "basic_iostream": "Sd",
+}
+
+
+def itanium_standard_substitution_token(symbol: str) -> str | None:
+    """The fixed Itanium ABI substitution abbreviation for *symbol*'s owning
+    class, if that class's qualified name is exactly ``std::<name>`` for one
+    of the six names :data:`_ITANIUM_STD_NAME_SUBSTITUTIONS` covers -- or
+    ``None`` otherwise (including when *symbol* is not a synthetic ctor/dtor
+    key, or its scope can't be recovered).
+
+    A caller asking "does any real exported symbol reference this class"
+    via :func:`itanium_source_name_token` alone is unsafe for these six
+    names specifically: a real ``std::allocator<T>::allocator()`` mangles
+    to ``_ZNSaIiEC1Ev`` (using the substitution `Sa`), never to anything
+    containing the literal source-name substring ``"9allocator"`` -- so a
+    literal-token-only search would always read "never exported" for such a
+    class regardless of the truth, silently letting a genuine removal
+    demote to ``COMPATIBLE_WITH_RISK``. Callers should check both this AND
+    :func:`itanium_source_name_token` of
+    :func:`synthetic_ctor_dtor_template_base_name`'s result.
+    """
+    scope = _synthetic_ctor_dtor_scope(symbol)
+    if not scope:
+        return None
+    idx = scope.find("<")
+    qualified = scope[:idx] if idx != -1 else scope
+    if not qualified.startswith("std::"):
+        return None
+    return _ITANIUM_STD_NAME_SUBSTITUTIONS.get(qualified[len("std::") :])
 
 
 def itanium_source_name_token(name: str) -> str:

--- a/abicheck/finding_identity_ctor_dtor.py
+++ b/abicheck/finding_identity_ctor_dtor.py
@@ -302,6 +302,60 @@ def synthetic_ctor_scope(mangled: str) -> str | None:
     return split[0] if split is not None else None
 
 
+def synthetic_ctor_dtor_template_base_name(symbol: str) -> str | None:
+    """The bare (namespace- and template-argument-stripped) name of the
+    class/class-template a castxml synthetic ctor/dtor key names as its
+    owner, or ``None`` if *symbol* is not such a key or its scope cannot be
+    recovered. Sits alongside this module's other synthetic-key helpers
+    (used by ``diff_templates.demote_lambda_closure_unexported_findings``
+    to ask "was this class template ever exported under ANY
+    instantiation" via a binary-export substring check, rather than "was
+    THIS EXACT instantiation exported" — the real, per-instantiation
+    Itanium mangling of a closure-type template argument uses the
+    compiler's own unnamed-type encoding (``Ul<parameter-types>E_``),
+    never castxml's ``(lambda:file:line:col)`` spelling, so the exact
+    mangled substring for one specific instantiation can't be reconstructed
+    from the snapshot text alone).
+    """
+    if is_synthetic_ctor_key(symbol):
+        scope = synthetic_ctor_scope(symbol)
+    elif is_synthetic_dtor_key(symbol):
+        scope = symbol[len(_SYNTHETIC_DTOR_KEY_PREFIX) :]
+    else:
+        return None
+    if not scope:
+        return None
+    bare = _bare_type_name(scope)
+    depth = 0
+    for i, ch in enumerate(bare):
+        if ch == "<":
+            if depth == 0:
+                base = bare[:i]
+                return base or None
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+    return bare or None
+
+
+def itanium_source_name_token(name: str) -> str:
+    """The Itanium ``<source-name>`` encoding of a plain identifier: its
+    encoded byte length immediately followed by the identifier text, e.g.
+    ``"raii_guard"`` → ``"10raii_guard"``. Every real Itanium-mangled symbol
+    naming *name* as a namespace/class/template component embeds this exact
+    substring (Itanium C++ ABI §5.1.1), so a substring search for it is a
+    dependency-free way to ask "does any real exported symbol reference
+    this identifier" without invoking an external demangler.
+
+    The length is the identifier's encoded **byte** count, not its Python
+    ``len()`` (character count): a non-ASCII identifier (GCC/Clang mangle a
+    UTF-8 source encoding) has a longer byte length than its character
+    count, e.g. ``"Café"`` mangles with length prefix ``5`` (4 characters,
+    one of them 2 bytes), not ``4``.
+    """
+    return f"{len(name.encode('utf-8'))}{name}"
+
+
 def _canonicalize_ctor_param_sig(param_sig: str) -> tuple[str, ...]:
     """Canonicalized parameter-type tuple from a synthetic ctor key's
     comma-joined ``param_sig`` portion.

--- a/changelog.d/1787694909_claude_lambda-closure-ctor-dtor-demotion.md
+++ b/changelog.d/1787694909_claude_lambda-closure-ctor-dtor-demotion.md
@@ -1,0 +1,27 @@
+### Fixed
+
+- **A destructor/constructor of a template instantiated over a local lambda
+  closure type was never demoted from BREAKING even when confirmed
+  unreachable from any consumer**, because `demote_lambda_closure_
+  unexported_findings` (added to demote a `FUNC_PARAMS_CHANGED`/
+  `TEMPLATE_PARAM_TYPE_CHANGED`/`TEMPLATE_RETURN_TYPE_CHANGED` finding whose
+  reported symbol is confirmed absent from both binaries' real exported
+  symbol table) deliberately excluded every castxml-synthesized ctor/dtor
+  key — such a key is never itself a real exported symbol, so checking it
+  against the export tables was vacuous. Reported against real oneTBB
+  2021.13.0 → 2022.3.0 binaries: 5 breaking `func_removed` findings on
+  synthetic ctor/dtor keys naming `tbb::detail::raii_guard<(lambda:...)>`/
+  `try_call_proxy<...>`/`task_arena_function<...>`/`delegated_function<...>`,
+  each paired with a compatible `func_added` differing only in the lambda's
+  source line. Fixed by checking the *owning class/class-template* for
+  export under any instantiation at all (a dependency-free Itanium
+  `<source-name>` substring match against the raw exported names, no
+  external demangler invoked) rather than the synthetic key text itself: a
+  template with zero exported members under any instantiation, on either
+  side, is now demoted (`Verdict.COMPATIBLE_WITH_RISK`,
+  `modulation_rule="lambda_closure_never_exported"` — annotated, never
+  removed, per this codebase's usual ADR-025 modulation hook); a template
+  that does export some other instantiation is left exactly as severe as
+  the detector made it, since that check cannot rule out the specific
+  closure-parameterized instantiation was the one a consumer actually
+  linked against.

--- a/changelog.d/1787694909_claude_lambda-closure-ctor-dtor-demotion.md
+++ b/changelog.d/1787694909_claude_lambda-closure-ctor-dtor-demotion.md
@@ -2,9 +2,10 @@
 
 - **A destructor/constructor of a template instantiated over a local lambda
   closure type was never demoted from BREAKING even when confirmed
-  unreachable from any consumer**, because `demote_lambda_closure_
-  unexported_findings` (added to demote a `FUNC_PARAMS_CHANGED`/
-  `TEMPLATE_PARAM_TYPE_CHANGED`/`TEMPLATE_RETURN_TYPE_CHANGED` finding whose
+  unreachable from any consumer**, because
+  `demote_lambda_closure_unexported_findings` (added to demote a
+  `FUNC_PARAMS_CHANGED`/`TEMPLATE_PARAM_TYPE_CHANGED`/
+  `TEMPLATE_RETURN_TYPE_CHANGED` finding whose
   reported symbol is confirmed absent from both binaries' real exported
   symbol table) deliberately excluded every castxml-synthesized ctor/dtor
   key — such a key is never itself a real exported symbol, so checking it
@@ -24,4 +25,10 @@
   that does export some other instantiation is left exactly as severe as
   the detector made it, since that check cannot rule out the specific
   closure-parameterized instantiation was the one a consumer actually
-  linked against.
+  linked against. Six `std::` names (`allocator`, `basic_string`,
+  `basic_istream`, `basic_ostream`, `basic_iostream`) carry a fixed,
+  mandatory Itanium ABI substitution instead of their literal source-name
+  in every real mangled symbol, so the check also matches that
+  substitution (e.g. `Sa` for `std::allocator`) — without it, a synthetic
+  `std::allocator<(lambda:...)>` finding would always read as unexported
+  and demote even when genuinely removed.

--- a/tests/test_lambda_closure_function_demotion.py
+++ b/tests/test_lambda_closure_function_demotion.py
@@ -405,6 +405,43 @@ class TestNonLambdaFindingsAreNeverTouched:
         assert change.effective_verdict is None
 
 
+class TestSyntheticCtorDtorTemplateBaseNamePrimitive:
+    """Direct, primitive-level coverage for ``synthetic_ctor_dtor_template_
+    base_name`` (per this repo's own "Primitive-level property tests"
+    convention) -- the demotion pipeline only ever calls it already knowing
+    *some* synthetic key is present, so these branches (non-key input, a
+    scope with no template args at all, and a scope with nested template
+    brackets) are otherwise unreached from that one call site."""
+
+    def test_non_synthetic_symbol_returns_none(self) -> None:
+        from abicheck.finding_identity_ctor_dtor import (
+            synthetic_ctor_dtor_template_base_name,
+        )
+
+        assert synthetic_ctor_dtor_template_base_name("_ZN3Foo3barEv") is None
+
+    def test_scope_with_no_template_args_returns_the_bare_name(self) -> None:
+        from abicheck.finding_identity_ctor_dtor import (
+            synthetic_ctor_dtor_template_base_name,
+        )
+
+        assert (
+            synthetic_ctor_dtor_template_base_name("~ns::PlainClass") == "PlainClass"
+        )
+
+    def test_nested_template_brackets_stop_at_the_outermost_open_bracket(
+        self,
+    ) -> None:
+        from abicheck.finding_identity_ctor_dtor import (
+            synthetic_ctor_dtor_template_base_name,
+        )
+
+        assert (
+            synthetic_ctor_dtor_template_base_name("~Wrapper<Inner<int>>")
+            == "Wrapper"
+        )
+
+
 class TestItaniumSourceNameTokenUsesEncodedByteLength:
     """Itanium ``<source-name>`` length prefixes count encoded **bytes**, not
     Python characters -- a non-ASCII identifier (GCC/Clang mangle a UTF-8

--- a/tests/test_lambda_closure_function_demotion.py
+++ b/tests/test_lambda_closure_function_demotion.py
@@ -306,6 +306,85 @@ class TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported:
         assert change.modulation_rule is None
 
 
+class TestSyntheticDtorKeyReportedThroughComparePipeline:
+    """The exact real-world shape reported for oneTBB: an unrelated edit
+    shifts a lambda's source line, so the destructor's castxml-synthesized
+    key changes spelling between old and new -- `compare()`'s own function
+    matching (keyed by this same synthetic identity) reports a
+    FUNC_REMOVED/FUNC_ADDED pair, not a rename. Exercised through the real
+    detection pipeline, not only against the demotion primitive in
+    isolation, proving the fix reaches the shape `compare()` actually
+    produces."""
+
+    def test_removal_demoted_when_owning_template_never_exported(self) -> None:
+        from abicheck.dumper_castxml import _SYNTHETIC_DTOR_KEY_PREFIX
+
+        old_key = f"{_SYNTHETIC_DTOR_KEY_PREFIX}{_OLD_PARAM}"
+        new_key = f"{_SYNTHETIC_DTOR_KEY_PREFIX}{_NEW_PARAM}"
+        old_fn = Function(
+            name="~raii_guard",
+            mangled=old_key,
+            return_type="void",
+            params=[],
+            visibility=Visibility.PUBLIC,
+        )
+        new_fn = Function(
+            name="~raii_guard",
+            mangled=new_key,
+            return_type="void",
+            params=[],
+            visibility=Visibility.PUBLIC,
+        )
+        old = _snap("1", old_fn, _elf("unrelated_symbol"))
+        new = _snap("2", new_fn, _elf("unrelated_symbol"))
+
+        result = compare(old, new)
+
+        removed = [
+            c
+            for c in result.changes
+            if c.kind == ChangeKind.FUNC_REMOVED and c.symbol == old_key
+        ]
+        assert removed, "expected a FUNC_REMOVED for the old synthetic dtor key"
+        assert removed[0].effective_verdict is Verdict.COMPATIBLE_WITH_RISK
+        assert removed[0].modulation_rule == "lambda_closure_never_exported"
+
+    def test_removal_untouched_when_owning_template_is_exported(self) -> None:
+        from abicheck.dumper_castxml import _SYNTHETIC_DTOR_KEY_PREFIX
+
+        old_key = f"{_SYNTHETIC_DTOR_KEY_PREFIX}{_OLD_PARAM}"
+        new_key = f"{_SYNTHETIC_DTOR_KEY_PREFIX}{_NEW_PARAM}"
+        old_fn = Function(
+            name="~raii_guard",
+            mangled=old_key,
+            return_type="void",
+            params=[],
+            visibility=Visibility.PUBLIC,
+        )
+        new_fn = Function(
+            name="~raii_guard",
+            mangled=new_key,
+            return_type="void",
+            params=[],
+            visibility=Visibility.PUBLIC,
+        )
+        # A real exported dtor of a DIFFERENT raii_guard<...> instantiation.
+        other_instantiation_dtor = "_ZN3tbb6detail10raii_guardIiED1Ev"
+        old = _snap("1", old_fn, _elf(other_instantiation_dtor))
+        new = _snap("2", new_fn, _elf(other_instantiation_dtor))
+
+        result = compare(old, new)
+
+        removed = [
+            c
+            for c in result.changes
+            if c.kind == ChangeKind.FUNC_REMOVED and c.symbol == old_key
+        ]
+        assert removed, "expected a FUNC_REMOVED for the old synthetic dtor key"
+        assert removed[0].effective_verdict is None
+        assert removed[0].modulation_rule is None
+
+
 class TestNonLambdaFindingsAreNeverTouched:
     def test_ordinary_param_change_with_no_lambda_marker_is_untouched(self) -> None:
         from abicheck.checker_types import Change

--- a/tests/test_lambda_closure_function_demotion.py
+++ b/tests/test_lambda_closure_function_demotion.py
@@ -24,11 +24,12 @@ A genuinely-exported symbol of the identical shape must stay untouched. A
 castxml-synthesized ctor/dtor key (never itself a real export by
 construction) is handled differently: its OWNING class/class-template is
 checked for export under any instantiation at all (see
-``_synthetic_ctor_dtor_template_base_name``/``_itanium_source_name_token``),
-since the exact per-instantiation mangling embedding a closure's own
-compiler-internal unnamed-type encoding can't be reconstructed from the
-snapshot text -- see AGENTS.md's "Lambda-closure churn survives at the
-function level" entry, item 1, for the investigation this closes.
+``finding_identity_ctor_dtor.synthetic_ctor_dtor_template_base_name``/
+``itanium_source_name_token``), since the exact per-instantiation mangling
+embedding a closure's own compiler-internal unnamed-type encoding can't be
+reconstructed from the snapshot text -- see AGENTS.md's "Lambda-closure
+churn survives at the function level" entry, item 1, for the investigation
+this closes.
 """
 
 from __future__ import annotations
@@ -402,3 +403,51 @@ class TestNonLambdaFindingsAreNeverTouched:
         demote_lambda_closure_unexported_findings([change], old, new)
 
         assert change.effective_verdict is None
+
+
+class TestItaniumSourceNameTokenUsesEncodedByteLength:
+    """Itanium ``<source-name>`` length prefixes count encoded **bytes**, not
+    Python characters -- a non-ASCII identifier (GCC/Clang mangle a UTF-8
+    source encoding) has a byte length longer than its character count, so
+    using ``len(name)`` directly would under-count and search for a token
+    that never appears in the real mangled symbol, silently defeating the
+    "is this template exported anywhere" check for such a name."""
+
+    def test_multi_byte_identifier_uses_byte_length_not_char_length(self) -> None:
+        from abicheck.finding_identity_ctor_dtor import itanium_source_name_token
+
+        # "Café" is 4 Python characters but 5 UTF-8 bytes (the "é" is 2
+        # bytes) -- the real Itanium encoding is "5Café", not "4Café".
+        assert itanium_source_name_token("Café") == "5Café"
+        assert len("Café") == 4
+
+    def test_ascii_identifier_byte_length_equals_char_length(self) -> None:
+        from abicheck.finding_identity_ctor_dtor import itanium_source_name_token
+
+        assert itanium_source_name_token("raii_guard") == "10raii_guard"
+
+    def test_multi_byte_class_name_is_found_when_exported(self) -> None:
+        """End-to-end through the primitive: a synthetic ctor key naming a
+        non-ASCII class must still be recognized as exported when the real
+        mangled symbol (using the correct UTF-8 byte-length encoding) is
+        present -- proving the fix, not just the helper in isolation."""
+        from abicheck.checker_types import Change
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}Café<(lambda:f.h:1:1)>()"
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value="Café",
+        )
+        # Real Itanium mangling of Café<...>::Café() uses the byte length 5,
+        # not the Python character count 4.
+        real_export = "_ZN5CaféIiEC1Ev"
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf(real_export))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf(real_export))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is None
+        assert change.modulation_rule is None

--- a/tests/test_lambda_closure_function_demotion.py
+++ b/tests/test_lambda_closure_function_demotion.py
@@ -20,11 +20,15 @@ exported symbol table, is demoted (never removed) via the ADR-025
 ``effective_verdict``/``modulation_reason``/``modulation_rule`` hook --
 mirroring ``diff_versioning.demote_internal_version_node_findings``.
 
-A genuinely-exported symbol of the identical shape, and a castxml-
-synthesized ctor/dtor key (never a real export by construction, so absence
-there is vacuous, not confirmed), must both stay untouched -- see
-AGENTS.md's "Lambda-closure churn survives at the function level" entry for
-the investigation this closes.
+A genuinely-exported symbol of the identical shape must stay untouched. A
+castxml-synthesized ctor/dtor key (never itself a real export by
+construction) is handled differently: its OWNING class/class-template is
+checked for export under any instantiation at all (see
+``_synthetic_ctor_dtor_template_base_name``/``_itanium_source_name_token``),
+since the exact per-instantiation mangling embedding a closure's own
+compiler-internal unnamed-type encoding can't be reconstructed from the
+snapshot text -- see AGENTS.md's "Lambda-closure churn survives at the
+function level" entry, item 1, for the investigation this closes.
 """
 
 from __future__ import annotations
@@ -175,15 +179,18 @@ class TestGenuinelyExportedSymbolStaysBreaking:
             assert c.modulation_rule is None
 
 
-class TestSyntheticCtorDtorKeysAreNeverDemoted:
+class TestSyntheticCtorDtorKeysDemotedWhenTemplateNeverExported:
     """A castxml-synthesized ctor/dtor key can never equal a real exported
-    symbol by construction, so "absent from the export table" is vacuous
-    for it -- demoting on that basis would be an unverified, unsafe
-    over-demotion. These must stay exactly as severe as the detector made
-    them, regardless of how much ELF evidence says nothing about the real,
-    castxml-omitted mangled name."""
+    symbol by construction (see ``dumper_castxml._function_mangled_name``),
+    so the OWNING class/class-template is checked instead: if it has zero
+    exported members under ANY instantiation on either side, no consumer
+    could ever have linked against this instantiation's ctor/dtor either --
+    the exact real-world shape reported for oneTBB's
+    ``tbb::detail::raii_guard``/``try_call_proxy``/``delegated_function``/
+    ``task_arena_function`` (all confirmed, via ``nm -D --defined-only``,
+    to export zero symbols under any instantiation)."""
 
-    def test_synthetic_dtor_key_with_lambda_marker_is_untouched(self) -> None:
+    def test_synthetic_dtor_key_is_demoted_when_template_never_exported(self) -> None:
         from abicheck.checker_types import Change
 
         symbol = f"~raii_guard<{_OLD_PARAM[len('raii_guard'):]}"  # "~raii_guard<(lambda:...)>"
@@ -193,15 +200,15 @@ class TestSyntheticCtorDtorKeysAreNeverDemoted:
             description="d",
             old_value="~raii_guard",
         )
-        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("process"))
-        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("process"))
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("unrelated_symbol"))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("unrelated_symbol"))
 
         demote_lambda_closure_unexported_findings([change], old, new)
 
-        assert change.effective_verdict is None
-        assert change.modulation_rule is None
+        assert change.effective_verdict is Verdict.COMPATIBLE_WITH_RISK
+        assert change.modulation_rule == "lambda_closure_never_exported"
 
-    def test_synthetic_ctor_key_with_lambda_marker_is_untouched(self) -> None:
+    def test_synthetic_ctor_key_is_demoted_when_template_never_exported(self) -> None:
         from abicheck.checker_types import Change
 
         symbol = f"__abicheck_ctor__raii_guard<{_OLD_PARAM[len('raii_guard<') :]}()"
@@ -211,8 +218,87 @@ class TestSyntheticCtorDtorKeysAreNeverDemoted:
             description="d",
             old_value="raii_guard",
         )
-        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("process"))
-        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("process"))
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("unrelated_symbol"))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("unrelated_symbol"))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is Verdict.COMPATIBLE_WITH_RISK
+        assert change.modulation_rule == "lambda_closure_never_exported"
+
+
+class TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported:
+    """The owning class/class-template genuinely exports SOME instantiation
+    on at least one side -- this check cannot rule out that the specific
+    closure-parameterized instantiation was the one a consumer actually
+    linked against, so the finding must stay exactly as severe as the
+    detector made it (fails closed)."""
+
+    def test_synthetic_ctor_key_untouched_when_another_instantiation_is_exported(
+        self,
+    ) -> None:
+        from abicheck.checker_types import Change
+
+        symbol = f"__abicheck_ctor__raii_guard<{_OLD_PARAM[len('raii_guard<') :]}()"
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value="raii_guard",
+        )
+        # A real exported ctor of a DIFFERENT raii_guard<...> instantiation
+        # (raii_guard<int>) -- the Itanium <source-name> encoding
+        # "10raii_guard" embedded in it is exactly what this check searches
+        # for, so this proves the class template does have linkable
+        # consumers under some instantiation.
+        other_instantiation_ctor = "_ZN3tbb6detail10raii_guardIiEC1Ev"
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf(other_instantiation_ctor))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf(other_instantiation_ctor))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is None
+        assert change.modulation_rule is None
+
+    def test_synthetic_dtor_key_untouched_when_another_instantiation_is_exported(
+        self,
+    ) -> None:
+        from abicheck.checker_types import Change
+
+        symbol = f"~raii_guard<{_OLD_PARAM[len('raii_guard'):]}"
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value="~raii_guard",
+        )
+        other_instantiation_dtor = "_ZN3tbb6detail10raii_guardIiED1Ev"
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf(other_instantiation_dtor))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf(other_instantiation_dtor))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is None
+        assert change.modulation_rule is None
+
+    def test_malformed_synthetic_ctor_key_scope_unrecoverable_is_not_demoted(
+        self,
+    ) -> None:
+        """``synthetic_ctor_scope`` returns ``None`` for a key with no
+        recoverable ``(params)`` suffix -- fails closed, same as any other
+        evidence gap in this function."""
+        from abicheck.checker_types import Change
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}Foo"  # missing "(params)" suffix
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value=_OLD_PARAM,
+        )
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("unrelated_symbol"))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("unrelated_symbol"))
 
         demote_lambda_closure_unexported_findings([change], old, new)
 

--- a/tests/test_lambda_closure_function_demotion.py
+++ b/tests/test_lambda_closure_function_demotion.py
@@ -488,3 +488,103 @@ class TestItaniumSourceNameTokenUsesEncodedByteLength:
 
         assert change.effective_verdict is None
         assert change.modulation_rule is None
+
+
+class TestItaniumStandardSubstitutionToken:
+    """Six ``std::`` names (``allocator``, ``basic_string``, ``basic_istream``,
+    ``basic_ostream``, ``basic_iostream``) always mangle via a fixed Itanium
+    ABI substitution (``Sa``/``Sb``/``Si``/``So``/``Sd``), never via their
+    literal source-name -- a literal-token-only search would therefore always
+    read such a class as "never exported" regardless of the truth."""
+
+    def test_known_std_names_map_to_their_fixed_substitution(self) -> None:
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+        from abicheck.finding_identity_ctor_dtor import (
+            itanium_standard_substitution_token,
+        )
+
+        cases = {
+            "allocator": "Sa",
+            "basic_string": "Sb",
+            "basic_istream": "Si",
+            "basic_ostream": "So",
+            "basic_iostream": "Sd",
+        }
+        for name, expected in cases.items():
+            symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}std::{name}<(lambda:f.h:1:1)>()"
+            assert itanium_standard_substitution_token(symbol) == expected
+
+    def test_non_std_owner_returns_none(self) -> None:
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+        from abicheck.finding_identity_ctor_dtor import (
+            itanium_standard_substitution_token,
+        )
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}raii_guard<(lambda:f.h:1:1)>()"
+        assert itanium_standard_substitution_token(symbol) is None
+
+    def test_std_name_outside_the_fixed_set_returns_none(self) -> None:
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+        from abicheck.finding_identity_ctor_dtor import (
+            itanium_standard_substitution_token,
+        )
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}std::vector<(lambda:f.h:1:1)>()"
+        assert itanium_standard_substitution_token(symbol) is None
+
+    def test_non_synthetic_symbol_returns_none(self) -> None:
+        from abicheck.finding_identity_ctor_dtor import (
+            itanium_standard_substitution_token,
+        )
+
+        assert itanium_standard_substitution_token("_ZN3Foo3barEv") is None
+
+
+class TestStdAllocatorSyntheticKeyNotFalselyDemoted:
+    """The exact counterexample from review: a real exported
+    ``std::allocator<int>::allocator()`` mangles to ``_ZNSaIiEC1Ev`` (the
+    fixed ``Sa`` substitution), never to anything containing the literal
+    source-name substring ``"9allocator"``. Checking only the literal token
+    would read this class as "never exported" and wrongly demote a genuine
+    removal to ``COMPATIBLE_WITH_RISK``."""
+
+    def test_allocator_ctor_not_demoted_when_another_instantiation_is_exported(
+        self,
+    ) -> None:
+        from abicheck.checker_types import Change
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}std::allocator<(lambda:f.h:1:1)>()"
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value="std::allocator",
+        )
+        real_export = "_ZNSaIiEC1Ev"  # std::allocator<int>::allocator()
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf(real_export))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf(real_export))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is None
+        assert change.modulation_rule is None
+
+    def test_allocator_ctor_still_demoted_when_genuinely_unexported(self) -> None:
+        from abicheck.checker_types import Change
+        from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
+
+        symbol = f"{SYNTHETIC_CTOR_KEY_PREFIX}std::allocator<(lambda:f.h:1:1)>()"
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol=symbol,
+            description="d",
+            old_value="std::allocator",
+        )
+        old = _snap("1", _fn(_MANGLED, _OLD_PARAM), _elf("unrelated_symbol"))
+        new = _snap("2", _fn(_MANGLED, _NEW_PARAM), _elf("unrelated_symbol"))
+
+        demote_lambda_closure_unexported_findings([change], old, new)
+
+        assert change.effective_verdict is Verdict.COMPATIBLE_WITH_RISK
+        assert change.modulation_rule == "lambda_closure_never_exported"


### PR DESCRIPTION
## Summary

`demote_lambda_closure_unexported_findings` now demotes a constructor/destructor finding on a castxml-synthesized ctor/dtor key when the *owning class/class-template* is confirmed to export zero members under any instantiation on either binary, instead of unconditionally skipping every such key.

## Motivation

Reported (item 1 of a real oneTBB 2021.13.0 → 2022.3.0 comparison) as 5 breaking `func_removed` findings, all on castxml-synthesized ctor/dtor keys (`tbb::detail::raii_guard<(lambda:task_group.h:522:26)>`, `try_call_proxy<...>`, `task_arena_function<...>`, `delegated_function<...>`), each paired 1:1 with a compatible `func_added` differing only in the lambda's source line — pure noise from an unrelated edit shifting a lambda's line number.

`demote_lambda_closure_unexported_findings` (`diff_templates.py`) already demotes a `FUNC_PARAMS_CHANGED`/`TEMPLATE_PARAM_TYPE_CHANGED`/`TEMPLATE_RETURN_TYPE_CHANGED` finding whose reported symbol is confirmed absent from both sides' real ELF exported symbol table. But it deliberately excluded every castxml-synthesized ctor/dtor key outright: such a key is never itself a real exported symbol (castxml synthesizes it precisely because it couldn't produce one), so a bare membership check against the key text would always read "confirmed absent" vacuously. That left every ctor/dtor of a closure-parameterized instantiation permanently un-demotable — exactly the reported shape.

## Changes

- `diff_templates.py`: when the finding's `symbol` is a synthetic ctor/dtor key, recover the owning class/class-template's bare name and check whether its Itanium `<source-name>` encoding (e.g. `"raii_guard"` → `"10raii_guard"`, keyed on encoded UTF-8 byte length) appears as a substring of any real exported symbol on either side — no external demangler invoked. Zero matches on both sides → demote via the existing ADR-025 `effective_verdict`/`modulation_reason`/`modulation_rule` hook (annotated, never removed); any match → left exactly as severe as the detector made it, since this check cannot rule out that the specific closure-parameterized instantiation was the one actually exported.
- `finding_identity_ctor_dtor.py`: hosts the two new reusable helpers (`synthetic_ctor_dtor_template_base_name`, `itanium_source_name_token`) — moved here (rather than added inline to `diff_templates.py`) because `diff_templates.py` is one of ADR-061's `debt.yaml` no-growth-baselined legacy files, a new flat `diff_*` sibling module is rejected outright by `scripts/check_architecture.py`'s `frozen_root_families` list, and a full `policy/` package migration for just this one function cascades into `unclassified-import` findings for ~8 currently-unclassified dependencies — a separate, larger ADR-061 slice. `finding_identity_ctor_dtor.py` already owns every other castxml synthetic-ctor/dtor-key helper and had headroom under the flat 800-line limit.
- `tests/test_lambda_closure_function_demotion.py`: flips the old "synthetic keys are never demoted" test class to the new, correct behavior (demoted when the template is never exported; untouched when some other instantiation is exported; fails closed when the scope can't be recovered), plus a new end-to-end `compare()`-pipeline test class reproducing the exact `FUNC_REMOVED`/synthetic-dtor-key shape from the report, plus a UTF-8-byte-length regression class for the Itanium token encoding.
- `AGENTS.md`: updates the "Lambda-closure churn survives at the function level" known-gaps entry to record this as closed, with the two residuals from the same report (type-level `func_added`/`declaration_renamed` line-shift noise, and an ELF-only mangled-symbol surface-scoping gap in `surface.py`) explicitly left open as separate, undone work.
- `changelog.d/`: fragment for the fix.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: An overly-broad exclusion in a demotion heuristic made a whole shape of finding (ctor/dtor of a lambda-closure-parameterized template instantiation) permanently un-demotable, even when confirmably unreachable from any consumer.
- Publicly observable failure: `compare()` reports a BREAKING `func_removed` for a constructor/destructor of a template instantiated over a local lambda closure whose owning class-template is never exported at all on either binary, paired with a compatible `func_added` for the same instantiation after an unrelated source-line shift — reproduced against real oneTBB 2021.13.0→2022.3.0 binaries (5 such findings, all currently `effective_verdict: None`).
- Regression test fails on base: Yes — `TestSyntheticCtorDtorKeysDemotedWhenTemplateNeverExported`'s two tests and `TestSyntheticDtorKeyReportedThroughComparePipeline::test_removal_demoted_when_owning_template_never_exported` all assert `effective_verdict is Verdict.COMPATIBLE_WITH_RISK`, which fails against the pre-fix code (every synthetic ctor/dtor key previously left `effective_verdict is None` unconditionally).
- Negative control: `TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported` and its `compare()`-level sibling confirm a synthetic-key finding is left untouched when the owning class-template *does* export some other instantiation — proving the fix doesn't just blanket-demote every synthetic ctor/dtor finding regardless of evidence.
- Public-surface test: `TestSyntheticDtorKeyReportedThroughComparePipeline`'s two tests go through the real `compare()` entry point (not only the `demote_lambda_closure_unexported_findings` primitive), building two `AbiSnapshot`s whose sole difference is the dtor's synthesized key's embedded lambda line number, and asserting the resulting `FUNC_REMOVED` finding's `effective_verdict`/`modulation_rule`.
- Axes covered: Both ctor and dtor synthetic-key shapes; the "confirmed absent under any instantiation" path and the "template exported under some other instantiation" path; the scope-unrecoverable fail-closed path; an ASCII and a non-ASCII (UTF-8 multi-byte) class name for the Itanium token encoding; and the pre-existing non-synthetic-key (real mangled symbol / export-alias) paths, all left green. ELF/Itanium only, matching this function's existing ELF-evidence gate — PE/Mach-O are out of scope and unchanged.
- General invariant: A castxml-synthesized ctor/dtor finding is demoted iff its owning class/class-template is confirmed to export zero members under any instantiation on both sides; it stays untouched whenever any instantiation is exported anywhere, since the exact per-instantiation mangling (embedding the compiler's own unnamed-closure-type encoding, never castxml's `(lambda:file:line:col)` spelling) can't be reconstructed from the snapshot text alone.
- Known unsupported cases: Two residuals from the same report are explicitly not addressed here (documented in AGENTS.md): (1) the sibling *type-level* churn — compatible `func_added` and risk `declaration_renamed` findings on the same symbols, pure noise from the lambda's identity embedding its source `line:col` rather than an ordinal position — needs a materially larger change to how a closure is identified; (2) an ELF-only, mangled-only public-surface-filter gap (`surface.py` never demangles, so an internal `std::once_flag`-guard thunk over a library-internal lambda can't be scope-classified) is a separate detector's gap, not this one's.
- Must-merge / must-not-merge pair: Triggered by this diff touching `finding_identity_ctor_dtor.py`, but the two functions added there (`synthetic_ctor_dtor_template_base_name`, `itanium_source_name_token`) are pure string-transformation helpers with no merge/dedup/grouping semantics of their own — they don't touch that file's existing ctor/dtor key-drift reconciliation logic (`find_ctor_dtor_key_drift_matches`/`reconcile_ctor_dtor_key_drift`, covered by `tests/test_ctor_dtor_key_drift.py`, unchanged and still green). The real "these two collapse vs. stay distinct" pair for this PR's actual behavior change is the demotion primitive's own negative control: `TestSyntheticCtorDtorKeysDemotedWhenTemplateNeverExported` (demotes/collapses to `COMPATIBLE_WITH_RISK` when the owning template exports nothing) vs. `TestSyntheticCtorDtorKeysNotDemotedWhenTemplateIsExported` (stays distinct/BREAKING when some other instantiation is exported) in `tests/test_lambda_closure_function_demotion.py`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`AGENTS.md` known-gaps entry)
- [x] `ruff check` / `mypy abicheck/` clean
- [x] Full fast unit suite green (30451 passed, 0 failed)
