### PR TITLE
fix: handle Click 8.5's widened is_flag sentinel default in CLI reference gen

### DIFF
--- a/changelog.d/20260826_click_8_5_sentinel_default.md
+++ b/changelog.d/20260826_click_8_5_sentinel_default.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`docs/reference/cli-reference.md`'s generator (`scripts/gen_cli_reference.py`)
+  mis-rendered every boolean flag's default as "—" under Click 8.5+.**
+  Click 8.5 widened its internal "no default was explicitly given"
+  sentinel to cover *every* `is_flag=True` option with no explicit
+  override, not just genuinely optionless ones (Click 8.4.2 reported a
+  concrete `False` for a plain flag's `.default`; Click 8.5.0 reports the
+  same internal sentinel Click already used for a truly-unset option). An
+  omitted flag still resolves to `False` at parse time either way, so
+  `_option_row` now treats a sentinel default as `False` specifically for
+  `is_flag` options, preserving the reference's existing distinction
+  between "a disabled-by-default flag" and "no default at all" instead of
+  collapsing every boolean flag into the latter the moment Click 8.5 is
+  installed.

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -121,6 +121,19 @@ def _option_row(param: Any) -> str:
     # behind the same "—" used for no-default-at-all would make a disabled-
     # by-default flag indistinguishable from one with no default.
     is_unset = type(default).__name__ == "Sentinel"
+    # Click 8.5 widened that same internal sentinel to *every* is_flag
+    # option with no explicit override, not just genuinely-optionless ones
+    # (verified: click 8.4.2 reports a concrete `False` for a plain
+    # `is_flag=True` option's `.default`; click 8.5.0 reports the sentinel
+    # for the identical option) -- an omitted flag still resolves to `False`
+    # at parse time either way (verified via CliRunner), so treating this
+    # case the same as "no default at all" would silently regress *every*
+    # boolean flag's committed default from `False` to "—" the moment the
+    # installed click crosses 8.5, defeating the whole point of the
+    # is-it-really-unset distinction this function exists to make.
+    if is_unset and getattr(param, "is_flag", False):
+        default = False
+        is_unset = False
     default_str = "—"
     if not is_unset and default is not None and default != ():
         default_str = f"`{_default_str(default)}`"

--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -155,3 +155,33 @@ def test_option_row_hides_click_internal_unset_sentinel():
     row = gen._option_row(_FakeParam())
     assert "Sentinel" not in row
     assert "| `--manifest` | no | — | Some help text. |" == row
+
+
+def test_option_row_renders_false_for_an_is_flag_sentinel_default():
+    """Click 8.5 widened the same internal "no default given" sentinel to
+    *every* `is_flag=True` option with no explicit override -- not just
+    genuinely optionless ones (click 8.4.2 reports a concrete `False` for
+    this exact param shape; click 8.5.0 reports the sentinel instead). An
+    omitted flag still resolves to `False` at parse time either way, so a
+    flag param must render `False`, not "—", even when its own `.default`
+    is the sentinel -- unlike a non-flag option (the sibling test above),
+    which correctly still hides a sentinel default behind "—"."""
+    gen = _load_gen()
+
+    class _FakeSentinel:
+        pass
+
+    _FakeSentinel.__name__ = "Sentinel"
+
+    class _FakeParam:
+        opts = ("--allow-unsupported-castxml",)
+        secondary_opts = ()
+        default = _FakeSentinel()
+        is_flag = True
+        required = False
+        help = "Proceed anyway."
+        type = None
+
+    row = gen._option_row(_FakeParam())
+    assert "Sentinel" not in row
+    assert "| `--allow-unsupported-castxml` | no | `False` | Proceed anyway. |" == row


### PR DESCRIPTION
## Summary

`scripts/gen_cli_reference.py` mis-rendered every boolean flag's default as "—" once Click 8.5 is installed, breaking `tests/test_cli_reference.py::test_generated_reference_is_in_sync_with_cli` on any environment that resolves `click>=8.5` (`pyproject.toml` pins `click>=8.0` with no ceiling). This is currently failing CI on several unrelated open PRs (#872, #873, #874) since Click 8.5.0 was just released to PyPI.

## Motivation

Click 8.5 widened its internal "no default was explicitly given" sentinel to cover *every* `is_flag=True` option with no explicit override, not just genuinely optionless ones — verified directly: Click 8.4.2 reports a concrete `False` for a plain flag's `.default`; Click 8.5.0 reports the same internal `Sentinel.UNSET` Click already used for a truly-unset option. An omitted flag still resolves to `False` at parse time either way (verified via `CliRunner`), so this silently regressed every boolean flag's rendered default in `docs/reference/cli-reference.md` from `` `False` `` to "—" the moment Click 8.5 is installed.

## Changes

- `_option_row` in `scripts/gen_cli_reference.py` now treats a sentinel default as `False` specifically for `is_flag` options, restoring the intended "real `False` default" vs. "genuinely no default" distinction regardless of installed Click version.
- Added `test_option_row_renders_false_for_an_is_flag_sentinel_default` in `tests/test_cli_reference.py`, confirmed to fail against the pre-fix code and pass post-fix.
- `docs/reference/cli-reference.md` regenerated (no content change — this environment already resolves Click 8.5.0, so the fix's output matches what was already committed).

## Bug-fix test contract

- Bug class: doc-generator misreading a third-party library's internal implementation detail (an unset-default sentinel) after an unpinned dependency's minor release changed what that detail means.
- Publicly observable failure: `docs/reference/cli-reference.md` shows "—" instead of `` `False` `` for every boolean CLI flag with no explicit `default=`, once Click 8.5+ is installed.
- Regression test fails on base: yes — `test_option_row_renders_false_for_an_is_flag_sentinel_default` fails against pre-fix `scripts/gen_cli_reference.py` with the exact "—" vs "`False`" mismatch.
- Negative control: `test_option_row_hides_click_internal_unset_sentinel` (a non-flag param with the same sentinel shape) is untouched and still passes — a genuinely optionless option still renders "—".
- Public-surface test: yes — exercises `gen._option_row`, the function `docs/reference/cli-reference.md` generation calls directly.
- Axes covered: is_flag + sentinel default (fixed), non-flag + sentinel default (already correct, pinned by the pre-existing negative control), is_flag + real `False` default (already correct, pre-existing test).
- General invariant: an omitted `is_flag` option's rendered default must always read `` `False` `` (its real runtime value when unspecified), independent of which internal representation the installed Click version uses for "not explicitly given".

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`changelog.d/20260826_click_8_5_sentinel_default.md`) — doesn't touch `abicheck/**/*.py` so the gate doesn't require one, but added for visibility
- [x] Docs updated (regenerated, no content diff in this environment)
- [x] `ruff check`/`ruff format --check`/`mypy` clean on touched files
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyPuuK9gg3EMgYcGMH3Fn9)_