### PR TITLE
fix: avoid crash indexing list-valued Change.old_value/new_value in cross-tier dedup

### DIFF
--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -1381,13 +1381,14 @@ def _dedup_cross_kind(
     requires the two findings' own old/new transitions to agree (see
     :func:`cross_tier_transition`) -- a mere kind+symbol match is not
     enough when the header and DWARF evidence disagree on the transition
-    itself, e.g. a stale header vs. inconsistent extractor evidence.
+    itself, e.g. a stale header vs. inconsistent extractor evidence. Only indexes the AST-tier kinds this dedup ever looks up (``_DWARF_TO_AST_EQUIV``'s values) -- indexing every kind unconditionally crashed on a kind (e.g. ``PYTHON_STABLE_ABI_VIOLATION``) whose ``old_value``/``new_value`` is a list, unhashable for the transition-agreement set below (Codex review).
     """
     names = record_names or {}
     _Transition = tuple[str | None, str | None] | None
     ast_findings: dict[tuple[str, str], set[_Transition]] = {}
     ast_field_findings: dict[tuple[str, str, str], set[_Transition]] = {}
-    for c in changes:
+    _relevant_ast = {ak for aks in _DWARF_TO_AST_EQUIV.values() for ak in aks}
+    for c in (c for c in changes if c.kind in _relevant_ast):
         canon = canonicalize_record_symbol(
             c.symbol, names, c.qualified_name, c.field_name
         )
@@ -1402,10 +1403,7 @@ def _dedup_cross_kind(
         transitions: set[_Transition] | None,
         dwarf_transition: _Transition,
     ) -> bool:
-        # None (no transitions recorded for a key never seen) -> not present.
-        # A None entry inside the set itself means "kind with no
-        # independent transition" (e.g. a removal) -- kind+symbol alone is
-        # agreement there, matching the pre-value-gate behavior.
+        # None (no transitions recorded for a key never seen) -> not present. A None entry inside the set itself means "kind with no independent transition" (e.g. a removal) -- kind+symbol alone is agreement there, matching the pre-value-gate behavior.
         if not transitions:
             return False
         return dwarf_transition is None or dwarf_transition in transitions

--- a/changelog.d/20260826_dedup_cross_kind_list_value_crash.md
+++ b/changelog.d/20260826_dedup_cross_kind_list_value_crash.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **`compare`/`scan` could crash with `TypeError: unhashable type: 'list'`
+  on a comparison containing a finding whose `Change.old_value`/`new_value`
+  is a list** (e.g. `PYTHON_STABLE_ABI_VIOLATION`, whose `new_value` is a
+  `list[str]` of offending imports, despite `Change`'s own declared
+  `old_value`/`new_value: str | None` type). `diff_filtering._dedup_cross_kind`
+  (the struct/type cross-tier dedup) indexed *every* change's
+  `cross_tier_transition()` into a `set`, regardless of kind, even though
+  only the AST-tier kinds named in `_DWARF_TO_AST_EQUIV`'s values are ever
+  looked up — a list is unhashable, so building the index crashed for any
+  comparison producing an unrelated finding of this shape. Now only
+  indexes the kinds this dedup actually queries.

--- a/tests/test_report_metadata.py
+++ b/tests/test_report_metadata.py
@@ -473,6 +473,28 @@ class TestDeduplication:
         result = _deduplicate_ast_dwarf(changes)
         assert len(result) == 1
 
+    def test_a_kind_carrying_list_valued_old_new_does_not_crash(self):
+        """Regression: `_dedup_cross_kind` used to index every change's
+        `cross_tier_transition()` unconditionally, including kinds outside
+        `_DWARF_TO_AST_EQUIV` entirely (e.g. `PYTHON_STABLE_ABI_VIOLATION`,
+        whose `new_value` is a `list[str]` despite `Change.old_value`/
+        `new_value`'s declared `str | None` type) -- a list is unhashable,
+        so building the lookup set raised `TypeError: unhashable type:
+        'list'` for any comparison containing such a finding. Only the
+        AST-tier kinds this dedup actually looks up need indexing at all."""
+        from abicheck.checker import _deduplicate_ast_dwarf
+
+        changes = [
+            Change(
+                ChangeKind.PYTHON_STABLE_ABI_VIOLATION,
+                "python:foo",
+                "Unstable ABI import",
+                new_value=["PyObject_Foo"],
+            ),
+        ]
+        result = _deduplicate_ast_dwarf(changes)
+        assert len(result) == 1
+
     def test_exact_dedup_same_kind(self):
         """Exact duplicates by (kind, description) are removed."""
         from abicheck.checker import _deduplicate_ast_dwarf


### PR DESCRIPTION
## Summary

`compare`/`scan` could crash with `TypeError: unhashable type: 'list'` on a comparison containing a finding whose `Change.old_value`/`new_value` is a list (e.g. `PYTHON_STABLE_ABI_VIOLATION`).

## Motivation

`diff_filtering._dedup_cross_kind` (the struct/type cross-tier dedup added in #873) indexes every `Change`'s `cross_tier_transition()` into a `set` unconditionally — even for kinds outside `_DWARF_TO_AST_EQUIV` entirely, which this dedup never looks up. `PYTHON_STABLE_ABI_VIOLATION`'s `new_value` is a `list[str]` of offending imports, despite `Change.old_value`/`new_value`'s declared `str | None` type (a pre-existing, if narrow, type-contract violation elsewhere in the codebase). A list is unhashable, so building the index raised `TypeError` for any comparison producing such a finding — confirmed live on `main` (`tests/test_python_ext.py` currently fails there with this exact traceback).

## Changes

- `_dedup_cross_kind` now only indexes the AST-tier kinds it actually queries (the values of `_DWARF_TO_AST_EQUIV`), instead of every kind unconditionally.
- Added `test_a_kind_carrying_list_valued_old_new_does_not_crash` in `tests/test_report_metadata.py`.
- Changelog fragment.

## Bug-fix test contract

- Bug class: an internal lookup index built unconditionally over every `Change`, including kinds whose value shape (a list) violates the assumption the index's key type requires (hashability).
- Publicly observable failure: `compare`/`scan` crashes with `TypeError: unhashable type: 'list'` instead of producing a report, whenever the comparison includes a `PYTHON_STABLE_ABI_VIOLATION` finding (or any other kind whose `old_value`/`new_value` happens to be a list).
- Regression test fails on base: yes — `test_a_kind_carrying_list_valued_old_new_does_not_crash` reproduces the exact crash against pre-fix `main` (confirmed via `git worktree` against `origin/main` directly, and via `tests/test_python_ext.py`'s own 9 pre-existing failures on `main`).
- Negative control: every kind already inside `_DWARF_TO_AST_EQUIV` (struct/type size, alignment, field kinds) is completely unaffected — the existing `tests/test_struct_cross_tier_dedup.py`/`tests/test_enum_cross_tier_dedup.py`/`tests/test_report_metadata.py` suites (214 tests) all still pass unchanged.
- Public-surface test: exercised through the real `_deduplicate_ast_dwarf` entry point, not the internal index directly.
- Axes covered: a list-valued kind outside the equivalence map (the crash case) and every kind inside it (the pre-existing, unaffected behavior).
- General invariant: `_dedup_cross_kind` never builds an index entry for a kind it will never query, so a kind's `old_value`/`new_value` shape can never affect an unrelated kind's dedup correctness or crash the whole comparison.
- Must-merge / must-not-merge pair: `test_struct_size_changed_across_both_tiers_collapses_to_one` (pre-existing, in `tests/test_struct_cross_tier_dedup.py`, unaffected by this fix — must still merge: a namespaced struct's DWARF- and header-tier size findings collapse to one) paired with the new `test_a_kind_carrying_list_valued_old_new_does_not_crash` (must NOT merge with anything, since `PYTHON_STABLE_ABI_VIOLATION` is outside `_DWARF_TO_AST_EQUIV` entirely — it now survives as its own single finding instead of crashing while trying to index it against unrelated kinds).
- False-positive removed / real break preserved: The false positive removed is the crash itself (an unrelated, list-valued finding aborting the whole comparison instead of being reported); no real break is at risk of being hidden by this fix, since it only *narrows which kinds get indexed for dedup* — it never suppresses or merges a finding that wasn't already being suppressed/merged before, confirmed by the unchanged 214-test pass count across `test_struct_cross_tier_dedup.py`/`test_enum_cross_tier_dedup.py`/`test_report_metadata.py`.

## Testing

- `pytest tests/test_python_ext.py tests/test_report_metadata.py tests/test_struct_cross_tier_dedup.py tests/test_enum_cross_tier_dedup.py`: 214 passed (was 9 failed on `main` for `test_python_ext.py` alone).
- Full fast unit suite: green (32232 passed, 0 failed).
- `ruff check` / `mypy` clean on all touched files.
- `scripts/check_architecture.py` (ADR-061 no-growth debt gate) and `scripts/check_ai_readiness.py`: both clean.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [ ] Docs updated if user-visible behaviour changed — no user-facing doc describes this internal dedup; none required
- [x] `ruff check`/`mypy` clean on touched files
- [x] No new `mypy` or `ruff` errors introduced