### PR TITLE
test: registry-completeness and evidence-completeness invariants (Phase 9)

### DIFF
--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -516,7 +516,7 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "every kind has a mapping, and every mapping key names an "
             "existing kind."
         ),
-        fixed_by=(753, 759),
+        fixed_by=(753, 759, 932),
         seed_tests=(
             "tests/test_canonical_finding_id_completeness.py",
             "tests/test_report_classifications_unit.py",
@@ -558,7 +558,7 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "result must agree, checked independently, not all derived "
             "from one production helper."
         ),
-        fixed_by=(834, 838, 860, 883),
+        fixed_by=(834, 838, 860, 883, 932),
         seed_tests=(
             "tests/test_fact_conservation_properties.py",
             "tests/test_bundle_side_input.py",

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -517,24 +517,32 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "existing kind."
         ),
         fixed_by=(753, 759),
-        seed_tests=("tests/test_canonical_finding_id_completeness.py",),
+        seed_tests=(
+            "tests/test_canonical_finding_id_completeness.py",
+            "tests/test_report_classifications_unit.py",
+        ),
         known_gaps=(
             KnownGap(
                 description=(
-                    "Only canonical_finding_id's classification is "
-                    "exhaustiveness-checked today; the same totality "
-                    "property is not yet generalized to every other "
-                    "kind-keyed registry named in Phase 9 of the plan "
-                    "(evidence kinds, providers, report renderers)."
+                    "canonical_finding_id's classification and "
+                    "report_classifications.py's seven hand-maintained "
+                    "kind-keyed frozensets are now reverse-completeness "
+                    "checked (every member names a live ChangeKind, with a "
+                    "mutation check proving the assertion actually fails on "
+                    "a corrupted set) — but the same totality property is "
+                    "not yet generalized to every other kind-keyed registry "
+                    "named in Phase 9 of the plan (evidence kinds, "
+                    "providers, other report renderers)."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md#phase-9",
             ),
             KnownGap(
                 description=(
-                    "The seed test calls `finding_identity."
-                    "report_canonical_finding_id` directly — no CLI, no "
-                    "python-api — so nothing here proves a real registry "
-                    "omission reaches a `compare()` report."
+                    "The seed tests call `finding_identity."
+                    "report_canonical_finding_id`/`report_classifications` "
+                    "helpers directly — no CLI, no python-api — so nothing "
+                    "here proves a real registry omission reaches a "
+                    "`compare()` report."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md#phase-9",
             ),
@@ -551,14 +559,17 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             "from one production helper."
         ),
         fixed_by=(834, 838, 860, 883),
-        seed_tests=("tests/test_fact_conservation_properties.py",),
+        seed_tests=(
+            "tests/test_fact_conservation_properties.py",
+            "tests/test_bundle_side_input.py",
+        ),
         known_gaps=(
             KnownGap(
                 description=(
                     "The fact-conservation suite covers a selected "
                     "detector-family subset today, not every ChangeKind "
                     "family and evidence-completeness failure mode named "
-                    "in AGENTS.md's 'Known gaps' section."
+                    "in `docs/contribute/known-gaps.md`."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md#phase-9",
             ),
@@ -568,7 +579,16 @@ BUG_CLASSES: tuple[BugClass, ...] = (
                     "directly on hand-built snapshots — real detection "
                     "logic, but no CLI/python-api/exit-code layer, so "
                     "report/gate/exit-code agreement (the second half of "
-                    "this class's own invariant) is untested."
+                    "this class's own invariant) is untested. Incident "
+                    "#883's own gap — a dropped `policy_file` reaching "
+                    "silently unverified through a mocked "
+                    "`compare_snapshots` — is now closed independently by "
+                    "`test_bundle_side_input.py`'s "
+                    "`test_policy_file_override_genuinely_demotes_a_real_"
+                    "verdict`, which runs the real, unmocked "
+                    "`compare_snapshots` and asserts the returned verdict "
+                    "is actually demoted (a mutation check: reverting the "
+                    "production fix fails this test)."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md#phase-9",
             ),

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -477,6 +477,101 @@ class TestCompareReleaseAgainstBundleFactsResolutionUnit:
         result = compare_release_against_bundle_facts(facts_path, new_dir, policy_file=pf)
         assert result.policy_file is pf
 
+    def test_policy_file_override_genuinely_demotes_a_real_verdict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bug-class regression (plan Phase 9, incident #883): the two
+        tests above only prove *forwarding* -- both mock
+        ``service.compare_snapshots`` itself, the very function whose real
+        behavior a ``policy_file`` override is supposed to change -- so
+        neither would catch a regression where the override reaches the
+        call but is silently ignored by it, or is threaded to the wrong
+        keyword and has no effect. This lets the real, production
+        ``compare_snapshots`` run end to end (only ``service.resolve_input``
+        is mocked, since the NEW side has no real compiled binary here) and
+        asserts the actual, returned verdict is genuinely demoted -- closing
+        #883's own registered gap of "checked independently, not all
+        derived from one production helper" for at least this one detector
+        family."""
+        import abicheck.package as package_mod
+        import abicheck.service as service_mod
+        from abicheck.policy_file import PolicyFile
+
+        old_fn = Function(
+            name="core_fn",
+            mangled="core_fn",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        old_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="old",
+            elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            functions=[old_fn],
+        )
+        facts = capture_bundle_facts({"libcore.so": old_snapshot})
+        facts_path = tmp_path / "old.bundlefacts.json"
+        save_bundle_facts(facts, facts_path)
+
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        new_so = new_dir / "libcore.so"
+        new_so.write_bytes(b"")
+
+        monkeypatch.setattr(
+            package_mod,
+            "discover_shared_libraries",
+            lambda d, include_private=False: [new_so],
+        )
+
+        new_fn = Function(
+            name="core_fn",
+            mangled="core_fn",
+            return_type="int",
+            visibility=Visibility.HIDDEN,
+        )
+
+        def _fake_resolve_input(path, **kwargs):
+            return AbiSnapshot(
+                library="libcore.so",
+                version="new",
+                elf=_meta(soname="libcore.so", exports=[]),
+                functions=[new_fn],
+            )
+
+        monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+        # Baseline: no override -- the real compare_snapshots reports this
+        # kind's built-in default verdict, BREAKING.
+        baseline = compare_release_against_bundle_facts(facts_path, new_dir)
+        baseline_diffs = [d for d in baseline.per_library if d.library == "libcore.so"]
+        assert len(baseline_diffs) == 1
+        assert any(
+            c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED
+            for c in baseline_diffs[0].changes
+        )
+        assert baseline_diffs[0].verdict == Verdict.BREAKING
+        assert baseline.verdict == Verdict.BREAKING
+
+        # Given: a real PolicyFile override demoting that one kind must
+        # actually change the per-library verdict AND the aggregate
+        # BundleDiffResult.verdict this driver returns -- not merely be
+        # accepted and discarded.
+        pf = PolicyFile(
+            overrides={ChangeKind.FUNC_VISIBILITY_CHANGED: Verdict.COMPATIBLE}
+        )
+        demoted = compare_release_against_bundle_facts(
+            facts_path, new_dir, policy_file=pf
+        )
+        demoted_diffs = [d for d in demoted.per_library if d.library == "libcore.so"]
+        assert len(demoted_diffs) == 1
+        assert any(
+            c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED
+            for c in demoted_diffs[0].changes
+        )
+        assert demoted_diffs[0].verdict == Verdict.COMPATIBLE
+        assert demoted.verdict == Verdict.COMPATIBLE
+
     def test_duplicate_new_side_versions_use_version_aware_selection(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_report_classifications_unit.py
+++ b/tests/test_report_classifications_unit.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import pytest
 
+from abicheck.checker_policy import ChangeKind
 from abicheck.report_classifications import (
     ADDED_KINDS,
     BINARY_ONLY_KINDS,
     BREAKING_KINDS,
     CHANGED_BREAKING_KINDS,
+    ENVIRONMENT_DRIFT_KINDS,
+    HIGH_SEVERITY_KINDS,
+    MEDIUM_SEVERITY_KINDS,
     REMOVED_KINDS,
     category,
     is_breaking,
@@ -217,3 +221,90 @@ class TestIsBreaking:
             kind = FakeKind()
 
         assert is_breaking(FakeChange()) is False
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness (bug-class regression, plan Phase 9)
+#
+# Generalizes #753 -> #759: a ChangeKind that gets renamed or removed can
+# leave a stale, silently-dead string behind in one of these hand-maintained
+# frozensets, with nothing anywhere failing to say so. This module has seven
+# such kind-keyed constants (BREAKING_KINDS is excluded — it is *derived*
+# from checker_policy at import time via `_kinds_for(...)`, not hand-
+# maintained, so it cannot go stale the same way).
+# ---------------------------------------------------------------------------
+
+_ALL_KIND_VALUES: frozenset[str] = frozenset(k.value for k in ChangeKind)
+
+#: Every hand-maintained kind-keyed set this module defines. Deliberately
+#: reverse-completeness only (every member must name a real ChangeKind) —
+#: NOT forward-completeness (every ChangeKind of some shape must be a
+#: member). REMOVED_KINDS/ADDED_KINDS in particular are small, deliberately
+#: curated subsets for one report section — as of this writing only 6 of the
+#: 56 real ``*_removed`` kinds and 8 of the 40 real ``*_added`` kinds are
+#: members — not an attempt to enumerate every kind sharing that suffix.
+#: Asserting forward-completeness there would invent a business rule this
+#: module's own authors never stated.
+_HAND_MAINTAINED_KIND_SETS: dict[str, frozenset[str]] = {
+    "REMOVED_KINDS": REMOVED_KINDS,
+    "ADDED_KINDS": ADDED_KINDS,
+    "BINARY_ONLY_KINDS": BINARY_ONLY_KINDS,
+    "ENVIRONMENT_DRIFT_KINDS": ENVIRONMENT_DRIFT_KINDS,
+    "CHANGED_BREAKING_KINDS": CHANGED_BREAKING_KINDS,
+    "HIGH_SEVERITY_KINDS": HIGH_SEVERITY_KINDS,
+    "MEDIUM_SEVERITY_KINDS": MEDIUM_SEVERITY_KINDS,
+}
+
+
+def _dangling_entries(kind_set: frozenset[str]) -> frozenset[str]:
+    """Members of *kind_set* that name no real, live ``ChangeKind`` value.
+
+    Shared by the real per-set assertion below and by the mutation-check
+    test that proves this helper actually has teeth, rather than passing
+    vacuously against a set that happens to already be clean.
+    """
+    return kind_set - _ALL_KIND_VALUES
+
+
+class TestRegistryCompleteness:
+    @pytest.mark.parametrize("set_name", sorted(_HAND_MAINTAINED_KIND_SETS))
+    def test_every_member_names_a_live_change_kind(self, set_name):
+        kind_set = _HAND_MAINTAINED_KIND_SETS[set_name]
+        dangling = _dangling_entries(kind_set)
+        assert not dangling, (
+            f"{set_name} contains {sorted(dangling)}, which no longer names "
+            "a real ChangeKind (renamed or removed?). This is exactly the "
+            "#753 -> #759 bug class: a stale string here is silently inert "
+            "-- it filters nothing anywhere -- and nothing fails to say so."
+        )
+
+    def test_dangling_entry_check_has_teeth(self):
+        """Mutation check: corrupt a real, currently-clean set with a fake
+        kind and confirm the completeness helper actually reports it,
+        rather than passing vacuously because every real set happens to be
+        clean today (the exact failure mode #753 -> #759 revealed: a check
+        that never fires because nothing ever exercises its failure path)."""
+        fake_kind = "this_change_kind_does_not_and_will_never_exist_xyz"
+        assert fake_kind not in _ALL_KIND_VALUES
+        corrupted = REMOVED_KINDS | {fake_kind}
+        assert _dangling_entries(corrupted) == frozenset({fake_kind})
+        # And the real, uncorrupted set stays clean -- the helper isn't just
+        # unconditionally reporting something.
+        assert not _dangling_entries(REMOVED_KINDS)
+
+
+class TestSeverityTiersAreDisjoint:
+    """HIGH_SEVERITY_KINDS and MEDIUM_SEVERITY_KINDS are two independently
+    hand-maintained lists feeding one if/elif chain in severity(). An
+    accidental overlap silently resolves to "High" regardless of the
+    MEDIUM_SEVERITY_KINDS entry's own intent -- this pins that the two lists
+    never disagree about the same kind in the first place."""
+
+    def test_no_kind_is_listed_at_two_severities(self):
+        overlap = HIGH_SEVERITY_KINDS & MEDIUM_SEVERITY_KINDS
+        assert not overlap, (
+            f"{sorted(overlap)} appear in both HIGH_SEVERITY_KINDS and "
+            "MEDIUM_SEVERITY_KINDS -- severity() silently resolves this to "
+            "'High' via if/elif order, masking the disagreement between the "
+            "two hand-maintained lists."
+        )


### PR DESCRIPTION
## Summary

Implements Phase 9 ("registry-completeness and silent-degradation invariants") of `docs/contribute/plans/bug-class-regression-testing.md` — as a single, bounded slice rather than the plan's full XL-effort scope.

## Motivation

Phase 9 generalizes two incidents already in `tests/regressions/manifest.py`:

- `registry.kind_completeness` (#753 → #759): a hand-maintained, kind-keyed list can silently go stale after a `ChangeKind` rename/removal, with nothing failing to say so.
- `evidence.silent_degradation_to_clean_verdict` (incident #883 among others): missing/dropped evidence handling must be checked independently, "not all derived from one production helper" — and the *existing* regression tests for #883 violate exactly that principle (they mock the very function whose real effect needs proving).

## Changes

- `tests/test_report_classifications_unit.py`: `report_classifications.py`'s seven hand-maintained kind-keyed frozensets (`REMOVED_KINDS`, `ADDED_KINDS`, `BINARY_ONLY_KINDS`, `ENVIRONMENT_DRIFT_KINDS`, `CHANGED_BREAKING_KINDS`, `HIGH_SEVERITY_KINDS`, `MEDIUM_SEVERITY_KINDS`) are now reverse-completeness checked (every member must name a real, live `ChangeKind`), with a mutation check proving the assertion actually fails against a deliberately corrupted set rather than passing vacuously. Also pins `HIGH_SEVERITY_KINDS`/`MEDIUM_SEVERITY_KINDS` disjointness, since `severity()`'s if/elif chain would silently resolve an overlap to `"High"`.
- `tests/test_bundle_side_input.py`: adds `test_policy_file_override_genuinely_demotes_a_real_verdict`, which runs the real, unmocked `service.compare_snapshots` (only `service.resolve_input` is mocked, for the NEW-side I/O boundary) and asserts a real `PolicyFile` override genuinely demotes a real `FUNC_VISIBILITY_CHANGED` finding's verdict — both per-library and in the aggregate `BundleDiffResult.verdict` — contrasted against the unpatched `BREAKING` baseline. Verified locally that reverting `bundle_side_input.py`'s `policy_file` forwarding (the #883 fix) makes this new test fail.
- `tests/regressions/manifest.py`: records the new seed tests on both bug classes and narrows (never deletes) their `known_gaps` to state what's still open.

Deliberately **out of scope** for this PR, per the plan's own listed incidents and this codebase's "known gaps over risky reactive patches" convention:
- Incidents #834/#860 — would need heavy CastXML/header-AST fixtures disproportionate to one bounded PR.
- Incident #838 — already guarded by its own targeted CLI warning.
- Forward-completeness for `REMOVED_KINDS`/`ADDED_KINDS` — both are small, deliberately curated subsets (6/56 and 8/40 of matching-suffix kinds today) for one report section, not an attempt to enumerate every kind sharing that suffix; asserting forward-exhaustiveness there would invent a business rule this module's own authors never stated.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) — not needed, diff touches only `tests/`
- [ ] Docs updated if user-visible behaviour changed — no user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally (`ruff check`, `mypy abicheck/`, `python scripts/check_architecture.py --base origin/main` all clean/pre-existing-only; `ruff format` flags pre-existing, unrelated formatting drift in both touched files per the repo's own documented known gap)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018USuGdPgyVaPK7z6iB2cKd

---
_Generated by [Claude Code](https://claude.ai/code/session_018USuGdPgyVaPK7z6iB2cKd)_