### PR TITLE
refactor(architecture): classify 19 more flat modules (ADR-061)

### DIFF
--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -18,13 +18,8 @@
         "abicheck/change_registry_types.py",
         "abicheck/checker_types.py",
         "abicheck/compile_context.py",
-        "abicheck/config_paths.py",
-        "abicheck/contract_coverage_ledger.py",
         "abicheck/contract_evidence.py",
-        "abicheck/contract_gating.py",
         "abicheck/contract_relevance_types.py",
-        "abicheck/deadline.py",
-        "abicheck/demangle.py",
         "abicheck/detectors.py",
         "abicheck/evidence_depth.py",
         "abicheck/name_classification.py"

--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -18,6 +18,14 @@
         "abicheck/change_registry_types.py",
         "abicheck/checker_types.py",
         "abicheck/compile_context.py",
+        "abicheck/config_paths.py",
+        "abicheck/contract_coverage_ledger.py",
+        "abicheck/contract_evidence.py",
+        "abicheck/contract_gating.py",
+        "abicheck/contract_relevance_types.py",
+        "abicheck/deadline.py",
+        "abicheck/demangle.py",
+        "abicheck/detectors.py",
         "abicheck/evidence_depth.py",
         "abicheck/name_classification.py"
       ]
@@ -132,6 +140,7 @@
         "abicheck/buildsource/graph_reconcile.py",
         "abicheck/buildsource/source_diff.py",
         "abicheck/confidence.py",
+        "abicheck/detector_registry.py",
         "abicheck/diff_abi_tags.py",
         "abicheck/diff_atomic.py",
         "abicheck/diff_bit_int.py",
@@ -182,6 +191,8 @@
       "legacy_paths": [
         "abicheck/analysis_assurance.py",
         "abicheck/contract_coverage_exit.py",
+        "abicheck/contract_evaluation.py",
+        "abicheck/contract_evidence_collect.py",
         "abicheck/exit_decision.py",
         "abicheck/severity.py"
       ]
@@ -199,6 +210,14 @@
         "abicheck/binder.py",
         "abicheck/buildsource/baseline_publish.py",
         "abicheck/compatibility_evaluation_frontend.py",
+        "abicheck/compatibility_evaluation_wiring.py",
+        "abicheck/contract_context.py",
+        "abicheck/contract_context_io.py",
+        "abicheck/contract_pipeline.py",
+        "abicheck/contract_replay.py",
+        "abicheck/contract_scoped_promotion.py",
+        "abicheck/debian_symbols.py",
+        "abicheck/dependency_info.py",
         "abicheck/resolver.py",
         "abicheck/service.py",
         "abicheck/service_compare_evidence.py",


### PR DESCRIPTION
## Summary

Classifies 14 of my assigned batch of 29 flat `abicheck/*.py` modules into
their ADR-061 responsibility layers (`architecture/modules.yaml`
`legacy_paths`). Classification only — no files moved, no behavior change.
15 modules are deliberately left unclassified; see "Skipped" below.

**Updated after Codex review**: 5 modules I originally classified as
`model` (`config_paths.py`, `contract_coverage_ledger.py`,
`contract_gating.py`, `deadline.py`, `demangle.py`) were correctly flagged
as real responsibility mismatches — each was only forced into `model` by
the checker's import-direction mechanics (their bare "which layer can
every importer legally reach" intersection reduces to `{model}`), not
because `model` is where any of them actually belong. None of the forcing
imports are typing-only, so no `TYPE_CHECKING` fix applies per the
original task's fallback rule — all five are now left **unclassified**,
moved from the "Changes" table into "Skipped" below with the real
conflicting importers named.

## Motivation

Part of the incremental ADR-061 flat-module classification effort
(parallel batches; this is batch 2). `python scripts/check_architecture.py`
reports `Architecture: 0 error(s)` after this change.

## Changes

Classified into `model` (imports nothing outside model, and matches its
real responsibility as vocabulary/shape or a detector-registration leaf,
not merely satisfying the checker):

| Module | Layer | Why |
|---|---|---|
| `contract_relevance_types.py` | model | Forced: `checker_types.py` (model) imports it at runtime (`model` same-layer is the only option satisfying that importer). Zero internal imports — a real fit, not just a technically-valid one (ADR-049 reserved vocabulary, sibling of the already-model-classified `checker_types.py`). |
| `contract_evidence.py` | model | Sibling shape/vocabulary module to `contract_relevance_types.py` (ADR-049 Phase 4 "block" dataclasses, explicitly documented as pure shape with nothing wired to detection/policy logic yet); only imports model-classified modules. |
| `detectors.py` | model | Forced: imported by `checker_types.py` (model) and `confidence.py` (compare) — `model` is the only common candidate. Zero internal imports; itself only individual detection *rule* data, not policy logic. |

