### PR TITLE
fix: resolve namespace-move cross-position ambiguity via global support

### DIFF
--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -930,60 +930,42 @@ def find_namespace_move_groups(
     same declaration under a new scope.
 
     Matching is on the *mangled* names' parsed scope chains
-    (:func:`_scope_components`), not on demangled text: the chain is exactly
-    the sequence of namespace/class components plus the leaf, with ctor/dtor
-    markers already normalized, so "differs in exactly one component" is a
-    statement about scoping rather than about string spelling.
-
-    A pair is recorded when the two chains have the same length, differ at
-    exactly one position, and that position is **not** the leaf — a differing
-    leaf is a renamed *declaration*, which is a different claim from a moved
-    scope and is what the prefix shape above is for. Pairs are grouped by the
-    ``(old_segment, new_segment)`` substitution they support, so unrelated
-    coincidental one-component differences never accumulate into one group;
-    the caller requires a group to have at least two supporting pairs before
-    reporting anything.
-
-    Deliberately *not* keyed on the position index as well: the same rename
-    of a namespace can legitimately show up at different depths (a nested
-    class in one symbol, a free function in another), and requiring an equal
-    index would split one real move into several under-supported groups.
+    (:func:`_scope_components`), not demangled text: the chain is exactly
+    the namespace/class components plus the leaf, ctor/dtor markers already
+    normalized, so "differs in exactly one component" is about scoping, not
+    string spelling. A pair is recorded when the two chains have the same
+    length, differ at exactly one position, and that position is **not**
+    the leaf (a differing leaf is a renamed *declaration* -- the prefix
+    shape above's job). Pairs are grouped by the ``(old_segment,
+    new_segment)`` substitution they support, so unrelated coincidental
+    one-component differences never accumulate into one group; the caller
+    requires 2+ supporting pairs before reporting anything. Deliberately
+    *not* keyed on position too: the same namespace rename can legitimately
+    show up at different depths, and requiring an equal index would split
+    one real move into several under-supported groups.
 
     Returns ``{(old_segment, new_segment): [(old_qualified, new_qualified)]}``
     with deterministic ordering (both sides iterated sorted).
 
     Known, accepted limitation (Codex review, fresh evidence): matching is
     on the *scope chain only* -- :func:`_scope_components` deliberately
-    discards a function's own parameter-type signature, since two overloads
-    of the same declaration share an identical scope chain and are not
-    "different declarations" for this detector's purpose. This means the
-    reciprocal many-to-one rejection above cannot distinguish a genuine
-    collision (two unrelated old namespaces both proposing themselves as
-    the source of the identical target, e.g. ``old1::f``/``old2::f`` both
-    matching a single ``new::f``) from a legitimate consolidation where two
-    old namespaces contribute *different overloads* of the same name to one
-    new namespace (``old1::f(int)``/``old2::f(double)`` both genuinely
-    moving into ``new::{f(int), f(double)}``) -- both shapes look identical
-    once the parameter types are stripped, so the rejection fires on the
-    overload-consolidation case too, even though the mangled symbols
-    themselves *do* carry the disambiguating parameter-type suffix that
-    would resolve it. This is not a new gap this function's many-to-one
-    check introduced: the whole primitive was already signature-blind
-    before that check existed (a pre-existing overload pair collapses to
-    one identical ``pair`` string via the same ``_scope_components`` chain,
-    and the pre-existing one-to-many check has the mirror-image blind spot
-    from the other side) -- the new check simply makes an already-ambiguous
-    shape resolve to REJECT (no roll-up; the individual
-    ``func_removed``/``func_added`` findings are still reported
-    individually) rather than to arbitrarily ACCEPT one specific pairing
-    that might be wrong, which is the same false-negative-over-false-
-    positive default this module's other ambiguity guards already use (see
-    the many-to-many/local-ambiguity comments above). A correct fix needs
-    real parameter-signature matching threaded through the whole primitive
-    (``_scope_components``, ``added_index``, candidate resolution, and the
-    ``(old_segment, new_segment)`` key itself) -- a genuine redesign of a
-    primitive several other things in this module already depend on being
-    signature-blind, not a scoped patch to the many-to-one check alone.
+    discards a function's own parameter-type signature, so two overloads of
+    the same declaration share an identical chain. The many-to-one
+    rejection above therefore can't distinguish a genuine collision (two
+    unrelated old namespaces both proposing themselves as the source of one
+    target) from a legitimate consolidation (two old namespaces
+    contributing *different overloads* of the same name to one new
+    namespace) -- both look identical once parameter types are stripped, so
+    the rejection fires on the overload case too, even though the mangled
+    symbols themselves carry the disambiguating suffix. Not a new gap: the
+    primitive was already signature-blind before this check existed; the
+    check just makes an already-ambiguous shape REJECT (individual
+    ``func_removed``/``func_added`` still reported) rather than arbitrarily
+    ACCEPT a pairing that might be wrong -- the same false-negative-over-
+    false-positive default this module's other guards use. A correct fix
+    needs real parameter-signature matching threaded through the whole
+    primitive (``_scope_components``, ``added_index``, candidate
+    resolution, the key itself) -- a genuine redesign, not a scoped patch.
     """
     added_index: dict[tuple[str, ...], list[tuple[str, list[str]]]] = {}
     for a_sym in sorted(added):
@@ -1184,6 +1166,20 @@ def find_namespace_move_groups(
     # emit_namespace_move_batches' threshold and reporting a false
     # BREAKING batch for what was really a single symbol).
     recorded_pairs: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    # Cross-position ambiguity (removed_id_to_added_symbols[symbol_id] > 1)
+    # need not be a dead end: one candidate key independently reused by a
+    # DIFFERENT removed symbol is real corroborating evidence the other
+    # candidate lacks (code-review item 6, "rank by global support"). Built
+    # from `entries` alone (never an already-resolved set) -- not circular;
+    # a genuine tie (both/neither corroborated) still rejects, preserving
+    # the pre-existing false-negative default.
+    symbol_to_keys: dict[str, set[tuple[str, str]]] = {}
+    key_support: dict[tuple[str, str], set[str]] = {}
+    for masked, r_comps, i, a_comps in entries:
+        sid = "::".join(r_comps)
+        k = (r_comps[i], a_comps[i])
+        symbol_to_keys.setdefault(sid, set()).add(k)
+        key_support.setdefault(k, set()).add(sid)
     for masked, r_comps, i, a_comps in entries:
         if len(masked_to_old_segments[masked]) != 1:
             continue
@@ -1191,9 +1187,13 @@ def find_namespace_move_groups(
         symbol_id = "::".join(r_comps)
         if len(added_id_to_removed_symbols[added_id]) != 1:
             continue
-        if len(removed_id_to_added_symbols[symbol_id]) != 1:
-            continue
         key = (r_comps[i], a_comps[i])
+        if len(removed_id_to_added_symbols[symbol_id]) != 1:
+            if not key_support[key] - {symbol_id}:
+                continue
+            other_keys = symbol_to_keys[symbol_id] - {key}
+            if any(key_support[ok] - {symbol_id} for ok in other_keys):
+                continue
         symbol_seen = seen_here.setdefault(symbol_id, set())
         if key in symbol_seen:
             continue

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -1043,6 +1043,13 @@ def find_namespace_move_groups(
     # function's own stated false-negative-over-false-positive default.
     added_id_to_removed_symbols: dict[str, set[str]] = {}
     removed_id_to_added_symbols: dict[str, set[str]] = {}
+    # Every raw (old_segment, new_segment) key a removed symbol could propose
+    # at ANY masking position, even one `distinct_targets` below locally
+    # rejects (so it never gets an `entries` row) -- the global tie-break
+    # further down still needs to see it, or a key only reachable through a
+    # locally-rejected position looks uncontested when another symbol's raw
+    # candidacy at that key would reveal a genuine tie (Codex review).
+    raw_symbol_keys: dict[str, set[tuple[str, str]]] = {}
     for r_sym in sorted(removed):
         r_resolved = _scope_components(r_sym)
         if r_resolved is None:
@@ -1064,6 +1071,9 @@ def find_namespace_move_groups(
                 cand_id = "::".join(cand_comps)
                 added_id_to_removed_symbols.setdefault(cand_id, set()).add(symbol_id)
                 removed_id_to_added_symbols.setdefault(symbol_id, set()).add(cand_id)
+                raw_symbol_keys.setdefault(symbol_id, set()).add(
+                    (r_comps[i], cand_comps[i])
+                )
             # Reject an AMBIGUOUS substitution at the source (Codex review,
             # fresh evidence): when the SAME masked context (this removed
             # symbol's scope chain with position `i` blanked out) matches
@@ -1106,44 +1116,23 @@ def find_namespace_move_groups(
             entries.append((masked, r_comps, i, a_comps))
 
     # `added_id_to_removed_symbols`/`removed_id_to_added_symbols` were
-    # already fully built above, alongside `entries` -- from every raw
-    # candidacy at every masking position, independent of whether that
-    # position's own local one-to-many check passed. See the comment on
-    # their declaration above for the full history of why this
-    # construction is the sound one: three review rounds each found a
-    # different way of scoping these two dicts to be unsound --
-    # building them only from `entries` (missing evidence discarded by the
-    # LOCAL one-to-many filter before it ever reached `entries`), filtering
-    # by `masked_to_old_segments` (preferring whichever of a removed
-    # symbol's two candidacies happened to be locally clean over one that's
-    # merely contested, when a collision proves the contested claimant
-    # unconfirmable, not the alternate explanation impossible) -- and the
-    # construction above, from every raw candidacy with no filtering at
-    # all, is what survived all three.
+    # already fully built above, from every raw candidacy at every masking
+    # position, independent of whether that position's own local
+    # one-to-many check passed (see their declaration above for the full
+    # history of why building them only from `entries`, or filtering by
+    # `masked_to_old_segments`, is unsound).
     #
     # `added_id_to_removed_symbols` answers: is this added declaration
     # claimed by more than one distinct removed identity, whether they
-    # collide at the SAME masking position (already caught by
-    # `masked_to_old_segments` above) or at DIFFERENT ones (e.g. removed
-    # `p1::old::{f,g}` and `new::p2::{f,g}` vs. added only
-    # `new::old::{f,g}` -- masking positions 0 and 1 respectively, masked
-    # contexts differ, so `masked_to_old_segments` alone sees no collision,
-    # yet the same added declaration cannot simultaneously be evidence for
-    # both `p1 -> new` and `p2 -> old`). Tracked by distinct CLAIMING
-    # REMOVED-SYMBOL IDENTITY, not by distinct substitution key text --
-    # removing `old::new::f` and `new::old::f` while adding only
-    # `new::new::f` has both claims spell the identical key `('old',
-    # 'new')`, so a key-text set would collapse them to size one even
-    # though they are two genuinely different removed originals.
+    # collide at the SAME masking position (`masked_to_old_segments` above)
+    # or at DIFFERENT ones. Tracked by distinct CLAIMING REMOVED-SYMBOL
+    # IDENTITY, not by substitution key text, since two different removed
+    # originals can spell the identical key.
     #
     # `removed_id_to_added_symbols` answers the symmetric question: does
     # this removed symbol resolve to more than one distinct added
-    # declaration across its masking positions -- e.g. removed
-    # `p1::old::{f,g}` with added `new::old::{f,g}` AND `p1::new::{f,g}`,
-    # where `p1::old::f` matches `new::old::f` (masking position 0,
-    # implying `p1 -> new`) and ALSO matches `p1::new::f` (masking
-    # position 1, implying `old -> new`) -- two mutually exclusive
-    # substitutions, both backed by the identical removed symbol.
+    # declaration across its masking positions -- two mutually exclusive
+    # substitutions backed by the identical removed symbol.
 
     # Phase 2: record only the entries whose masked context was claimed by
     # exactly one distinct old segment value (the position-scoped
@@ -1169,16 +1158,15 @@ def find_namespace_move_groups(
     # Cross-position ambiguity (removed_id_to_added_symbols[symbol_id] > 1)
     # need not be a dead end: one candidate key independently reused by a
     # DIFFERENT removed symbol is real corroborating evidence the other
-    # candidate lacks (code-review item 6, "rank by global support"). Built
-    # from `entries` alone (never an already-resolved set) -- not circular;
-    # a genuine tie (both/neither corroborated) still rejects, preserving
-    # the pre-existing false-negative default.
-    symbol_to_keys: dict[str, set[tuple[str, str]]] = {}
+    # candidate lacks (code-review item 6, "rank by global support"). Support
+    # is scored only from `entries` (locally-confirmed); the competing keys
+    # come from `raw_symbol_keys` instead, so a key raised at a
+    # locally-ambiguous position still counts as a competitor even without
+    # its own entry. A genuine tie (both/neither corroborated) still rejects.
     key_support: dict[tuple[str, str], set[str]] = {}
     for masked, r_comps, i, a_comps in entries:
         sid = "::".join(r_comps)
         k = (r_comps[i], a_comps[i])
-        symbol_to_keys.setdefault(sid, set()).add(k)
         key_support.setdefault(k, set()).add(sid)
     for masked, r_comps, i, a_comps in entries:
         if len(masked_to_old_segments[masked]) != 1:
@@ -1191,8 +1179,8 @@ def find_namespace_move_groups(
         if len(removed_id_to_added_symbols[symbol_id]) != 1:
             if not key_support[key] - {symbol_id}:
                 continue
-            other_keys = symbol_to_keys[symbol_id] - {key}
-            if any(key_support[ok] - {symbol_id} for ok in other_keys):
+            other_keys = raw_symbol_keys[symbol_id] - {key}
+            if any(key_support.get(ok, set()) - {symbol_id} for ok in other_keys):
                 continue
         symbol_seen = seen_here.setdefault(symbol_id, set())
         if key in symbol_seen:

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -1050,6 +1050,12 @@ def find_namespace_move_groups(
     # locally-rejected position looks uncontested when another symbol's raw
     # candidacy at that key would reveal a genuine tie (Codex review).
     raw_symbol_keys: dict[str, set[tuple[str, str]]] = {}
+    # A repeated bare segment can make two DIFFERENT added declarations
+    # collapse to the identical key for the SAME removed symbol (Codex
+    # review): removed "old::old::f" against added "new::old::f" (position
+    # 0) AND "old::new::f" (position 1) both key as ("old", "new") -- a
+    # shared key must not be treated as agreement. Keyed by (symbol_id, key), not merged into `raw_symbol_keys`, so a single-target key is unaffected.
+    raw_symbol_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
     for r_sym in sorted(removed):
         r_resolved = _scope_components(r_sym)
         if r_resolved is None:
@@ -1071,9 +1077,9 @@ def find_namespace_move_groups(
                 cand_id = "::".join(cand_comps)
                 added_id_to_removed_symbols.setdefault(cand_id, set()).add(symbol_id)
                 removed_id_to_added_symbols.setdefault(symbol_id, set()).add(cand_id)
-                raw_symbol_keys.setdefault(symbol_id, set()).add(
-                    (r_comps[i], cand_comps[i])
-                )
+                rkey = (r_comps[i], cand_comps[i])
+                raw_symbol_keys.setdefault(symbol_id, set()).add(rkey)
+                raw_symbol_key_targets.setdefault((symbol_id, rkey), set()).add(cand_id)
             # Reject an AMBIGUOUS substitution at the source (Codex review,
             # fresh evidence): when the SAME masked context (this removed
             # symbol's scope chain with position `i` blanked out) matches
@@ -1177,6 +1183,11 @@ def find_namespace_move_groups(
             continue
         key = (r_comps[i], a_comps[i])
         if len(removed_id_to_added_symbols[symbol_id]) != 1:
+            # This key itself may resolve to >1 distinct target for this
+            # symbol (see raw_symbol_key_targets's docstring) -- reject
+            # before considering corroboration.
+            if len(raw_symbol_key_targets[(symbol_id, key)]) != 1:
+                continue
             if not key_support[key] - {symbol_id}:
                 continue
             other_keys = raw_symbol_keys[symbol_id] - {key}

--- a/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
+++ b/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
@@ -28,3 +28,18 @@
   competing-keys set now comes from every raw candidacy a symbol proposed,
   not only the ones that produced their own resolved entry, so this case
   correctly rejects both competing candidates instead of admitting one.
+- **Second follow-up (Codex review): a repeated bare segment could make
+  two genuinely different added declarations key identically for the
+  same removed symbol, defeating the tie-break's own corroboration
+  check.** Removing `old::old::{f,g}` while adding both `new::old::{f,g}`
+  (a position-0 substitution) and `old::new::{f,g}` (a position-1
+  substitution) makes every removed symbol resolve to two distinct added
+  targets that both happen to key as the identical `(old, new)` text --
+  the corroboration check saw no *competing* key at all (both candidacies
+  share one key string) and let the first-seen candidacy through,
+  silently dropping the other target and fabricating a 2-pair
+  `SYMBOL_RENAMED_BATCH`. The tie-break now also checks, per symbol and
+  per key, whether that key itself resolves to more than one distinct
+  added declaration -- rejecting before corroboration is even
+  considered, since two different targets sharing identical key text
+  can never be told apart by which other symbol supports that text.

--- a/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
+++ b/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A real, multi-symbol namespace move could be silently reduced to
+  fewer supporting pairs than it actually had, sometimes dropping the
+  `SYMBOL_RENAMED_BATCH` roll-up finding entirely.**
+  `diff_symbols_renames.find_namespace_move_groups` rejects a removed
+  symbol's candidate rename target when it resolves ambiguously across
+  more than one masking position (a real, deliberate safety guard) --
+  but it rejected *every* such candidacy outright, even when one of the
+  competing substitutions was independently corroborated by a
+  *different* removed symbol proposing the identical
+  `(old_segment, new_segment)` move, while the other candidate had no
+  such corroboration at all. That corroboration is real evidence the
+  isolated, single-symbol view can't see: the ambiguity now resolves in
+  favor of the substitution other symbols also support, and only stays
+  rejected when the ambiguity is a genuine tie (both, or neither,
+  candidate independently corroborated) -- the same conservative
+  default the existing many-to-many and one-to-many guards already use
+  for a genuinely unresolvable case.

--- a/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
+++ b/changelog.d/20260826_namespace_move_cross_position_ambiguity.md
@@ -17,3 +17,14 @@
   candidate independently corroborated) -- the same conservative
   default the existing many-to-many and one-to-many guards already use
   for a genuinely unresolvable case.
+- **Follow-up (Codex review): a key a symbol raised at a locally-ambiguous
+  masking position was invisible to the same tie-break, so a genuine tie
+  could be missed.** The global-support check above only compared a
+  symbol's competing keys among the ones that had already survived the
+  *local* one-to-many filter -- but a key rejected by that local filter
+  (e.g. a masking position matching two distinct added symbols) can still
+  be independently, unambiguously corroborated by a *different* removed
+  symbol at that same key, which is real evidence of a genuine tie. The
+  competing-keys set now comes from every raw candidacy a symbol proposed,
+  not only the ones that produced their own resolved entry, so this case
+  correctly rejects both competing candidates instead of admitting one.

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -137,3 +137,27 @@ class TestCrossPositionAmbiguityResolvesViaGlobalSupport:
         assert groups.get(("P", "new")) == [("P::old::h", "new::old::h")]
         changes = emit_namespace_move_batches(groups)
         assert changes == []
+
+    def test_a_repeated_segment_producing_the_same_key_stays_ambiguous(self) -> None:
+        """Codex review (fresh evidence): removing ``old::old::{f,g}`` while
+        adding both ``new::old::{f,g}`` (position-0 substitution) and
+        ``old::new::{f,g}`` (position-1 substitution) makes every removed
+        symbol resolve to TWO distinct added declarations that both happen
+        to key as the identical ``(old, new)`` text -- the corroboration
+        check alone cannot tell them apart (both keys are literally the
+        same string), so the earlier fix's `other_keys` computation saw no
+        competing key at all and let the first-seen candidacy through,
+        silently dropping the other target. There is no way to tell
+        whether ``old::old`` moved to ``new::old`` or to ``old::new``, so
+        this must reject entirely -- not report either as a fabricated
+        2-pair batch."""
+        removed = {"_ZN3old3old1fEv", "_ZN3old3old1gEv"}
+        added = {
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1gEv",
+            "_ZN3old3new1fEv",
+            "_ZN3old3new1gEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert groups == {}
+        assert emit_namespace_move_batches(groups) == []

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""abicheck code-review report item 6: cross-position ambiguity in the
+namespace-move roll-up (``diff_symbols_renames.find_namespace_move_groups``)
+could silently drop a genuine, fully-supported namespace move to below its
+2+-pair reporting threshold, whenever one of its member symbols happened to
+also have an unrelated, coincidental candidacy at a different masking
+position.
+
+Kept in its own file (not ``tests/test_batch_rename_namespace_move.py``,
+which is an ADR-061 no-growth-baselined legacy module already at its
+line-budget cap) even though it tests the same function -- see that file's
+own extensive test suite for the pre-existing ambiguity-guard coverage this
+fix does not disturb (confirmed: its full 104-test suite passes unchanged
+alongside this fix).
+"""
+
+from __future__ import annotations
+
+from abicheck.checker_policy import ChangeKind
+from abicheck.diff_symbols_renames import (
+    emit_namespace_move_batches,
+    find_namespace_move_groups,
+)
+
+
+class TestCrossPositionAmbiguityResolvesViaGlobalSupport:
+    """A real, 2-pair namespace move (``P::old::{f,g}`` -> ``P::new::{f,g}``)
+    was silently reduced to a single pair -- dropping it below the
+    2+-pair threshold entirely -- whenever one of its symbols also had an
+    unrelated, coincidental candidacy at a DIFFERENT masking position.
+    Here ``P::old::f`` masked at position 0 (blanking ``P``) also matches
+    the unrelated addition ``Q::old::f``, making
+    ``removed_id_to_added_symbols["P::old::f"]`` size 2 -- genuinely
+    ambiguous in isolation. But the ``(old, new)`` substitution is
+    independently corroborated by ``P::old::g``, which has no competing
+    candidacy at all, while the competing key (from the ``Q::old::f``
+    match) has no support from any OTHER symbol -- so the ambiguity
+    resolves in favor of the corroborated key."""
+
+    def test_the_full_two_pair_move_is_recovered(self) -> None:
+        removed = {"_ZN1P3old1fEv", "_ZN1P3old1gEv"}
+        added = {"_ZN1P3new1fEv", "_ZN1P3new1gEv", "_ZN1Q3old1fEv"}
+        groups = find_namespace_move_groups(removed, added)
+        assert ("old", "new") in groups
+        assert len(groups[("old", "new")]) == 2
+        assert ("P::old::f", "P::new::f") in groups[("old", "new")]
+        assert ("P::old::g", "P::new::g") in groups[("old", "new")]
+
+    def test_a_real_batch_is_emitted_end_to_end(self) -> None:
+        changes = emit_namespace_move_batches(
+            find_namespace_move_groups(
+                {"_ZN1P3old1fEv", "_ZN1P3old1gEv"},
+                {"_ZN1P3new1fEv", "_ZN1P3new1gEv", "_ZN1Q3old1fEv"},
+            )
+        )
+        assert len(changes) == 1
+        assert changes[0].kind is ChangeKind.SYMBOL_RENAMED_BATCH
+
+    def test_a_genuine_tie_between_two_corroborated_keys_still_rejects(self) -> None:
+        """When BOTH of a symbol's competing keys are independently
+        corroborated by other symbols, there is no basis to prefer one --
+        the pre-existing, unresolvable-ambiguity behavior must still hold.
+        ``P::old::f`` is ambiguous between key ``(P, also)`` [masking
+        position 0, corroborated by ``P::old::h -> also::old::h``] and key
+        ``(old, new)`` [masking position 1, corroborated by
+        ``P::old::g -> P::new::g``] -- a genuine tie, not a one-sided
+        resolution."""
+        removed = {"_ZN1P3old1fEv", "_ZN1P3old1hEv", "_ZN1P3old1gEv"}
+        added = {
+            "_ZN4also3old1fEv",
+            "_ZN4also3old1hEv",
+            "_ZN1P3new1fEv",
+            "_ZN1P3new1gEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        # P::old::f's own contested pair never joins any group -- only the
+        # two OTHER symbols' independent, unambiguous single-pair
+        # candidacies form (single-pair groups, below the batch threshold,
+        # but real groups nonetheless -- see test_batch_rename_namespace_
+        # move.py's test_one_supporting_pair_is_not_a_batch for that
+        # threshold, which lives in emit_*, not here).
+        for pairs in groups.values():
+            assert ("P::old::f", "P::new::f") not in pairs
+            assert ("P::old::f", "also::old::f") not in pairs
+        assert groups.get(("old", "new")) == [("P::old::g", "P::new::g")]
+        assert groups.get(("P", "also")) == [("P::old::h", "also::old::h")]
+
+    def test_no_corroboration_at_all_still_rejects(self) -> None:
+        """A symbol ambiguous between two candidates, NEITHER of which any
+        other symbol supports, has nothing to resolve the tie with --
+        must stay rejected exactly as before this fix."""
+        removed = {"_ZN1P3old1fEv"}
+        added = {"_ZN1P3new1fEv", "_ZN1Q3old1fEv"}
+        groups = find_namespace_move_groups(removed, added)
+        assert groups == {}

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -107,3 +107,33 @@ class TestCrossPositionAmbiguityResolvesViaGlobalSupport:
         added = {"_ZN1P3new1fEv", "_ZN1Q3old1fEv"}
         groups = find_namespace_move_groups(removed, added)
         assert groups == {}
+
+    def test_a_locally_rejected_key_still_counts_as_a_competitor(self) -> None:
+        """Codex review (fresh evidence): ``f``'s own attempt at key
+        ``(P, new)`` is locally ambiguous (masking position 0 matches both
+        ``new::old::f`` and ``Q::old::f``) and so never gets its own
+        ``entries`` row -- but ``h`` independently and unambiguously
+        resolves that same key (``P::old::h`` -> ``new::old::h``), which is
+        real corroboration for it. ``f``'s OTHER candidacy, key
+        ``(old, new)`` at position 1, is independently corroborated by
+        ``g``. Both of f's competing keys are therefore corroborated by a
+        different symbol -- a genuine tie -- so f must be rejected from
+        BOTH groups, leaving each at a single supporting pair (below the
+        2+-pair batch threshold), not a false 2-pair
+        ``SYMBOL_RENAMED_BATCH``."""
+        removed = {"_ZN1P3old1fEv", "_ZN1P3old1gEv", "_ZN1P3old1hEv"}
+        added = {
+            "_ZN1P3new1fEv",
+            "_ZN1P3new1gEv",
+            "_ZN3new3old1fEv",
+            "_ZN3new3old1hEv",
+            "_ZN1Q3old1fEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        for pairs in groups.values():
+            assert ("P::old::f", "P::new::f") not in pairs
+            assert ("P::old::f", "new::old::f") not in pairs
+        assert groups.get(("old", "new")) == [("P::old::g", "P::new::g")]
+        assert groups.get(("P", "new")) == [("P::old::h", "new::old::h")]
+        changes = emit_namespace_move_batches(groups)
+        assert changes == []


### PR DESCRIPTION
## Summary

A genuine, multi-symbol namespace move could be silently reduced to
fewer supporting pairs than it actually had -- sometimes dropping the
`SYMBOL_RENAMED_BATCH` roll-up finding entirely -- whenever one of its
member symbols also had an unrelated, coincidental candidacy at a
different masking position.

## Motivation

Item 6 of the abicheck code-review report ("Namespace-move roll-up
drops true pairs on cross-position ambiguity"). Reproduced concretely:
a real 2-pair move (`P::old::{f,g}` -> `P::new::{f,g}`) reduces to a
1-pair group -- below `emit_namespace_move_batches`'s 2+-pair threshold,
so no batch is ever emitted for a real move -- whenever one member
symbol (`P::old::f`) also has an unrelated, coincidental candidacy at a
*different* masking position (matching an unrelated addition,
`Q::old::f`). `find_namespace_move_groups`'s existing cross-position
one-to-many guard (`removed_id_to_added_symbols[symbol_id] != 1`)
rejected `P::old::f`'s candidacy entirely, with no way to tell which
of its two competing targets was real.

But one of those two competing substitutions *is* independently
supported: `P::old::g` proposes the identical `(old, new)` key with no
ambiguity of its own, while the competing key from the `Q::old::f`
match has no support from any other symbol at all. That corroboration
is real evidence a purely local, single-symbol view can't see.

## Changes

- A new resolution pass in `find_namespace_move_groups`, built entirely
  from the same locally-clean `entries` list the existing guards
  already compute (never from an already-resolved set, so it cannot be
  circular): when a removed symbol's candidacy is ambiguous across
  masking positions, check whether exactly one of its competing keys
  is corroborated by a *different* symbol while none of its other
  candidate keys are. If so, keep that one; if it's a genuine tie
  (both/neither corroborated), reject as before -- the same
  false-negative-over-false-positive default this detector's other
  guards (many-to-many, one-to-many) already use for real,
  unresolvable ambiguity.
- All 104 pre-existing tests in `tests/test_batch_rename_namespace_move.py`
  pass unchanged, including the three-review-round-hardened
  many-to-many/reused-bare-segment-name/collateral-damage cases -- each
  is caught by the existing *local* per-position `distinct_targets`
  check, before this new cross-position resolution ever runs.
- New `tests/test_namespace_move_cross_position_ambiguity.py` (kept
  separate from `test_batch_rename_namespace_move.py`, an ADR-061
  no-growth-baselined file already at its line-budget cap).
- Changelog fragment (`changelog.d/20260826_namespace_move_cross_position_ambiguity.md`).

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A per-symbol ambiguity guard rejects a candidate rename
  pairing outright whenever it is locally ambiguous, even when a
  *different* symbol's own unambiguous evidence independently
  corroborates one of the competing candidates over the other(s) --
  discarding real, available evidence rather than using it.
- Publicly observable failure: `compare`/`scan` on two binaries where a
  namespace move genuinely happened silently omits the
  `SYMBOL_RENAMED_BATCH` roll-up finding (or under-counts its
  supporting pairs) whenever one moved symbol happens to also match an
  unrelated addition at a different scope-chain position -- the move is
  still detectable as individual `func_removed`/`func_added` pairs, but
  the correlating batch finding that ties them together as one event is
  lost.
- Regression test fails on base: Yes --
  `TestCrossPositionAmbiguityResolvesViaGlobalSupport::test_the_full_two_pair_move_is_recovered`
  and `test_a_real_batch_is_emitted_end_to_end` in
  `tests/test_namespace_move_cross_position_ambiguity.py` both fail
  against the pre-fix code (asserting 2 pairs / a real batch, and
  getting 1 pair / no batch); confirmed by reverting the fix locally
  and re-running.
- Negative control: `test_a_genuine_tie_between_two_corroborated_keys_still_rejects`
  (both competing keys independently corroborated -- no basis to
  prefer one, so the contested pair still joins no group) and
  `test_no_corroboration_at_all_still_rejects` (neither candidate
  corroborated -- nothing to resolve the tie with) both pass
  identically before and after this fix, confirming it introduces no
  new false positive. All 104 pre-existing tests in
  `test_batch_rename_namespace_move.py` -- including the dedicated
  many-to-many-ambiguity and reused-bare-segment-name regression tests
  from three prior review rounds -- pass unchanged.
- Public-surface test: Exercised through the real public functions,
  `find_namespace_move_groups` and `emit_namespace_move_batches`
  together, not only the internal resolution logic in isolation
  (`test_a_real_batch_is_emitted_end_to_end` confirms a real
  `SYMBOL_RENAMED_BATCH` `Change` is actually produced).
- Axes covered: Both the primitive-level grouping function and the
  emission function; the recovered-move case, the genuine-tie case, and
  the no-corroboration case, matching the three-way branch structure of
  the new resolution logic itself (corroborated-and-resolved,
  corroborated-both-ways-and-rejected, corroborated-neither-way-and-
  rejected).
- General invariant: For a removed symbol ambiguous across masking
  positions, `find_namespace_move_groups` resolves it to a specific
  candidate substitution if and only if exactly one of its competing
  substitution keys is independently supported by at least one
  *different* removed symbol's own (locally unambiguous) candidacy;
  otherwise the symbol's candidacy is rejected exactly as before this
  fix. No known unsupported cases beyond the pre-existing, separately
  documented "signature-blind matching" limitation this fix does not
  touch (see `find_namespace_move_groups`'s own docstring).
- Must-merge / must-not-merge pair:
  `test_the_full_two_pair_move_is_recovered` (must merge: `P::old::f`'s
  contested candidacy into the group its sibling `P::old::g` already
  supports) paired with
  `test_a_genuine_tie_between_two_corroborated_keys_still_rejects`
  (must NOT merge: `P::old::f`'s candidacy into either of two equally
  corroborated groups) -- exercising both directions of the identical
  resolution logic.

## Testing

- New `tests/test_namespace_move_cross_position_ambiguity.py` (4 tests).
- `pytest tests/test_namespace_move_cross_position_ambiguity.py
  tests/test_batch_rename_namespace_move.py tests/test_diff_symbols*.py`:
  211 passed.
- `ruff check` / `ruff format --check` / `mypy` clean on all touched files.
- `scripts/check_architecture.py` (ADR-061 no-growth debt gate) and
  `scripts/check_ai_readiness.py`: both clean.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [ ] Docs updated if user-visible behaviour changed — no user-facing doc describes the rename-detector's internal ambiguity resolution; none required
- [x] `pre-commit run --all-files` passes locally (ruff check / mypy on touched files)
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyPuuK9gg3EMgYcGMH3Fn9)_