### PR TITLE
refactor(adr-061): classify remaining parser modules as extract

### DIFF
--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1665,8 +1665,7 @@ def compare_release_cmd(
                 # Resolved here, not in the leaf write_bundle_facts_out() (see its docstring).
                 def _resolve_stranded_library(old_path: Path) -> AbiSnapshot:
                     from .cli_resolve import _resolve_input
-                    from .elf_metadata import parse_elf_metadata
-                    from .workflows.extraction import split_public_header_inputs
+                    from .workflows import extraction
 
                     old_dbg = (
                         resolve_debug_info(old_path, old_debug_dir)
@@ -1675,7 +1674,7 @@ def compare_release_cmd(
                     )
                     # old_h doubles as the public-header set, matching the
                     # normal compare path (else origin=UNKNOWN; Codex review).
-                    pub_headers, pub_dirs = split_public_header_inputs(old_h)
+                    pub_headers, pub_dirs = extraction.split_public_header_inputs(old_h)
                     try:
                         return _resolve_input(
                             old_path,
@@ -1695,7 +1694,7 @@ def compare_release_cmd(
                         return AbiSnapshot(
                             library=old_path.name,
                             version="",
-                            elf=parse_elf_metadata(old_path),
+                            elf=extraction.parse_elf_metadata(old_path),
                         )
 
                 write_bundle_facts_out(

--- a/abicheck/cli_datasources.py
+++ b/abicheck/cli_datasources.py
@@ -33,7 +33,7 @@ def print_data_sources(
 
     if binary_fmt == "elf":
         from .dwarf_unified import parse_dwarf
-        from .elf_metadata import parse_elf_metadata
+        from .workflows.extraction import parse_elf_metadata
 
         elf_meta = parse_elf_metadata(normalized_path)
         dwarf_meta, _ = parse_dwarf(normalized_path)

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -607,7 +607,7 @@ def _add_dump_data_layers(
         dwarf_meta = None
         if binary_fmt == "elf":
             from .dwarf_unified import parse_dwarf
-            from .elf_metadata import parse_elf_metadata
+            from .workflows.extraction import parse_elf_metadata
 
             elf_meta = parse_elf_metadata(normalized_path)
             dwarf_meta, _ = parse_dwarf(normalized_path)
@@ -1456,7 +1456,7 @@ def perform_elf_dump(
         # cycle) and a no-op for ordinary libraries. `compare` also derives it on
         # load as a backstop for snapshots written without it.
         if snap.python_ext is None:
-            from .python_ext import detect_python_extension
+            from .workflows.extraction import detect_python_extension
 
             snap.python_ext = detect_python_extension(snap)
 
@@ -1465,7 +1465,7 @@ def perform_elf_dump(
         # `import`s — the surface the C-ABI export view cannot see. A no-op when no
         # stub is found alongside the binary.
         if snap.python_api is None:
-            from .python_api import detect_python_api
+            from .workflows.extraction import detect_python_api
 
             snap.python_api = detect_python_api(snap)
 
@@ -1477,7 +1477,7 @@ def perform_elf_dump(
         # later `compare` on the written JSON stays silently disabled (Codex
         # review).
         if snap.numpy_capi is None:
-            from .numpy_capi import extract_numpy_capi_surface
+            from .workflows.extraction import extract_numpy_capi_surface
 
             snap.numpy_capi = extract_numpy_capi_surface(so_path)
 

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -127,7 +127,7 @@ def _sniff_text_format(path: Path) -> str:
         return "perl"
     if head.startswith("{"):
         return "json"
-    from .symvers_metadata import looks_like_symvers
+    from .workflows.extraction import looks_like_symvers
 
     return "symvers" if looks_like_symvers(head) else "unknown"
 

--- a/abicheck/workflows/extraction.py
+++ b/abicheck/workflows/extraction.py
@@ -71,6 +71,7 @@ from ..debug_resolver import DebugArtifact, resolve_debug_info
 from ..dump_manifest import DumpManifest, load_manifest
 from ..dumper_clang import resolve_source_frontend_clang_bin
 from ..dumper_scoping import dump_manifest_header_roots, resolve_dependency_scope
+from ..elf_metadata import parse_elf_metadata
 from ..header_conditionals import attach_build_context_for_parsed_headers
 from ..header_utils import (
     dedup_paths_preserve_order,
@@ -80,6 +81,10 @@ from ..header_utils import (
     resolve_inferred_header_roots,
     split_public_header_inputs,
 )
+from ..numpy_capi import extract_numpy_capi_surface
+from ..python_api import detect_python_api
+from ..python_ext import detect_python_extension
+from ..symvers_metadata import looks_like_symvers
 
 __all__ = [
     "BuildConfig",
@@ -94,9 +99,12 @@ __all__ = [
     "dedup_paths_preserve_order",
     "deferred_token_dirs",
     "detect_binary_format",
+    "detect_python_api",
+    "detect_python_extension",
     "discover_build_config",
     "dump_manifest_header_roots",
     "embed_build_source",
+    "extract_numpy_capi_surface",
     "has_explicit_std",
     "include_operand_dirs",
     "ingest_inputs_pack",
@@ -107,7 +115,9 @@ __all__ = [
     "load_build_config",
     "load_inputs_manifest",
     "load_manifest",
+    "looks_like_symvers",
     "normalize_binary_input",
+    "parse_elf_metadata",
     "resolve_debug_info",
     "resolve_dependency_scope",
     "resolve_inferred_header_roots",

--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -13,6 +13,7 @@
       "legacy_paths": [
         "abicheck/buildsource/model.py",
         "abicheck/buildsource/pack.py",
+        "abicheck/buildsource/scan_levels.py",
         "abicheck/change_registry_types.py",
         "abicheck/checker_types.py",
         "abicheck/compile_context.py",
@@ -35,6 +36,7 @@
       "legacy_paths": [
         "abicheck/_compiler_options.py",
         "abicheck/binary_utils.py",
+        "abicheck/build_mode.py",
         "abicheck/buildsource/embed.py",
         "abicheck/buildsource/inline.py",
         "abicheck/buildsource/inputs_pack.py",
@@ -44,8 +46,18 @@
         "abicheck/dump_manifest.py",
         "abicheck/dumper_clang.py",
         "abicheck/dumper_scoping.py",
+        "abicheck/dwarf_advanced.py",
+        "abicheck/dwarf_metadata.py",
+        "abicheck/elf_metadata.py",
         "abicheck/header_conditionals.py",
-        "abicheck/header_utils.py"
+        "abicheck/header_utils.py",
+        "abicheck/macho_metadata.py",
+        "abicheck/numpy_capi.py",
+        "abicheck/pe_metadata.py",
+        "abicheck/python_api.py",
+        "abicheck/python_ext.py",
+        "abicheck/symvers_metadata.py",
+        "abicheck/sycl_metadata.py"
       ]
     },
     "compare": {

--- a/changelog.d/1787866151_claude_adr061-extract-classification.md
+++ b/changelog.d/1787866151_claude_adr061-extract-classification.md
@@ -1,0 +1,22 @@
+### Changed
+
+- **The eleven remaining flat metadata-parser modules are now classified
+  `extract`** (ADR-061): `elf_metadata.py`, `pe_metadata.py`, `macho_metadata.py`,
+  `dwarf_metadata.py`, `dwarf_advanced.py`, `sycl_metadata.py`,
+  `symvers_metadata.py`, `python_api.py`, `python_ext.py`, `numpy_capi.py`,
+  `build_mode.py`. Classifying them surfaced seven real `frontends -> extract`
+  edges (`cli_compare_release.py`, `cli_datasources.py`, `cli_dump_helpers.py`
+  x4, `cli_resolve.py`) reaching a parser module directly rather than through
+  the engine; each now goes through `abicheck.workflows.extraction`, which
+  already owns this re-export role for the sibling extraction helpers.
+  `abicheck.buildsource.scan_levels` (the `scan` depth/mode/source-method
+  resolver — pure enums and functions over them, no first-party imports) is
+  now classified `model` for the same reason.
+
+### Notes
+
+- The same "patch where the call actually resolves" gotcha `workflows`
+  re-export modules already carry applies here too: a test patching
+  `abicheck.python_ext.detect_python_extension` no longer reaches
+  `cli_dump_helpers.perform_elf_dump`, which now calls it through
+  `abicheck.workflows.extraction` — patch the re-export module instead.

--- a/tests/test_cli_dump_helpers_coverage.py
+++ b/tests/test_cli_dump_helpers_coverage.py
@@ -1578,7 +1578,7 @@ def test_perform_elf_dump_cleans_up_when_enrichment_raises_before_header_graph(
         fake_seed_and_fold,
     )
     monkeypatch.setattr("abicheck.cli_dump_helpers.dump", fake_dump)
-    monkeypatch.setattr("abicheck.python_ext.detect_python_extension", _raise_ext)
+    monkeypatch.setattr("abicheck.workflows.extraction.detect_python_extension", _raise_ext)
     monkeypatch.setattr("abicheck.service._attach_header_graph", fake_attach)
 
     _events, _stamp, _write, _expand, _populate = _elf_dump_callables()
@@ -1660,13 +1660,13 @@ def test_perform_elf_dump_detects_python_surfaces_and_follow_deps(
     api_sentinel = object()
     numpy_sentinel = object()
     monkeypatch.setattr(
-        "abicheck.python_ext.detect_python_extension", lambda _s: ext_sentinel
+        "abicheck.workflows.extraction.detect_python_extension", lambda _s: ext_sentinel
     )
     monkeypatch.setattr(
-        "abicheck.python_api.detect_python_api", lambda _s: api_sentinel
+        "abicheck.workflows.extraction.detect_python_api", lambda _s: api_sentinel
     )
     monkeypatch.setattr(
-        "abicheck.numpy_capi.extract_numpy_capi_surface", lambda _p: numpy_sentinel
+        "abicheck.workflows.extraction.extract_numpy_capi_surface", lambda _p: numpy_sentinel
     )
 
     events, _stamp, _write, _expand, _populate = _elf_dump_callables()
@@ -1736,9 +1736,9 @@ def test_perform_elf_dump_preserves_existing_python_metadata(
     def _boom(_s):  # noqa: ANN001, ANN202
         raise AssertionError("detection must not run when metadata is present")
 
-    monkeypatch.setattr("abicheck.python_ext.detect_python_extension", _boom)
-    monkeypatch.setattr("abicheck.python_api.detect_python_api", _boom)
-    monkeypatch.setattr("abicheck.numpy_capi.extract_numpy_capi_surface", _boom)
+    monkeypatch.setattr("abicheck.workflows.extraction.detect_python_extension", _boom)
+    monkeypatch.setattr("abicheck.workflows.extraction.detect_python_api", _boom)
+    monkeypatch.setattr("abicheck.workflows.extraction.extract_numpy_capi_surface", _boom)
 
     events, _stamp, _write, _expand, _populate = _elf_dump_callables()
 


### PR DESCRIPTION
## Summary

Permanently classifies the eleven flat metadata-parser modules Phase 5's `*_metadata.py` split left unclassified as `extract`, fixes the 7 real `frontends -> extract` violations that surfaces, and classifies `buildsource/scan_levels.py` as `model`.

## Motivation

ADR-061's Phase 4 section had already measured this exact slice as a temporary experiment: temporarily classifying `elf_metadata.py`, `pe_metadata.py`, `macho_metadata.py`, `dwarf_metadata.py`, `dwarf_advanced.py`, `sycl_metadata.py`, `symvers_metadata.py`, `python_api.py`, `python_ext.py`, `numpy_capi.py`, `build_mode.py` as `extract` and re-running `check_architecture.py` produced 7 findings, all `frontends -> extract`, with exact file:line citations. This PR makes that classification permanent and closes the 7 findings for real, plus a second, independently-scoped win: `buildsource/scan_levels.py` (confirmed stdlib-only imports — pure enums and functions over them) classified `model`, the same shape already used for `evidence_depth.py`.

## Changes

- `architecture/modules.yaml`: the 11 parser modules added to `extract`'s `legacy_paths`; `buildsource/scan_levels.py` added to `model`'s.
- `abicheck/workflows/extraction.py`: re-exports `parse_elf_metadata`, `detect_python_extension`, `detect_python_api`, `extract_numpy_capi_surface`, `looks_like_symvers` — the same "one owner per operation" re-export role this module already documents for its sibling extraction helpers.
- `cli_compare_release.py`, `cli_datasources.py`, `cli_dump_helpers.py` (×3), `cli_resolve.py`: each of the 7 real violation sites now imports through `abicheck.workflows.extraction` instead of the parser module directly.
- `tests/test_cli_dump_helpers_coverage.py`: fixed three `monkeypatch.setattr` targets that patched the parser module directly (e.g. `abicheck.python_ext.detect_python_extension`) — since `perform_elf_dump` now imports these through `workflows.extraction`, the patch no longer reached the real call site. Two of the three were silently defeated (the assertion on the mocked return value was checking against a value that was never actually returned, because the *real* function ran instead); the third (a "detection must not run when metadata already present" guard) was silently unprotected. This is the same gotcha `workflows/extraction.py`'s own docstring already documents: "a test that needs to substitute one of these must patch it *here*, where the call actually resolves."

## Verification

- `python scripts/check_architecture.py` → 0 errors
- `python scripts/check_ai_readiness.py` → 0 errors, same warning count as base
- `python scripts/adr_status_sync.py` → clean
- `pytest -k "compare_release or datasources or dump_helpers or cli_resolve or extraction"` → 409 passed
- `pytest tests/test_cli_dump_helpers_coverage.py tests/test_architecture_check.py` → 85 passed
- Full fast unit suite run in progress at push time; will report/fix if it surfaces anything beyond the above.

## Checklist

- [x] Tests added / updated for new behaviour — fixed 3 stale monkeypatch targets that were silently no-ops
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — n/a, no user-visible behavior change
- [x] `pre-commit run --all-files` passes locally (architecture + ai-readiness gates checked directly)
- [x] No new `mypy` or `ruff` errors introduced (checked the 5 touched source files directly; the only `mypy` output is the repo's pre-existing 17 `yaml`-stub errors, unaffected by this change)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tong8fcUn1FAXt44xK321

---
_Generated by [Claude Code](https://claude.ai/code/session_011tong8fcUn1FAXt44xK321)_