### PR TITLE
test: add python-api/CLI-level compression round trip at scale (Phase 7)

### DIFF
--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -460,17 +460,22 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "never approach the boundary being defended."
         ),
         fixed_by=(699, 721),
-        seed_tests=("tests/test_snapshot_compression.py",),
+        seed_tests=(
+            "tests/test_snapshot_compression.py",
+            "tests/test_snapshot_compression_public_api_scale.py",
+        ),
+        public_surfaces=("python-api", "cli"),
         axes={"algorithm": ("zstd", "gzip")},
         known_gaps=(
             KnownGap(
                 description=(
-                    "The seed test calls `abicheck.serialization`/"
-                    "`abicheck.snapshot_io`'s real read/write chokepoints "
-                    "directly (real gzip/zstd, real scale) but never "
-                    "through `abicheck.service`/the CLI — no python-api "
-                    "or CLI-level round-trip test exists for this class "
-                    "yet."
+                    "No archive/bundle-reader (`snapshot_cache.py`, "
+                    "the G40 bundle-facts archive path) or python-api/"
+                    "CLI-level round trip has yet been generalized to "
+                    "the same production scale for a mixed-container "
+                    "payload — only the flat AbiSnapshot storage "
+                    "envelope has a scale-realistic seed test at every "
+                    "layer."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md#phase-7",
             ),

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -459,7 +459,7 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "highly-compressible fixture whose actual required parameters "
             "never approach the boundary being defended."
         ),
-        fixed_by=(699, 721),
+        fixed_by=(699, 721, 911),
         seed_tests=(
             "tests/test_snapshot_compression.py",
             "tests/test_snapshot_compression_public_api_scale.py",

--- a/tests/test_snapshot_compression_public_api_scale.py
+++ b/tests/test_snapshot_compression_public_api_scale.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public-API/CLI-level compression round-trip coverage at production scale
+(bug-class-regression-testing.md Phase 7).
+
+Split out of ``test_snapshot_compression.py`` (already at that file's own
+1500-line AI-readiness soft cap) rather than grown in place -- reuses
+``_graph_heavy_snapshot`` from there, the same fixture builder
+``test_zstd_round_trip_at_production_scale_and_level``/
+``test_gzip_round_trip_at_production_scale`` already use to produce a real,
+>8 MiB serialized snapshot (the threshold where zstd's auto-selected window
+actually reproduces the real oneDAL-scale ADR-059 §12 regression, rather
+than collapsing to the content size the way a toy-scale fixture would).
+
+Those two existing tests are real and already go through the true public
+entry point *one layer down* -- ``abicheck.snapshot_io.write_snapshot_bytes``/
+``read_snapshot_bytes``, exactly what ``dump``/``compare`` call internally --
+but stop there. The registered gap this file closes
+(``tests/regressions/manifest.py``'s ``storage.third_party_contract_at_scale``
+``BugClass``) is one layer higher still: no test previously went through
+``abicheck.serialization.save_snapshot``/``load_snapshot`` (the public
+Python API a caller of this library actually uses) or through the real
+``compare`` CLI command, at this same realistic scale, for either supported
+algorithm. A bug reintroduced above ``write_snapshot_bytes`` itself --
+e.g. ``save_snapshot``'s compression-from-suffix resolution
+(``resolve_write_compression``), or ``service.py``'s ``sniff_text_format``/
+``resolve_input`` dispatch a live ``compare`` invocation goes through --
+would not be caught by either existing test, since neither one is ever
+routed through those functions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from test_snapshot_compression import _graph_heavy_snapshot
+
+from abicheck.cli import main
+from abicheck.serialization import load_snapshot, save_snapshot, snapshot_to_dict
+from abicheck.snapshot_io import SnapshotCompression, detect_snapshot_compression
+
+
+def _production_scale_bytes(snap) -> int:
+    """Sanity-checks and returns the serialized size, matching the >8 MiB
+    threshold the sibling module's own production-scale tests assert --
+    the point past which zstd's auto-selected window stops collapsing to
+    the content size and actually reproduces the real ADR-059 §12 shape."""
+    size = len(json.dumps(snapshot_to_dict(snap)).encode())
+    assert size > 8 * 1024 * 1024
+    return size
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param(".abicheck.json.zst", id="zstd"),
+        pytest.param(".abicheck.json.gz", id="gzip"),
+    ],
+)
+def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
+    """``abicheck.serialization.save_snapshot``/``load_snapshot`` -- the
+    public Python API layer ``dump``'s/``compare``'s implicit-dump operand
+    actually call, one layer above ``write_snapshot_bytes``/
+    ``read_snapshot_bytes`` -- round-trip a real, production-scale snapshot
+    losslessly, for both supported compression algorithms.
+
+    ``suffix`` alone selects the algorithm via ``save_snapshot``'s default
+    ``compression="auto"`` (``resolve_write_compression``, ADR-059 Section
+    3.5) -- exactly how a real caller picks compression, by filename, not by
+    passing an explicit ``SnapshotCompression`` the way the sibling
+    module's lower-level tests do.
+    """
+    zstandard = pytest.importorskip("zstandard")
+
+    original = _graph_heavy_snapshot(n=8600)
+    _production_scale_bytes(original)
+
+    p = tmp_path / f"production_scale{suffix}"
+    save_snapshot(original, p)
+
+    expected_compression = (
+        SnapshotCompression.ZSTD
+        if suffix.endswith(".zst")
+        else SnapshotCompression.GZIP
+    )
+    assert detect_snapshot_compression(p) is expected_compression
+    if expected_compression is SnapshotCompression.ZSTD:
+        # Same auto-selected-window sanity check the sibling module's own
+        # zstd production-scale test performs, confirming this really is
+        # the realistic (not toy-collapsed) frame shape.
+        frame = zstandard.get_frame_parameters(p.read_bytes())
+        assert frame.window_size == 8 * 1024 * 1024
+
+    reloaded = load_snapshot(p)
+    # A full dataclass round trip -- not merely "it loaded without raising".
+    assert reloaded == original
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param(".abicheck.json.zst", id="zstd"),
+        pytest.param(".abicheck.json.gz", id="gzip"),
+    ],
+)
+def test_compare_cli_round_trips_a_compressed_snapshot_at_production_scale(
+    tmp_path, suffix
+):
+    """The real ``compare`` CLI command -- ``service.resolve_input``'s
+    JSON-format dispatch (``sniff_text_format`` -> ``load_snapshot``, see
+    ``service.py``) -- reads a production-scale, genuinely compressed
+    snapshot file operand losslessly and reports it as unchanged against
+    itself, with no compiler/castxml/binary toolchain involved (both
+    operands are plain snapshot files, exactly the established pattern in
+    ``tests/test_build_source_cli.py::test_compare_without_evidence_is_
+    unchanged``).
+
+    This is the CLI-level half of the same registered gap the sibling test
+    above closes at the Python-API level -- a regression anywhere in
+    ``sniff_text_format``'s bounded-prefix compression sniff, or in
+    ``resolve_input``'s JSON-format branch, would show up here even if
+    ``save_snapshot``/``load_snapshot`` themselves stayed correct.
+    """
+    pytest.importorskip("zstandard")
+
+    snap = _graph_heavy_snapshot(n=8600)
+    _production_scale_bytes(snap)
+
+    p = tmp_path / f"production_scale{suffix}"
+    save_snapshot(snap, p)
+
+    result = CliRunner().invoke(main, ["compare", str(p), str(p)])
+    assert result.exit_code == 0, result.output

