### PR TITLE
fix(architecture): unclassify contract_evidence.py to break model->policy cycle

### DIFF
--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -20,7 +20,6 @@
         "abicheck/change_registry_types.py",
         "abicheck/checker_types.py",
         "abicheck/compile_context.py",
-        "abicheck/contract_evidence.py",
         "abicheck/contract_relevance_types.py",
         "abicheck/detectors.py",
         "abicheck/evidence_depth.py",

--- a/changelog.d/1787926920_claude_fix-contract-evidence-model-policy-cycle.md
+++ b/changelog.d/1787926920_claude_fix-contract-evidence-model-policy-cycle.md
@@ -15,4 +15,8 @@
   (see `AGENTS.md`'s and recent ADR-061 PRs' own "deliberately left
   unclassified" sections). `python scripts/check_architecture.py` returns to
   0 errors; this was blocking every other in-flight ADR-061 classification PR
-  whose merge with `main` surfaced the same pre-existing violation.
+  whose merge with `main` surfaced the same pre-existing violation. The
+  identical one-line change was also ported directly onto two other
+  in-flight PRs (#784, #922) that hit this same failure before this fix
+  merged, so neither had to wait on merge order; both ports become no-ops
+  once this PR merges and those branches re-merge `main`.

--- a/changelog.d/1787926920_claude_fix-contract-evidence-model-policy-cycle.md
+++ b/changelog.d/1787926920_claude_fix-contract-evidence-model-policy-cycle.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **ADR-061**: reclassifying `compatibility_evaluation_config.py` into `policy`
+  (an already-merged sibling PR) exposed a pre-existing `model -> policy`
+  forbidden import: `contract_evidence.py` (classified `model`) imports
+  `CompatibilityEvaluationConfig` from it as a real dataclass field type
+  (`EvaluationContextBlock`), not a type-only reference — `contract_evidence.py`
+  is itself ADR-049 Phase 4's persisted contract-relevance evidence/decision
+  shape, which genuinely depends on the policy-layer resolved-configuration
+  type it records, so `model` (whose `may_import` is `[]` by design) was
+  always the wrong classification for it, not a fixable import direction.
+  Removed `contract_evidence.py` from `model`'s `legacy_paths`, leaving it
+  unclassified — the same "leave it, document why" pattern this migration
+  already uses for several other genuinely cross-layer-conflicted modules
+  (see `AGENTS.md`'s and recent ADR-061 PRs' own "deliberately left
+  unclassified" sections). `python scripts/check_architecture.py` returns to
+  0 errors; this was blocking every other in-flight ADR-061 classification PR
+  whose merge with `main` surfaced the same pre-existing violation.


### PR DESCRIPTION
## Summary

`python scripts/check_architecture.py` currently fails on plain `main` with 3 errors:

```
ERROR: [dependency-direction] abicheck/contract_evidence.py:86: model -> policy is forbidden; allowed: (none)
ERROR: [dependency-direction] abicheck/contract_evidence.py:86: model -> policy is forbidden; allowed: (none)
ERROR: [dependency-cycle] observed responsibility cycle: compare -> model -> policy -> compare
```

This isn't caused by any one PR's own diff — it's the intersection of two independently-correct, already-merged ADR-061 classifications: `contract_evidence.py` was classified `model`, and a separate sibling PR later classified `compatibility_evaluation_config.py` (which `contract_evidence.py` imports as a real dataclass field type in `EvaluationContextBlock`, not a type-only reference) into `policy`. `model.may_import` is `[]` by design, so this was never actually a valid `model` classification — `contract_evidence.py` is ADR-049 Phase 4's persisted contract-relevance evidence/decision-context shape, which genuinely, structurally depends on the resolved policy configuration it records.

Confirmed at least four other in-flight ADR-061 classification PRs (#912, #913, #926, #927, #928) independently hit this exact same pre-existing violation the moment they merged `main` back in, and are blocked on it.

## Fix

Removes `contract_evidence.py` from `model`'s `legacy_paths`, leaving it unclassified — the same "leave it, document why" pattern this migration already uses for other genuinely cross-layer-conflicted modules (see `AGENTS.md`'s and recent ADR-061 PRs' own "deliberately left unclassified" sections). Reclassifying it into `policy` instead was considered and rejected: several `frontends`-layer files (`cli_compare_receipt.py`, `cli_scan_receipt.py`) import `contract_evidence.py` directly via function-local imports, and `frontends.may_import` excludes `policy` — so `policy` would just relocate the identical class of violation rather than fix it.

## Bug-fix test contract

- Bug class: A module's `legacy_paths` classification in `architecture/modules.yaml` asserted a `may_import`-empty layer (`model`) for a module that has a real, structural import dependency the layer's own allowlist cannot express — a static architecture-classification defect, not a runtime code bug. This class recurs whenever two independently-correct classification PRs are each locally valid but jointly forbidden.
- Publicly observable failure: `python scripts/check_architecture.py` — a required CI gate — fails on plain `main` with 2 `dependency-direction` errors and 1 `dependency-cycle` error, blocking every PR that merges `main` back in and re-runs the gate (confirmed independently blocking #912, #913, #926, #927, #928).
- Regression test fails on base: Running `python scripts/check_architecture.py` against `main` at this PR's base commit reproduces exactly the 3 errors quoted above; after removing `contract_evidence.py` from `model.legacy_paths`, the identical command reports 0 errors.
- Negative control: Every other already-classified module keeps its layer and its own `dependency-direction`/`dependency-cycle` checks unchanged — `tests/test_architecture_check.py`'s full 40-test suite still passes, confirming no other classification's enforcement was weakened or removed; only the one invalid `contract_evidence.py -> model` assignment is removed. `contract_evidence.py` itself remains fully functional and imported exactly as before (this is a classification-metadata change only, zero runtime code touched).
- Public-surface test: Verified through the actual public entry point contributors and CI use, `python scripts/check_architecture.py`, not an internal helper or a mocked layer graph.
- Axes covered: N/A in the runtime-platform sense — this is a static, whole-repo architecture linter, not code with backend/platform axes. Verified across every classified responsibility layer (`model`/`storage`/`extract`/`compare`/`policy`/`workflows`/`report`/`frontends`) via the tool's own exhaustive AST-based scan of every `.py` file in the repo, and via the full `tests/test_architecture_check.py` suite (40 tests) rather than one hand-picked case.
- General invariant: For every module classified into a responsibility layer, none of its imports may resolve to a module outside that layer's `may_import` allowlist, and no cycle may exist among classified layers' aggregate import edges. `check_architecture.py`'s own AST-based scan checks this exhaustively for every `.py` file in the repository on every invocation — not just the one path this PR fixes — so the existing tool is itself the generalized, always-on check; this PR corrects the one classification that violated that invariant.

## Verification

- `python scripts/check_architecture.py` → 0 errors (was 3)
- `python scripts/check_ai_readiness.py` → 0 errors, 152 warnings (unchanged)
- `pytest tests/test_architecture_check.py` → 40 passed
- Changelog fragment added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tong8fcUn1FAXt44xK321)_