### PR TITLE
docs: confirm PR 3C's L4-extractor-default divergence with real castxml

### DIFF
--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -2169,13 +2169,22 @@ pipelines a fourth time.
   > around a resolve-time embed, and the still-unstarted third step —
   > actually migrating `dump_cmd`'s real ELF/PE/Mach-O execution onto
   > `execute_dump_request`. Of those two, only the migration step is blocked
-  > on an external dependency: castxml, still unavailable in every
-  > environment this work has been done in (item 2 of the 3A sub-section's
-  > own "What still blocks routing `dump_cmd`'s real run" note) — an
-  > implementer resuming this item should not read that as license to skip
-  > the reordering, which has no such external blocker and could be done
-  > independently. Items 2 (the L4 extractor default divergence) and 3 (the
-  > `-H` directory gap, below) are unchanged.
+  > on an external dependency: castxml, unavailable in every environment
+  > this work had been done in as of this note (item 2 of the 3A
+  > sub-section's own "What still blocks routing `dump_cmd`'s real run"
+  > note) — an implementer resuming this item should not read that as
+  > license to skip the reordering, which has no such external blocker and
+  > could be done independently. **Update (2026-08-27): the tooling half of
+  > this specific blocker is closed — see the 2026-08-27 item-2 note below,
+  > which obtained and verified a local, policy-compliant castxml. That
+  > note's own castxml install was used only to reproduce the already-known
+  > L4 extractor divergence (a narrower, already-scoped test run); "the
+  > migration itself" — this bullet's own byte-identical-output
+  > verification — was not attempted in that same session and remains open
+  > for exactly that reason: not for lack of castxml any more, but for lack
+  > of the work itself.** Items 2 (the L4 extractor default divergence) and
+  > 3 (the `-H` directory gap, below) are unchanged in substance, item 2's
+  > "unverifiable" framing corrected per its own note.
   >
   > **Investigated further (2026-08-27): the reordering is real work to
   > *verify*, and its depth-gate/provenance/dependency-scope half is now
@@ -2268,8 +2277,13 @@ pipelines a fourth time.
   > migrated pipeline (a real `perform_elf_dump` calling
   > `execute_dump_request` end to end, ADR-039 collector included) produces
   > output byte-identical to today's write-time-embed path under the
-  > *default* castxml backend — "the migration itself," and it remains
-  > exactly as blocked on castxml as this note already said.
+  > *default* castxml backend — "the migration itself." **No longer blocked
+  > on castxml being unavailable** (see the 2026-08-27 item-2 note below,
+  > which obtained one), but this exact byte-identical-output verification
+  > was not attempted with it — the castxml install that session was used
+  > only to reproduce the L4 extractor divergence, a different, narrower,
+  > already-scoped test run. This step stays open until someone actually
+  > runs it.
   >
   > **Item 2 (the L4 extractor default divergence) is now locally
   > reconfirmed under real castxml — but this is a reproduction of an
@@ -2332,13 +2346,17 @@ pipelines a fourth time.
   > production usage* half — the two xfail tests exercise one project shape
   > each, not the breadth "production usage" implies, and a default-changing
   > fix here is exactly the class of decision this file's own established
-  > pattern (see `AGENTS.md`'s "Known gaps" entries throughout this same
-  > code area) treats as needing explicit maintainer sign-off before
-  > landing, not something to flip as a side effect of narrating a plan
-  > document. Left as item 2, unchanged in substance, with its
-  > "unverifiable" framing corrected to "verified and reproduced, fix not
-  > yet attempted" so a future session does not have to redo the castxml
-  > acquisition to pick this up.
+  > "known gaps over risky reactive patches" convention (see this plan's own
+  > 2026-08-19 note above, and `AGENTS.md`'s "Known gaps" entries throughout
+  > this same code area) says belongs in its own dedicated, deliberately
+  > verified pass rather than a rushed follow-on to an investigation whose
+  > actual subject was the plan doc, not this call site — not a claim that
+  > any repository rule requires a maintainer's explicit sign-off before it
+  > can land (Codex review — an earlier revision of this note overstated
+  > that). Left as item 2, unchanged in substance, with its "unverifiable"
+  > framing corrected to "verified and reproduced, fix not yet attempted"
+  > so a future session does not have to redo the castxml acquisition to
+  > pick this up.
 
 `dump --build-query` and `dump --build-compile-db` describe how the *project*
 is built, not what this snapshot is. They are already documented as CLI

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -2271,24 +2271,35 @@ pipelines a fourth time.
   > *default* castxml backend — "the migration itself," and it remains
   > exactly as blocked on castxml as this note already said.
   >