--- a/tests/test_snapshot_compression_public_api_scale.py
+++ b/tests/test_snapshot_compression_public_api_scale.py
@@ -29,16 +29,34 @@ entry point *one layer down* -- ``abicheck.snapshot_io.write_snapshot_bytes``/
 ``read_snapshot_bytes``, exactly what ``dump``/``compare`` call internally --
 but stop there. The registered gap this file closes
 (``tests/regressions/manifest.py``'s ``storage.third_party_contract_at_scale``
-``BugClass``) is one layer higher still: no test previously went through
-``abicheck.serialization.save_snapshot``/``load_snapshot`` (the public
-Python API a caller of this library actually uses) or through the real
-``compare`` CLI command, at this same realistic scale, for either supported
-algorithm. A bug reintroduced above ``write_snapshot_bytes`` itself --
-e.g. ``save_snapshot``'s compression-from-suffix resolution
+``BugClass``) is one layer higher still. Two genuinely distinct public
+surfaces, each earning its own ``public_surfaces`` tag in that registry entry
+(see that field's own docstring: ``"python-api"`` requires a call through
+``abicheck.service``, not merely ``abicheck.serialization``):
+
+- ``abicheck.serialization.save_snapshot``/``load_snapshot`` -- the plain
+  Python compatibility surface a caller of this library uses directly.
+- ``abicheck.service.resolve_input`` -- the actual ``abicheck.service`` typed
+  entry point ``dump``'s/``compare``'s implicit-dump operand call, which
+  dispatches a JSON-format input to ``load_snapshot`` internally
+  (``sniff_text_format`` -> ``load_snapshot``, see ``service.py``).
+- The real ``compare`` CLI command, which itself calls ``resolve_input``.
+
+A bug reintroduced above ``write_snapshot_bytes`` itself -- e.g.
+``save_snapshot``'s compression-from-suffix resolution
 (``resolve_write_compression``), or ``service.py``'s ``sniff_text_format``/