Classified into `policy` ("decide relevance/classification/gating"):

| Module | Layer | Why |
|---|---|---|
| `contract_evaluation.py` | policy | ADR-049's contract-relevance evaluator; imports `compare` (`finding_identity`) and `model`, both within policy's `may_import`. No importer constraint yet. |
| `contract_evidence_collect.py` | policy | Observed-provider-evidence ledger feeding relevance decisions; imports `compare` (`diff_cxx_rules`) and `model`. Imported by `workflows` (`compatibility_evaluation_frontend.py`), which can reach `policy`. |

Classified into `compare` (detector registration machinery):

| Module | Layer | Why |
|---|---|---|
| `detector_registry.py` | compare | Registry pattern used by every `diff_*.py` detector module; only imports model-classified modules. |

Classified into `workflows` (coordination across compare/policy/extract):

| Module | Layer | Why |
|---|---|---|
| `compatibility_evaluation_wiring.py` | workflows | Forced: imports `policy` (`severity`) at runtime; only `workflows` (or `report`, which its `workflows`-layer importer can't reach) is reachable from its `frontends` importer while still being able to import `policy`. |
| `contract_context.py`, `contract_context_io.py`, `contract_pipeline.py`, `contract_replay.py`, `contract_scoped_promotion.py` | workflows | ADR-049 Phase 4/7's contract-evaluation-stage assembly/coordination modules — each imports a mix of `model`/`compare`/`policy`/sibling `workflows` modules, all within `workflows`'s `may_import`. This matches their real job (coordinating the contract-evaluation stage within the compare pipeline), not just a checker-satisfying label. |
| `debian_symbols.py` | workflows | Forced: imports `elf_metadata` (`extract`) directly; its only `frontends` importer (`cli_compare_release_helpers.py`) can only reach `extract` transitively via `workflows`. |
| `dependency_info.py` | workflows | Forced: imports `extract` (`binary_utils`) *and* `workflows` (`binder.py`, `resolver.py`); `workflows` is the only candidate reachable from both its `frontends` and `workflows` importers that can also import `extract`. Matches its real job (coordinating dependency-resolution behavior). |

## Skipped — genuine dependency-direction / responsibility-mismatch conflicts (15 modules)

**Five, corrected after Codex review — real responsibility mismatch, not just an import-direction conflict:**

- **`config_paths.py`** — does real filesystem-discovery work (probing
  candidate `.abicheck.yml` locations), not a model value. It's imported
  by an `extract`-classified file (`buildsource/inline.py`) *and* by
  `frontends`-classified files (`cli_helpers_compare.py`, `cli_options.py`)
  — `model` is the only layer both can legally reach, but that's a
  checker artifact of its zero imports, not a real fit. Left unclassified.
- **`contract_coverage_ledger.py`** — `coverage_failures()`/
  `coverage_exit_contribution()` apply real policy/gate logic (ADR-049
  Phase 5's unsuppressible coverage ledger), not persisted values. Imported
  by `frontends` files (`cli_compare_release.py`, `cli_scan_baseline.py`)
  and by a `policy`-classified file (`contract_coverage_exit.py`) — `model`
  is the only common candidate, again a checker artifact. Left unclassified.
- **`contract_gating.py`** — decides whether policy/gate evaluate a
  finding (`is_evaluated()`), real policy logic. `checker_types.py`
  (model) calls `is_evaluated()` at runtime (not a type annotation, so no
  `TYPE_CHECKING` fix applies) — the only way to satisfy that importer is
  `model` itself. Left unclassified rather than mislabeling real policy
  logic as a model value.
- **`deadline.py`** — owns scan-wide deadline propagation and directly
  launches/kills subprocess process groups (`run_bounded()`,
  `_kill_process_tree()`, `install_sigterm_cleanup()`) — real
  execution/extraction behavior. `cli.py` (`frontends`) calls
  `deadline.install_sigterm_cleanup()` at runtime; `frontends` cannot
  reach `extract` (its real home) directly, only `model`. Left
  unclassified rather than mislabeling subprocess-execution code as a
  model value.
- **`demangle.py`** — executes an external demangler via `subprocess.run()`
  — extraction/comparison behavior, not a model value. Imported by many
  `compare`-classified `diff_*.py` files *and* by `dwarf_snapshot.py`
  (`extract`) — `model` is the only layer both can reach, a checker
  artifact of its zero imports. Left unclassified.

**Ten, unchanged from the original submission — real dependency-direction conflicts:**

- **`dumper.py`** — its own dependencies are entirely `extract`-layer
  (`dumper_castxml`, `dumper_clang`, `castxml_policy`, etc.), but
  `probe_harness.py` (already classified `compare`) calls
  `dumper.dump()` directly at runtime (`abicheck/probe_harness.py:413`).
  `compare`'s `may_import=[model]` cannot reach `extract`, and `model`
  cannot reach `extract` either — no candidate layer satisfies both
  constraints simultaneously.
- **`diff_platform.py`, `diff_platform_elf_dynamic.py`, `diff_versioning.py`,
  `diff_wheel_deployment.py`, `diff_cpp_patterns.py`** — each imports
  `binary_utils.strip_vendor_hash` (and some, `elf_metadata`/`dwarf_metadata`/
  `pe_metadata`/`macho_metadata`) directly at runtime, all `extract`-classified,
  *while also* importing already-`compare`-classified sibling detector
  modules (`diff_helpers`, `diff_symbols`, `diff_types`,
  `diff_platform_elf_symbols`, `diff_serialization`, `diff_templates`).
  No single layer permits importing both `compare` and `extract` except
  `workflows`, which would misrepresent these modules' real responsibility
  (ABI-change detector functions, not coordination).
- **`diff_numpy_capi.py`** — imports `numpy_capi.NumPyCapiSurface`
  (`extract`) under a `TYPE_CHECKING` guard. Note: `check_architecture.py`'s
  `_imports()` walks the *entire* AST (`ast.walk`) with no `TYPE_CHECKING`
  special-casing, so this import counts as a real edge regardless of the
  guard — converting it further would need editing this non-model file,
  which is outside this PR's guardrail (code edits limited to at most one
  *model-layer* file for the specific forced-conflict case).
- **`diff_python.py`** — imports `python_ext.PythonExtMetadata` (`extract`)
  at runtime alongside `compare`-classified `diff_helpers`.
- **`diff_python_api.py`** — imports `python_api` (`extract`) at runtime
  alongside `compare`-classified `diff_helpers`.
- **`diff_stdlib_impl.py`** — imports `build_mode` (`extract`) at runtime
  alongside `compare`-classified `diff_helpers`.

All fifteen are real, pre-existing architectural coupling or gaps, not
something introduced by this PR. Closing the ten dependency-direction ones
needs either moving the relevant fact dataclasses into `model/`, or an
ADR-sanctioned addition to `compare`'s `may_import`. Closing the five
responsibility-mismatch ones needs a genuine cross-package plumbing change
(e.g. converting `cli.py`'s/`checker_types.py`'s runtime calls into
something that doesn't force a direct import edge, or accepting the
architectural reality that these leaf-ish modules sit at a real join point
between layers) — out of scope for a classification-only batch either way.

## Verification

```
python scripts/check_architecture.py
# Architecture: 0 error(s)

python scripts/verify.py --profile fast --only lint,typecheck
# lint: passed
# typecheck: passed (mypy: no issues found in 468 source files)
```

No `.py` files were touched (classification-only, `architecture/modules.yaml`
edits), so this diff cannot affect lint/typecheck/runtime behavior.

## CI: `e2e` check is red for a reason unrelated to this PR

The failing `e2e` job (run
https://github.com/abicheck/abicheck/actions/runs/33146970145/job/98770033778)
fails during `apt-get update` in the workflow setup step, before any
repository code runs:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

This is an external package-mirror outage (Microsoft's apt repo returning
403/unsigned), not anything this PR's diff (a 5-line-net `architecture/modules.yaml`
edit) could cause or fix. Left as-is per the "CI red for a reason unrelated
to the diff" handling — a re-run once the mirror recovers should clear it.

## Checklist

- [x] No files moved; classification-only change
- [x] `python scripts/check_architecture.py` passes (0 errors)
- [x] `ruff check` / `mypy` pass (no code touched)
- [ ] Changelog fragment — not needed: `architecture/modules.yaml` is not under `abicheck/**/*.py`
- [ ] Docs updated — not user-visible behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