-  > **Item 2 (the L4 extractor default divergence) is now empirically
-  > confirmed, not merely reasoned about — but deliberately still not fixed
-  > (2026-08-27).** Every prior note on this item said the divergence was
-  > "unverifiable without castxml" because no environment this work had been
-  > done in had one. That changed this session: a genuine, policy-compliant
-  > castxml (0.7.0, conda-forge, within `castxml_policy.py`'s
-  > `>=0.6.11,<0.8.0` range, bundled Clang 20) was obtained and installed —
-  > `.conda` files are zip archives around zstd-compressed tarballs, not
-  > tarballs themselves, and the extracted binary needs its `share/castxml/`
-  > resource tree alongside it at a real install prefix, not just the bare
-  > executable on `PATH` — and verified via
-  > `castxml_policy.evaluate_castxml_version()` returning `supported=True`.
-  > With it, `tests/test_dump_scan_l3_comparability.py`'s two
-  > `_SCAN_KNOWN_DIVERGENT_FRONTENDS = frozenset({"castxml"})` xfail cases
+  > **Item 2 (the L4 extractor default divergence) is now locally
+  > reconfirmed under real castxml — but this is a reproduction of an
+  > already-established fact, not its first verification, and deliberately
+  > still not fixed (2026-08-27, corrected same day — Codex review caught an
+  > earlier revision of this note overclaiming both halves of that
+  > sentence).** The divergence was already the *fact owner*'s own recorded
+  > finding, not new: `tests/test_dump_scan_l3_comparability.py`'s own
+  > docstring (added in an earlier commit, `2f1accaa`) already states that
+  > running its `scan`-comparison tests under castxml surfaced this exact
+  > divergence and pinned its signature as
+  > `_SCAN_KNOWN_DIVERGENT_FRONTENDS = frozenset({"castxml"})` — and
+  > `.github/workflows/ci.yml`'s `integration` lane already installs a real,
+  > policy-compliant castxml (`./.github/actions/setup-castxml`) and already
+  > runs this exact module there. So this was neither "unverifiable" nor
+  > "first-time" in any absolute sense; what this session's environment
+  > specifically lacked, and what genuinely changed, was a local castxml
+  > install to reproduce that CI-side finding without waiting on a CI run.
+  > A genuine, policy-compliant castxml (0.7.0, conda-forge, within
+  > `castxml_policy.py`'s `>=0.6.11,<0.8.0` range, bundled Clang 20) was
+  > obtained and installed in *this* environment — `.conda` files are zip
+  > archives around zstd-compressed tarballs, not tarballs themselves, and
+  > the extracted binary needs its `share/castxml/` resource tree alongside
+  > it at a real install prefix, not just the bare executable on `PATH` —
+  > and verified via `castxml_policy.evaluate_castxml_version()` returning
+  > `supported=True`. With it, the two already-pinned xfail cases
   > (`test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source`
   > and `test_scan_against_real_dump_baseline_matches_reported_cli_invocation`)
-  > were run for real for the first time and reproduce exactly the divergence
-  > their own long-standing module docstring already predicted: `scan`'s
+  > were reproduced locally, matching exactly the divergence their own
+  > long-standing module docstring already predicted: `scan`'s
   > candidate resolution uses `source_extractor="auto"` (`scan_engine.py`,
   > `_build_new_snapshot`), which `_make_source_extractor`
   > (`buildsource/inline.py`) resolves to clang, while `dump`/`compare` reach
@@ -2305,17 +2316,19 @@ pipelines a fourth time.
   > Deliberately **not** changed as part of confirming this: flipping
   > `scan_engine.py`'s `source_extractor="auto"` to
   > `effective_frontend(compile_context, header_backend)` (or an equivalent
-  > shared resolver — `buildsource/source_extractors.py` already has one,
-  > `resolve_source_extractor`, independent of `_make_source_extractor`,
-  > worth checking for reuse before hand-rolling a call site) would make
+  > shared resolver — `abicheck/buildsource/source_extractors/` already has
+  > one, `resolve_source_extractor` in its `resolver.py` (re-exported by the
+  > package's `__init__.py`), independent of `_make_source_extractor`, worth
+  > checking for reuse before hand-rolling a call site) would make
   > `scan --depth source` require castxml at its defaults for every user who
   > doesn't already have one installed — that line's own existing comment
   > already names this precisely: "a real behaviour change for real users...
   > unverifiable without a castxml-capable lane," calling for "its own
   > dedicated verification against real castxml/clang divergence in
   > production usage, not a side effect of hardening this module's test
-  > coverage." Having castxml available for the first time closes the
-  > *unverifiable* half of that sentence, not the *dedicated verification in
+  > coverage." Having a local castxml install closes the *unverifiable*
+  > half of that sentence for this environment (CI's own `integration` lane
+  > already had it, per above), not the *dedicated verification in
   > production usage* half — the two xfail tests exercise one project shape
   > each, not the breadth "production usage" implies, and a default-changing
   > fix here is exactly the class of decision this file's own established

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -2125,9 +2125,10 @@ pipelines a fourth time.
   > 2. **The L4 extractor default still diverges** between `scan` (clang, via
   >    `embed_build_source`'s `"auto"`) and `dump`/`compare` (castxml, via
   >    `effective_frontend`). Removing the flags does not cause this, but it
-  >    is a live "two interpreters of one config" instance, and it remains
-  >    unverifiable without castxml — re-checked and still absent in the
-  >    2026-08-21 environment.
+  >    is a live "two interpreters of one config" instance. **No longer
+  >    "unverifiable without castxml"** — see the 2026-08-27 note below this
+  >    block, which obtained a real one and reproduced the divergence
+  >    directly; the fix itself is still not attempted, deliberately.
   > 3. **Prerequisite 3's own remaining `-H`-directory gap**, below, is
   >    unchanged.
   >
@@ -2269,6 +2270,62 @@ pipelines a fourth time.
   > output byte-identical to today's write-time-embed path under the
   > *default* castxml backend — "the migration itself," and it remains
   > exactly as blocked on castxml as this note already said.
+  >
+  > **Item 2 (the L4 extractor default divergence) is now empirically
+  > confirmed, not merely reasoned about — but deliberately still not fixed
+  > (2026-08-27).** Every prior note on this item said the divergence was
+  > "unverifiable without castxml" because no environment this work had been
+  > done in had one. That changed this session: a genuine, policy-compliant
+  > castxml (0.7.0, conda-forge, within `castxml_policy.py`'s
+  > `>=0.6.11,<0.8.0` range, bundled Clang 20) was obtained and installed —
+  > `.conda` files are zip archives around zstd-compressed tarballs, not
+  > tarballs themselves, and the extracted binary needs its `share/castxml/`
+  > resource tree alongside it at a real install prefix, not just the bare
+  > executable on `PATH` — and verified via
+  > `castxml_policy.evaluate_castxml_version()` returning `supported=True`.
+  > With it, `tests/test_dump_scan_l3_comparability.py`'s two
+  > `_SCAN_KNOWN_DIVERGENT_FRONTENDS = frozenset({"castxml"})` xfail cases
+  > (`test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source`
+  > and `test_scan_against_real_dump_baseline_matches_reported_cli_invocation`)
+  > were run for real for the first time and reproduce exactly the divergence
+  > their own long-standing module docstring already predicted: `scan`'s
+  > candidate resolution uses `source_extractor="auto"` (`scan_engine.py`,
+  > `_build_new_snapshot`), which `_make_source_extractor`
+  > (`buildsource/inline.py`) resolves to clang, while `dump`/`compare` reach
+  > `effective_frontend(...)` (`service_compare_evidence.py`), which resolves
+  > `"auto"` through `dumper._resolve_header_backend` to castxml
+  > unconditionally (no clang fallback). The rest of the `integration`-marked
+  > suite for this area — `test_dump_cli_typed_api_parity.py`,
+  > `test_dump_scan_l3_comparability.py`'s non-xfailed cases,
+  > `test_dump_write_after_resolve_time_embed.py`,
+  > `test_dump_embed_idempotence.py` — is 23 passed / 9 deselected / 2 xfailed
+  > under real castxml, i.e. this is the *only* known divergence this suite
+  > can currently see.
+  >
+  > Deliberately **not** changed as part of confirming this: flipping
+  > `scan_engine.py`'s `source_extractor="auto"` to
+  > `effective_frontend(compile_context, header_backend)` (or an equivalent
+  > shared resolver — `buildsource/source_extractors.py` already has one,
+  > `resolve_source_extractor`, independent of `_make_source_extractor`,
+  > worth checking for reuse before hand-rolling a call site) would make
+  > `scan --depth source` require castxml at its defaults for every user who
+  > doesn't already have one installed — that line's own existing comment
+  > already names this precisely: "a real behaviour change for real users...
+  > unverifiable without a castxml-capable lane," calling for "its own
+  > dedicated verification against real castxml/clang divergence in
+  > production usage, not a side effect of hardening this module's test
+  > coverage." Having castxml available for the first time closes the
+  > *unverifiable* half of that sentence, not the *dedicated verification in
+  > production usage* half — the two xfail tests exercise one project shape
+  > each, not the breadth "production usage" implies, and a default-changing
+  > fix here is exactly the class of decision this file's own established
+  > pattern (see `AGENTS.md`'s "Known gaps" entries throughout this same
+  > code area) treats as needing explicit maintainer sign-off before
+  > landing, not something to flip as a side effect of narrating a plan
+  > document. Left as item 2, unchanged in substance, with its
+  > "unverifiable" framing corrected to "verified and reproduced, fix not
+  > yet attempted" so a future session does not have to redo the castxml
+  > acquisition to pick this up.
 
 `dump --build-query` and `dump --build-compile-db` describe how the *project*
 is built, not what this snapshot is. They are already documented as CLI


### PR DESCRIPTION
## Summary

Continuing work on `docs/contribute/plans/cli-cleanup-phase-two.md` (PR F / PR 3C — removing `dump --build-query`/`dump --build-compile-db`).

`tests/test_dump_scan_l3_comparability.py`'s own docstring already recorded that `scan`'s L4 source-ABI replay diverges from `dump`/`compare`'s under real castxml (`scan` hardcodes `source_extractor="auto"`, which resolves to clang; `dump`/`compare` resolve `"auto"` through `effective_frontend`/`_resolve_header_backend` to castxml unconditionally), and `.github/workflows/ci.yml`'s `integration` lane already installs castxml and runs this module. What this session's environment specifically lacked was a local castxml install to reproduce that CI-side finding directly. A genuine, policy-compliant castxml (0.7.0, conda-forge, within `castxml_policy.py`'s `>=0.6.11,<0.8.0` range) was obtained and installed here, and used to locally reproduce the two already-pinned xfail tests (`_SCAN_KNOWN_DIVERGENT_FRONTENDS = frozenset({"castxml"})`), confirming the divergence exactly as documented.