-``resolve_input`` dispatch a live ``compare`` invocation goes through --
-would not be caught by either existing test, since neither one is ever
-routed through those functions.
+``resolve_input`` dispatch -- would not be caught by either of the two
+existing lower-level tests, since neither is ever routed through those
+functions.
+
+Every round trip here proves *lossless, correct* decoding, not merely "it
+didn't raise": the two Python-level tests assert full dataclass equality
+against the original in-memory snapshot, and the CLI test diffs two
+genuinely distinct (not self-identical) production-scale operands and
+asserts the CLI's own JSON output names the exact one expected finding --
+comparing a compressed file against itself would pass even if the CLI
+silently returned the same truncated/default snapshot for both operands
+(Codex review, PR #911), which this design rules out.
 """
 
 from __future__ import annotations
@@ -50,8 +68,13 @@ from click.testing import CliRunner
 from test_snapshot_compression import _graph_heavy_snapshot
 
 from abicheck.cli import main
+from abicheck.model import Function, Visibility
 from abicheck.serialization import load_snapshot, save_snapshot, snapshot_to_dict
+from abicheck.service import resolve_input
 from abicheck.snapshot_io import SnapshotCompression, detect_snapshot_compression
+
+_MARKER_NAME = "brand_new_marker_fn"
+_MARKER_MANGLED = "_Z20brand_new_marker_fnv"
 
 
 def _production_scale_bytes(snap) -> int:
@@ -64,6 +87,22 @@ def _production_scale_bytes(snap) -> int:
     return size
 
 
+def _assert_realistic_zstd_window(zstandard, p) -> None:
+    """Same auto-selected-window sanity check the sibling module's own
+    zstd production-scale test performs, confirming this really is the
+    realistic (not toy-collapsed) frame shape."""
+    frame = zstandard.get_frame_parameters(p.read_bytes())
+    assert frame.window_size == 8 * 1024 * 1024
+
+
+def _compression_for_suffix(suffix: str) -> SnapshotCompression:
+    return (
+        SnapshotCompression.ZSTD
+        if suffix.endswith(".zst")
+        else SnapshotCompression.GZIP
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "suffix",
@@ -74,10 +113,8 @@ def _production_scale_bytes(snap) -> int:
 )
 def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
     """``abicheck.serialization.save_snapshot``/``load_snapshot`` -- the
-    public Python API layer ``dump``'s/``compare``'s implicit-dump operand
-    actually call, one layer above ``write_snapshot_bytes``/
-    ``read_snapshot_bytes`` -- round-trip a real, production-scale snapshot
-    losslessly, for both supported compression algorithms.
+    public Python compatibility surface -- round-trip a real, production-
+    scale snapshot losslessly, for both supported compression algorithms.
 
     ``suffix`` alone selects the algorithm via ``save_snapshot``'s default
     ``compression="auto"`` (``resolve_write_compression``, ADR-059 Section
@@ -93,18 +130,10 @@ def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
     p = tmp_path / f"production_scale{suffix}"
     save_snapshot(original, p)
 
-    expected_compression = (
-        SnapshotCompression.ZSTD
-        if suffix.endswith(".zst")
-        else SnapshotCompression.GZIP
-    )
+    expected_compression = _compression_for_suffix(suffix)
     assert detect_snapshot_compression(p) is expected_compression
     if expected_compression is SnapshotCompression.ZSTD:
-        # Same auto-selected-window sanity check the sibling module's own
-        # zstd production-scale test performs, confirming this really is
-        # the realistic (not toy-collapsed) frame shape.
-        frame = zstandard.get_frame_parameters(p.read_bytes())
-        assert frame.window_size == 8 * 1024 * 1024
+        _assert_realistic_zstd_window(zstandard, p)
 
     reloaded = load_snapshot(p)
     # A full dataclass round trip -- not merely "it loaded without raising".
@@ -119,31 +148,86 @@ def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
         pytest.param(".abicheck.json.gz", id="gzip"),
     ],
 )
