### PR TITLE
ADR-061 Phase 2: close the compare -&gt; policy blocker, classify severity/analysis_assurance as policy

### DIFF
--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -710,7 +710,7 @@ class DiffResult:
 
     def _effective_verdict_for_change(self, change: Change) -> Verdict:
         """Return the per-change verdict, including frozen namespace guards."""
-        from .severity import effective_verdict_for_change
+        from .reclassify import effective_verdict_for_change  # severity re-exports it
 
         return effective_verdict_for_change(
             change,

--- a/abicheck/contract_scoped_promotion.py
+++ b/abicheck/contract_scoped_promotion.py
@@ -184,7 +184,7 @@ def recompute_verdict_after_promotion(
     """
     from .checker_policy import compute_verdict
     from .contract_gating import is_evaluated
-    from .severity import _VERDICT_ORDER
+    from .reclassify import _VERDICT_ORDER
 
     changes = getattr(result, "changes", None)
     if not changes:

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -91,6 +91,31 @@ through ``CompatibilityPolicyConfig``, its JSON serialization (a real
 schema-version concern -- see ``contract_context_io.py``), and
 ``contract_replay.py``'s policy-independent replay evaluator -- a scoped,
 independently-verified follow-up, not a same-PR extension of this change.
+
+**This module also owns the per-change effective-verdict resolver**
+(:func:`effective_verdict_for_change`) and its disclosure sibling
+(:func:`reclassify_rule_for_change`), which moved here from ``severity.py``
+during ADR-061 Phase 2. Two reasons, one architectural and one local:
+
+- Architectural: ``checker_types.DiffResult``'s verdict buckets
+  (``breaking``/``source_breaks``/``compatible``/``risk``) and
+  ``severity.py``'s severity/gating layer both need that resolver, and
+  ADR-061 classifies those two callers into *different* responsibility
+  layers (``compare`` and ``policy``) whose dependency contract forbids the
+  first importing the second. This module is the leaf both may depend on --
+  the "pull the shared logic out to a leaf both sides can depend on" pattern
+  ADR-061 names for exactly this class of blocker. It stays deliberately
+  unclassified until ``checker_policy.py``'s own model/policy split lands,
+  which is what will decide the leaf's final owner.
+- Local: the resolver's precedence chain is built *around* the selector
+  rules defined here, and :func:`reclassify_rule_for_change` has to mirror
+  that chain step for step. Three separate review rounds have already
+  corrected a disagreement between the two; co-locating them puts both
+  implementations of one precedence order in one file.
+
+``severity.effective_verdict_for_change`` / ``severity.reclassify_rule_for_change``
+/ ``severity.KindSets`` remain importable and unchanged -- ``severity.py``
+re-exports all three, so no caller (in this repo or out of it) moved.
 """
 
 from __future__ import annotations
@@ -98,9 +123,19 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any
+from typing import Any, cast
 
-from .checker_policy import Verdict
+from .checker_policy import (
+    API_BREAK_KINDS,
+    BREAKING_KINDS,
+    COMPATIBLE_KINDS,
+    RISK_KINDS,
+    ChangeKind,
+    HasKind,
+    Verdict,
+    effective_category,
+    policy_kind_sets,
+)
 
 #: The four verdicts a `to:` value is allowed to resolve to -- the exact set
 #: `policy_file.parse_severity_value`'s `break`/`warn`/`risk`/`ignore`
@@ -389,3 +424,261 @@ def active_reclassify_rules(
     downgrade is in effect when it no longer is.
     """
     return [r for r in rules if not r.is_expired(today)]
+
+
+# ---------------------------------------------------------------------------
+# Per-change effective-verdict resolution (moved from severity.py, ADR-061
+# Phase 2 -- see this module's docstring for why it lives here)
+# ---------------------------------------------------------------------------
+
+#: Pre-computed (breaking, api_break, compatible, risk) kind sets.
+KindSets = tuple[
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+]
+
+_VERDICT_ORDER = [
+    Verdict.NO_CHANGE,
+    Verdict.COMPATIBLE,
+    Verdict.COMPATIBLE_WITH_RISK,
+    Verdict.API_BREAK,
+    Verdict.BREAKING,
+]
+
+
+def resolve_kind_sets(
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+) -> KindSets:
+    """Return (breaking, api_break, compatible, risk) kind sets.
+
+    *kind_sets* takes precedence when provided (e.g. from
+    ``DiffResult._effective_kind_sets()`` which includes PolicyFile overrides).
+    Falls back to ``policy_kind_sets(policy)`` or canonical sets.
+    """
+    if kind_sets is not None:
+        return kind_sets
+    if policy is None or policy == "strict_abi":
+        return (
+            frozenset(BREAKING_KINDS),
+            frozenset(API_BREAK_KINDS),
+            frozenset(COMPATIBLE_KINDS),
+            RISK_KINDS,
+        )
+    return policy_kind_sets(policy)
+
+
+def _has_frozen_namespace_violation(change: HasKind) -> bool:
+    """Return True only for a real frozen-namespace tag string."""
+    fnv = getattr(change, "frozen_namespace_violation", None)
+    return isinstance(fnv, str) and bool(fnv)
+
+
+def _raw_verdict_for_kind(kind: ChangeKind, kind_sets: KindSets) -> Verdict:
+    """Return the verdict for *kind* without per-finding overrides."""
+    breaking, api_break, compatible, risk = kind_sets
+    if kind in breaking:
+        return Verdict.BREAKING
+    if kind in api_break:
+        return Verdict.API_BREAK
+    if kind in risk:
+        return Verdict.COMPATIBLE_WITH_RISK
+    if kind in compatible:
+        return Verdict.COMPATIBLE
+    return Verdict.BREAKING
+
+
+def effective_verdict_for_change(
+    change: HasKind,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
+    today: date | None = None,
+) -> Verdict:
+    """Return the effective verdict for one change.
+
+    Policy-file overrides usually move an entire ``ChangeKind`` into another
+    verdict bucket. Frozen-namespace violations are deliberately per-change: if
+    an override would downgrade a tagged finding below the base-policy verdict,
+    the override is ignored for that one finding.
+
+    *today* is forwarded to a matching `reclassify:` rule's own expiry check
+    (:func:`first_matching_reclassify_verdict`) -- pass a fixed date for a
+    deterministic/testable caller (e.g. ``SuppressionList.audit()``'s own
+    *today* parameter); ``None`` uses the real current date, same as every
+    other caller already relies on.
+    """
+    kind = change.kind
+    base_policy = getattr(policy_file, "base_policy", policy)
+    base_sets = (
+        resolve_kind_sets(base_policy, None)
+        if policy_file is not None
+        else resolve_kind_sets(base_policy, kind_sets)
+    )
+
+    eff = getattr(change, "effective_verdict", None)
+    if isinstance(eff, Verdict):
+        raw_v = _raw_verdict_for_kind(kind, base_sets)
+        if (
+            _has_frozen_namespace_violation(change)
+            and _VERDICT_ORDER.index(eff) < _VERDICT_ORDER.index(raw_v)
+        ):
+            return raw_v
+        return eff
+
+    # A: selector-scoped reclassification (the rules above) -- consulted
+    # ahead of the kind-global `overrides` below, mirroring
+    # PolicyFile._resolve_change_verdict's own priority order exactly, so
+    # this per-finding resolver (severity/category buckets, JSON/HTML/SARIF
+    # labels, severity-based gating) agrees with the legacy verdict
+    # PolicyFile.compute_verdict already computes instead of silently
+    # re-deriving a different answer for the same change.
+    reclassify_rules = (
+        getattr(policy_file, "reclassify", None) if policy_file is not None else None
+    )
+    if reclassify_rules:
+        reclass_v = first_matching_reclassify_verdict(reclassify_rules, change, today)
+        if reclass_v is not None:
+            base_v = effective_category(change, *base_sets)
+            if (
+                _has_frozen_namespace_violation(change)
+                and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
+            ):
+                return base_v
+            return reclass_v
+
+    overrides = (
+        getattr(policy_file, "overrides", None)
+        if policy_file is not None
+        else None
+    )
+    if overrides and kind in overrides:
+        base_v = effective_category(change, *base_sets)
+        override_v = cast(Verdict, overrides[kind])
+        if (
+            _has_frozen_namespace_violation(change)
+            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
+        ):
+            return base_v
+        return override_v
+    # Reuses `base_sets` (already computed above from `policy_file.
+    # base_policy` when a policy_file is given) rather than recomputing from
+    # the outer `policy`/`kind_sets` parameters directly (Codex review,
+    # pre-existing bug surfaced by suppression.py's audit() calling this
+    # with only `policy_file=` set, no `policy=`/`kind_sets=`): for a
+    # policy_file whose base_policy isn't strict_abi (e.g. plugin_abi), a
+    # finding with no effective_verdict/reclassify/override match fell all
+    # the way back to strict_abi's own kind sets, silently ignoring the
+    # policy file's own base policy. For the no-policy_file case this is a
+    # pure simplification, not a behavior change: base_sets there is already
+    # computed as `resolve_kind_sets(policy, kind_sets)` -- identical to
+    # what this line used to recompute.
+    return effective_category(change, *base_sets)
+
+
+def reclassify_rule_for_change(
+    change: HasKind, policy_file: object | None, today: date | None = None
+) -> Any | None:
+    """Return the ``ReclassifyRule`` that actually decided *change*'s
+    effective verdict, or ``None`` if no rule did.
+
+    Mirrors :func:`effective_verdict_for_change`'s own precedence exactly: a
+    rule that *matches* but is shadowed by a higher-priority
+    ``effective_verdict`` (an ADR-027 pipeline modulation) or blocked by the
+    frozen-namespace verdict floor did not actually decide the change's
+    verdict, so it is not "the reclassifying rule" for disclosure purposes
+    even though :meth:`ReclassifyRule.matches` would say yes.
+
+    Used by ``reporter.py`` to stamp a per-change ``reclassified_by`` field
+    on the JSON report (Codex review: ``cli_pr_comment``'s
+    ``pr_comment._reclassified_count()`` only recognized the kind-global
+    ``policy_overrides`` map, so a PR comment silently omitted the
+    "reclassified by --policy-file" notice for a finding downgraded by a
+    selector-scoped ``reclassify:`` rule instead). Computing this from the
+    real ``Change`` object here -- rather than having ``pr_comment.py``
+    reimplement selector matching against the JSON report alone -- is
+    deliberate: a JSON-serialized change doesn't carry every selector field a
+    rule can match on (``type_pattern``/``member_name``/``namespace``/
+    ``entity_namespace``/``cause_namespace`` have no JSON counterpart), so a
+    JSON-only reimplementation could not be sound.
+
+    A matching rule whose ``to_verdict`` merely *restates* the verdict the
+    next-priority path (a same-kind ``overrides:`` entry, or the base policy)
+    would already have produced is a no-op, not a reclassification -- e.g.
+    ``func_removed: to: break`` under ``strict_abi``, where ``func_removed``
+    is already BREAKING (Codex review: a matching-but-no-op rule was still
+    stamping ``reclassified_by``, making the PR comment falsely report a
+    downgrade that never happened). Only a rule that actually *changes* the
+    verdict from what would apply in its absence counts as deciding it. That
+    comparison verdict is computed through the identical frozen-namespace
+    floor the ``overrides:`` branch below applies -- not the override's raw
+    value (Codex review, second round: a frozen-namespace finding with e.g.
+    ``overrides: func_removed: ignore`` plus ``reclassify: ... to: break``
+    would, absent the rule, already clamp back to BREAKING via the floor;
+    comparing against the raw COMPATIBLE override instead made the rule read
+    as deciding a verdict that was already going to be BREAKING anyway).
+    """
+    if isinstance(getattr(change, "effective_verdict", None), Verdict):
+        return None
+    rules = (
+        getattr(policy_file, "reclassify", None) if policy_file is not None else None
+    )
+    if not rules:
+        return None
+    base_policy = getattr(policy_file, "base_policy", None)
+    base_sets = resolve_kind_sets(base_policy, None)
+    base_v = effective_category(change, *base_sets)
+    overrides = (
+        getattr(policy_file, "overrides", None) if policy_file is not None else None
+    )
+    kind = change.kind
+    # The verdict that would apply if *this* reclassify rule didn't exist --
+    # the next step down the same precedence chain effective_verdict_for_change
+    # walks (a same-kind overrides: entry, else the base policy's own
+    # verdict), with the identical frozen-namespace floor clamp the overrides:
+    # branch below applies -- so a rule that merely restates it is recognized
+    # as a no-op regardless of which of the two it happens to restate, and
+    # regardless of whether the floor would already have clamped it.
+    if overrides and kind in overrides:
+        override_v = cast(Verdict, overrides[kind])
+        if (
+            _has_frozen_namespace_violation(change)
+            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
+        ):
+            next_priority_v = base_v
+        else:
+            next_priority_v = override_v
+    else:
+        next_priority_v = base_v
+    for rule in rules:
+        if rule.matches(change, today):
+            reclass_v = rule.to_verdict
+            # The verdict this matching rule *actually* produces, applying
+            # the identical frozen-namespace floor
+            # effective_verdict_for_change's own reclassify branch applies:
+            # when reclass_v is blocked, that branch returns base_v directly
+            # -- it never falls through to consult overrides:, even though
+            # overrides: would have applied had no reclassify rule matched
+            # at all (Codex review, third round: a blocked rule was
+            # previously always read as a no-op, but the real effective
+            # verdict it produces -- base_v -- can still differ from
+            # next_priority_v, e.g. a global `overrides: ... to: break` with
+            # a frozen-namespace `reclassify: ... to: ignore` blocked back
+            # to a weaker base_v than the override would have given: the
+            # rule genuinely changed the outcome from what overrides: alone
+            # would have produced, just not to the verdict it asked for).
+            effective_v = (
+                base_v
+                if (
+                    _has_frozen_namespace_violation(change)
+                    and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
+                )
+                else reclass_v
+            )
+            if effective_v == next_priority_v:
+                return None
+            return rule
+    return None

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -61,23 +61,31 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum
-from typing import Any, cast
 
 from .checker_policy import (
     ADDITION_KINDS,
-    API_BREAK_KINDS,
-    BREAKING_KINDS,
-    COMPATIBLE_KINDS,
-    RISK_KINDS,
     ChangeKind,
     HasKind,
     Verdict,
-    effective_category,
-    policy_kind_sets,
 )
 from .contract_gating import is_evaluated
 from .errors import PolicyError
-from .reclassify import first_matching_reclassify_verdict
+
+# ADR-061 Phase 2: the per-change effective-verdict resolver, its disclosure
+# sibling, and the kind-set alias/resolver they share now live in
+# ``reclassify.py`` -- the leaf ``checker_types.DiffResult`` (``compare``) and
+# this module (``policy``) may both depend on, since the dependency contract
+# forbids the first importing the second. Re-exported through the redundant-
+# alias form so ``abicheck.severity.effective_verdict_for_change`` /
+# ``reclassify_rule_for_change`` / ``KindSets`` keep working unchanged for
+# every existing caller; see ``reclassify.py``'s docstring for the reasoning.
+from .reclassify import (
+    KindSets as KindSets,
+    effective_verdict_for_change as effective_verdict_for_change,
+    first_matching_reclassify_verdict,
+    reclassify_rule_for_change as reclassify_rule_for_change,
+    resolve_kind_sets as _resolve_kind_sets,
+)
 
 
 def gate_eligible_changes(changes: Sequence[HasKind]) -> list[HasKind]:
@@ -89,15 +97,6 @@ def gate_eligible_changes(changes: Sequence[HasKind]) -> list[HasKind]:
     class of bug ``compute_gate_decision`` was introduced to close.
     """
     return [c for c in changes if is_evaluated(c)]
-
-
-#: Pre-computed (breaking, api_break, compatible, risk) kind sets.
-KindSets = tuple[
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-]
 
 
 class SeverityLevel(str, Enum):
@@ -124,28 +123,6 @@ class IssueCategory(str, Enum):
 # When a *policy* is provided, uses the policy-adjusted sets so that
 # kinds downgraded/upgraded by the policy (e.g. sdk_vendor, plugin_abi)
 # are classified correctly.
-
-
-def _resolve_kind_sets(
-    policy: str | None = None,
-    kind_sets: KindSets | None = None,
-) -> KindSets:
-    """Return (breaking, api_break, compatible, risk) kind sets.
-
-    *kind_sets* takes precedence when provided (e.g. from
-    ``DiffResult._effective_kind_sets()`` which includes PolicyFile overrides).
-    Falls back to ``policy_kind_sets(policy)`` or canonical sets.
-    """
-    if kind_sets is not None:
-        return kind_sets
-    if policy is None or policy == "strict_abi":
-        return (
-            frozenset(BREAKING_KINDS),
-            frozenset(API_BREAK_KINDS),
-            frozenset(COMPATIBLE_KINDS),
-            RISK_KINDS,
-        )
-    return policy_kind_sets(policy)
 
 
 def classify_change(
@@ -210,230 +187,6 @@ def classify_change_object(
     return classify_effective_change(
         change, policy=policy, kind_sets=kind_sets, policy_file=policy_file
     )
-
-
-_VERDICT_ORDER = [
-    Verdict.NO_CHANGE,
-    Verdict.COMPATIBLE,
-    Verdict.COMPATIBLE_WITH_RISK,
-    Verdict.API_BREAK,
-    Verdict.BREAKING,
-]
-
-
-def _has_frozen_namespace_violation(change: HasKind) -> bool:
-    """Return True only for a real frozen-namespace tag string."""
-    fnv = getattr(change, "frozen_namespace_violation", None)
-    return isinstance(fnv, str) and bool(fnv)
-
-
-def _raw_verdict_for_kind(kind: ChangeKind, kind_sets: KindSets) -> Verdict:
-    """Return the verdict for *kind* without per-finding overrides."""
-    breaking, api_break, compatible, risk = kind_sets
-    if kind in breaking:
-        return Verdict.BREAKING
-    if kind in api_break:
-        return Verdict.API_BREAK
-    if kind in risk:
-        return Verdict.COMPATIBLE_WITH_RISK
-    if kind in compatible:
-        return Verdict.COMPATIBLE
-    return Verdict.BREAKING
-
-
-def effective_verdict_for_change(
-    change: HasKind,
-    *,
-    policy: str | None = None,
-    kind_sets: KindSets | None = None,
-    policy_file: object | None = None,
-    today: date | None = None,
-) -> Verdict:
-    """Return the effective verdict for one change.
-
-    Policy-file overrides usually move an entire ``ChangeKind`` into another
-    verdict bucket. Frozen-namespace violations are deliberately per-change: if
-    an override would downgrade a tagged finding below the base-policy verdict,
-    the override is ignored for that one finding.
-
-    *today* is forwarded to a matching `reclassify:` rule's own expiry check
-    (:func:`abicheck.reclassify.first_matching_reclassify_verdict`) -- pass a
-    fixed date for a deterministic/testable caller (e.g.
-    ``SuppressionList.audit()``'s own *today* parameter); ``None`` uses the
-    real current date, same as every other caller already relies on.
-    """
-    kind = change.kind
-    base_policy = getattr(policy_file, "base_policy", policy)
-    base_sets = (
-        _resolve_kind_sets(base_policy, None)
-        if policy_file is not None
-        else _resolve_kind_sets(base_policy, kind_sets)
-    )
-
-    eff = getattr(change, "effective_verdict", None)
-    if isinstance(eff, Verdict):
-        raw_v = _raw_verdict_for_kind(kind, base_sets)
-        if (
-            _has_frozen_namespace_violation(change)
-            and _VERDICT_ORDER.index(eff) < _VERDICT_ORDER.index(raw_v)
-        ):
-            return raw_v
-        return eff
-
-    # A: selector-scoped reclassification (abicheck/reclassify.py) --
-    # consulted ahead of the kind-global `overrides` below, mirroring
-    # PolicyFile._resolve_change_verdict's own priority order exactly, so
-    # this per-finding resolver (severity/category buckets, JSON/HTML/SARIF
-    # labels, severity-based gating) agrees with the legacy verdict
-    # PolicyFile.compute_verdict already computes instead of silently
-    # re-deriving a different answer for the same change.
-    reclassify_rules = (
-        getattr(policy_file, "reclassify", None) if policy_file is not None else None
-    )
-    if reclassify_rules:
-        reclass_v = first_matching_reclassify_verdict(reclassify_rules, change, today)
-        if reclass_v is not None:
-            base_v = effective_category(change, *base_sets)
-            if (
-                _has_frozen_namespace_violation(change)
-                and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
-            ):
-                return base_v
-            return reclass_v
-
-    overrides = (
-        getattr(policy_file, "overrides", None)
-        if policy_file is not None
-        else None
-    )
-    if overrides and kind in overrides:
-        base_v = effective_category(change, *base_sets)
-        override_v = cast(Verdict, overrides[kind])
-        if (
-            _has_frozen_namespace_violation(change)
-            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
-        ):
-            return base_v
-        return override_v
-    # Reuses `base_sets` (already computed above from `policy_file.
-    # base_policy` when a policy_file is given) rather than recomputing from
-    # the outer `policy`/`kind_sets` parameters directly (Codex review,
-    # pre-existing bug surfaced by suppression.py's audit() calling this
-    # with only `policy_file=` set, no `policy=`/`kind_sets=`): for a
-    # policy_file whose base_policy isn't strict_abi (e.g. plugin_abi), a
-    # finding with no effective_verdict/reclassify/override match fell all
-    # the way back to strict_abi's own kind sets, silently ignoring the
-    # policy file's own base policy. For the no-policy_file case this is a
-    # pure simplification, not a behavior change: base_sets there is already
-    # computed as `_resolve_kind_sets(policy, kind_sets)` -- identical to
-    # what this line used to recompute.
-    return effective_category(change, *base_sets)
-
-
-def reclassify_rule_for_change(
-    change: HasKind, policy_file: object | None, today: date | None = None
-) -> Any | None:
-    """Return the ``ReclassifyRule`` that actually decided *change*'s
-    effective verdict, or ``None`` if no rule did.
-
-    Mirrors :func:`effective_verdict_for_change`'s own precedence exactly: a
-    rule that *matches* but is shadowed by a higher-priority
-    ``effective_verdict`` (an ADR-027 pipeline modulation) or blocked by the
-    frozen-namespace verdict floor did not actually decide the change's
-    verdict, so it is not "the reclassifying rule" for disclosure purposes
-    even though :meth:`~abicheck.reclassify.ReclassifyRule.matches` would say
-    yes.
-
-    Used by ``reporter.py`` to stamp a per-change ``reclassified_by`` field
-    on the JSON report (Codex review: ``cli_pr_comment``'s
-    ``pr_comment._reclassified_count()`` only recognized the kind-global
-    ``policy_overrides`` map, so a PR comment silently omitted the
-    "reclassified by --policy-file" notice for a finding downgraded by a
-    selector-scoped ``reclassify:`` rule instead). Computing this from the
-    real ``Change`` object here -- rather than having ``pr_comment.py``
-    reimplement selector matching against the JSON report alone -- is
-    deliberate: a JSON-serialized change doesn't carry every selector field a
-    rule can match on (``type_pattern``/``member_name``/``namespace``/
-    ``entity_namespace``/``cause_namespace`` have no JSON counterpart), so a
-    JSON-only reimplementation could not be sound.
-
-    A matching rule whose ``to_verdict`` merely *restates* the verdict the
-    next-priority path (a same-kind ``overrides:`` entry, or the base policy)
-    would already have produced is a no-op, not a reclassification -- e.g.
-    ``func_removed: to: break`` under ``strict_abi``, where ``func_removed``
-    is already BREAKING (Codex review: a matching-but-no-op rule was still
-    stamping ``reclassified_by``, making the PR comment falsely report a
-    downgrade that never happened). Only a rule that actually *changes* the
-    verdict from what would apply in its absence counts as deciding it. That
-    comparison verdict is computed through the identical frozen-namespace
-    floor the ``overrides:`` branch below applies -- not the override's raw
-    value (Codex review, second round: a frozen-namespace finding with e.g.
-    ``overrides: func_removed: ignore`` plus ``reclassify: ... to: break``
-    would, absent the rule, already clamp back to BREAKING via the floor;
-    comparing against the raw COMPATIBLE override instead made the rule read
-    as deciding a verdict that was already going to be BREAKING anyway).
-    """
-    if isinstance(getattr(change, "effective_verdict", None), Verdict):
-        return None
-    rules = (
-        getattr(policy_file, "reclassify", None) if policy_file is not None else None
-    )
-    if not rules:
-        return None
-    base_policy = getattr(policy_file, "base_policy", None)
-    base_sets = _resolve_kind_sets(base_policy, None)
-    base_v = effective_category(change, *base_sets)
-    overrides = (
-        getattr(policy_file, "overrides", None) if policy_file is not None else None
-    )
-    kind = change.kind
-    # The verdict that would apply if *this* reclassify rule didn't exist --
-    # the next step down the same precedence chain effective_verdict_for_change
-    # walks (a same-kind overrides: entry, else the base policy's own
-    # verdict), with the identical frozen-namespace floor clamp the overrides:
-    # branch below applies -- so a rule that merely restates it is recognized
-    # as a no-op regardless of which of the two it happens to restate, and
-    # regardless of whether the floor would already have clamped it.
-    if overrides and kind in overrides:
-        override_v = cast(Verdict, overrides[kind])
-        if (
-            _has_frozen_namespace_violation(change)
-            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
-        ):
-            next_priority_v = base_v
-        else:
-            next_priority_v = override_v
-    else:
-        next_priority_v = base_v
-    for rule in rules:
-        if rule.matches(change, today):
-            reclass_v = rule.to_verdict
-            # The verdict this matching rule *actually* produces, applying
-            # the identical frozen-namespace floor
-            # effective_verdict_for_change's own reclassify branch applies:
-            # when reclass_v is blocked, that branch returns base_v directly
-            # -- it never falls through to consult overrides:, even though
-            # overrides: would have applied had no reclassify rule matched
-            # at all (Codex review, third round: a blocked rule was
-            # previously always read as a no-op, but the real effective
-            # verdict it produces -- base_v -- can still differ from
-            # next_priority_v, e.g. a global `overrides: ... to: break` with
-            # a frozen-namespace `reclassify: ... to: ignore` blocked back
-            # to a weaker base_v than the override would have given: the
-            # rule genuinely changed the outcome from what overrides: alone
-            # would have produced, just not to the verdict it asked for).
-            effective_v = (
-                base_v
-                if (
-                    _has_frozen_namespace_violation(change)
-                    and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
-                )
-                else reclass_v
-            )
-            if effective_v == next_priority_v:
-                return None
-            return rule
-    return None
 
 
 def _reclassify_resolved_to_compatible(

--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -43,6 +43,10 @@
       "may_import": [
         "model",
         "compare"
+      ],
+      "legacy_paths": [
+        "abicheck/severity.py",
+        "abicheck/analysis_assurance.py"
       ]
     },
     "workflows": {

--- a/changelog.d/20260826_adr061_phase2_policy_layer_classification.md
+++ b/changelog.d/20260826_adr061_phase2_policy_layer_classification.md
@@ -1,0 +1,18 @@
+### Changed
+
+- Closed ADR-061 Phase 2's `compare -> policy` dependency blocker, so
+  `severity.py` and `analysis_assurance.py` are now classified into the
+  `policy` responsibility layer in `architecture/modules.yaml` with
+  `check_architecture.py` reporting zero findings. Re-measuring the recorded
+  blocker found one real forbidden edge rather than the five it named —
+  `checker_types.py`'s function-local import of
+  `severity.effective_verdict_for_change`, which also closed the
+  `compare -> policy -> compare` cycle against `analysis_assurance.py`'s own
+  (allowed) import of `DiffResult`. That edge is removed by moving the shared
+  logic to a leaf both layers may depend on: `effective_verdict_for_change`,
+  `reclassify_rule_for_change`, and the `KindSets`/`resolve_kind_sets` pair
+  they share now live in `reclassify.py`, which already owned the
+  selector-scoped rules the resolver's precedence chain is built around.
+  Behavior is unchanged and no public name moved — `severity.py` re-exports
+  all three, and `DiffResult`'s `breaking`/`source_breaks`/`compatible`/
+  `risk` properties are untouched.

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -636,24 +636,58 @@ first non-JSON format to do so. Markdown's richer modes (`to_markdown`,
 this partial status must not be read as the phase acceptance criteria having
 been met.
 
-Known blocker for the remaining Markdown modes: their JSON counterparts
-(`full`/`leaf`/`root-cause`) build a severity-aware document by calling into
-`severity.py`/`analysis_assurance.py`, and `checker_types.py` (`DiffResult`'s
-own methods) and `checker.py` (`compare()`'s own orchestration) already call
-directly into those same modules — a real, pre-existing `compare -> policy`
-coupling `architecture/modules.yaml`'s dependency contract does not yet
-permit. Classifying `severity.py`/`analysis_assurance.py`/`contract_gating.py`
-as `policy` while `checker.py`/`checker_types.py` stay `compare` reproduces
-this edge as a `check_architecture.py` `dependency-direction`/
-`dependency-cycle` failure immediately (verified directly: adding both sides
-surfaces the cycle at `checker.py:1277`, `checker_types.py:36,713,737,749`).
-A physically migrated `report/`-package module touching any richer,
-severity-aware document shape hits the same wall the moment it imports
-`severity.py`. Resolving it needs `checker_types.py`'s
-`_effective_verdict_for_change`/`_evaluated_changes`/`not_evaluated` (and
-`checker.py`'s `compare()` call into `analysis_assurance.compute_
-analysis_assurance`) moved off `compare`'s core types — a real, scoped
-migration in its own right, not a follow-up edit to a reporting slice.
+**The `compare -> policy` blocker this section previously recorded is
+closed**, and how it was re-measured is worth keeping: the earlier note
+claimed classifying `severity.py`/`analysis_assurance.py`/`contract_gating.py`
+as `policy` "surfaces the cycle at `checker.py:1277`,
+`checker_types.py:36,713,737,749`". Re-running that experiment against the
+tree as it actually stood reproduced **one** edge, not five —
+`checker_types.py:713`'s function-local `from .severity import
+effective_verdict_for_change` — plus the `compare -> policy -> compare`
+cycle that single edge closes against `analysis_assurance.py`'s own
+(allowed) `policy -> compare` import of `DiffResult`. The other four cited
+positions never fired: `checker.py` is not classified at all, so its
+`compute_analysis_assurance` call is unchecked either way, and
+`checker_types.py`'s `contract_gating` imports are only a violation if
+`contract_gating.py` is itself classified `policy`, which the fix below
+deliberately declines to do. The lesson is the ordinary one — a blocker
+recorded once goes stale as the tree moves, so re-measure before scoping
+work against it.
+
+`severity.py` and `analysis_assurance.py` are now classified `policy` in
+`architecture/modules.yaml`, with `check_architecture.py` reporting zero
+findings. The one real edge was removed by extracting the shared logic to a
+leaf both sides may depend on — the same pattern Phase 3's own blocker note
+below names: `severity.py`'s `effective_verdict_for_change`, its disclosure
+sibling `reclassify_rule_for_change`, and the `KindSets`/`resolve_kind_sets`
+pair they share moved into `reclassify.py`, which already owned the
+selector-scoped rules that resolver's precedence chain is built around (and
+whose two mirrored implementations of that chain had already needed three
+separate review rounds to stop disagreeing). `severity.py` re-exports all
+three names, so `abicheck.severity.effective_verdict_for_change` and its
+siblings keep working unchanged for every caller in and out of this repo;
+`DiffResult`'s public `breaking`/`source_breaks`/`compatible`/`risk`
+properties are untouched.
+
+Two scope decisions are deliberate rather than oversights. `reclassify.py`
+stays **unclassified**: it is the leaf `compare`'s result type and `policy`'s
+severity/gating layer both depend on, and which layer finally owns it is
+decided by `checker_policy.py`'s own model-vs-policy split, not by this
+slice. `contract_gating.py` stays unclassified for the same reason — it is
+already documented as a leaf by construction, and `checker_types.py`'s
+`_evaluated_changes`/`not_evaluated` depend on it exactly as `severity.py`'s
+gate functions do.
+
+What this does **not** resolve: `DiffResult` still exposes policy-resolved
+verdict buckets from a `compare`-classified type, which is the underlying
+design tension rather than the import edge. Moving those properties off
+`DiffResult` outright would be a breaking change to the documented public
+Python API (`abicheck/CLAUDE.md`: "Changing their public surface is a
+breaking change to the Python API — coordinate it") across ~20 first-party
+modules and ~30 test modules, so it is not folded into a reporting slice.
+The same applies to `policy_file.py`, which `checker_types.py` imports at
+module scope: whichever layer eventually owns it has to answer the same
+question.
 
 1. Define immutable `ReportDocument` contracts from existing report-model
    behavior rather than inventing a second schema.


### PR DESCRIPTION
## Summary

Closes the `compare -> policy` dependency blocker ADR-061 Phase 2 recorded, so `severity.py` and `analysis_assurance.py` are now classified into the `policy` responsibility layer with `check_architecture.py` reporting zero findings.

## Motivation

ADR-061's Phase 2 status note recorded a blocker: classifying `severity.py`/`analysis_assurance.py`/`contract_gating.py` as `policy` "surfaces the cycle at `checker.py:1277`, `checker_types.py:36,713,737,749`". That blocker gates the remaining Phase 2 work (the richer Markdown/HTML/SARIF/JUnit modes crossing the `ReportDocument` boundary), because a physically migrated `report/`-package module hits the same wall the moment it imports `severity.py`.

**Re-measuring it against the tree as it actually stands reproduced one edge, not five.** The other four cited positions never fired:

- `checker.py` is not classified in `architecture/modules.yaml` at all, so its `compute_analysis_assurance` call is unchecked either way.
- `checker_types.py`'s `contract_gating` imports (lines 737/749) are only a violation if `contract_gating.py` is itself classified `policy` — which this change deliberately declines to do.
- Line 36 is the `contract_relevance_types` import, also unclassified.

What actually fires is `checker_types.py:713`'s function-local `from .severity import effective_verdict_for_change`, plus the `compare -> policy -> compare` cycle that single edge closes against `analysis_assurance.py`'s own (allowed) `policy -> compare` import of `DiffResult`. The general lesson is the ordinary one, and it's recorded in the ADR: a blocker measured once goes stale as the tree moves, so re-measure before scoping work against it.

## Changes

- **Extract the shared resolver to a leaf both layers may depend on** — the same pattern ADR-061's own Phase 3 blocker note names ("pull the shared logic out to a leaf both sides can depend on"). `severity.py`'s `effective_verdict_for_change`, its disclosure sibling `reclassify_rule_for_change`, and the `KindSets`/`resolve_kind_sets` pair they share move into `reclassify.py`, which already owned the selector-scoped rules that resolver's precedence chain is built around — and whose two mirrored implementations of that one precedence order had already needed three separate review rounds to stop disagreeing. Co-locating them puts both in one file.
- **No public name moved.** `severity.py` re-exports all three through the redundant-alias form the repo's `ruff.toml` is already configured for, so `abicheck.severity.effective_verdict_for_change` / `reclassify_rule_for_change` / `KindSets` keep working unchanged for every caller in and out of this repo. `DiffResult`'s public `breaking`/`source_breaks`/`compatible`/`risk` properties are untouched.
- **`checker_types.py` and `contract_scoped_promotion.py`** now import from `reclassify.py` rather than `severity.py` (same functions; `contract_scoped_promotion.py`'s use of `severity._VERDICT_ORDER` was a second, mypy-caught caller of the moved private).
- **`architecture/modules.yaml`**: `severity.py` and `analysis_assurance.py` join the `policy` layer's `legacy_paths`.
- **ADR-061 Phase 2 status note** rewritten: records the stale-measurement correction, the fix, the two deliberate scope decisions, and what this explicitly does *not* resolve.

### Two scope decisions, deliberate rather than oversights

`reclassify.py` stays **unclassified**: it is the leaf `compare`'s result type and `policy`'s severity/gating layer both depend on, and which layer finally owns it is decided by `checker_policy.py`'s own model-vs-policy split, not by this slice. `contract_gating.py` stays unclassified for the same reason — it is already documented as a leaf by construction, and `checker_types.py`'s `_evaluated_changes`/`not_evaluated` depend on it exactly as `severity.py`'s gate functions do.

### What this does not resolve

`DiffResult` still exposes policy-resolved verdict buckets from a `compare`-classified type, which is the underlying design tension rather than the import edge. Moving those properties off `DiffResult` outright would be a breaking change to the documented public Python API (`abicheck/CLAUDE.md`: "Changing their public surface is a breaking change to the Python API — coordinate it") across ~20 first-party modules and ~30 test modules, so it is not folded into this slice. The same question applies to `policy_file.py`, which `checker_types.py` imports at module scope.

## Checklist

- [x] Tests added / updated for new behaviour — this is a behaviour-preserving relocation with no new public surface; verified by the existing suites that exercise the moved code (8,084 tests across every `severity`/`policy`/`verdict`/`suppression`/`reclassify`/`report`/`contract`/`gate` module pass unchanged, including `test_effective_verdict.py`, `test_reclassify.py`, `test_frozen_namespace.py`, `test_report_integrity.py`, and `test_contract_authoritative_pipeline.py`)
- [x] Changelog fragment added (`changelog.d/20260826_adr061_phase2_policy_layer_classification.md`)
- [x] Docs updated (ADR-061's Phase 2 status note; `reclassify.py`'s module docstring records why the resolver lives there and what re-exports it)
- [x] `python scripts/check_architecture.py` (0 errors, with the new `policy` classification in place), `python scripts/check_ai_readiness.py` (0 errors), `python scripts/check_docs_contract.py` (0 errors), `mypy abicheck/`, and `ruff check abicheck/` all pass locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFyaqTr1FLG4hp34ub2fa2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFyaqTr1FLG4hp34ub2fa2)_