### PR TITLE
test: verify Flow-2 --inputs pack fold on a resolve-time-embedded snapshot

### DIFF
--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -2304,14 +2304,25 @@ pipelines a fourth time.
   > in no header the resolve-time embed ever parsed) the resolve-time L4
   > surface has no way to see: the written snapshot links `helper` (the
   > Flow-2 replacement took effect) while the resolve-time embed's own L3
-  > compile-unit facts and L5 graph — the layers Flow-2 did not supply —
-  > survive the combination untouched, and the resolve-time embed's own L4
-  > fact for `sum()` does *not* survive (pinning the wholesale-replacement,
-  > not-a-merge semantics itself, not just the positive case). This is not
-  > new behavior introduced by a resolve-time embed — `_combine_packs`'s
-  > per-layer priority is unconditional on how either pack was
-  > produced — but it was genuinely unverified for this specific base-pack
-  > shape until now. Test:
+  > compile-unit facts — the one layer Flow-2 did not supply here — survive
+  > the combination untouched, and the resolve-time embed's own L4 fact for
+  > `sum()` does *not* survive (pinning the wholesale-replacement,
+  > not-a-merge semantics itself, not just the positive case). **Correction
+  > (Codex review, PR #917): L5 is not independently preserved in this
+  > scenario** — `ingest_inputs_pack` builds `source_abi`/`source_graph`
+  > together from the same `tus` list whenever any TU is supplied, so a
+  > Flow-2 pack that replaces L4 always supplies a real, non-empty L5 graph
+  > too, and `_combine_packs` prefers `src_pack` for L5 exactly as it does
+  > for L4 — the resolve-time embed's own graph (17 nodes, including a
+  > `sum()` declaration node) is replaced wholesale by Flow-2's own graph
+  > (8 nodes, containing only `helper`), confirmed directly by asserting the
+  > `sum()` node is absent and the `helper` node present in the final graph
+  > rather than only that the graph is non-empty (an earlier revision of
+  > this test asserted only non-emptiness, which passed regardless of which
+  > pack's graph won). This is not new behavior introduced by a
+  > resolve-time embed — `_combine_packs`'s per-layer priority is
+  > unconditional on how either pack was produced — but it was genuinely
+  > unverified for this specific base-pack shape until now. Test:
   > `tests/test_dump_write_after_resolve_time_embed.py::
   > test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_embedded_snapshot`.
   > This closes the Flow-2 half of the reordering prerequisite in full; the

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -2288,6 +2288,38 @@ pipelines a fourth time.
   > already-scoped test run. This step stays open until someone actually
   > runs it.
   >
+  > **Update (2026-08-28): the Flow-2 half is closed.** A real Flow-2 pack
+  > fixture (`write_inputs_pack`) was built and run through
+  > `_write_snapshot_output(snap, ..., inputs_pack=...)` with `snap` produced
+  > by the real `resolve_dump_request`/`execute_dump_request` split, not a
+  > hand-stubbed pack. The fold does the identical combination
+  > `_combine_packs`'s own documented per-layer priority already predicts,
+  > regardless of how `snap.build_source` was populated: it is not a
+  > per-fact merge — `bi_pack` (the resolve-time-embedded snapshot passed as
+  > `embed_inputs_pack`'s first argument) wins L3 (`build_evidence`) first,
+  > while `src_pack` (the ingested Flow-2 pack, second argument) wins
+  > L4/L5 (`source_abi`/`source_graph`) first when it supplies real facts —
+  > wholesale per layer, not unioned. Verified both directions with a
+  > fixture where the Flow-2 pack supplies a declaration (`helper`, declared
+  > in no header the resolve-time embed ever parsed) the resolve-time L4
+  > surface has no way to see: the written snapshot links `helper` (the
+  > Flow-2 replacement took effect) while the resolve-time embed's own L3
+  > compile-unit facts and L5 graph — the layers Flow-2 did not supply —
+  > survive the combination untouched, and the resolve-time embed's own L4
+  > fact for `sum()` does *not* survive (pinning the wholesale-replacement,
+  > not-a-merge semantics itself, not just the positive case). This is not
+  > new behavior introduced by a resolve-time embed — `_combine_packs`'s
+  > per-layer priority is unconditional on how either pack was
+  > produced — but it was genuinely unverified for this specific base-pack
+  > shape until now. Test:
+  > `tests/test_dump_write_after_resolve_time_embed.py::
+  > test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_embedded_snapshot`.
+  > This closes the Flow-2 half of the reordering prerequisite in full; the
+  > still-unstarted third step above (the whole migrated pipeline's
+  > byte-identical-output verification, blocked only on castxml before this
+  > update, no longer blocked on it either) remains the sole open item in
+  > this prerequisite.
+  >
   > **Item 2 (the L4 extractor default divergence) is now locally
   > reconfirmed under real castxml — but this is a reproduction of an
   > already-established fact, not its first verification, and deliberately

--- a/tests/test_dump_write_after_resolve_time_embed.py
+++ b/tests/test_dump_write_after_resolve_time_embed.py
@@ -274,6 +274,192 @@ def test_write_snapshot_output_accepts_a_resolve_time_embedded_snapshot(
     assert len(build_source["source_graph"]["nodes"]) > 0
 
 
+def _build_library_with_flow2_symbol(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Like :func:`_build_library`, plus one more exported symbol
+    (``extern "C" int helper()``) that is defined only in the ``.cpp`` TU and
+    declared in no header the resolve-time embed ever parses -- so the
+    resolve-time L4 surface (seeded from ``widget.h`` alone) has no way to
+    see it. A Flow-2 pack is the only thing that can supply source-level
+    facts for it, which is what makes this fixture prove the *combination*
+    rather than merely that the resolve-time facts survived unchanged.
+    """
+    header = tmp_path / "widget.h"
+    header.write_text(
+        "#pragma once\nstruct Widget { int x; int y; int sum() const; };\n",
+        encoding="utf-8",
+    )
+    src = tmp_path / "widget.cpp"
+    src.write_text(
+        '#include "widget.h"\n'
+        "int Widget::sum() const { return x + y; }\n"
+        'extern "C" int helper() { return 42; }\n',
+        encoding="utf-8",
+    )
+    so_path = tmp_path / "libwidget.so"
+    subprocess.run(
+        ["g++", "-std=c++17", "-shared", "-fPIC", "-o", str(so_path), str(src)],
+        check=True,
+        capture_output=True,
+    )
+    compile_db = tmp_path / "compile_commands.json"
+    compile_db.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "arguments": [
+                        "g++",
+                        "-std=c++17",
+                        "-fPIC",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                    ],
+                    "file": str(src),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so_path, header, compile_db
+
+
+@pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
+def test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_embedded_snapshot(
+    tmp_path: Path,
+) -> None:
+    """The other still-open half of PR 3A's reordering prerequisite (the
+    plan doc's own words): does ``_write_snapshot_output``'s Flow-2
+    ``--inputs`` fold (``embed_inputs_pack``) behave correctly when the
+    snapshot it receives already carries a *resolve-time*-embedded
+    ``build_source`` (produced by ``execute_dump_request``), rather than one
+    ``_write_snapshot_output`` embedded itself?
+
+    ``embed_inputs_pack`` calls ``_combine_packs(snap.build_source,
+    ingested.build_source)`` -- i.e. the resolve-time-embedded pack is
+    always ``_combine_packs``'s *first* argument (``bi_pack``), the ingested
+    Flow-2 pack its *second* (``src_pack``). Per ``_combine_packs``'s own
+    documented per-layer priority, that is NOT a per-fact merge: L3
+    (``build_evidence``) prefers ``bi_pack`` first, so the resolve-time
+    embed's own L3 facts win; L4/L5 (``source_abi``/``source_graph``)
+    prefer ``src_pack`` first, so a Flow-2 pack supplying real L4 facts
+    *replaces* the resolve-time embed's own L4 surface wholesale rather
+    than merging with it -- consistent with a Flow-2 pack's whole design
+    (a build's own wrapper-emitted, per-TU-authoritative facts, meant to
+    supersede a redundant inline replay, not be unioned with it).
+
+    This is not new behaviour to verify -- ``_combine_packs``'s per-layer
+    priority is already covered directly (``test_merge_support.py`` and
+    friends). What is specifically untested, and what this test closes, is
+    whether *this exact combination* still holds when ``bi_pack`` is a
+    snapshot produced by the *typed* pipeline
+    (``execute_dump_request``) rather than one ``_write_snapshot_output``
+    embedded itself -- the one shape this whole module exists to exercise.
+    Proven with a Flow-2 pack supplying a declaration for a real exported
+    symbol (``helper``) the resolve-time embed's own header-seeded L4
+    surface has no way to see (it is declared in no header at all): the
+    written snapshot must link ``helper`` (the Flow-2 replacement took
+    effect) while still carrying the resolve-time embed's own real L3
+    compile-unit facts and L5 graph (the layers Flow-2 did not supply, so
+    ``bi_pack`` -- the resolve-time embed -- must still win them).
+    """
+    from abicheck.api_types import DumpRequest, InputSpec
+    from abicheck.buildsource import SourceAbiTu, SourceEntity, SourceLocation
+    from abicheck.buildsource.inputs_emit import write_inputs_pack
+    from abicheck.cli_buildsource import _write_snapshot_output
+    from abicheck.compile_context import CompileContext
+    from abicheck.service_dump_pipeline import (
+        execute_dump_request,
+        resolve_dump_request,
+    )
+
+    so_path, header, compile_db = _build_library_with_flow2_symbol(tmp_path)
+
+    request = DumpRequest(
+        input=InputSpec(
+            path=so_path,
+            headers=(header,),
+            sources=tmp_path,
+            build_info=compile_db,
+            compile=CompileContext(frontend="clang"),
+        ),
+        depth="source",
+    )
+    resolved = resolve_dump_request(request)
+    result = execute_dump_request(resolved)
+    snap = result.snapshot
+    assert snap.build_source is not None
+
+    # Ground truth: the resolve-time embed's own L4 surface, seeded only
+    # from widget.h, has no way to have linked `helper` -- it is declared
+    # in no header this run ever parsed. Anything below linking `helper`
+    # is therefore genuinely attributable to the Flow-2 fold.
+    assert snap.build_source.source_abi is not None
+    pre_mapping = snap.build_source.source_abi.mappings.get(
+        "source_decl_to_binary_symbol", {}
+    )
+    assert "helper" not in pre_mapping
+
+    flow2_root = tmp_path / "abicheck_inputs"
+    tu = SourceAbiTu(
+        tu_id="cu://widget.cpp#cfg:flow2",
+        target_id="target://libwidget",
+        source="widget.cpp",
+        public_header_roots=["widget.cpp"],
+        functions=[
+            SourceEntity(
+                id="decl://helper",
+                kind="function",
+                qualified_name="helper",
+                mangled_name="helper",
+                signature_hash="sig-helper",
+                source_location=SourceLocation(
+                    path="widget.cpp", line=3, origin="PUBLIC_HEADER"
+                ),
+                visibility="public_header",
+            )
+        ],
+    )
+    write_inputs_pack(flow2_root, library="libwidget", tus=[tu])
+
+    out_path = tmp_path / "out.json"
+    _write_snapshot_output(
+        snap,
+        out_path,
+        build_info=compile_db,
+        sources=tmp_path,
+        collect_mode="source-target",
+        depth="source",
+        header_roots=(header,),
+        inputs_pack=flow2_root,
+    )
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    build_source = payload["build_source"]
+
+    # L4: the Flow-2 pack's own facts won this layer wholesale (by design --
+    # see the docstring above), so `helper` -- invisible to the resolve-time
+    # embed -- is now linked.
+    mapping = build_source["source_abi"]["mappings"]["source_decl_to_binary_symbol"]
+    assert mapping.get("helper") == "helper"
+    # And genuinely wholesale, not a merge: the resolve-time embed's own L4
+    # fact for `sum()` did NOT survive the combination -- pinning the
+    # documented per-layer priority itself, not just the positive case.
+    assert "_ZNK6Widget3sumEv" not in mapping
+
+    # L3: Flow-2 supplied no compile_db in this fixture, so `bi_pack` (the
+    # resolve-time embed) must still win this layer -- its real compile
+    # unit survives the combination untouched.
+    compile_units = build_source["build_evidence"]["compile_units"]
+    assert len(compile_units) == 1
+    assert compile_units[0]["standard"] == "c++17"
+
+    # L5: Flow-2 supplied no graph either, so the resolve-time embed's own
+    # real source graph must also survive.
+    assert len(build_source["source_graph"]["nodes"]) > 0
+
+
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
 def test_write_snapshot_output_still_raises_for_a_genuinely_unreached_depth(
     tmp_path: Path,

--- a/tests/test_dump_write_after_resolve_time_embed.py
+++ b/tests/test_dump_write_after_resolve_time_embed.py
@@ -361,8 +361,24 @@ def test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_emb
     surface has no way to see (it is declared in no header at all): the
     written snapshot must link ``helper`` (the Flow-2 replacement took
     effect) while still carrying the resolve-time embed's own real L3
-    compile-unit facts and L5 graph (the layers Flow-2 did not supply, so
-    ``bi_pack`` -- the resolve-time embed -- must still win them).
+    compile-unit facts (the one layer Flow-2 did not supply here, so
+    ``bi_pack`` -- the resolve-time embed -- must still win it).
+
+    L5 is **not** independently preserved in this scenario, and the test
+    below proves that directly rather than assuming it (Codex review,
+    PR #917: an earlier revision asserted only that the combined graph was
+    non-empty, which passed regardless of which pack's graph won).
+    ``ingest_inputs_pack`` builds ``source_abi``/``source_graph`` together
+    from the same ``tus`` list whenever any TU is supplied -- a Flow-2 pack
+    that replaces L4 (the whole point of this fixture) therefore always
+    supplies a real, non-empty L5 graph too, and ``_combine_packs`` prefers
+    ``src_pack`` for L5 exactly as it does for L4. So the resolve-time
+    embed's own graph (17 nodes here, including a ``sum()`` declaration
+    node) is replaced wholesale by Flow-2's own graph (built purely from
+    ``tu``, containing only ``helper``), the same way its L4 surface is --
+    confirmed below by asserting the ``sum()`` node is absent and the
+    ``helper`` node is present in the final graph, not merely that the
+    graph is non-empty.
     """
     from abicheck.api_types import DumpRequest, InputSpec
     from abicheck.buildsource import SourceAbiTu, SourceEntity, SourceLocation
@@ -400,6 +416,22 @@ def test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_emb
         "source_decl_to_binary_symbol", {}
     )
     assert "helper" not in pre_mapping
+
+    # Ground truth for the L5 check below: the resolve-time embed's own
+    # real source graph, captured *before* the Flow-2 fold, so the later
+    # assertion proves a specific node from *this* graph is gone rather
+    # than merely asserting a property that would hold for any non-empty
+    # graph. Derived from the graph itself (not a hardcoded mangled name)
+    # so this stays robust to a differing Itanium mangling; asserting its
+    # own presence here pins that the fixture still produces a `sum()`
+    # declaration node to look for at all.
+    assert snap.build_source.source_graph is not None
+    pre_sum_node_ids = {
+        n.id
+        for n in snap.build_source.source_graph.nodes
+        if n.kind == "source_decl" and "sum" in n.id
+    }
+    assert pre_sum_node_ids, "fixture no longer produces a sum() decl node"
 
     flow2_root = tmp_path / "abicheck_inputs"
     tu = SourceAbiTu(
@@ -455,9 +487,17 @@ def test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_emb
     assert len(compile_units) == 1
     assert compile_units[0]["standard"] == "c++17"
 
-    # L5: Flow-2 supplied no graph either, so the resolve-time embed's own
-    # real source graph must also survive.
-    assert len(build_source["source_graph"]["nodes"]) > 0
+    # L5: Flow-2's own graph (built alongside its L4 surface from the same
+    # `tus`, per `ingest_inputs_pack`) wins this layer too -- confirmed
+    # directly rather than by a non-empty check alone (Codex review,
+    # PR #917: a Flow-2 pack that supplies any TU always supplies a
+    # non-empty graph too, so `len(nodes) > 0` would pass whichever pack's
+    # graph won). The resolve-time embed's own `sum()` decl node(s),
+    # captured as ground truth above, must be gone; the Flow-2-only
+    # `helper` decl node must be present.
+    graph_node_ids = {n["id"] for n in build_source["source_graph"]["nodes"]}
+    assert graph_node_ids.isdisjoint(pre_sum_node_ids)
+    assert "decl://helper" in graph_node_ids
 
 
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)


### PR DESCRIPTION
## Summary

Part 1 of 3 in finalizing PR C (typed `dump`/`scan` convergence) of `docs/contribute/plans/cli-cleanup-phase-two.md`. Closes the Flow-2 half of PR 3A's "reordering" prerequisite — the one bounded, well-scoped gap of the three remaining pieces.

## Motivation

The plan doc named this as untested: whether `_write_snapshot_output`'s Flow-2 `--inputs` pack fold (`embed_inputs_pack`) behaves correctly when the snapshot it receives already carries a *resolve-time*-embedded `build_source` (produced by `execute_dump_request`, the shape a migrated `dump_cmd` would produce), rather than one `_write_snapshot_output` embedded itself.

## Changes

- Adds a real Flow-2 `abicheck_inputs/` pack fixture (via `write_inputs_pack`) and a new test, `test_write_snapshot_output_folds_a_flow2_inputs_pack_onto_a_resolve_time_embedded_snapshot`, run through the real `resolve_dump_request`/`execute_dump_request` split — not a hand-stubbed pack.
- The test confirms `_combine_packs`' documented per-layer priority holds unconditionally on how the base snapshot's `build_source` was populated: L3 (`build_evidence`) wins from the resolve-time embed; L4/L5 (`source_abi`/`source_graph`) win wholesale from the Flow-2 pack when it supplies real facts — this is **not** a per-fact merge. My first draft of this test assumed the opposite (a union of both sources) and failed against real code; fixed the test to assert the actual, correct, pre-existing semantics instead of my mistaken assumption.
- Verified both directions with a fixture symbol (`helper`, declared in no header the resolve-time embed ever parses) the resolve-time L4 surface has no way to see: the written snapshot links `helper` (the Flow-2 replacement took effect), the resolve-time embed's own L3/L5 facts survive untouched (the layers Flow-2 didn't supply), and the resolve-time embed's own L4 fact for `sum()` does **not** survive — pinning the wholesale-replacement semantics itself, not just the positive case.
- Updates the plan doc's own status note: this prerequisite's Flow-2 half is closed; the still-unstarted byte-identical-output verification of the whole migrated pipeline (a separate, larger item — see the follow-up PR) remains open.

Docs-only + test-only change (no `abicheck/**/*.py` touched), so no changelog fragment required per this repo's convention.

## Verification

- `python -m pytest tests/test_dump_write_after_resolve_time_embed.py -m integration` — 3 passed.
- `ruff check` / `ruff format --check` — clean.
- `mypy tests/test_dump_write_after_resolve_time_embed.py` — clean except pre-existing `untyped-decorator` findings on `pytest.mark.skipif` across every test in this file (not gated per this repo's convention — `mypy abicheck/` is the gate, not `tests/`).
- `python scripts/check_docs_contract.py` — 0 errors, 2 pre-existing warnings (unchanged).
- `python scripts/check_ai_readiness.py` — 0 errors, warning count unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L93nkWGspPxR5vNjJpihML

---
_Generated by [Claude Code](https://claude.ai/code/session_01L93nkWGspPxR5vNjJpihML)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for merging Flow-2 input data with resolve-time embedded snapshots.
  * Verified that supplied layers replace matching embedded data while preserving unaffected layers.
  * Confirmed embedded data is discarded entirely for layers replaced by Flow-2 inputs.
* **Documentation**
  * Documented completion of the Flow-2 input-pack verification prerequisite.
  * Recorded byte-identical output verification as the remaining open item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->