-def test_compare_cli_round_trips_a_compressed_snapshot_at_production_scale(
+def test_service_resolve_input_round_trips_a_compressed_snapshot_at_production_scale(
     tmp_path, suffix
 ):
+    """``abicheck.service.resolve_input`` -- the documented ``python-api``
+    entry point (``AGENTS.md``'s ``public_surfaces`` convention requires a
+    call through ``abicheck.service``, not only ``abicheck.serialization``)
+    -- reads a production-scale, genuinely compressed snapshot file
+    losslessly, via its JSON-format dispatch branch (``sniff_text_format``
+    detects the compression from a bounded decoded prefix, then delegates
+    to ``load_snapshot``).
+    """
+    zstandard = pytest.importorskip("zstandard")
+
+    original = _graph_heavy_snapshot(n=8600)
+    _production_scale_bytes(original)
+
+    p = tmp_path / f"production_scale{suffix}"
+    save_snapshot(original, p)
+
+    if _compression_for_suffix(suffix) is SnapshotCompression.ZSTD:
+        _assert_realistic_zstd_window(zstandard, p)
+
+    reloaded = resolve_input(p)
+    assert reloaded == original
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param(".abicheck.json.zst", id="zstd"),
+        pytest.param(".abicheck.json.gz", id="gzip"),
+    ],
+)
+def test_compare_cli_diffs_compressed_snapshots_at_production_scale(tmp_path, suffix):
     """The real ``compare`` CLI command -- ``service.resolve_input``'s
-    JSON-format dispatch (``sniff_text_format`` -> ``load_snapshot``, see
-    ``service.py``) -- reads a production-scale, genuinely compressed
-    snapshot file operand losslessly and reports it as unchanged against
-    itself, with no compiler/castxml/binary toolchain involved (both
-    operands are plain snapshot files, exactly the established pattern in
+    JSON-format dispatch (``sniff_text_format`` -> ``load_snapshot``) --
+    reads two production-scale, genuinely compressed snapshot file operands
+    losslessly and correctly identifies the *one* real difference between
+    them, with no compiler/castxml/binary toolchain involved (both operands
+    are plain snapshot files, the established pattern in
     ``tests/test_build_source_cli.py::test_compare_without_evidence_is_
     unchanged``).
 
-    This is the CLI-level half of the same registered gap the sibling test
-    above closes at the Python-API level -- a regression anywhere in
-    ``sniff_text_format``'s bounded-prefix compression sniff, or in
-    ``resolve_input``'s JSON-format branch, would show up here even if
-    ``save_snapshot``/``load_snapshot`` themselves stayed correct.
+    Deliberately does NOT compare a compressed file against itself: doing so
+    would pass even if the CLI path silently decoded both operands to the
+    same truncated or default snapshot, which would not support the claim
+    that the CLI reads the real content losslessly (Codex review, PR #911).
+    Instead, ``new`` is ``old`` plus exactly one added public function
+    (``_MARKER_MANGLED``) buried among ~8600 other functions/types -- the
+    CLI's own JSON output must name that one finding and no other, which
+    only holds if the full, real (not truncated/replaced) content of both
+    multi-megabyte compressed operands was decoded and diffed correctly.
     """
     pytest.importorskip("zstandard")
 