This closes the "unverifiable without castxml" half of PR 3C's blocking item 2 *for this environment*, not the blocker itself — flipping `scan`'s default L4 extractor is a real behaviour change for every user without castxml installed, and this codebase's well-established "known gaps over risky reactive patches" convention (see `AGENTS.md`'s "Known gaps" section, and this plan's own prior notes) treats a change like that as needing its own dedicated, deliberately verified pass — not something to fold in as a side effect of narrating the plan doc. So the fix itself is deliberately left unattempted here.

## Changes

- Updated `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3C status notes:
  - Item 2's bullet now says the divergence is locally reconfirmed rather than "unverifiable."
  - Added a dated (2026-08-27) status note recording the castxml acquisition, the exact test IDs reproduced, the full test-suite result under real castxml (23 passed / 9 deselected / 2 xfailed), and why the fix itself is not attempted in this change.
  - Corrected two review-caught inaccuracies from an earlier revision of this same note (both fixed in follow-up commits): an overclaimed "first ever verification" chronology (it wasn't — see above), and stale text elsewhere in the same section that still said the dump-migration verification was blocked on castxml being unavailable.

No `abicheck/**/*.py` changes, so no changelog fragment is needed.

## Verification

- `python scripts/check_docs_contract.py` — 0 errors, 2 pre-existing unrelated warnings.
- `ruff check` on the touched file — clean (no Python content).
- Two rounds of Codex review findings addressed, replied to, and resolved.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