-    snap = _graph_heavy_snapshot(n=8600)
-    _production_scale_bytes(snap)
+    old_snap = _graph_heavy_snapshot(n=8600)
+    _production_scale_bytes(old_snap)
 
-    p = tmp_path / f"production_scale{suffix}"
-    save_snapshot(snap, p)
+    new_snap = _graph_heavy_snapshot(n=8600)
+    new_snap.functions.append(
+        Function(
+            name=_MARKER_NAME,
+            mangled=_MARKER_MANGLED,
+            return_type="void",
+            visibility=Visibility.PUBLIC,
+        )
+    )
 
-    result = CliRunner().invoke(main, ["compare", str(p), str(p)])
-    assert result.exit_code == 0, result.output
+    old_p = tmp_path / f"old{suffix}"
+    new_p = tmp_path / f"new{suffix}"
+    save_snapshot(old_snap, old_p)
+    save_snapshot(new_snap, new_p)
+
+    result = CliRunner().invoke(
+        main, ["compare", str(old_p), str(new_p), "--format", "json"]
+    )
+    assert result.exit_code in (0, 2, 4), result.output
+    payload = json.loads(result.stdout)
+    changes = payload["changes"]
+    assert [(c["kind"], c["symbol"]) for c in changes] == [
+        ("func_added", _MARKER_MANGLED)
+    ]

--- a/tests/test_snapshot_compression_public_api_scale.py
+++ b/tests/test_snapshot_compression_public_api_scale.py
@@ -121,8 +121,17 @@ def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
     3.5) -- exactly how a real caller picks compression, by filename, not by
     passing an explicit ``SnapshotCompression`` the way the sibling
     module's lower-level tests do.
+
+    ``zstandard`` is only ever imported for the zstd case -- the gzip case
+    must not be skipped just because that optional dependency is absent
+    (CodeRabbit review, PR #911).
     """
-    zstandard = pytest.importorskip("zstandard")
+    expected_compression = _compression_for_suffix(suffix)
+    zstandard = (
+        pytest.importorskip("zstandard")
+        if expected_compression is SnapshotCompression.ZSTD
+        else None
+    )
 
     original = _graph_heavy_snapshot(n=8600)
     _production_scale_bytes(original)
@@ -130,9 +139,8 @@ def test_save_load_snapshot_round_trips_at_production_scale(tmp_path, suffix):
     p = tmp_path / f"production_scale{suffix}"
     save_snapshot(original, p)
 
-    expected_compression = _compression_for_suffix(suffix)
     assert detect_snapshot_compression(p) is expected_compression
-    if expected_compression is SnapshotCompression.ZSTD:
+    if zstandard is not None:
         _assert_realistic_zstd_window(zstandard, p)
 
     reloaded = load_snapshot(p)
@@ -158,8 +166,13 @@ def test_service_resolve_input_round_trips_a_compressed_snapshot_at_production_s
     losslessly, via its JSON-format dispatch branch (``sniff_text_format``
     detects the compression from a bounded decoded prefix, then delegates
     to ``load_snapshot``).
+
+    ``zstandard`` is only ever imported for the zstd case -- the gzip case
+    must not be skipped just because that optional dependency is absent
+    (CodeRabbit review, PR #911).
     """
-    zstandard = pytest.importorskip("zstandard")
+    is_zstd = _compression_for_suffix(suffix) is SnapshotCompression.ZSTD
+    zstandard = pytest.importorskip("zstandard") if is_zstd else None
 
     original = _graph_heavy_snapshot(n=8600)
     _production_scale_bytes(original)
@@ -167,7 +180,7 @@ def test_service_resolve_input_round_trips_a_compressed_snapshot_at_production_s
     p = tmp_path / f"production_scale{suffix}"
     save_snapshot(original, p)
 
-    if _compression_for_suffix(suffix) is SnapshotCompression.ZSTD:
+    if zstandard is not None:
         _assert_realistic_zstd_window(zstandard, p)
 
     reloaded = resolve_input(p)
@@ -201,8 +214,13 @@ def test_compare_cli_diffs_compressed_snapshots_at_production_scale(tmp_path, su
     CLI's own JSON output must name that one finding and no other, which
     only holds if the full, real (not truncated/replaced) content of both
     multi-megabyte compressed operands was decoded and diffed correctly.
+
+    ``zstandard`` is only ever required for the zstd case -- the gzip case
+    must not be skipped just because that optional dependency is absent
+    (CodeRabbit review, PR #911).
     """
-    pytest.importorskip("zstandard")
+    if _compression_for_suffix(suffix) is SnapshotCompression.ZSTD:
+        pytest.importorskip("zstandard")
 
     old_snap = _graph_heavy_snapshot(n=8600)
     _production_scale_bytes(old_snap)


### PR DESCRIPTION
## Summary

Adds the python-api/CLI-level compression round-trip test that
`tests/regressions/manifest.py`'s `storage.third_party_contract_at_scale`
`BugClass` (Phase 7 of `docs/contribute/plans/bug-class-regression-testing.md`)
had registered as an open `KnownGap`.

## Motivation

Phase 7 generalizes ADR-059 §12's zstd window-size unit bug (#699 → #721):
the invariant is `read(write(x)) == x` at realistic production scale, through
the *actual* public entry point, for every supported storage algorithm — not
only a toy-scale fixture, and not only through a low-level chokepoint several
layers below what a real caller uses.

`tests/test_snapshot_compression.py` already has real, production-scale
(>8 MiB, past zstd's window-collapse threshold) round-trip tests for both
zstd and gzip — but they stop at `abicheck.snapshot_io.write_snapshot_bytes`/
`read_snapshot_bytes`, one layer below the public Python API
(`abicheck.serialization.save_snapshot`/`load_snapshot`) that `dump`/`compare`
actually call, and below the real `compare` CLI dispatch
(`service.resolve_input` → `sniff_text_format` → `load_snapshot`). This was
the exact, explicitly registered gap in the `BugClass` entry: "no python-api
or CLI-level round-trip test exists for this class yet."

## Changes

- Adds `tests/test_snapshot_compression_public_api_scale.py` (split out
  rather than grown in `tests/test_snapshot_compression.py`, which is at its
  1500-line AI-readiness soft cap), reusing the existing
  `_graph_heavy_snapshot(n=8600)` fixture:
  - `test_save_load_snapshot_round_trips_at_production_scale`: a full
    dataclass round trip through `save_snapshot`/`load_snapshot`, for both
    zstd and gzip, selected via the real auto-compression-from-suffix path
    (`resolve_write_compression`) rather than an explicit
    `SnapshotCompression` value.
  - `test_compare_cli_round_trips_a_compressed_snapshot_at_production_scale`:
    the real `compare` CLI command (`CliRunner`) reading a genuinely
    compressed, production-scale snapshot file operand losslessly, with no
    compiler/castxml toolchain involved.
- Updates the `storage.third_party_contract_at_scale` registry entry: adds
  the new seed test, records the now-genuinely-earned `python-api`/`cli`
  `public_surfaces`, and narrows `known_gaps` to the remaining, still-open
  half of Phase 7 (archive/bundle-reader and `snapshot_cache.py` coverage at
  the same production scale, which this PR does not attempt).

Test-only change; no `abicheck/**/*.py` touched, so no changelog fragment is
required.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md` (N/A — test-only change)
- [ ] Docs updated if user-visible behaviour changed (N/A)
- [x] `pre-commit run --all-files`-equivalent checks pass locally (`ruff format`/`ruff check`, `mypy abicheck/`, `python scripts/check_architecture.py`, the new tests, `tests/test_regressions_manifest.py`)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018USuGdPgyVaPK7z6iB2cKd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved confidence in large snapshot compression and decompression through the public Python API and CLI.
  * Added coverage for lossless round trips using both gzip and zstd compression.
  * Verified compressed snapshots exceeding 8 MiB, including realistic zstd settings and CLI JSON output.
* **Known Limitations**
  * Archive and bundle-reader paths, along with mixed-container production-scale round trips, remain ungeneralized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->