### PR TITLE
feat(model): ADR-063 Phase 2 first slice — EntityId/ScopePath primitive

### DIFF
--- a/abicheck/model/declarator_qualifiers.py
+++ b/abicheck/model/declarator_qualifiers.py
@@ -1,0 +1,368 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarator-grouping recognition and pointer-to-member/trailing-qualifier
+normalization for :mod:`abicheck.model.signature_normalization`
+(ADR-063 Phase 2).
+
+Split out of ``signature_normalization.py`` (its only caller) purely to keep
+that file under the AI-readiness gate's 800-line production maximum -- this
+module's own contents are otherwise that module's, not a separate design
+decision, the identical reason ``signature_normalization.py`` itself was
+split out of ``model/identity.py`` one round earlier. See
+``docs/contribute/plans/one-semantic-pipeline.md``'s Phase 2 section for the
+full review history (Codex/CodeRabbit, PR #941) behind each piece here.
+
+Leaf module: imports nothing above ``model`` and no sibling module at all,
+per ADR-063 D10 -- the same leaf-module contract ``model/identity.py`` and
+``signature_normalization.py`` themselves state. In particular this module
+does NOT import back from ``signature_normalization.py``: that module's own
+``canonicalize_function_signature_param_type`` calls into this module (via
+``_find_member_pointer_qualifier``/``_split_at_trailing_param_list``/
+``_canonicalize_member_qualifiers``), so the reverse import would be a real
+cycle between two sibling leaf modules -- ``_CV_WORD_RE`` is consequently
+duplicated here rather than shared, since it is the one piece both modules
+independently need.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "_is_declarator_group",
+    "_find_member_pointer_qualifier",
+    "_split_at_trailing_param_list",
+    "_canonicalize_member_qualifiers",
+]
+
+_CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
+
+# A declarator-grouping paren's content, up to its own sigil: an optional
+# MSVC calling-convention keyword, then either a bare pointer/reference
+# (`*`, `&`) or a pointer-to-member's qualified-name prefix (`C::*`,
+# `ns::C::*`, `C<int>::*` -- one or more `identifier[<template-args>]::`
+# segments) then the sigil. Used to tell a declarator-grouping paren
+# (transparent, not a real nesting level) from a genuine parameter-list
+# paren (opaque): a parameter list's first token is always a type, which
+# can itself start with an identifier, but is never a calling-convention
+# keyword and never immediately followed by `::` then only a bare sigil --
+# both shapes are unique to a declarator (Codex review, PR #941: the
+# ninth round added the qualified-name-prefix form, so `void (C::*
+# const)(int)` -- cv on a pointer-to-member's own outermost sigil -- was
+# found at depth 0; the tenth round added the calling-convention keyword,
+# since a real MSVC/PE calling-convention decoration -- e.g. `void
+# (__cdecl * const)(int)` -- otherwise defeated the same transparency
+# test the identical way; the eleventh round added the template-argument
+# list, since a real nested-name-specifier's segment can itself be a
+# template-id, e.g. `void (C<int>::* const)(int)`, which a plain
+# `identifier::` match can't recognize -- checked with a manual scanner,
+# not a single regex, since a template-argument list can nest arbitrarily
+# deep, `Box<Pair<int, int>>::`, which `re`'s non-recursive matching
+# cannot balance). The convention keyword and any template-argument list
+# are matched, not consumed/erased -- they stay in the returned prefix
+# verbatim, genuine parts of the type, same as the plain qualified-name
+# prefix already does.
+_CALLING_CONVENTIONS = (
+    "__cdecl",
+    "__stdcall",
+    "__fastcall",
+    "__thiscall",
+    "__vectorcall",
+)
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_]\w*")
+
+
+def _is_declarator_group(s: str, start: int) -> bool:
+    """Whether ``s[start:]`` is a declarator-grouping paren's own content
+    (see :data:`_CALLING_CONVENTIONS`'s module-level comment for the full
+    shape) -- called with *start* right after the paren's own ``(``.
+    """
+    n = len(s)
+    i = start
+    while i < n and s[i] == " ":
+        i += 1
+    for conv in _CALLING_CONVENTIONS:
+        if s.startswith(conv, i):
+            i += len(conv)
+            while i < n and s[i] == " ":
+                i += 1
+            break
+    while True:
+        j = i
+        while j < n and s[j] == " ":
+            j += 1
+        m = _IDENTIFIER_RE.match(s, j)
+        if not m:
+            break
+        k = m.end()
+        if k < n and s[k] == "<":
+            depth = 0
+            p = k
+            while p < n:
+                if s[p] == "<":
+                    depth += 1
+                elif s[p] == ">":
+                    depth -= 1
+                    if depth == 0:
+                        p += 1
+                        break
+                p += 1
+            else:
+                return False  # unmatched '<' -- malformed, bail out
+            k = p
+        while k < n and s[k] == " ":
+            k += 1
+        if not s.startswith("::", k):
+            break
+        i = k + 2
+    while i < n and s[i] == " ":
+        i += 1
+    return i < n and s[i] in "*&"
+
+
+def _extract_top_level_cv(s: str) -> tuple[bool, bool, str]:
+    """Depth-aware scan: finds ``const``/``volatile`` tokens at nesting
+    depth 0 only (outside any ``<...>``/``(...)``/``[...]``), reports which
+    were found, and returns *s* with those depth-0 tokens removed -- a
+    cv-looking word sitting INSIDE a parenthesized region (a
+    ``noexcept(expr)`` argument's own text, a template argument) is
+    untouched, since it belongs to that expression, not to this
+    declarator's own trailing qualifier sequence (Codex review, PR #941,
+    thirteenth round: an earlier revision used a plain, depth-blind
+    ``re.search``/``re.sub`` over the whole trailing region, which wrongly
+    reached inside a non-literal ``noexcept(expr)``'s own argument, e.g.
+    ``noexcept(Foo<const int>)``).
+    """
+    depth = 0
+    has_const = False
+    has_volatile = False
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        ch = s[i]
+        if ch in "<([":
+            depth += 1
+            out.append(ch)
+            i += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+            out.append(ch)
+            i += 1
+        elif depth == 0 and (m := _CV_WORD_RE.match(s, i)):
+            if m.group() == "const":
+                has_const = True
+            else:
+                has_volatile = True
+            i = m.end()
+        else:
+            out.append(ch)
+            i += 1
+    rest = re.sub(r"\s+", " ", "".join(out)).strip()
+    return has_const, has_volatile, rest
+
+
+_MEMBER_POINTER_TAIL_RE = re.compile(r"(?:\s*(?:const|volatile))*\s*")
+
+
+def _find_member_pointer_qualifier(prefix: str) -> tuple[int, int] | None:
+    """If *prefix* (the text up to and including a declarator's own
+    outermost sigil) ends in a BARE, non-parenthesized data-member-pointer
+    qualifier -- one or more ``Identifier::`` segments belonging to the
+    member pointer's own class, e.g. the ``C::`` in ``int C::*`` -- return
+    ``(qualifier_start, qualifier_end)`` spanning that qualifier run (not
+    including any cv token between it and the sigil). Returns ``None`` for
+    every other shape: an ordinary pointer whose pointee happens to be
+    namespace-qualified (``ns::Foo *`` -- the ``::`` there is nowhere near
+    the sigil, since a whole identifier separates them) does not match,
+    and neither does a PARENTHESIZED member-pointer/-function declarator
+    group (``(C::*)``) -- the caller only invokes this when the
+    surrounding text has no unmatched open paren, since inside one the
+    "base" this would split off is a return type/fragment, not a real
+    standalone pointee type.
+
+    Detection relies on a reliable, ``canonicalize_type_name``-specific
+    marker: a member pointer's own qualifier is always followed by a
+    single space before whatever comes next (``"C:: *"``, ``"C:: const
+    *"``) -- unlike ordinary namespace qualification within a type's own
+    spelling, which never has a space after ``::`` (``"ns::Foo"``). A
+    chained qualifier (``ns::C::``) has no space at ITS OWN internal
+    ``::`` either, only at the final, outermost one -- so the LAST ``::``
+    followed by a space reliably marks the end of the member pointer's
+    own qualifier, and is walked backward from to find where multi-segment
+    qualifiers begin (template arguments are not supported in this bare,
+    unparenthesized position -- an accepted, narrower limitation than the
+    parenthesized case's own manual scanner, since a templated class as
+    the target of an unparenthesized bare data-member-pointer is a
+    genuinely rare combination).
+
+    Used to correctly canonicalize the pointee cv-qualifier on a bare
+    data-member-pointer parameter (Codex review, PR #941, fifteenth
+    round): ``canonicalize_type_name``'s own east-const regex -- which
+    this module cannot modify, since ``name_classification.py`` is a
+    frozen, no-growth legacy file -- does not know how to normalize a
+    leading cv-qualifier across a ``ClassName::`` infix, and MISPLACES it
+    depending on which side it started on: ``"int const C::*"`` stays
+    ``"int const C:: *"`` (cv kept attached to the base, matching this
+    function's own canonical output), but ``"const int C::*"`` becomes
+    ``"int C:: const *"`` -- the cv-word shoved in BETWEEN the qualifier
+    and the sigil, where it looks like (but is not) the pointer's own
+    by-value qualifier. Both are the identical pointer-to-const-int-member
+    type and must canonicalize identically; the caller re-collects any cv
+    word found on either side of the qualifier and re-derives the pointee
+    base type from both combined.
+    """
+    if not prefix or prefix[-1] not in "*&":
+        return None
+    marker = prefix.rfind(":: ")
+    if marker == -1:
+        return None
+    qualifier_end = marker + 2
+    tail = prefix[qualifier_end : len(prefix) - 1]
+    if _MEMBER_POINTER_TAIL_RE.fullmatch(tail) is None:
+        return None
+    i = marker
+    qualifier_start = -1
+    while True:
+        j = i - 1
+        while j >= 0 and (prefix[j].isalnum() or prefix[j] == "_"):
+            j -= 1
+        if j == i - 1:
+            return None  # no identifier immediately before "::"
+        qualifier_start = j + 1
+        if j >= 1 and prefix[j - 1 : j + 1] == "::":
+            i = j - 1
+            continue
+        break
+    return qualifier_start, qualifier_end
+
+
+def _split_at_trailing_param_list(suffix: str) -> tuple[str, str] | None:
+    """If *suffix* (the text after a declarator's own outermost sigil)
+    contains a top-level ``(...)`` group -- the declarator's own trailing
+    parameter list, e.g. the ``(int)`` in ``void (*)(int)`` -- return
+    ``(head, params_and_after)`` split so ``params_and_after`` starts
+    exactly at that paren's ``(``. Returns ``None`` when *suffix* has no
+    top-level ``(`` at all (a bare pointer, with no trailing declarator to
+    split off).
+    """
+    depth = 0
+    for i, ch in enumerate(suffix):
+        if ch == "(" and depth == 0:
+            return suffix[:i], suffix[i:]
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+    return None
+
+
+_NOEXCEPT_RE = re.compile(r"\bnoexcept\b(?:\s*\(\s*([^()]*)\s*\))?")
+
+
+def _canonicalize_noexcept(s: str) -> str:
+    """Normalize the two constant ``noexcept`` spellings this trailing
+    region can carry: bare ``noexcept``/``noexcept(true)`` (the
+    "non-throwing" type) collapse to the single canonical spelling
+    ``"noexcept"``; ``noexcept(false)`` (equivalent, for type purposes, to
+    no exception-specification at all) is dropped entirely, same as an
+    already-absent specifier. Any other ``noexcept(expr)`` -- a non-
+    literal constant expression this function cannot evaluate -- is left
+    untouched, verbatim.
+    """
+    m = _NOEXCEPT_RE.search(s)
+    if not m:
+        return s
+    arg = m.group(1)
+    if arg is None or arg.strip() == "true":
+        replacement = "noexcept"
+    elif arg.strip() == "false":
+        replacement = ""
+    else:
+        return s
+    return re.sub(r"\s+", " ", s[: m.start()] + replacement + s[m.end() :]).strip()
+
+
+def _canonicalize_member_qualifiers(s: str) -> str:
+    """Canonicalize a pointer-to-member-function's own trailing
+    specifiers -- the cv-qualifiers, ref-qualifier, and (post-C++17)
+    ``noexcept``-specifier that can follow its parameter list, e.g. the
+    ``const`` in ``void (C::*)(int) const`` or the ``noexcept`` in
+    ``void (*)(int) noexcept``. These qualify the POINTED-TO member
+    function itself: genuine, standard-mandated overload/type
+    discriminators (``void (C::*)(int) const`` and ``void (C::*)(int)``
+    are two different, non-interchangeable pointer-to-member types; since
+    C++17 a ``noexcept``/non-``noexcept`` function is likewise a distinct
+    type), unlike the pointer's own by-value qualifier already stripped
+    separately -- so this function only ever REORDERS ``const``/
+    ``volatile`` relative to each other (the same "eliminate ordering by
+    construction" treatment ``entity_id_for_function``'s own
+    ``is_const``/``is_volatile`` booleans already give the outer
+    function's member-cv), while every other specifier -- ref-qualifier,
+    ``noexcept``, and anything else this function does not need to
+    individually name -- passes through verbatim, in its original
+    relative order (Codex review, PR #941, tenth round: an earlier
+    revision blanket-stripped every depth-0 cv token found anywhere after
+    the sigil, which wrongly erased this genuinely-distinguishing trailing
+    region entirely; eleventh round: the fix for that then reconstructed
+    the trailing region from ONLY cv/ref, which silently dropped
+    ``noexcept`` instead -- a second, different over-merge of the same
+    class, `void (*)(int) noexcept` and `void (*)(int)` wrongly collapsing
+    to one identity. `dcl.fct`'s own grammar already fixes cv-qualifier-
+    seq first among these trailing specifiers, so a real producer's
+    placement never needs inferring -- only cv needs reordering relative
+    to itself; everything else keeps whatever order it was already
+    spelled in; twelfth round: preserving ``noexcept`` verbatim was
+    necessary but not sufficient -- since C++17, a function type's
+    exception specification collapses to exactly two kinds for TYPE
+    purposes, "non-throwing" (bare ``noexcept``/``noexcept(true)``) and
+    "potentially-throwing" (no specifier at all, or ``noexcept(false)``),
+    so those pairs are the SAME type and must canonicalize identically,
+    the same "verbatim preservation isn't canonicalization" gap the
+    by-value cv/array-decay fixes each already closed for their own
+    shape. Only the two literal, constant-expression spellings are
+    normalized; any other, non-literal ``noexcept(expr)`` is left
+    completely untouched -- evaluating an arbitrary constant expression is
+    out of scope, the same "don't solve the fully general grammar" limit
+    this module already draws elsewhere; thirteenth round: extracting
+    ``const``/``volatile`` via a plain, depth-blind ``re.search`` over the
+    WHOLE trailing region wrongly reached inside a non-literal
+    ``noexcept(expr)``'s own argument too -- a ``const``/``volatile``
+    token that is part of THAT expression's own text, e.g.
+    ``noexcept(Foo<const int>)``, is not this declarator's own
+    cv-qualifier at all, and extracting it both corrupted the expression
+    (mutating text this function has no business touching, since it
+    cannot evaluate it) and could merge two genuinely different overloads
+    that happen to share a nested "const" by coincidence. Fixed with a
+    depth-aware scan, :func:`_extract_top_level_cv`, mirroring
+    ``signature_normalization._strip_cv_tokens_outside_nesting``'s own
+    outside-nesting discipline: only a cv word sitting at depth 0 --
+    outside any ``(...)``/``<...>``/``[...]`` -- is ever this
+    declarator's own trailing qualifier).
+    """
+    stripped = s.strip()
+    if not stripped:
+        return ""
+    has_const, has_volatile, rest = _extract_top_level_cv(stripped)
+    rest = _canonicalize_noexcept(rest)
+    parts = [
+        p
+        for p, present in (("const", has_const), ("volatile", has_volatile))
+        if present
+    ]
+    if rest:
+        parts.append(rest)
+    return " ".join(parts)

--- a/abicheck/model/declarator_qualifiers.py
+++ b/abicheck/model/declarator_qualifiers.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import re
 
 __all__ = [
+    "_CALLING_CONVENTIONS",
     "_is_declarator_group",
     "_find_member_pointer_qualifier",
     "_split_at_trailing_param_list",

--- a/abicheck/model/declarator_qualifiers.py
+++ b/abicheck/model/declarator_qualifiers.py
@@ -275,22 +275,36 @@ _NOEXCEPT_RE = re.compile(r"\bnoexcept\b(?:\s*\(\s*([^()]*)\s*\))?")
 
 
 def _canonicalize_noexcept(s: str) -> str:
-    """Normalize the two constant ``noexcept`` spellings this trailing
-    region can carry: bare ``noexcept``/``noexcept(true)`` (the
-    "non-throwing" type) collapse to the single canonical spelling
-    ``"noexcept"``; ``noexcept(false)`` (equivalent, for type purposes, to
-    no exception-specification at all) is dropped entirely, same as an
-    already-absent specifier. Any other ``noexcept(expr)`` -- a non-
-    literal constant expression this function cannot evaluate -- is left
-    untouched, verbatim.
+    """Normalize the constant ``noexcept`` spellings this trailing region
+    can carry: bare ``noexcept``, ``noexcept(true)``, and ``noexcept(1)``
+    (all the "non-throwing" type, since a ``noexcept`` argument is
+    contextually converted to ``bool``) collapse to the single canonical
+    spelling ``"noexcept"``; ``noexcept(false)``/``noexcept(0)``
+    (equivalent, for type purposes, to no exception-specification at all)
+    are dropped entirely, same as an already-absent specifier. Any other
+    ``noexcept(expr)`` -- a non-literal constant expression this function
+    cannot evaluate -- is left untouched, verbatim.
+
+    ``0``/``1`` are recognized alongside ``true``/``false`` because
+    Clang's own ``qualType`` genuinely emits these integer-literal
+    spellings verbatim (confirmed via ``clang -Xclang -ast-dump=json``:
+    ``void (int) noexcept(1)``) rather than folding them to the
+    boolean-literal spelling -- and direct compilation confirms
+    ``noexcept(1)``/``noexcept(true)`` are the identical type, as are
+    ``noexcept(0)``/no-specifier/``noexcept(false)`` (Codex review, PR
+    #941, twenty-first round). Deliberately narrow to exactly these two
+    integer literals, not "any nonzero integer" -- a non-0/1 integer
+    constant in this position triggers a narrowing-conversion diagnostic
+    in real compilers and is not a spelling this module has confirmed
+    evidence for.
     """
     m = _NOEXCEPT_RE.search(s)
     if not m:
         return s
     arg = m.group(1)
-    if arg is None or arg.strip() == "true":
+    if arg is None or arg.strip() in ("true", "1"):
         replacement = "noexcept"
-    elif arg.strip() == "false":
+    elif arg.strip() in ("false", "0"):
         replacement = ""
     else:
         return s

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass, field
 
-from ..name_classification import canonicalize_type_name
+from ..name_classification import canonicalize_function_signature_type
 
 __all__ = [
     "Anonymous",
@@ -389,7 +389,8 @@ def entity_id_for_function(
     mangled_name: str | None = None,
     is_extern_c: bool = False,
     param_types: tuple[str, ...] = (),
-    cv_qualifiers: tuple[str, ...] = (),
+    is_const: bool = False,
+    is_volatile: bool = False,
     ref_qualifier: str = "",
     is_variadic: bool | None = None,
 ) -> EntityId:
@@ -413,15 +414,24 @@ def entity_id_for_function(
     "C"`` function with no real mangling (a DWARF-only snapshot, which
     *can* be legally overloaded) -- does ``extra`` fall back to the
     normalized signature discriminator, ``("sig", *param_types,
-    *cv_qualifiers, ref_qualifier, is_variadic)``. ``ref_qualifier``
-    (``"&"``/``"&&"``/``""``) and ``is_variadic`` mirror
-    ``resolve_function_identity``'s own fallback dimensions -- without them
-    ``C::f() &`` vs. ``C::f() &&``, or ``void f(int)`` vs. ``void f(int,
-    ...)``, would collide on identical scope/name/param_types/cv_qualifiers.
-    ``is_variadic`` is ``bool | None`` rather than defaulting to ``False``
-    so a producer that genuinely doesn't know stays distinguishable from one
-    that confirmed non-variadic, the same reason
-    ``resolve_function_identity`` keeps that tri-state. Unlike
+    f"const:{is_const}", f"volatile:{is_volatile}", ref_qualifier,
+    is_variadic)``. *is_const*/*is_volatile* are two independent booleans,
+    not a ``cv_qualifiers`` string tuple -- deliberately mirroring
+    ``resolve_function_identity``'s own ``func.is_const``/
+    ``func.is_volatile`` representation exactly, rather than a tuple of
+    qualifier tokens whose *order* a caller could supply inconsistently
+    for the identical member-cv qualification (``"const volatile"`` vs.
+    ``"volatile const"`` spell the same qualification but would collide as
+    two different tuples; Codex review, PR #941). *ref_qualifier*
+    (``"&"``/``"&&"``/``""``) and *is_variadic* mirror
+    ``resolve_function_identity``'s own remaining fallback dimensions --
+    without them ``C::f() &`` vs. ``C::f() &&``, or ``void f(int)`` vs.
+    ``void f(int, ...)``, would collide on identical
+    scope/name/param_types/const/volatile. ``is_variadic`` is ``bool |
+    None`` rather than defaulting to ``False`` so a producer that
+    genuinely doesn't know stays distinguishable from one that confirmed
+    non-variadic, the same reason ``resolve_function_identity`` keeps that
+    tri-state. Unlike
     ``finding_identity.normalized_signature``'s own fallback tuple, the
     callable's qualified name does *not* need to be repeated inside
     ``extra`` here -- ``scope``/``leaf_name`` already carry it losslessly,
@@ -445,10 +455,10 @@ def entity_id_for_function(
     signature-free branch in that case, rather than silently falling
     through to the signature-based fallback the way a caller relying on
     ``mangled_name`` alone would. When *mangled_name* is genuinely present,
-    it wins outright and *is_extern_c*/*param_types*/*cv_qualifiers*/
-    *ref_qualifier*/*is_variadic* are all ignored -- there is nothing left
-    for a signature-free tag to add once the mangled name already
-    disambiguates the declaration.
+    it wins outright and *is_extern_c*/*param_types*/*is_const*/
+    *is_volatile*/*ref_qualifier*/*is_variadic* are all ignored -- there is
+    nothing left for a signature-free tag to add once the mangled name
+    already disambiguates the declaration.
 
     Both the *mangled* and *is_extern_c* branches' resulting
     ``EntityId.scope`` are always ``()``, regardless of *scope*.
@@ -477,14 +487,27 @@ def entity_id_for_function(
     different scopes distinct.
 
     *param_types* are canonicalized via
-    ``name_classification.canonicalize_type_name`` before joining into
-    ``extra`` -- CastXML's ``"char const*"`` and Clang's ``"char const *"``
-    spell an otherwise-identical parameter type differently, and without
-    canonicalization the same declaration observed by the two backends
-    would get two different ``EntityId``s, fragmenting identity across
-    header-AST backends the same way an uncanonicalized qualified name
-    would. Mirrors ``resolve_function_identity``'s own canonicalization of
-    ``func.params`` for the identical reason (Codex review, PR #941).
+    ``name_classification.canonicalize_function_signature_type`` before
+    joining into ``extra`` -- CastXML's ``"char const*"`` and Clang's
+    ``"char const *"`` spell an otherwise-identical parameter type
+    differently, and without canonicalization the same declaration
+    observed by the two backends would get two different ``EntityId``s,
+    fragmenting identity across header-AST backends the same way an
+    uncanonicalized qualified name would. That function *also* drops a
+    top-level BY-VALUE cv-qualifier a plain ``canonicalize_type_name``
+    would keep (``"int"`` vs. ``"const int"``): per the C++ standard that
+    qualifier is absent from the function's own type for linkage/mangling
+    purposes, so ``void f(int)``/``void f(const int)`` name the same
+    function and must not collide as two overloads -- while a *pointee*
+    cv-qualifier on a pointer/reference parameter (``"char *"`` vs.
+    ``"const char *"``) is deliberately left alone, since that genuinely
+    is a standard-mandated, independently-mangled overload discriminator;
+    see that function's own docstring for why the more permissive
+    ``_strip_cv_qualifiers`` diff-reporting helpers use is wrong to reuse
+    here. Mirrors ``resolve_function_identity``'s own canonicalization of
+    ``func.params`` for the identical cross-backend-spelling reason, and
+    its own ``func.is_extern_c``-gated omission of by-value param cv for
+    the identical linkage reason (Codex review, PR #941).
 
     When *mangled_name* is present, *leaf_name* is likewise ignored -- see
     :func:`entity_id_for_variable`'s docstring for the confirmed reason
@@ -506,8 +529,9 @@ def entity_id_for_function(
     else:
         extra = (
             "sig",
-            *(canonicalize_type_name(p) for p in param_types),
-            *cv_qualifiers,
+            *(canonicalize_function_signature_type(p) for p in param_types),
+            f"const:{is_const}",
+            f"volatile:{is_volatile}",
             ref_qualifier,
             str(is_variadic),
         )

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -58,9 +58,10 @@ Leaf module: no dependency on ``checker_types``/``diff_*``/anything above
 from __future__ import annotations
 
 import enum
+import re
 from dataclasses import dataclass, field
 
-from ..name_classification import canonicalize_function_signature_type
+from ..name_classification import canonicalize_type_name
 
 __all__ = [
     "Anonymous",
@@ -274,18 +275,173 @@ def _scope_path(scope: ScopePath) -> ScopePath:
     return tuple(scope)
 
 
-def entity_id_for_type(scope: ScopePath, leaf_name: str) -> EntityId:
-    """``EntityId`` for a record/class/struct/union type. No kind-specific
-    discriminator: a bare name is unambiguous once ``ScopePath`` disambiguates
-    the containing scope, since two types cannot share one name in one
-    scope in valid C/C++.
+_CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
+
+
+def _has_top_level_ptr_or_ref(canonical_type: str) -> bool:
+    """Whether *canonical_type* is pointer-shaped at nesting depth 0 --
+    a ``*``/``&`` sigil, or a top-level ``[`` array declarator (Codex
+    review, PR #941: a function PARAMETER's array type always decays to a
+    pointer, e.g. ``int []`` -> ``int *``, so any cv-qualifier on the
+    element type is pointee-level, exactly like an explicit pointer --
+    ``void f(int[])`` and ``void f(const int[])`` are two distinct,
+    independently-mangled overloads, not one). Either shape means the
+    value itself is a pointer, not merely something passed by value that
+    happens to *contain* one (``Box<int *>``, ``std::function<void(int&)>``,
+    an array *bound inside* a template argument). A minimal, self-
+    contained reimplementation of the identical algorithm
+    ``name_classification._has_top_level_ptr_or_ref`` already applies for
+    a different purpose -- deliberately duplicated rather than imported,
+    since ``name_classification.py`` is a frozen, no-growth legacy module
+    (ADR-061 debt ledger, `architecture/debt.yaml`) that new code must not
+    grow, and the helper it would be imported from is private besides.
+    The array case is added here rather than upstream because this
+    module's fallback signature discriminator is built directly from a
+    caller-supplied *string* that may still spell an array literally
+    (``"int []"``) -- it makes no assumption about whether a given
+    producer's own parsed representation already reflects the decay.
     """
-    return EntityId(scope=_scope_path(scope), kind=EntityKind.TYPE, leaf_name=leaf_name)
+    depth = 0
+    for ch in canonical_type:
+        if ch == "[" and depth == 0:
+            return True
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            return True
+    return False
 
 
-def entity_id_for_enum(scope: ScopePath, leaf_name: str) -> EntityId:
-    """``EntityId`` for an enum type. See :func:`entity_id_for_type`."""
-    return EntityId(scope=_scope_path(scope), kind=EntityKind.ENUM, leaf_name=leaf_name)
+def _canonicalize_function_signature_param_type(name: str) -> str:
+    """The canonical form of a function *parameter* type, for
+    identity/overload-discriminator purposes -- as opposed to
+    ``canonicalize_type_name``, which normalizes only cross-producer
+    spelling differences and deliberately keeps every cv-qualifier,
+    including a top-level by-value one, as real, distinguishing content.
+
+    Drops a top-level BY-VALUE cv-qualifier (``int`` -> ``const int``):
+    per the C++ standard, that qualifier is dropped from the function's
+    own type for linkage/mangling purposes -- ``void f(int)`` and ``void
+    f(const int)`` name the very same function (see
+    ``name_classification.func_signature_cv_only_differ``'s own docstring
+    for the citation). **Deliberately narrower than reusing that sibling
+    module's own private ``_strip_cv_qualifiers`` helper** (which is what
+    a first attempt at this reached for, since Codex's own finding named
+    it): that helper is permissive at the true top level, stripping a
+    *pointee* cv-qualifier too (``"const char *"`` -> ``"char *"``) --
+    correct for *"is this an already-matched declaration's param change
+    worth reporting as ABI-breaking"* (``diff_symbols._params_differ``'s
+    own question), but wrong for *this* function's job. A pointee
+    cv-qualifier on a pointer/reference parameter is a genuine, standard-
+    mandated overload discriminator (``void f(char *)`` and ``void
+    f(const char *)`` are two simultaneously-declarable, independently-
+    mangled overloads, not one declaration): collapsing them here would
+    silently merge two distinct functions into one identity, reintroducing
+    exactly the sibling-overload-collision class this whole primitive
+    exists to prevent. So this function strips a cv token only when the
+    canonicalized type carries no top-level pointer/reference sigil at
+    all (:func:`_has_top_level_ptr_or_ref`) -- the one case where every cv
+    token present is unambiguously by-value, not pointee, cv -- and, when
+    it does, only a token outside any ``<...>``/``(...)``/``[...]``
+    nesting (a cv-qualifier nested in a template argument names a
+    genuinely different type, e.g. ``Box<const int>`` vs. ``Box<int>``,
+    the same rule ``canonicalize_type_name`` itself already documents).
+
+    >>> _canonicalize_function_signature_param_type("int")
+    'int'
+    >>> _canonicalize_function_signature_param_type("const int")
+    'int'
+    >>> _canonicalize_function_signature_param_type("volatile unsigned long long")
+    'unsigned long long'
+    >>> _canonicalize_function_signature_param_type("char const*")
+    'char const *'
+    >>> _canonicalize_function_signature_param_type("const char *")
+    'char const *'
+    >>> _canonicalize_function_signature_param_type("const std::vector<const int>")
+    'std::vector<const int>'
+    >>> _canonicalize_function_signature_param_type("const int []")
+    'const int []'
+    """
+    canonical = canonicalize_type_name(name)
+    if _has_top_level_ptr_or_ref(canonical):
+        return canonical
+    depth = 0
+    out: list[str] = []
+    i = 0
+    n = len(canonical)
+    while i < n:
+        ch = canonical[i]
+        if ch in "<([":
+            depth += 1
+            out.append(ch)
+            i += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+            out.append(ch)
+            i += 1
+        elif depth == 0 and (m := _CV_WORD_RE.match(canonical, i)):
+            i = m.end()
+        else:
+            out.append(ch)
+            i += 1
+    return re.sub(r"\s+", " ", "".join(out)).strip()
+
+
+def _anonymous_self_extra(
+    leaf_name: str, anonymous_ordinal: int | None
+) -> tuple[str, ...]:
+    """``extra`` for an anonymous record/enum declaration's OWN identity --
+    distinct from :class:`Anonymous`'s ``ordinal``, which disambiguates a
+    *descendant's* containing scope, not the anonymous declaration itself.
+    ``ScopePath`` explicitly names only the containing scope, never the
+    leaf declaration (this module's own docstring), so two anonymous
+    sibling records/enums both passing ``leaf_name=""`` would otherwise
+    collide onto one identical ``EntityId`` regardless of which one is
+    meant (Codex review, PR #941). Only meaningful when *leaf_name* is
+    empty -- a named declaration already disambiguates via ``leaf_name``,
+    so *anonymous_ordinal* is ignored there rather than adding a second,
+    redundant discriminator. Same deterministic per-parent sequence-number
+    semantics, and the identical within-one-parse-only accepted
+    limitation, as :class:`Anonymous`'s own ``ordinal``.
+    """
+    if leaf_name or anonymous_ordinal is None:
+        return ()
+    return ("anonymous", str(anonymous_ordinal))
+
+
+def entity_id_for_type(
+    scope: ScopePath, leaf_name: str, *, anonymous_ordinal: int | None = None
+) -> EntityId:
+    """``EntityId`` for a record/class/struct/union type. No kind-specific
+    discriminator beyond *anonymous_ordinal*: a bare name is unambiguous
+    once ``ScopePath`` disambiguates the containing scope, since two named
+    types cannot share one name in one scope in valid C/C++ -- but an
+    *anonymous* struct/union has no name to disambiguate with at all; see
+    :func:`_anonymous_self_extra` for why *anonymous_ordinal* exists and
+    when it applies.
+    """
+    return EntityId(
+        scope=_scope_path(scope),
+        kind=EntityKind.TYPE,
+        leaf_name=leaf_name,
+        extra=_anonymous_self_extra(leaf_name, anonymous_ordinal),
+    )
+
+
+def entity_id_for_enum(
+    scope: ScopePath, leaf_name: str, *, anonymous_ordinal: int | None = None
+) -> EntityId:
+    """``EntityId`` for an enum type. See :func:`entity_id_for_type`,
+    including for *anonymous_ordinal* -- an anonymous enum is exactly as
+    real a case as an anonymous struct/union."""
+    return EntityId(
+        scope=_scope_path(scope),
+        kind=EntityKind.ENUM,
+        leaf_name=leaf_name,
+        extra=_anonymous_self_extra(leaf_name, anonymous_ordinal),
+    )
 
 
 def entity_id_for_typedef(scope: ScopePath, leaf_name: str) -> EntityId:
@@ -486,9 +642,9 @@ def entity_id_for_function(
     makes two same-named, same-signature sibling declarations in
     different scopes distinct.
 
-    *param_types* are canonicalized via
-    ``name_classification.canonicalize_function_signature_type`` before
-    joining into ``extra`` -- CastXML's ``"char const*"`` and Clang's
+    *param_types* are canonicalized via this module's own
+    ``_canonicalize_function_signature_param_type`` before joining into
+    ``extra`` -- CastXML's ``"char const*"`` and Clang's
     ``"char const *"`` spell an otherwise-identical parameter type
     differently, and without canonicalization the same declaration
     observed by the two backends would get two different ``EntityId``s,
@@ -529,7 +685,7 @@ def entity_id_for_function(
     else:
         extra = (
             "sig",
-            *(canonicalize_function_signature_type(p) for p in param_types),
+            *(_canonicalize_function_signature_param_type(p) for p in param_types),
             f"const:{is_const}",
             f"volatile:{is_volatile}",
             ref_qualifier,

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -195,10 +195,28 @@ class Anonymous:
 
 @dataclass(frozen=True)
 class LocalToFunction:
-    """A scope local to one function body. Both fields are identity --
-    nothing else disambiguates two same-named locals in one function."""
+    """A scope local to one function body.
+
+    Both fields are identity, deliberately, for exactly the reason
+    :class:`Anonymous` gives for its own ``ordinal``: ``owner`` alone
+    disambiguates two same-named locals across *different* functions, but
+    not two same-named locals in *sibling compound blocks of the same
+    function* (``void f() { { struct A {}; } { struct A {}; } }`` -- two
+    distinct declarations, same ``owner``, same leaf name). ``block_ordinal``
+    closes that gap the same way ``Anonymous.ordinal`` closes its sibling
+    case: a deterministic per-function sequence number assigned at parse
+    time, stable *within one parse*, not across revisions -- the identical
+    accepted, documented limitation :class:`Anonymous` already states (an
+    edit that adds or removes an earlier local block shifts every later
+    sibling's ordinal and therefore its whole ``EntityId``, even though
+    nothing about those later declarations changed). No default is given,
+    matching :class:`Anonymous.ordinal` for the same reason: a caller must
+    supply a real value rather than silently under-specifying identity by
+    relying on an unwired default.
+    """
 
     owner: str
+    block_ordinal: int
 
 
 ScopeSegment = Namespace | Record | InlineNamespace | Anonymous | LocalToFunction
@@ -312,8 +330,11 @@ def entity_id_for_function(
     leaf_name: str,
     *,
     mangled_name: str | None = None,
+    is_extern_c: bool = False,
     param_types: tuple[str, ...] = (),
     cv_qualifiers: tuple[str, ...] = (),
+    ref_qualifier: str = "",
+    is_variadic: bool | None = None,
 ) -> EntityId:
     """``EntityId`` for a function.
 
@@ -324,37 +345,66 @@ def entity_id_for_function(
     ``finding_identity.resolve_function_identity``/``SymbolIdentityIndex``
     and ADR-048's normalized identity already establish: mangled name first
     when one exists (the common case, already globally unique per
-    overload) -- ``extra`` becomes ``("mangled", mangled_name)`` -- and only
-    for the genuinely mangling-free case (a non-``extern "C"`` function on a
-    DWARF-only snapshot) does ``extra`` fall back to the normalized
-    signature discriminator, ``("sig", *param_types, *cv_qualifiers)``.
-    Unlike ``finding_identity.normalized_signature``'s own fallback tuple,
-    the callable's qualified name does *not* need to be repeated inside
+    overload) -- ``extra`` becomes ``("mangled", mangled_name)``. Next,
+    *is_extern_c* (a genuinely mangling-free C-linkage function -- ``extra``
+    becomes the bare ``("extern_c",)`` tag, deliberately dropping every
+    signature dimension: C has no overload resolution, so a changed
+    parameter list is a modification of the one function named
+    ``leaf_name``, not a different overload -- the same rule
+    ``finding_identity.resolve_function_identity`` documents and applies via
+    ``func.is_extern_c``). Only for the remaining case -- a non-``extern
+    "C"`` function with no real mangling (a DWARF-only snapshot, which
+    *can* be legally overloaded) -- does ``extra`` fall back to the
+    normalized signature discriminator, ``("sig", *param_types,
+    *cv_qualifiers, ref_qualifier, is_variadic)``. ``ref_qualifier``
+    (``"&"``/``"&&"``/``""``) and ``is_variadic`` mirror
+    ``resolve_function_identity``'s own fallback dimensions -- without them
+    ``C::f() &`` vs. ``C::f() &&``, or ``void f(int)`` vs. ``void f(int,
+    ...)``, would collide on identical scope/name/param_types/cv_qualifiers.
+    ``is_variadic`` is ``bool | None`` rather than defaulting to ``False``
+    so a producer that genuinely doesn't know stays distinguishable from one
+    that confirmed non-variadic, the same reason
+    ``resolve_function_identity`` keeps that tri-state. Unlike
+    ``finding_identity.normalized_signature``'s own fallback tuple, the
+    callable's qualified name does *not* need to be repeated inside
     ``extra`` here -- ``scope``/``leaf_name`` already carry it losslessly,
     with no string-joining involved, so there is nothing left for the
     fallback tuple to lose by omitting it.
 
-    Both branches are tagged (``"mangled"``/``"sig"``) rather than left as a
-    bare tuple, so a mangled name that happens to equal some function's
-    literal signature-tuple spelling can never collide with it -- the two
-    branches occupy disjoint regions of ``extra``'s value space by
-    construction, not by coincidence of what real mangled names or type
-    spellings look like.
+    All three branches are tagged (``"mangled"``/``"extern_c"``/``"sig"``)
+    rather than left as a bare tuple, so a mangled name that happens to
+    equal some function's literal signature-tuple spelling can never
+    collide with it -- the branches occupy disjoint regions of ``extra``'s
+    value space by construction, not by coincidence of what real mangled
+    names or type spellings look like.
 
     *mangled_name* must already be established as a genuine mangling by the
     caller -- see this module's docstring for why that determination is not
-    made here. When a genuine mangled name is supplied, *param_types*/
-    *cv_qualifiers* are ignored (an ``extern "C"`` function has no
-    overloading, so a changed parameter list is a modification of the one
-    function named ``leaf_name``, not a different overload -- the same rule
-    ``finding_identity.resolve_function_identity`` already documents and
-    applies).
+    made here. *is_extern_c* is a separate, caller-supplied linkage signal:
+    an ``extern "C"`` producer's ``mangled_name`` is typically ``None``
+    (its raw export spelling is not a genuine mangling, so a caller
+    following *mangled_name*'s own contract passes ``None`` for it) --
+    *is_extern_c* is what tells this constructor to still take the
+    signature-free branch in that case, rather than silently falling
+    through to the signature-based fallback the way a caller relying on
+    ``mangled_name`` alone would. When *mangled_name* is genuinely present,
+    it wins outright and *is_extern_c*/*param_types*/*cv_qualifiers*/
+    *ref_qualifier*/*is_variadic* are all ignored -- there is nothing left
+    for a signature-free tag to add once the mangled name already
+    disambiguates the declaration.
     """
-    extra = (
-        ("mangled", mangled_name)
-        if mangled_name
-        else ("sig", *param_types, *cv_qualifiers)
-    )
+    if mangled_name:
+        extra: tuple[str, ...] = ("mangled", mangled_name)
+    elif is_extern_c:
+        extra = ("extern_c",)
+    else:
+        extra = (
+            "sig",
+            *param_types,
+            *cv_qualifiers,
+            ref_qualifier,
+            str(is_variadic),
+        )
     return EntityId(
         scope=_scope_path(scope),
         kind=EntityKind.FUNCTION,

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -308,6 +308,7 @@ def entity_id_for_variable(
     leaf_name: str,
     *,
     mangled_name: str | None = None,
+    is_extern_c: bool = False,
 ) -> EntityId:
     """``EntityId`` for a variable.
 
@@ -327,11 +328,38 @@ def entity_id_for_variable(
     *mangled_name* must already be established as a genuine mangling by the
     caller, never a bare name that merely rode in the mangled field (an
     ``extern "C"`` producer's ``mangled == name``) -- see this module's
-    docstring for why that determination is not made here.
+    docstring for why that determination is not made here. *is_extern_c* is
+    the same separate, caller-supplied linkage signal
+    :func:`entity_id_for_function` accepts, for the identical reason: a
+    caller following *mangled_name*'s own contract passes ``None`` for an
+    ``extern "C"`` variable (Codex review, PR #941 -- the fresh gap this
+    parameter closes).
+
+    When either *mangled_name* or *is_extern_c* applies, the resulting
+    ``EntityId.scope`` is always ``()``, regardless of the caller-supplied
+    *scope*. A genuine mangled name already fully and deterministically
+    encodes scope, so folding a caller-supplied *scope* in on top adds
+    nothing when it is available and actively fragments identity when it
+    is not: a header/DWARF-derived observation may supply a real
+    ``ScopePath`` for the identical symbol an export-table-only snapshot
+    observes with no scope at all (Codex review, PR #941 -- the same
+    evidence-tier-fragmentation mechanism :func:`entity_id_for_function`'s
+    own *is_extern_c* branch already guards against, generalized here to
+    every name-based -- as opposed to signature-based -- discriminator,
+    mangled included). Only the genuinely mangling-free, non-``extern
+    "C"`` degenerate case keeps *scope* as given.
     """
-    extra = ("mangled", mangled_name) if mangled_name else ()
+    if mangled_name:
+        extra: tuple[str, ...] = ("mangled", mangled_name)
+        resolved_scope: ScopePath = ()
+    elif is_extern_c:
+        extra = ("extern_c",)
+        resolved_scope = ()
+    else:
+        extra = ()
+        resolved_scope = _scope_path(scope)
     return EntityId(
-        scope=_scope_path(scope),
+        scope=resolved_scope,
         kind=EntityKind.VARIABLE,
         leaf_name=leaf_name,
         extra=extra,
@@ -406,27 +434,31 @@ def entity_id_for_function(
     for a signature-free tag to add once the mangled name already
     disambiguates the declaration.
 
-    The *is_extern_c* branch's resulting ``EntityId.scope`` is always
-    ``()``, regardless of *scope*: ``resolve_symbol_identity`` deliberately
-    bases an extern-"C" identity on the raw export spelling alone rather
+    Both the *mangled* and *is_extern_c* branches' resulting
+    ``EntityId.scope`` are always ``()``, regardless of *scope*.
+    ``resolve_symbol_identity`` deliberately bases a real-mangled or
+    extern-"C" identity on the raw name alone (``mangled:...``) rather
     than a qualified name, precisely because scope availability varies by
     evidence tier -- a header/DWARF-derived observation of a namespaced
-    ``extern "C"`` function may supply a real ``ScopePath``, while an
-    export-table-only snapshot of the identical binary symbol knows only
-    the bare exported name (extern "C" linkage means the symbol *is* that
-    bare name at the ABI level, so no namespace is even recoverable from
-    the export table alone). Folding a caller-supplied *scope* into the id
-    here would fragment one entity's identity across those two evidence
-    tiers -- the same reason ``resolve_symbol_identity`` explicitly prefers
-    the raw literal over ``qualified_name`` for this exact case (Codex
-    review, PR #941). The *mangled* branch keeps *scope* as given: a real
-    mangled name already fully and deterministically encodes scope, so no
-    evidence-tier divergence is possible there, and the extra `scope` field
-    is redundant but harmless. The *sig* fallback also keeps *scope* as
-    given -- a DWARF-only, mangling-free function has no comparable
-    varying-availability-by-tier problem to guard against, and scope is
-    exactly what makes two same-named, same-signature sibling declarations
-    in different scopes distinct.
+    function (mangled or ``extern "C"``) may supply a real ``ScopePath``,
+    while an export-table-only snapshot of the identical binary symbol
+    knows only the bare exported/mangled name. Folding a caller-supplied
+    *scope* into the id would fragment one entity's identity across those
+    two evidence tiers even though the name already, on its own,
+    unambiguously identifies the declaration -- for a genuine mangled
+    name this holds losslessly (the mangling itself fully encodes scope);
+    for ``extern "C"`` it holds because the symbol *is* that bare name at
+    the ABI level, so no namespace is even recoverable from an export
+    table alone. (An earlier revision of this docstring claimed the
+    *mangled* branch's redundant `scope` was merely harmless rather than
+    actively fragmenting -- Codex review on PR #941 caught that this is
+    the identical mechanism the *is_extern_c* branch already guards
+    against, not a different, safe case; corrected here.) The *sig*
+    fallback is the one branch that keeps *scope* as given -- a DWARF-only,
+    mangling-free, non-``extern "C"`` function has no authoritative,
+    scope-independent name to fall back on, and scope is exactly what
+    makes two same-named, same-signature sibling declarations in
+    different scopes distinct.
 
     *param_types* are canonicalized via
     ``name_classification.canonicalize_type_name`` before joining into
@@ -440,7 +472,7 @@ def entity_id_for_function(
     """
     if mangled_name:
         extra: tuple[str, ...] = ("mangled", mangled_name)
-        resolved_scope = _scope_path(scope)
+        resolved_scope: ScopePath = ()
     elif is_extern_c:
         extra = ("extern_c",)
         resolved_scope = ()

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -1,0 +1,363 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``ScopePath``/``EntityId`` — the one identity primitive (ADR-063 Phase 2).
+
+**This module is a first, isolated slice of Phase 2, not the whole
+phase.** See ``docs/contribute/plans/one-semantic-pipeline.md``'s "Phase 2
+— EntityId/ScopePath as the one identity primitive" section for the full
+design, including two questions this slice deliberately leaves open:
+
+1. *Where ``ScopePath`` gets built from.* This module's ``entity_id_for_*``
+   constructors take an already-built :data:`ScopePath` as input — they do
+   not derive one from a parser's internal scope-tracking state
+   (``entry.scope`` in ``dumper_clang.py``/``dumper_castxml.py`` today is a
+   bare ``list[str]``, structurally insufficient to build a typed
+   ``ScopePath`` from; see the plan). Widening that parser state, and
+   deciding whether the resulting ``EntityId`` is computed once and carried
+   on the model object or recomputed on demand (the plan's "no carrier
+   field" open question, options (a)/(b)), is separate follow-on work.
+2. *The mangled-name-is-genuine determination.* ``entity_id_for_function``/
+   ``entity_id_for_variable`` take a caller-supplied ``mangled_name`` and
+   trust it is a real mangling, not a bare name that merely rode in the
+   mangled field (the ``extern "C"`` case). That determination stays owned
+   by ``finding_identity.is_real_mangled_name``/``normalize_mangled_name``
+   for now — this slice does not migrate that ~450-line, independently
+   reviewed Itanium-mangling-validation machinery, and
+   ``finding_identity.py`` does not yet delegate to this module. A future
+   slice is expected to move that algorithm here and make
+   ``finding_identity.resolve_function_identity`` a thin wrapper, per the
+   plan's "direction of reuse" note — not attempted here, to keep this
+   slice reviewable on its own.
+
+What *is* real and load-bearing in this slice: the ``ScopePath`` segment
+types and their identity-vs-payload field split, the ``EntityId`` shape
+itself (``scope``, ``kind``, ``leaf_name``, ``extra`` — never a bare
+``(ScopePath, kind)``, which collides sibling declarations), and the
+``EntityKind``/``ObservationKind`` relocation from ``storage.entity_ids``
+(domain vocabulary belongs in ``model``, not the storage wire layer, per
+ADR-061's ``storage -> model`` import direction — ``storage.entity_ids`` now
+imports these two enums rather than redefining them).
+
+Leaf module: no dependency on ``checker_types``/``diff_*``/anything above
+``model``, per ADR-063 D10.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+__all__ = [
+    "Anonymous",
+    "EntityId",
+    "EntityKind",
+    "InlineNamespace",
+    "LocalToFunction",
+    "Namespace",
+    "ObservationKind",
+    "Record",
+    "ScopePath",
+    "ScopeSegment",
+    "entity_id_for_constant",
+    "entity_id_for_enum",
+    "entity_id_for_function",
+    "entity_id_for_type",
+    "entity_id_for_typedef",
+    "entity_id_for_variable",
+]
+
+
+class EntityKind(enum.Enum):
+    """What kind of logical thing an :class:`EntityId` names.
+
+    Relocated here from ``storage.entity_ids`` (ADR-063 Phase 2 note above):
+    this is domain vocabulary, not a storage wire concern.
+    ``storage.entity_ids.EntityKind`` is this same enum, imported rather
+    than redefined — exactly one ``EntityKind`` exists in the repository.
+    """
+
+    FUNCTION = "function"
+    VARIABLE = "variable"
+    TYPE = "type"
+    ENUM = "enum"
+    TYPEDEF = "typedef"
+    CONSTANT = "constant"
+    SYMBOL = "symbol"
+    FIELD = "field"
+    BASE = "base"
+
+
+class ObservationKind(enum.Enum):
+    """Where an occurrence of an entity was observed.
+
+    Relocated from ``storage.entity_ids`` alongside :class:`EntityKind`,
+    for the same reason. See ``storage.entity_ids.OccurrenceId`` for what
+    consumes it today.
+    """
+
+    AST = "ast"
+    DWARF = "dwarf"
+    PDB = "pdb"
+    EXPORT_TABLE = "export_table"
+    TRANSLATION_UNIT = "translation_unit"
+    SOURCE_LOCATION = "source_location"
+    BUILD_UNIT = "build_unit"
+
+
+# --------------------------------------------------------------------------
+# ScopePath segment types
+#
+# Each segment states which of its own fields are identity and which are
+# payload -- a bare frozen dataclass would make every field identity by
+# default, which is wrong for `Record.access`. `field(compare=False)`
+# excludes a field from both `__eq__` and the frozen-dataclass-generated
+# `__hash__` (dataclass's `hash=None` default follows `compare`), so no
+# separate `__eq__`/`__hash__` override is needed anywhere below.
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Namespace:
+    """An ordinary (non-inline) namespace segment. Every field is identity."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class Record:
+    """A record (class/struct/union) nesting scope.
+
+    ``access`` (public/protected/private) is carried on the segment because
+    a nested record's access is a real fact a consumer may want, but it is
+    not part of *where* the nesting scope is: two snapshots of the same
+    class with a member's access level changed still name the identical
+    containing scope. Making ``access`` part of identity would turn an
+    access-level change into a spurious identity mismatch -- the matcher
+    would see "removed, then added" at a different ``EntityId`` instead of
+    "this declaration changed."
+    """
+
+    name: str
+    access: str = field(default="", compare=False)
+
+
+@dataclass(frozen=True)
+class InlineNamespace:
+    """An inline namespace segment. Every field is identity.
+
+    ``version_tag`` is exactly the dimension ADR-025's versioned-inline-
+    namespace-alias handling already keys matching on; excluding it here
+    would silently re-widen the ``v1``/``v2``-shaped collision that
+    machinery exists to avoid.
+    """
+
+    name: str
+    version_tag: str = ""
+
+
+@dataclass(frozen=True)
+class Anonymous:
+    """An anonymous struct/union/enum/namespace scope.
+
+    Both fields are identity, deliberately: nothing else disambiguates two
+    sibling anonymous scopes coexisting in the same parent. ``ordinal`` is a
+    deterministic per-parent sequence number assigned at parse time --
+    stable *within one parse*, which is what makes it a legitimate
+    disambiguator for two anonymous siblings in one snapshot. It is **not**
+    stable across revisions: inserting a new anonymous sibling ahead of
+    existing ones shifts every later sibling's ordinal, and therefore its
+    whole ``EntityId``, even though nothing about those later declarations
+    changed. No stable across-snapshot discriminator is adopted here -- see
+    the plan's Phase 2 Design section for why (a source-location anchor and
+    a structural fingerprint of the anonymous scope's own members were both
+    considered and are each independently documented elsewhere in this
+    codebase's AGENTS.md as unreliable for this exact purpose). This is an
+    accepted, documented limitation of ``Anonymous`` identity specifically,
+    not a silent gap.
+    """
+
+    kind: str
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class LocalToFunction:
+    """A scope local to one function body. Both fields are identity --
+    nothing else disambiguates two same-named locals in one function."""
+
+    owner: str
+
+
+ScopeSegment = Namespace | Record | InlineNamespace | Anonymous | LocalToFunction
+
+#: An immutable, ordered sequence of typed scope segments, outermost first,
+#: naming only the *containing* scope -- never the leaf declaration itself.
+ScopePath = tuple[ScopeSegment, ...]
+
+
+# --------------------------------------------------------------------------
+# EntityId
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EntityId:
+    """A logical declaration's identity.
+
+    Never a bare ``(scope, kind)`` pair -- that collides any two sibling
+    declarations of the same kind in the same scope (two enums, two
+    variables, two typedefs, and -- the case that first exposed this --
+    two function overloads). ``leaf_name`` is the declaration's own
+    (unqualified) name, carried explicitly for every kind. ``extra`` is
+    kind-specific and empty for most kinds (a record/enum/typedef/
+    constant); a variable's and a function's constructors below populate it
+    with the discriminator each of those two kinds specifically needs.
+    """
+
+    scope: ScopePath
+    kind: EntityKind
+    leaf_name: str
+    extra: tuple[str, ...] = ()
+
+
+def _scope_path(scope: ScopePath) -> ScopePath:
+    """Normalize *scope* to a real ``tuple`` regardless of what iterable a
+    caller passed, so two calls built from value-equal-but-not-identical
+    scope sequences (e.g. a list vs. a tuple) produce ``EntityId``s that
+    compare equal -- "computed once" here means one algorithm producing one
+    answer for one input, not object identity of the scope argument.
+    """
+    return tuple(scope)
+
+
+def entity_id_for_type(scope: ScopePath, leaf_name: str) -> EntityId:
+    """``EntityId`` for a record/class/struct/union type. No kind-specific
+    discriminator: a bare name is unambiguous once ``ScopePath`` disambiguates
+    the containing scope, since two types cannot share one name in one
+    scope in valid C/C++.
+    """
+    return EntityId(scope=_scope_path(scope), kind=EntityKind.TYPE, leaf_name=leaf_name)
+
+
+def entity_id_for_enum(scope: ScopePath, leaf_name: str) -> EntityId:
+    """``EntityId`` for an enum type. See :func:`entity_id_for_type`."""
+    return EntityId(scope=_scope_path(scope), kind=EntityKind.ENUM, leaf_name=leaf_name)
+
+
+def entity_id_for_typedef(scope: ScopePath, leaf_name: str) -> EntityId:
+    """``EntityId`` for a typedef/alias. See :func:`entity_id_for_type`."""
+    return EntityId(
+        scope=_scope_path(scope), kind=EntityKind.TYPEDEF, leaf_name=leaf_name
+    )
+
+
+def entity_id_for_constant(scope: ScopePath, leaf_name: str) -> EntityId:
+    """``EntityId`` for a manifest/macro constant. See
+    :func:`entity_id_for_type`."""
+    return EntityId(
+        scope=_scope_path(scope), kind=EntityKind.CONSTANT, leaf_name=leaf_name
+    )
+
+
+def entity_id_for_variable(
+    scope: ScopePath,
+    leaf_name: str,
+    *,
+    mangled_name: str | None = None,
+) -> EntityId:
+    """``EntityId`` for a variable.
+
+    A bare ``(scope, "variable", leaf_name, ())`` is not enough: two
+    exported variables sharing scope and leaf name but differing mangled
+    names (two distinct, non-overloadable template-instantiation statics,
+    or a declaration-vs-definition spelling mismatch the mangler doesn't
+    collapse) are two different exports, not one -- "variables enable no
+    alias tier at all ... a display-name join would hide a real removal"
+    (AGENTS.md's own ``finding_identity.py``/``SymbolIdentityIndex`` entry,
+    which this constructor generalizes rather than contradicts). So
+    ``extra`` carries the mangled spelling whenever one exists, falling back
+    to ``()`` only for the genuinely mangling-free case (no linker symbol at
+    all -- e.g. a variable known only from a header declaration with no
+    corresponding binary evidence).
+
+    *mangled_name* must already be established as a genuine mangling by the
+    caller, never a bare name that merely rode in the mangled field (an
+    ``extern "C"`` producer's ``mangled == name``) -- see this module's
+    docstring for why that determination is not made here.
+    """
+    extra = ("mangled", mangled_name) if mangled_name else ()
+    return EntityId(
+        scope=_scope_path(scope),
+        kind=EntityKind.VARIABLE,
+        leaf_name=leaf_name,
+        extra=extra,
+    )
+
+
+def entity_id_for_function(
+    scope: ScopePath,
+    leaf_name: str,
+    *,
+    mangled_name: str | None = None,
+    param_types: tuple[str, ...] = (),
+    cv_qualifiers: tuple[str, ...] = (),
+) -> EntityId:
+    """``EntityId`` for a function.
+
+    ``scope`` plus a bare name is not enough: ``f(int)`` and ``f(double)``
+    share the same ``ScopePath`` and the same ``function`` kind, so without
+    a third component two genuinely distinct overloads collapse into one
+    id. Mirrors the existing tiered resolution
+    ``finding_identity.resolve_function_identity``/``SymbolIdentityIndex``
+    and ADR-048's normalized identity already establish: mangled name first
+    when one exists (the common case, already globally unique per
+    overload) -- ``extra`` becomes ``("mangled", mangled_name)`` -- and only
+    for the genuinely mangling-free case (a non-``extern "C"`` function on a
+    DWARF-only snapshot) does ``extra`` fall back to the normalized
+    signature discriminator, ``("sig", *param_types, *cv_qualifiers)``.
+    Unlike ``finding_identity.normalized_signature``'s own fallback tuple,
+    the callable's qualified name does *not* need to be repeated inside
+    ``extra`` here -- ``scope``/``leaf_name`` already carry it losslessly,
+    with no string-joining involved, so there is nothing left for the
+    fallback tuple to lose by omitting it.
+
+    Both branches are tagged (``"mangled"``/``"sig"``) rather than left as a
+    bare tuple, so a mangled name that happens to equal some function's
+    literal signature-tuple spelling can never collide with it -- the two
+    branches occupy disjoint regions of ``extra``'s value space by
+    construction, not by coincidence of what real mangled names or type
+    spellings look like.
+
+    *mangled_name* must already be established as a genuine mangling by the
+    caller -- see this module's docstring for why that determination is not
+    made here. When a genuine mangled name is supplied, *param_types*/
+    *cv_qualifiers* are ignored (an ``extern "C"`` function has no
+    overloading, so a changed parameter list is a modification of the one
+    function named ``leaf_name``, not a different overload -- the same rule
+    ``finding_identity.resolve_function_identity`` already documents and
+    applies).
+    """
+    extra = (
+        ("mangled", mangled_name)
+        if mangled_name
+        else ("sig", *param_types, *cv_qualifiers)
+    )
+    return EntityId(
+        scope=_scope_path(scope),
+        kind=EntityKind.FUNCTION,
+        leaf_name=leaf_name,
+        extra=extra,
+    )

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -348,20 +348,36 @@ def entity_id_for_variable(
     every name-based -- as opposed to signature-based -- discriminator,
     mangled included). Only the genuinely mangling-free, non-``extern
     "C"`` degenerate case keeps *scope* as given.
+
+    When *mangled_name* is present, *leaf_name* is likewise ignored, for
+    a confirmed, not merely hypothetical, reason: the ELF-only fallback
+    path (``dumper_elf_fallback.py``) constructs an export-only
+    ``Variable``/``Function`` with ``name=sym, mangled=sym`` -- the raw
+    exported symbol reused for *both* fields -- while a header/DWARF
+    observation of the identical symbol supplies the real demangled short
+    name for ``name``. Keying the mangled branch on *leaf_name* too would
+    therefore fail to merge the two observations of one symbol precisely
+    when the mangled evidence agrees they are the same declaration (Codex
+    review, PR #941). The mangled spelling alone already disambiguates
+    every declaration in ``extra``, so nothing is lost by dropping
+    *leaf_name* here.
     """
     if mangled_name:
         extra: tuple[str, ...] = ("mangled", mangled_name)
         resolved_scope: ScopePath = ()
+        resolved_leaf_name = ""
     elif is_extern_c:
         extra = ("extern_c",)
         resolved_scope = ()
+        resolved_leaf_name = leaf_name
     else:
         extra = ()
         resolved_scope = _scope_path(scope)
+        resolved_leaf_name = leaf_name
     return EntityId(
         scope=resolved_scope,
         kind=EntityKind.VARIABLE,
-        leaf_name=leaf_name,
+        leaf_name=resolved_leaf_name,
         extra=extra,
     )
 
@@ -469,13 +485,24 @@ def entity_id_for_function(
     header-AST backends the same way an uncanonicalized qualified name
     would. Mirrors ``resolve_function_identity``'s own canonicalization of
     ``func.params`` for the identical reason (Codex review, PR #941).
+
+    When *mangled_name* is present, *leaf_name* is likewise ignored -- see
+    :func:`entity_id_for_variable`'s docstring for the confirmed reason
+    (the ELF-only fallback path reuses the raw exported symbol for both
+    ``Function.name`` and ``Function.mangled``, so a header/DWARF
+    observation's demangled ``name`` and an export-only observation's raw
+    name would otherwise disagree despite an identical, genuine mangling;
+    Codex review, PR #941). The mangled spelling alone already
+    disambiguates every declaration in ``extra``.
     """
     if mangled_name:
         extra: tuple[str, ...] = ("mangled", mangled_name)
         resolved_scope: ScopePath = ()
+        resolved_leaf_name = ""
     elif is_extern_c:
         extra = ("extern_c",)
         resolved_scope = ()
+        resolved_leaf_name = leaf_name
     else:
         extra = (
             "sig",
@@ -485,9 +512,10 @@ def entity_id_for_function(
             str(is_variadic),
         )
         resolved_scope = _scope_path(scope)
+        resolved_leaf_name = leaf_name
     return EntityId(
         scope=resolved_scope,
         kind=EntityKind.FUNCTION,
-        leaf_name=leaf_name,
+        leaf_name=resolved_leaf_name,
         extra=extra,
     )

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -60,6 +60,8 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass, field
 
+from ..name_classification import canonicalize_type_name
+
 __all__ = [
     "Anonymous",
     "EntityId",
@@ -213,9 +215,20 @@ class LocalToFunction:
     matching :class:`Anonymous.ordinal` for the same reason: a caller must
     supply a real value rather than silently under-specifying identity by
     relying on an unwired default.
+
+    ``owner`` is the *owning function's own* :class:`EntityId`, not a bare
+    string -- a plain function name collides two overloads that each
+    declare a same-named local in their (corresponding) block
+    (``f(int) { struct A {}; }`` vs. ``f(double) { struct A {}; }`` --
+    identical ``owner="f"`` string, identical leaf name, so the two locals
+    would wrongly merge under an unconstrained-string owner; Codex review,
+    PR #941). Recursion is intentional and safe: `EntityId` is frozen/
+    hashable, so an `EntityId` naming a function whose own scope path
+    happens to include an outer `LocalToFunction` nests exactly as deep as
+    the real declaration does, with no special-casing needed here.
     """
 
-    owner: str
+    owner: EntityId
     block_ordinal: int
 
 
@@ -392,21 +405,56 @@ def entity_id_for_function(
     *ref_qualifier*/*is_variadic* are all ignored -- there is nothing left
     for a signature-free tag to add once the mangled name already
     disambiguates the declaration.
+
+    The *is_extern_c* branch's resulting ``EntityId.scope`` is always
+    ``()``, regardless of *scope*: ``resolve_symbol_identity`` deliberately
+    bases an extern-"C" identity on the raw export spelling alone rather
+    than a qualified name, precisely because scope availability varies by
+    evidence tier -- a header/DWARF-derived observation of a namespaced
+    ``extern "C"`` function may supply a real ``ScopePath``, while an
+    export-table-only snapshot of the identical binary symbol knows only
+    the bare exported name (extern "C" linkage means the symbol *is* that
+    bare name at the ABI level, so no namespace is even recoverable from
+    the export table alone). Folding a caller-supplied *scope* into the id
+    here would fragment one entity's identity across those two evidence
+    tiers -- the same reason ``resolve_symbol_identity`` explicitly prefers
+    the raw literal over ``qualified_name`` for this exact case (Codex
+    review, PR #941). The *mangled* branch keeps *scope* as given: a real
+    mangled name already fully and deterministically encodes scope, so no
+    evidence-tier divergence is possible there, and the extra `scope` field
+    is redundant but harmless. The *sig* fallback also keeps *scope* as
+    given -- a DWARF-only, mangling-free function has no comparable
+    varying-availability-by-tier problem to guard against, and scope is
+    exactly what makes two same-named, same-signature sibling declarations
+    in different scopes distinct.
+
+    *param_types* are canonicalized via
+    ``name_classification.canonicalize_type_name`` before joining into
+    ``extra`` -- CastXML's ``"char const*"`` and Clang's ``"char const *"``
+    spell an otherwise-identical parameter type differently, and without
+    canonicalization the same declaration observed by the two backends
+    would get two different ``EntityId``s, fragmenting identity across
+    header-AST backends the same way an uncanonicalized qualified name
+    would. Mirrors ``resolve_function_identity``'s own canonicalization of
+    ``func.params`` for the identical reason (Codex review, PR #941).
     """
     if mangled_name:
         extra: tuple[str, ...] = ("mangled", mangled_name)
+        resolved_scope = _scope_path(scope)
     elif is_extern_c:
         extra = ("extern_c",)
+        resolved_scope = ()
     else:
         extra = (
             "sig",
-            *param_types,
+            *(canonicalize_type_name(p) for p in param_types),
             *cv_qualifiers,
             ref_qualifier,
             str(is_variadic),
         )
+        resolved_scope = _scope_path(scope)
     return EntityId(
-        scope=_scope_path(scope),
+        scope=resolved_scope,
         kind=EntityKind.FUNCTION,
         leaf_name=leaf_name,
         extra=extra,

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -58,10 +58,9 @@ Leaf module: no dependency on ``checker_types``/``diff_*``/anything above
 from __future__ import annotations
 
 import enum
-import re
 from dataclasses import dataclass, field
 
-from ..name_classification import canonicalize_type_name
+from .signature_normalization import canonicalize_function_signature_param_type
 
 __all__ = [
     "Anonymous",
@@ -273,120 +272,6 @@ def _scope_path(scope: ScopePath) -> ScopePath:
     answer for one input, not object identity of the scope argument.
     """
     return tuple(scope)
-
-
-_CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
-
-
-def _has_top_level_ptr_or_ref(canonical_type: str) -> bool:
-    """Whether *canonical_type* is pointer-shaped at nesting depth 0 --
-    a ``*``/``&`` sigil, or a top-level ``[`` array declarator (Codex
-    review, PR #941: a function PARAMETER's array type always decays to a
-    pointer, e.g. ``int []`` -> ``int *``, so any cv-qualifier on the
-    element type is pointee-level, exactly like an explicit pointer --
-    ``void f(int[])`` and ``void f(const int[])`` are two distinct,
-    independently-mangled overloads, not one). Either shape means the
-    value itself is a pointer, not merely something passed by value that
-    happens to *contain* one (``Box<int *>``, ``std::function<void(int&)>``,
-    an array *bound inside* a template argument). A minimal, self-
-    contained reimplementation of the identical algorithm
-    ``name_classification._has_top_level_ptr_or_ref`` already applies for
-    a different purpose -- deliberately duplicated rather than imported,
-    since ``name_classification.py`` is a frozen, no-growth legacy module
-    (ADR-061 debt ledger, `architecture/debt.yaml`) that new code must not
-    grow, and the helper it would be imported from is private besides.
-    The array case is added here rather than upstream because this
-    module's fallback signature discriminator is built directly from a
-    caller-supplied *string* that may still spell an array literally
-    (``"int []"``) -- it makes no assumption about whether a given
-    producer's own parsed representation already reflects the decay.
-    """
-    depth = 0
-    for ch in canonical_type:
-        if ch == "[" and depth == 0:
-            return True
-        if ch in "<([":
-            depth += 1
-        elif ch in ">)]":
-            depth = max(0, depth - 1)
-        elif ch in "*&" and depth == 0:
-            return True
-    return False
-
-
-def _canonicalize_function_signature_param_type(name: str) -> str:
-    """The canonical form of a function *parameter* type, for
-    identity/overload-discriminator purposes -- as opposed to
-    ``canonicalize_type_name``, which normalizes only cross-producer
-    spelling differences and deliberately keeps every cv-qualifier,
-    including a top-level by-value one, as real, distinguishing content.
-
-    Drops a top-level BY-VALUE cv-qualifier (``int`` -> ``const int``):
-    per the C++ standard, that qualifier is dropped from the function's
-    own type for linkage/mangling purposes -- ``void f(int)`` and ``void
-    f(const int)`` name the very same function (see
-    ``name_classification.func_signature_cv_only_differ``'s own docstring
-    for the citation). **Deliberately narrower than reusing that sibling
-    module's own private ``_strip_cv_qualifiers`` helper** (which is what
-    a first attempt at this reached for, since Codex's own finding named
-    it): that helper is permissive at the true top level, stripping a
-    *pointee* cv-qualifier too (``"const char *"`` -> ``"char *"``) --
-    correct for *"is this an already-matched declaration's param change
-    worth reporting as ABI-breaking"* (``diff_symbols._params_differ``'s
-    own question), but wrong for *this* function's job. A pointee
-    cv-qualifier on a pointer/reference parameter is a genuine, standard-
-    mandated overload discriminator (``void f(char *)`` and ``void
-    f(const char *)`` are two simultaneously-declarable, independently-
-    mangled overloads, not one declaration): collapsing them here would
-    silently merge two distinct functions into one identity, reintroducing
-    exactly the sibling-overload-collision class this whole primitive
-    exists to prevent. So this function strips a cv token only when the
-    canonicalized type carries no top-level pointer/reference sigil at
-    all (:func:`_has_top_level_ptr_or_ref`) -- the one case where every cv
-    token present is unambiguously by-value, not pointee, cv -- and, when
-    it does, only a token outside any ``<...>``/``(...)``/``[...]``
-    nesting (a cv-qualifier nested in a template argument names a
-    genuinely different type, e.g. ``Box<const int>`` vs. ``Box<int>``,
-    the same rule ``canonicalize_type_name`` itself already documents).
-
-    >>> _canonicalize_function_signature_param_type("int")
-    'int'
-    >>> _canonicalize_function_signature_param_type("const int")
-    'int'
-    >>> _canonicalize_function_signature_param_type("volatile unsigned long long")
-    'unsigned long long'
-    >>> _canonicalize_function_signature_param_type("char const*")
-    'char const *'
-    >>> _canonicalize_function_signature_param_type("const char *")
-    'char const *'
-    >>> _canonicalize_function_signature_param_type("const std::vector<const int>")
-    'std::vector<const int>'
-    >>> _canonicalize_function_signature_param_type("const int []")
-    'const int []'
-    """
-    canonical = canonicalize_type_name(name)
-    if _has_top_level_ptr_or_ref(canonical):
-        return canonical
-    depth = 0
-    out: list[str] = []
-    i = 0
-    n = len(canonical)
-    while i < n:
-        ch = canonical[i]
-        if ch in "<([":
-            depth += 1
-            out.append(ch)
-            i += 1
-        elif ch in ">)]":
-            depth = max(0, depth - 1)
-            out.append(ch)
-            i += 1
-        elif depth == 0 and (m := _CV_WORD_RE.match(canonical, i)):
-            i = m.end()
-        else:
-            out.append(ch)
-            i += 1
-    return re.sub(r"\s+", " ", "".join(out)).strip()
 
 
 def _anonymous_self_extra(
@@ -642,9 +527,9 @@ def entity_id_for_function(
     makes two same-named, same-signature sibling declarations in
     different scopes distinct.
 
-    *param_types* are canonicalized via this module's own
-    ``_canonicalize_function_signature_param_type`` before joining into
-    ``extra`` -- CastXML's ``"char const*"`` and Clang's
+    *param_types* are canonicalized via the sibling
+    ``signature_normalization.canonicalize_function_signature_param_type``
+    before joining into ``extra`` -- CastXML's ``"char const*"`` and Clang's
     ``"char const *"`` spell an otherwise-identical parameter type
     differently, and without canonicalization the same declaration
     observed by the two backends would get two different ``EntityId``s,
@@ -685,7 +570,7 @@ def entity_id_for_function(
     else:
         extra = (
             "sig",
-            *(_canonicalize_function_signature_param_type(p) for p in param_types),
+            *(canonicalize_function_signature_param_type(p) for p in param_types),
             f"const:{is_const}",
             f"volatile:{is_volatile}",
             ref_qualifier,

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -52,25 +52,26 @@ from .declarator_qualifiers import (
 
 __all__ = ["canonicalize_function_signature_param_type"]
 
-_CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
-
-# `restrict`/`__restrict`/`__restrict__` -- a pointer type qualifier with NO
-# effect on the Itanium C++ ABI's mangling at all, unlike `const`/
-# `volatile` (which stay genuinely distinguishing at the pointee level).
-# This repository already models the fact separately, on `Param.
-# is_restrict` (`dumper_castxml.py`'s/`dumper_clang_qualifiers.py`'s own
-# extraction comments state the same thing: restrict has no ABI/mangling
-# effect) -- so, unlike cv, it is safe to strip UNCONDITIONALLY, at any
-# position and nesting depth a real declarator can place it (the grammar
-# only ever allows it directly after the `*` it qualifies), not merely on
-# this parameter's own outermost pointer (Codex review, PR #941, sixteenth
-# round: the finding as reported scoped a fix to only the outermost
-# pointer, matching how a genuine BY-VALUE cv-qualifier is scoped -- but
-# restrict is not cv; its total absence from mangling holds regardless of
-# position, so narrowing to "outermost only" would leave
-# `int * restrict *` and `int * *` still distinguishing, when they must
-# not).
-_RESTRICT_WORD_RE = re.compile(r"\b(?:__restrict__|__restrict|restrict)\b")
+# `restrict`/`__restrict`/`__restrict__` -- a qualifier attached to a
+# specific pointer, positioned exactly where a `const`/`volatile` on that
+# same pointer would be, and it turns out to be POSITION-SENSITIVE the
+# identical way: real-compiler verification (`g++ -c`, GCC's own Itanium
+# mangler) confirms `void f(int *)` and `void f(int * restrict)` are the
+# SAME function (restrict on the parameter's own outermost, by-value
+# pointer position drops from the mangled name, `_Z1fPi` both ways --
+# GCC even refuses to compile that pair as a legal overload set, exactly
+# the "same function" signal) -- but `void f(int **)` and
+# `void f(int * restrict *)` mangle to two DIFFERENT, simultaneously-
+# declarable symbols (`_Z1fPPi` vs `_Z1fPrPi`). So restrict is folded
+# into this same strippable-word set, reusing the SAME outermost-vs-
+# pointee position discipline `const`/`volatile` already have throughout
+# this module -- not stripped unconditionally (Codex review, PR #941,
+# eighteenth round: the sixteenth round's own "restrict never affects
+# mangling, strip it everywhere" fix turned out to be the wrong
+# generalization, verified wrong by direct compilation rather than mere
+# assertion -- restrict does NOT behave like a pure no-op token, it
+# behaves like cv).
+_CV_WORD_RE = re.compile(r"\b(?:const|volatile|restrict|__restrict__|__restrict)\b")
 
 # Clang's own ``qualType`` spelling for a calling-convention-decorated
 # function-pointer declarator does NOT use the leading ``__cdecl``-style
@@ -93,14 +94,18 @@ _CALLING_CONVENTION_ATTR_RE = re.compile(
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
-    """Blank out every ``const``/``volatile`` token in *s* that sits at
-    nesting depth 0 (outside any ``<...>``/``(...)``/``[...]``), then
-    collapse the resulting whitespace. The one primitive both branches of
+    """Blank out every ``const``/``volatile``/``restrict`` (any of its
+    three spellings) token in *s* that sits at nesting depth 0 (outside
+    any ``<...>``/``(...)``/``[...]``), then collapse the resulting
+    whitespace. The one primitive both branches of
     :func:`canonicalize_function_signature_param_type` reduce to -- the
     by-value case applies it to the whole string, the pointer case applies
     it only to the suffix after the parameter's outermost pointer/
     reference sigil (see that function's own docstring for why those are
-    the two, and only the two, safe places to strip).
+    the two, and only the two, safe places to strip). ``restrict`` shares
+    this exact position discipline with ``const``/``volatile`` -- it is
+    NOT unconditionally mangling-inert (see ``_CV_WORD_RE``'s own comment
+    for the direct-compilation evidence).
     """
     depth = 0
     out: list[str] = []
@@ -525,12 +530,14 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("int const C::*")
     'int const C:: *'
 
-    ``restrict``/``__restrict``/``__restrict__`` -- a pointer-qualifier
-    with NO effect on the Itanium C++ ABI's mangling at all, unlike
-    ``const``/``volatile`` -- is stripped unconditionally, at any position,
-    rather than only on this parameter's own outermost pointer: unlike a
-    genuine by-value cv-qualifier, restrict's total absence from mangling
-    does not depend on where in the declarator it sits.
+    ``restrict``/``__restrict``/``__restrict__`` shares the exact same
+    outermost-vs-pointee position discipline ``const``/``volatile``
+    already have here: dropped on the parameter's own outermost, by-value
+    pointer position (real-compiler mangling confirms ``void f(int *)``
+    and ``void f(int * restrict)`` are the SAME function), but preserved,
+    genuinely distinguishing, on an inner pointer level (``void f(int
+    **)`` and ``void f(int * restrict *)`` mangle to two different
+    symbols) -- restrict is not unconditionally mangling-inert.
 
     >>> canonicalize_function_signature_param_type("int *")
     'int *'
@@ -538,8 +545,8 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'int *'
     >>> canonicalize_function_signature_param_type("int *__restrict")
     'int *'
-    >>> canonicalize_function_signature_param_type("int * restrict *")
-    'int * *'
+    >>> canonicalize_function_signature_param_type("int * restrict *") == canonicalize_function_signature_param_type("int * *")
+    False
     >>> canonicalize_function_signature_param_type("void (*)(int *restrict)")
     'void ( * )(int *)'
 
@@ -559,10 +566,6 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
-    # `restrict` never affects mangling, at any position -- strip it
-    # unconditionally before any of the position-sensitive cv/pointer
-    # logic below runs, rather than special-casing it into that logic.
-    canonical = re.sub(r"\s+", " ", _RESTRICT_WORD_RE.sub("", canonical)).strip()
     depth = 0
     # True for a paren currently open on `transparent_parens` that groups a
     # declarator's own sigil (see the docstring above) -- popped, not

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -39,6 +39,19 @@ __all__ = ["canonicalize_function_signature_param_type"]
 
 _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 
+# A declarator-grouping paren's content, up to its own sigil: either a bare
+# pointer/reference (`*`, `&`), or a pointer-to-member's qualified-name
+# prefix (`C::*`, `ns::C::*`) -- one or more `identifier::` segments then
+# the sigil. Used to tell a declarator-grouping paren (transparent, not a
+# real nesting level) from a genuine parameter-list paren (opaque): a
+# parameter list's first token is always a type, which can itself start
+# with an identifier, but is never immediately followed by `::` then only
+# a bare sigil -- that specific shape is unique to a member-pointer
+# declarator (Codex review, PR #941, ninth round: an earlier revision here
+# recognized only the bare-sigil form, so `void (C::* const)(int)` -- cv on
+# a pointer-to-member's own outermost sigil -- was never found at depth 0).
+_DECLARATOR_GROUP_RE = re.compile(r"\s*(?:[A-Za-z_]\w*\s*::\s*)*[*&]")
+
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
     """Blank out every ``const``/``volatile`` token in *s* that sits at
@@ -118,6 +131,112 @@ def _decay_top_level_array(canonical_type: str) -> str:
         return canonical_type
     prefix = canonical_type[: bracket_positions[0]].rstrip()
     return f"{prefix} *"
+
+
+def _split_top_level_commas(s: str) -> list[str]:
+    """Split *s* on commas that sit at nesting depth 0 (outside any
+    ``<...>``/``(...)``/``[...]``) -- the boundaries between a parameter
+    list's own individual parameters, as opposed to a comma nested inside
+    one parameter's own type (a template-argument list, a nested callback's
+    own parameter list).
+    """
+    depth = 0
+    parts: list[str] = []
+    current: list[str] = []
+    for ch in s:
+        if ch in "<([":
+            depth += 1
+            current.append(ch)
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def _find_matching_paren(s: str, open_idx: int) -> int:
+    """Index of the ``)`` matching the ``(`` at *open_idx* (which must
+    itself be ``"("``), tracking only paren nesting -- ``s[open_idx]`` is
+    always ``(`` at every call site. Defensively returns ``len(s)`` for a
+    malformed, unmatched string rather than raising.
+    """
+    depth = 0
+    for i in range(open_idx, len(s)):
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return len(s)
+
+
+def _normalize_param_list_contents(inner: str) -> str:
+    """Canonicalize each individual parameter inside one parameter list's
+    raw ``(...)`` content -- the by-value cv rule this whole module exists
+    to apply is not unique to this function's own top-level parameter; a
+    callback or member-function-pointer parameter's OWN parameters are
+    exactly as much "a function's parameter list" as the outer one is, and
+    C++ drops their top-level by-value cv from the function type the same
+    way. An empty list, a bare ``void``, and a variadic ``...`` marker
+    (which is not itself a parameter type at all) are left untouched.
+    """
+    if inner.strip() == "" or inner.strip().lower() == "void":
+        return inner
+    normalized = []
+    for part in _split_top_level_commas(inner):
+        p = part.strip()
+        normalized.append(
+            p
+            if (p == "" or p == "...")
+            else canonicalize_function_signature_param_type(p)
+        )
+    return ", ".join(normalized)
+
+
+def _normalize_nested_param_lists(s: str) -> str:
+    """Recursively canonicalize the contents of every top-level ``(...)``
+    parameter list appearing in *s* -- a declarator's own trailing
+    parameter list, e.g. the ``(int)`` in ``void (*)(int)`` or
+    ``void (C::*)(int)``, to any nesting depth (a callback parameter that
+    itself takes a callback parameter). Depth-tracks ``<([``/``>)]``
+    generally so a paren nested inside a template argument or array bound
+    is not mistaken for a top-level parameter list; recursion through
+    :func:`canonicalize_function_signature_param_type` (via
+    :func:`_normalize_param_list_contents`) applies this same nested
+    treatment at every level, so it needs no explicit depth limit -- each
+    recursive call operates on a strictly shorter substring, which is what
+    guarantees termination (Codex review, PR #941, ninth round: an earlier
+    revision left a callback parameter's own parameter list entirely
+    opaque, so ``void (*)(int)`` and ``void (*)(const int)`` -- the
+    identical adjusted callback type -- canonicalized to two different
+    strings).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    depth = 0
+    while i < n:
+        ch = s[i]
+        if ch == "(" and depth == 0:
+            close = _find_matching_paren(s, i)
+            out.append("(")
+            out.append(_normalize_param_list_contents(s[i + 1 : close]))
+            out.append(")")
+            i = close + 1
+            continue
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def canonicalize_function_signature_param_type(name: str) -> str:
@@ -259,6 +378,30 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'int ( * )[3]'
     >>> canonicalize_function_signature_param_type("int (* const)[3]")
     'int ( * )[3]'
+
+    A *pointer-to-member-function* declarator (``void (C::* const)(int)``)
+    has the identical shape one level deeper: its own outermost sigil is
+    ``*``, preceded by the member's qualified-name prefix (``C::``) inside
+    the same declarator-grouping parens, rather than a bare sigil. That
+    qualified-name prefix is recognized too, so its own trailing
+    cv-qualifier is by-value and dropped the same way. And a declarator's
+    trailing parameter list (the ``(int)`` above) is itself exactly as much
+    "a function's parameters" as this function's own top-level one -- so
+    each of ITS parameters gets this identical by-value treatment too,
+    recursively, to any nesting depth (a callback parameter that itself
+    takes a callback parameter): ``void (*)(int)`` and
+    ``void (*)(const int)`` are the same adjusted callback type, not two.
+
+    >>> canonicalize_function_signature_param_type("void (C::*)(int)")
+    'void (C:: * )(int)'
+    >>> canonicalize_function_signature_param_type("void (C::* const)(int)")
+    'void (C:: * )(int)'
+    >>> canonicalize_function_signature_param_type("void (*)(const int)")
+    'void ( * )(int)'
+    >>> canonicalize_function_signature_param_type("void (*)(char *)")
+    'void ( * )(char *)'
+    >>> canonicalize_function_signature_param_type("void (*)(const char *)")
+    'void ( * )(char const *)'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -270,13 +413,9 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     transparent_parens: list[bool] = []
     last_top_level_sigil = -1
     has_top_level_bracket = False
-    n = len(canonical)
     for i, ch in enumerate(canonical):
         if ch == "(":
-            j = i + 1
-            while j < n and canonical[j] == " ":
-                j += 1
-            transparent = j < n and canonical[j] in "*&"
+            transparent = _DECLARATOR_GROUP_RE.match(canonical, i + 1) is not None
             transparent_parens.append(transparent)
             if not transparent:
                 depth += 1
@@ -307,4 +446,5 @@ def canonicalize_function_signature_param_type(name: str) -> str:
         )
     prefix = canonical[: last_top_level_sigil + 1]
     suffix = _strip_cv_tokens_outside_nesting(canonical[last_top_level_sigil + 1 :])
+    suffix = _normalize_nested_param_lists(suffix)
     return f"{prefix} {suffix}".rstrip() if suffix else prefix

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Function-parameter-type canonicalization for identity/overload-
+discriminator purposes (ADR-063 Phase 2).
+
+Split out of ``model/identity.py`` (its only caller) purely to keep that
+file under the AI-readiness gate's 800-line production maximum -- this
+module's own contents are otherwise identity.py's, not a separate design
+decision. See ``docs/contribute/plans/one-semantic-pipeline.md``'s Phase 2
+section for the full history of the several review rounds (Codex, PR #941)
+that grew this from a single ``canonicalize_type_name`` call into the
+dedicated cv/array-decay logic here.
+
+Leaf module: imports only ``name_classification.canonicalize_type_name``
+(a dependency-free sibling), nothing above ``model``, per ADR-063 D10 --
+the same leaf-module contract ``model/identity.py`` itself states.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..name_classification import canonicalize_type_name
+
+__all__ = ["canonicalize_function_signature_param_type"]
+
+_CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
+
+
+def _has_top_level_ptr_or_ref(canonical_type: str) -> bool:
+    """Whether *canonical_type* is pointer-shaped at nesting depth 0 --
+    a ``*``/``&`` sigil, or a top-level ``[`` array declarator (Codex
+    review, PR #941: a function PARAMETER's array type always decays to a
+    pointer, e.g. ``int []`` -> ``int *``, so any cv-qualifier on the
+    element type is pointee-level, exactly like an explicit pointer --
+    ``void f(int[])`` and ``void f(const int[])`` are two distinct,
+    independently-mangled overloads, not one). Either shape means the
+    value itself is a pointer, not merely something passed by value that
+    happens to *contain* one (``Box<int *>``, ``std::function<void(int&)>``,
+    an array *bound inside* a template argument). A minimal, self-
+    contained reimplementation of the identical algorithm
+    ``name_classification._has_top_level_ptr_or_ref`` already applies for
+    a different purpose -- deliberately duplicated rather than imported,
+    since ``name_classification.py`` is a frozen, no-growth legacy module
+    (ADR-061 debt ledger, `architecture/debt.yaml`) that new code must not
+    grow, and the helper it would be imported from is private besides.
+    The array case is added here rather than upstream because this
+    module's fallback signature discriminator is built directly from a
+    caller-supplied *string* that may still spell an array literally
+    (``"int []"``) -- it makes no assumption about whether a given
+    producer's own parsed representation already reflects the decay.
+    """
+    depth = 0
+    for ch in canonical_type:
+        if ch == "[" and depth == 0:
+            return True
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            return True
+    return False
+
+
+def _strip_cv_tokens_outside_nesting(s: str) -> str:
+    """Blank out every ``const``/``volatile`` token in *s* that sits at
+    nesting depth 0 (outside any ``<...>``/``(...)``/``[...]``), then
+    collapse the resulting whitespace. The one primitive both branches of
+    :func:`canonicalize_function_signature_param_type` reduce to -- the
+    by-value case applies it to the whole string, the pointer case applies
+    it only to the suffix after the parameter's outermost pointer/
+    reference sigil (see that function's own docstring for why those are
+    the two, and only the two, safe places to strip).
+    """
+    depth = 0
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        ch = s[i]
+        if ch in "<([":
+            depth += 1
+            out.append(ch)
+            i += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+            out.append(ch)
+            i += 1
+        elif depth == 0 and (m := _CV_WORD_RE.match(s, i)):
+            i = m.end()
+        else:
+            out.append(ch)
+            i += 1
+    return re.sub(r"\s+", " ", "".join(out)).strip()
+
+
+def _decay_top_level_array(canonical_type: str) -> str:
+    """Best-effort single-dimension array-to-pointer decay for a function
+    *parameter* type: ``T[]``/``T[N]`` -> ``T *`` (the bound is dropped --
+    it plays no part in the adjusted parameter type at all, so ``T[]``,
+    ``T[3]``, and ``T[4]`` must all canonicalize identically -- and any
+    element-level cv-qualifier survives verbatim as the decayed pointer's
+    pointee cv, e.g. ``const int [3]`` -> ``const int *``). Codex review,
+    PR #941: an earlier revision of this module treated a top-level ``[``
+    as "pointer-shaped enough not to strip its cv" (:func:`_has_top_level_
+    ptr_or_ref`) but never performed the decay itself, so ``int []``/
+    ``int [3]``/``int [4]``/``int *`` -- all the identical adjusted
+    parameter type -- still canonicalized to four different strings.
+
+    Deliberately narrow: a genuinely *multi-dimensional* array parameter
+    (``T[][N]``, which adjusts to ``T(*)[N]``, a pointer to an array, not
+    a plain pointer) is left entirely unchanged rather than attempted --
+    correctly re-spelling that adjusted type needs declarator-rewriting
+    (inserting a grouping ``(*)``) this function does not implement, and
+    it is a genuinely rare shape for a real ABI-relevant function
+    parameter. Likewise left unchanged whenever a top-level ``(`` appears
+    before the bracket at all -- a *parenthesized* declarator
+    (``int (*)[3]``, "pointer to array of 3 ints") already has its own
+    outermost ``*``, and the trailing ``[3]`` there names the *pointee's*
+    array bound, not the parameter's own top-level shape; naively decaying
+    it would wrongly append a second, spurious ``*``. Both are accepted,
+    documented limitations, not a silent gap -- the same "don't solve the
+    fully general C declarator grammar, scope to the shapes review
+    evidence actually names" discipline ``_strip_cv_in_segment``'s own
+    docstring already applies to the strict/non-strict split it makes.
+    """
+    depth = 0
+    bracket_positions: list[int] = []
+    has_top_level_paren = False
+    for i, ch in enumerate(canonical_type):
+        if ch == "(" and depth == 0:
+            has_top_level_paren = True
+        if ch in "<(":
+            depth += 1
+        elif ch in ">)":
+            depth = max(0, depth - 1)
+        elif ch == "[" and depth == 0:
+            bracket_positions.append(i)
+    if len(bracket_positions) != 1 or has_top_level_paren:
+        return canonical_type
+    prefix = canonical_type[: bracket_positions[0]].rstrip()
+    return f"{prefix} *"
+
+
+def canonicalize_function_signature_param_type(name: str) -> str:
+    """The canonical form of a function *parameter* type, for
+    identity/overload-discriminator purposes -- as opposed to
+    ``canonicalize_type_name``, which normalizes only cross-producer
+    spelling differences and deliberately keeps every cv-qualifier,
+    including a top-level by-value one, as real, distinguishing content.
+
+    Drops a top-level BY-VALUE cv-qualifier (``int`` -> ``const int``):
+    per the C++ standard, that qualifier is dropped from the function's
+    own type for linkage/mangling purposes -- ``void f(int)`` and ``void
+    f(const int)`` name the very same function (see
+    ``name_classification.func_signature_cv_only_differ``'s own docstring
+    for the citation). **Deliberately narrower than reusing that sibling
+    module's own private ``_strip_cv_qualifiers`` helper** (which is what
+    a first attempt at this reached for, since Codex's own finding named
+    it): that helper is permissive at the true top level, stripping a
+    *pointee* cv-qualifier too (``"const char *"`` -> ``"char *"``) --
+    correct for *"is this an already-matched declaration's param change
+    worth reporting as ABI-breaking"* (``diff_symbols._params_differ``'s
+    own question), but wrong for *this* function's job. A pointee
+    cv-qualifier on a pointer/reference parameter is a genuine, standard-
+    mandated overload discriminator (``void f(char *)`` and ``void
+    f(const char *)`` are two simultaneously-declarable, independently-
+    mangled overloads, not one declaration): collapsing them here would
+    silently merge two distinct functions into one identity, reintroducing
+    exactly the sibling-overload-collision class this whole primitive
+    exists to prevent.
+
+    An array parameter is decayed first (:func:`_decay_top_level_array`),
+    since ``T[]``/``T[N]`` are themselves pointer-shaped once adjusted
+    (Codex review, PR #941) -- except the two shapes that function itself
+    declines to decay (multi-dimensional, or a parenthesized declarator),
+    which fall through here unchanged and untouched, exactly like the
+    genuinely no-pointer-at-all case below.
+
+    Once a type carries a real top-level ``*``/``&`` (after decay), a
+    plain top-level pointee cv-qualifier stays (``const char *`` above),
+    but a cv-qualifier trailing the pointer's OWN, outermost sigil is
+    still by-value -- it qualifies the pointer value itself, not what it
+    points to, and the standard drops that exactly like any other
+    top-level parameter qualifier: ``void f(int *)`` and ``void f(int *
+    const)`` name the same function (Codex review, PR #941 -- fresh
+    evidence that an earlier revision here skipped *all* cv processing as
+    soon as it saw a pointer, unable to distinguish the pointer's own
+    trailing qualifier from a genuinely different pointee one). So the
+    split is: everything up to and including the LAST top-level ``*``/
+    ``&`` is kept verbatim (it may itself contain an earlier pointer's own
+    now-meaningful qualifier, e.g. ``int * const *`` -- "pointer to a
+    const-qualified pointer to int" -- which is NOT the outermost sigil
+    and remains genuinely distinguishing, unlike ``int **``); only the
+    suffix after it is stripped. When there is no top-level ``*``/``&``
+    *and* no top-level ``[`` either -- truly no pointer, reference, or
+    array of any kind -- every cv token outside ``<...>``/``(...)``/
+    ``[...]`` nesting is by-value and safe to strip (a cv-qualifier nested
+    in a template argument names a genuinely different type, e.g.
+    ``Box<const int>`` vs. ``Box<int>``, the same rule
+    ``canonicalize_type_name`` itself already documents). But when a
+    top-level ``[`` survives *undecayed* (one of the two shapes
+    :func:`_decay_top_level_array` declines above), this function returns
+    the type completely unchanged instead -- deliberately not falling
+    through to the by-value stripper: an undecayed array's own
+    element-level cv-qualifier (``const int [3][4]``'s ``const``) sits
+    *before* its bracket, at nesting depth 0, exactly where the by-value
+    stripper would wrongly treat it as a stripped-away, non-distinguishing
+    qualifier. Since this shape is already an accepted, undecayed
+    limitation, actively stripping a real pointee-level qualifier from it
+    would be a strictly worse, newly-introduced correctness regression on
+    top of the already-documented incompleteness, not merely leaving that
+    incompleteness as it was found.
+
+    ``canonicalize_type_name`` is applied a *second* time, after decay --
+    not merely once up front -- because its own east-const normalization
+    (``"const T"`` -> ``"T const"``) never fires on a bracket-containing
+    string in the first place (that regex's base-type group excludes
+    ``[``/``]``), so ``"const int [3]"`` reaches the decay step with its
+    leading ``const`` untouched and still leading after decay
+    (``"const int *"``), while a direct ``"const int *"`` spelling is
+    already east-const-normalized before decay ever runs
+    (``"int const *"``) -- two spellings of the identical adjusted
+    parameter type that would otherwise canonicalize to two different
+    strings (own test suite, ``test_element_cv_becomes_pointee_cv``,
+    caught this before it shipped).
+
+    >>> canonicalize_function_signature_param_type("int")
+    'int'
+    >>> canonicalize_function_signature_param_type("const int")
+    'int'
+    >>> canonicalize_function_signature_param_type("volatile unsigned long long")
+    'unsigned long long'
+    >>> canonicalize_function_signature_param_type("char const*")
+    'char const *'
+    >>> canonicalize_function_signature_param_type("const char *")
+    'char const *'
+    >>> canonicalize_function_signature_param_type("const std::vector<const int>")
+    'std::vector<const int>'
+    >>> canonicalize_function_signature_param_type("int []")
+    'int *'
+    >>> canonicalize_function_signature_param_type("int [3]")
+    'int *'
+    >>> canonicalize_function_signature_param_type("const int [3]")
+    'int const *'
+    >>> canonicalize_function_signature_param_type("int * const")
+    'int *'
+    >>> canonicalize_function_signature_param_type("int * const *")
+    'int *const *'
+    >>> canonicalize_function_signature_param_type("int [3][4]")
+    'int [3][4]'
+    >>> canonicalize_function_signature_param_type("const int [3][4]")
+    'const int [3][4]'
+    >>> canonicalize_function_signature_param_type("int (*)[3]")
+    'int ( *)[3]'
+    """
+    canonical = canonicalize_type_name(
+        _decay_top_level_array(canonicalize_type_name(name))
+    )
+    depth = 0
+    last_top_level_sigil = -1
+    has_top_level_bracket = False
+    for i, ch in enumerate(canonical):
+        if ch == "[" and depth == 0:
+            has_top_level_bracket = True
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            last_top_level_sigil = i
+    if last_top_level_sigil == -1:
+        # No real pointer/reference sigil. An undecayed top-level array
+        # (multi-dimensional, or a parenthesized declarator) is returned
+        # untouched -- see this function's own docstring for why stripping
+        # it would be actively wrong, not merely incomplete. Otherwise
+        # this is a genuine by-value scalar/class type, safe to strip.
+        return (
+            canonical
+            if has_top_level_bracket
+            else _strip_cv_tokens_outside_nesting(canonical)
+        )
+    prefix = canonical[: last_top_level_sigil + 1]
+    suffix = _strip_cv_tokens_outside_nesting(canonical[last_top_level_sigil + 1 :])
+    return f"{prefix} {suffix}".rstrip() if suffix else prefix

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -43,6 +43,7 @@ import re
 
 from ..name_classification import canonicalize_type_name
 from .declarator_qualifiers import (
+    _CALLING_CONVENTIONS,
     _canonicalize_member_qualifiers,
     _find_member_pointer_qualifier,
     _is_declarator_group,
@@ -70,6 +71,25 @@ _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 # `int * restrict *` and `int * *` still distinguishing, when they must
 # not).
 _RESTRICT_WORD_RE = re.compile(r"\b(?:__restrict__|__restrict|restrict)\b")
+
+# Clang's own ``qualType`` spelling for a calling-convention-decorated
+# function-pointer declarator does NOT use the leading ``__cdecl``-style
+# keyword ``_CALLING_CONVENTIONS``/``_is_declarator_group`` recognize --
+# instead it renders the attribute AFTER the declarator's own trailing
+# parameter list, e.g. ``void (*)(int) __attribute__((cdecl))`` for the
+# identical type MSVC/castxml spell ``void (__cdecl *)(int)``
+# (`dumper_clang_attributes.py`'s own `_CLANG_ATTR_TOKENS` mapping already
+# recognizes these same attribute-node kinds for a FunctionDecl's own
+# top-level contract attributes; this is the textual, parameter-type-
+# spelling equivalent, for the mangling-free signature-fallback identity
+# this module computes). Without normalizing this too, two backends
+# observing the identical DWARF-only or header-only declaration would
+# fragment into two different `EntityId`s purely because one produces
+# CastXML-style leading-keyword text and the other Clang-style trailing-
+# attribute text (Codex review, PR #941, seventeenth round).
+_CALLING_CONVENTION_ATTR_RE = re.compile(
+    r"__attribute__\s*\(\(\s*(cdecl|stdcall|fastcall|thiscall|vectorcall)\s*\)\)"
+)
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
@@ -522,6 +542,19 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'int * *'
     >>> canonicalize_function_signature_param_type("void (*)(int *restrict)")
     'void ( * )(int *)'
+
+    Clang's own ``qualType`` spelling for a calling-convention-decorated
+    function-pointer declarator trails the attribute AFTER the parameter
+    list (``__attribute__((cdecl))``) rather than using the leading
+    ``__cdecl``-style keyword MSVC/castxml spell it with -- both spellings
+    of the identical type now converge on one canonical form.
+
+    >>> canonicalize_function_signature_param_type("void (__cdecl *)(int)")
+    'void (__cdecl * )(int)'
+    >>> canonicalize_function_signature_param_type("void (*)(int) __attribute__((cdecl))")
+    'void (__cdecl * )(int)'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) __attribute__((thiscall))")
+    'void (__thiscall C:: * )(int)'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -632,7 +665,28 @@ def canonicalize_function_signature_param_type(name: str) -> str:
         head = _strip_cv_tokens_outside_nesting(head)
         close = _find_matching_paren(params_and_after, 0)
         params = _normalize_nested_param_lists(params_and_after[: close + 1])
-        member_quals = _canonicalize_member_qualifiers(params_and_after[close + 1 :])
+        tail = params_and_after[close + 1 :]
+        # Clang's trailing `__attribute__((cdecl))`-style calling-
+        # convention spelling (see `_CALLING_CONVENTION_ATTR_RE`'s own
+        # comment) is not itself a member/pointed-to-function qualifier --
+        # normalize it into the SAME leading-keyword position
+        # `_is_declarator_group` already recognizes, so both spellings of
+        # one identical type converge on one `prefix`, before whatever
+        # remains of `tail` goes through the ordinary member-qualifier
+        # canonicalization below.
+        attr_match = _CALLING_CONVENTION_ATTR_RE.search(tail)
+        if attr_match is not None:
+            tail = tail[: attr_match.start()] + tail[attr_match.end() :]
+            if not any(cc in prefix for cc in _CALLING_CONVENTIONS):
+                open_idx = prefix.rfind("(")
+                if open_idx != -1:
+                    keyword = f"__{attr_match.group(1)}"
+                    prefix = re.sub(
+                        r"\s+",
+                        " ",
+                        prefix[: open_idx + 1] + f"{keyword} " + prefix[open_idx + 1 :],
+                    )
+        member_quals = _canonicalize_member_qualifiers(tail)
         # `head` (a bare pointer-declarator's own closing paren, plus any
         # by-value cv already stripped out of it) is joined directly onto
         # `params` -- no separator space -- since `head` always ends in

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -154,6 +154,49 @@ def _strip_cv_tokens_outside_nesting(s: str) -> str:
     return re.sub(r"\s+", " ", "".join(out)).strip()
 
 
+def _extract_top_level_cv(s: str) -> tuple[bool, bool, str]:
+    """Depth-aware sibling of :func:`_strip_cv_tokens_outside_nesting`:
+    finds ``const``/``volatile`` tokens at nesting depth 0 only (outside
+    any ``<...>``/``(...)``/``[...]``), reports which were found, and
+    returns *s* with those depth-0 tokens removed -- a cv-looking word
+    sitting INSIDE a parenthesized region (a ``noexcept(expr)``
+    argument's own text, a template argument) is untouched, since it
+    belongs to that expression, not to this declarator's own trailing
+    qualifier sequence (Codex review, PR #941, thirteenth round: an
+    earlier revision used a plain, depth-blind ``re.search``/``re.sub``
+    over the whole trailing region, which wrongly reached inside a
+    non-literal ``noexcept(expr)``'s own argument, e.g.
+    ``noexcept(Foo<const int>)``).
+    """
+    depth = 0
+    has_const = False
+    has_volatile = False
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        ch = s[i]
+        if ch in "<([":
+            depth += 1
+            out.append(ch)
+            i += 1
+        elif ch in ">)]":
+            depth = max(0, depth - 1)
+            out.append(ch)
+            i += 1
+        elif depth == 0 and (m := _CV_WORD_RE.match(s, i)):
+            if m.group() == "const":
+                has_const = True
+            else:
+                has_volatile = True
+            i = m.end()
+        else:
+            out.append(ch)
+            i += 1
+    rest = re.sub(r"\s+", " ", "".join(out)).strip()
+    return has_const, has_volatile, rest
+
+
 def _decay_top_level_array(canonical_type: str) -> str:
     """Best-effort single-dimension array-to-pointer decay for a function
     *parameter* type: ``T[]``/``T[N]`` -> ``T *`` (the bound is dropped --
@@ -252,11 +295,17 @@ def _normalize_param_list_contents(inner: str) -> str:
     callback or member-function-pointer parameter's OWN parameters are
     exactly as much "a function's parameter list" as the outer one is, and
     C++ drops their top-level by-value cv from the function type the same
-    way. An empty list, a bare ``void``, and a variadic ``...`` marker
-    (which is not itself a parameter type at all) are left untouched.
+    way. An empty list and a bare ``void`` are the identical "no
+    parameters" adjusted type (Codex review, PR #941, thirteenth round:
+    an earlier revision returned each spelling unchanged instead of
+    unifying them, so ``void (*)()`` and ``void (*)(void)`` -- one
+    identical adjusted callback type -- canonicalized to two different
+    strings), so both collapse to the same canonical empty form. A
+    variadic ``...`` marker (which is not itself a parameter type at all)
+    is left untouched.
     """
     if inner.strip() == "" or inner.strip().lower() == "void":
-        return inner
+        return ""
     normalized = []
     for part in _split_top_level_commas(inner):
         p = part.strip()
@@ -353,14 +402,26 @@ def _canonicalize_member_qualifiers(s: str) -> str:
     normalized; any other, non-literal ``noexcept(expr)`` is left
     completely untouched -- evaluating an arbitrary constant expression is
     out of scope, the same "don't solve the fully general grammar" limit
-    this module already draws elsewhere).
+    this module already draws elsewhere; thirteenth round: extracting
+    ``const``/``volatile`` via a plain, depth-blind ``re.search`` over the
+    WHOLE trailing region wrongly reached inside a non-literal
+    ``noexcept(expr)``'s own argument too -- a ``const``/``volatile``
+    token that is part of THAT expression's own text, e.g.
+    ``noexcept(Foo<const int>)``, is not this declarator's own
+    cv-qualifier at all, and extracting it both corrupted the expression
+    (mutating text this function has no business touching, since it
+    cannot evaluate it) and could merge two genuinely different overloads
+    that happen to share a nested "const" by coincidence. Fixed with a
+    depth-aware scan, :func:`_extract_top_level_cv`, mirroring
+    :func:`_strip_cv_tokens_outside_nesting`'s own outside-nesting
+    discipline: only a cv word sitting at depth 0 -- outside any
+    ``(...)``/``<...>``/``[...]`` -- is ever this declarator's own
+    trailing qualifier).
     """
     stripped = s.strip()
     if not stripped:
         return ""
-    has_const = re.search(r"\bconst\b", stripped) is not None
-    has_volatile = re.search(r"\bvolatile\b", stripped) is not None
-    rest = re.sub(r"\s+", " ", _CV_WORD_RE.sub("", stripped)).strip()
+    has_const, has_volatile, rest = _extract_top_level_cv(stripped)
     rest = _canonicalize_noexcept(rest)
     parts = [
         p
@@ -613,6 +674,29 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'void ( * )(int) noexcept'
     >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(false)")
     'void ( * )(int)'
+
+    An empty parameter list and a bare ``void`` are the identical "no
+    parameters" adjusted type. And a ``const``/``volatile`` token that
+    sits INSIDE a non-literal ``noexcept(expr)``'s own argument -- e.g.
+    ``Foo<const int>`` below -- is that expression's own content, not
+    this declarator's own trailing qualifier, and is never extracted.
+
+    >>> canonicalize_function_signature_param_type("void (*)(void)")
+    'void ( * )()'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) noexcept(Foo<const int>)")
+    'void (C:: * )(int) noexcept(Foo<const int>)'
+
+    An opaque (non-declarator-group) paren can also appear BEFORE the
+    parameter's own actual pointer sigil, not only after it -- a real
+    producer spelling for a type in an anonymous namespace,
+    ``(anonymous namespace)::Foo``. That paren must not be mistaken for a
+    declarator's trailing parameter list; a genuine pointee cv-qualifier
+    on the sigil that follows it still distinguishes.
+
+    >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo const *")
+    '(anonymous namespace)::Foo const *'
+    >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo *")
+    '(anonymous namespace)::Foo *'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -624,22 +708,34 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     transparent_parens: list[bool] = []
     last_top_level_sigil = -1
     has_top_level_bracket = False
-    # Once a genuine (opaque) top-level paren has been seen -- the
-    # declarator's own trailing parameter list -- nothing after it is
-    # eligible to become a new "last top-level sigil". Without this, a
-    # trailing ref-qualifier on a pointer-to-member-function
-    # (`void (C::*)(int) &&`) -- itself a `*`/`&`-shaped token sitting at
-    # depth 0, textually after the parameter list closes -- would wrongly
-    # override the declarator's own already-found sigil and corrupt the
-    # prefix/suffix split (Codex review, PR #941, tenth round: caught by
-    # this round's own new ref-qualifier test, not by a reviewer finding).
+    # Once the declarator's own sigil has ALREADY been found and a
+    # genuine (opaque) top-level paren is then seen -- its trailing
+    # parameter list -- nothing after that paren is eligible to become a
+    # NEW "last top-level sigil". Without this, a trailing ref-qualifier
+    # on a pointer-to-member-function (`void (C::*)(int) &&`) -- itself a
+    # `*`/`&`-shaped token sitting at depth 0, textually after the
+    # parameter list closes -- would wrongly override the declarator's
+    # own already-found sigil and corrupt the prefix/suffix split (Codex
+    # review, PR #941, tenth round). The `last_top_level_sigil != -1`
+    # guard matters: an opaque paren can also appear BEFORE any
+    # declarator sigil has been found at all -- a real, observed
+    # producer spelling for an anonymous-namespace-qualified type,
+    # `(anonymous namespace)::Foo const *` -- and that paren is not a
+    # declarator's parameter list at all, just qualifier text preceding
+    # the parameter's actual pointer sigil; arming the flag on ANY
+    # top-level opaque paren, sigil-found or not, wrongly locked out that
+    # later real `*` entirely, falling through to the by-value branch and
+    # merging `Foo const *` with `Foo *` (CodeRabbit review, PR #941,
+    # fourteenth round: caught with the codebase's own real
+    # `"(anonymous namespace)::T"` spelling convention, not a hypothetical
+    # one).
     seen_top_level_opaque_paren = False
     for i, ch in enumerate(canonical):
         if ch == "(":
             transparent = _is_declarator_group(canonical, i + 1)
             transparent_parens.append(transparent)
             if not transparent:
-                if depth == 0:
+                if depth == 0 and last_top_level_sigil != -1:
                     seen_top_level_opaque_paren = True
                 depth += 1
             continue

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -53,6 +53,24 @@ __all__ = ["canonicalize_function_signature_param_type"]
 
 _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 
+# `restrict`/`__restrict`/`__restrict__` -- a pointer type qualifier with NO
+# effect on the Itanium C++ ABI's mangling at all, unlike `const`/
+# `volatile` (which stay genuinely distinguishing at the pointee level).
+# This repository already models the fact separately, on `Param.
+# is_restrict` (`dumper_castxml.py`'s/`dumper_clang_qualifiers.py`'s own
+# extraction comments state the same thing: restrict has no ABI/mangling
+# effect) -- so, unlike cv, it is safe to strip UNCONDITIONALLY, at any
+# position and nesting depth a real declarator can place it (the grammar
+# only ever allows it directly after the `*` it qualifies), not merely on
+# this parameter's own outermost pointer (Codex review, PR #941, sixteenth
+# round: the finding as reported scoped a fix to only the outermost
+# pointer, matching how a genuine BY-VALUE cv-qualifier is scoped -- but
+# restrict is not cv; its total absence from mangling holds regardless of
+# position, so narrowing to "outermost only" would leave
+# `int * restrict *` and `int * *` still distinguishing, when they must
+# not).
+_RESTRICT_WORD_RE = re.compile(r"\b(?:__restrict__|__restrict|restrict)\b")
+
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
     """Blank out every ``const``/``volatile`` token in *s* that sits at
@@ -486,10 +504,32 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'int const C:: *'
     >>> canonicalize_function_signature_param_type("int const C::*")
     'int const C:: *'
+
+    ``restrict``/``__restrict``/``__restrict__`` -- a pointer-qualifier
+    with NO effect on the Itanium C++ ABI's mangling at all, unlike
+    ``const``/``volatile`` -- is stripped unconditionally, at any position,
+    rather than only on this parameter's own outermost pointer: unlike a
+    genuine by-value cv-qualifier, restrict's total absence from mangling
+    does not depend on where in the declarator it sits.
+
+    >>> canonicalize_function_signature_param_type("int *")
+    'int *'
+    >>> canonicalize_function_signature_param_type("int *restrict")
+    'int *'
+    >>> canonicalize_function_signature_param_type("int *__restrict")
+    'int *'
+    >>> canonicalize_function_signature_param_type("int * restrict *")
+    'int * *'
+    >>> canonicalize_function_signature_param_type("void (*)(int *restrict)")
+    'void ( * )(int *)'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
+    # `restrict` never affects mangling, at any position -- strip it
+    # unconditionally before any of the position-sensitive cv/pointer
+    # logic below runs, rather than special-casing it into that logic.
+    canonical = re.sub(r"\s+", " ", _RESTRICT_WORD_RE.sub("", canonical)).strip()
     depth = 0
     # True for a paren currently open on `transparent_parens` that groups a
     # declarator's own sigil (see the docstring above) -- popped, not

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -43,7 +43,6 @@ import re
 
 from ..name_classification import canonicalize_type_name
 from .declarator_qualifiers import (
-    _CALLING_CONVENTIONS,
     _canonicalize_member_qualifiers,
     _find_member_pointer_qualifier,
     _is_declarator_group,
@@ -90,6 +89,25 @@ _CV_WORD_RE = re.compile(r"\b(?:const|volatile|restrict|__restrict__|__restrict)
 # attribute text (Codex review, PR #941, seventeenth round).
 _CALLING_CONVENTION_ATTR_RE = re.compile(
     r"__attribute__\s*\(\(\s*(cdecl|stdcall|fastcall|thiscall|vectorcall)\s*\)\)"
+)
+
+# Whether *prefix* already carries a leading calling-convention keyword,
+# used to decide whether to inject the equivalent one for a trailing
+# ``__attribute__(...)`` spelling (see the attribute-injection code
+# below). Matched as a genuine WHOLE TOKEN positioned immediately after
+# the declarator's own opening paren (allowing leading whitespace) --
+# never a bare substring test anywhere in `prefix` -- since `prefix`
+# also contains the return type, and a return type can legitimately
+# CONTAIN one of these keywords as a substring of an unrelated identifier
+# (e.g. `my__cdecl_result`) without that identifier being a calling-
+# convention keyword at all. A prior revision used `any(cc in prefix for
+# cc in _CALLING_CONVENTIONS)`, which matched that substring, wrongly
+# concluded a convention keyword was already present, and both skipped
+# injecting the real one AND still stripped the trailing attribute text
+# -- silently merging two distinct callback types (Codex review, PR #941,
+# twentieth round).
+_CALLING_CONVENTION_KEYWORD_RE = re.compile(
+    r"\s*(?:__cdecl|__stdcall|__fastcall|__thiscall|__vectorcall)\b"
 )
 
 # A leading `::` explicitly requesting GLOBAL-namespace lookup for the
@@ -589,6 +607,14 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("void (C::*)(int) __attribute__((thiscall))")
     'void (__thiscall C:: * )(int)'
 
+    A return type that merely CONTAINS a calling-convention keyword as a
+    substring of an unrelated identifier (``my__cdecl_result``) must not
+    be mistaken for a declarator that already has one -- the trailing
+    attribute is still injected as the declarator's own leading keyword.
+
+    >>> canonicalize_function_signature_param_type("my__cdecl_result (*)(int) __attribute__((stdcall))")
+    'my__cdecl_result (__stdcall * )(int)'
+
     An explicit leading ``::`` (global-namespace lookup) names the
     identical type an unqualified spelling of that same, unambiguous name
     does -- direct-clang's own ``qualType`` preserves this qualifier
@@ -730,15 +756,16 @@ def canonicalize_function_signature_param_type(name: str) -> str:
         attr_match = _CALLING_CONVENTION_ATTR_RE.search(tail)
         if attr_match is not None:
             tail = tail[: attr_match.start()] + tail[attr_match.end() :]
-            if not any(cc in prefix for cc in _CALLING_CONVENTIONS):
-                open_idx = prefix.rfind("(")
-                if open_idx != -1:
-                    keyword = f"__{attr_match.group(1)}"
-                    prefix = re.sub(
-                        r"\s+",
-                        " ",
-                        prefix[: open_idx + 1] + f"{keyword} " + prefix[open_idx + 1 :],
-                    )
+            open_idx = prefix.rfind("(")
+            if open_idx != -1 and not _CALLING_CONVENTION_KEYWORD_RE.match(
+                prefix, open_idx + 1
+            ):
+                keyword = f"__{attr_match.group(1)}"
+                prefix = re.sub(
+                    r"\s+",
+                    " ",
+                    prefix[: open_idx + 1] + f"{keyword} " + prefix[open_idx + 1 :],
+                )
         member_quals = _canonicalize_member_qualifiers(tail)
         # `head` (a bare pointer-declarator's own closing paren, plus any
         # by-value cv already stripped out of it) is joined directly onto

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -39,18 +39,35 @@ __all__ = ["canonicalize_function_signature_param_type"]
 
 _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 
-# A declarator-grouping paren's content, up to its own sigil: either a bare
-# pointer/reference (`*`, `&`), or a pointer-to-member's qualified-name
-# prefix (`C::*`, `ns::C::*`) -- one or more `identifier::` segments then
-# the sigil. Used to tell a declarator-grouping paren (transparent, not a
-# real nesting level) from a genuine parameter-list paren (opaque): a
-# parameter list's first token is always a type, which can itself start
-# with an identifier, but is never immediately followed by `::` then only
-# a bare sigil -- that specific shape is unique to a member-pointer
-# declarator (Codex review, PR #941, ninth round: an earlier revision here
-# recognized only the bare-sigil form, so `void (C::* const)(int)` -- cv on
-# a pointer-to-member's own outermost sigil -- was never found at depth 0).
-_DECLARATOR_GROUP_RE = re.compile(r"\s*(?:[A-Za-z_]\w*\s*::\s*)*[*&]")
+# A declarator-grouping paren's content, up to its own sigil: an optional
+# MSVC calling-convention keyword, then either a bare pointer/reference
+# (`*`, `&`) or a pointer-to-member's qualified-name prefix (`C::*`,
+# `ns::C::*` -- one or more `identifier::` segments) then the sigil. Used
+# to tell a declarator-grouping paren (transparent, not a real nesting
+# level) from a genuine parameter-list paren (opaque): a parameter list's
+# first token is always a type, which can itself start with an identifier,
+# but is never a calling-convention keyword and never immediately followed
+# by `::` then only a bare sigil -- both shapes are unique to a declarator
+# (Codex review, PR #941: the ninth round added the qualified-name-prefix
+# form, so `void (C::* const)(int)` -- cv on a pointer-to-member's own
+# outermost sigil -- was found at depth 0; the tenth round added the
+# calling-convention keyword, since a real MSVC/PE calling-convention
+# decoration -- e.g. `void (__cdecl * const)(int)` -- otherwise defeated
+# the same transparency test the identical way).  The convention keyword
+# itself is matched, not consumed/erased -- it stays in the returned
+# prefix verbatim, a genuine part of the type, same as the qualified-name
+# prefix already does.
+_CALLING_CONVENTIONS = (
+    "__cdecl",
+    "__stdcall",
+    "__fastcall",
+    "__thiscall",
+    "__vectorcall",
+)
+_DECLARATOR_GROUP_RE = re.compile(
+    r"\s*(?:(?:" + "|".join(_CALLING_CONVENTIONS) + r")\s*)?"
+    r"(?:[A-Za-z_]\w*\s*::\s*)*[*&]"
+)
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
@@ -200,16 +217,19 @@ def _normalize_param_list_contents(inner: str) -> str:
 
 
 def _normalize_nested_param_lists(s: str) -> str:
-    """Recursively canonicalize the contents of every top-level ``(...)``
-    parameter list appearing in *s* -- a declarator's own trailing
-    parameter list, e.g. the ``(int)`` in ``void (*)(int)`` or
-    ``void (C::*)(int)``, to any nesting depth (a callback parameter that
-    itself takes a callback parameter). Depth-tracks ``<([``/``>)]``
-    generally so a paren nested inside a template argument or array bound
-    is not mistaken for a top-level parameter list; recursion through
-    :func:`canonicalize_function_signature_param_type` (via
-    :func:`_normalize_param_list_contents`) applies this same nested
-    treatment at every level, so it needs no explicit depth limit -- each
+    """Canonicalize the contents of the one top-level ``(...)`` parameter
+    list *s* is -- a declarator's own trailing parameter list, e.g. the
+    ``(int)`` in ``void (*)(int)`` or ``void (C::*)(int)``. *s* is always
+    exactly that: from its own opening paren to its matching closing paren
+    (its only caller slices it out via :func:`_find_matching_paren`
+    first), so no scan for a top-level paren is needed here.
+
+    Reaches arbitrary nesting depth (a callback parameter that itself
+    takes a callback parameter) through :func:`_normalize_param_list_
+    contents`, which recurses back into
+    :func:`canonicalize_function_signature_param_type` for each individual
+    parameter -- each of ITS own trailing parameter lists (if any) then
+    makes its own, identically-shaped call back into this function. Each
     recursive call operates on a strictly shorter substring, which is what
     guarantees termination (Codex review, PR #941, ninth round: an earlier
     revision left a callback parameter's own parameter list entirely
@@ -217,26 +237,65 @@ def _normalize_nested_param_lists(s: str) -> str:
     identical adjusted callback type -- canonicalized to two different
     strings).
     """
-    out: list[str] = []
-    i = 0
-    n = len(s)
+    return "(" + _normalize_param_list_contents(s[1:-1]) + ")"
+
+
+def _split_at_trailing_param_list(suffix: str) -> tuple[str, str] | None:
+    """If *suffix* (the text after a declarator's own outermost sigil)
+    contains a top-level ``(...)`` group -- the declarator's own trailing
+    parameter list, e.g. the ``(int)`` in ``void (*)(int)`` -- return
+    ``(head, params_and_after)`` split so ``params_and_after`` starts
+    exactly at that paren's ``(``. Returns ``None`` when *suffix* has no
+    top-level ``(`` at all (a bare pointer, with no trailing declarator to
+    split off).
+    """
     depth = 0
-    while i < n:
-        ch = s[i]
+    for i, ch in enumerate(suffix):
         if ch == "(" and depth == 0:
-            close = _find_matching_paren(s, i)
-            out.append("(")
-            out.append(_normalize_param_list_contents(s[i + 1 : close]))
-            out.append(")")
-            i = close + 1
-            continue
+            return suffix[:i], suffix[i:]
         if ch in "<([":
             depth += 1
         elif ch in ">)]":
             depth = max(0, depth - 1)
-        out.append(ch)
-        i += 1
-    return "".join(out)
+    return None
+
+
+def _canonicalize_member_qualifiers(s: str) -> str:
+    """Canonicalize a pointer-to-member-function's own trailing cv/ref
+    qualifiers -- the ``const``/``volatile``/``&``/``&&`` that can follow
+    its parameter list, e.g. the ``const`` in ``void (C::*)(int) const``.
+    These qualify the POINTED-TO member function itself: a genuine,
+    standard-mandated overload/type discriminator (``void (C::*)(int)
+    const`` and ``void (C::*)(int)`` are two different, non-interchangeable
+    pointer-to-member types), unlike the pointer's own by-value qualifier
+    already stripped separately -- so this function only reorders (never
+    drops) them, the same "eliminate ordering by construction" treatment
+    ``entity_id_for_function``'s own ``is_const``/``is_volatile`` booleans
+    already give the outer function's member-cv (Codex review, PR #941,
+    tenth round: an earlier revision blanket-stripped every depth-0 cv
+    token found anywhere after the sigil, which wrongly erased this
+    genuinely-distinguishing trailing qualifier instead of only the
+    pointer's own by-value one before the parameter list).
+    """
+    stripped = s.strip()
+    if not stripped:
+        return ""
+    has_const = re.search(r"\bconst\b", stripped) is not None
+    has_volatile = re.search(r"\bvolatile\b", stripped) is not None
+    # canonicalize_type_name spells "&&" as "& &" (its own established
+    # sigil-spacing convention, same source as "int * const *" -> "int
+    # *const *" elsewhere in this module) -- compare on a whitespace-
+    # collapsed form so a trailing rvalue-ref qualifier is still found.
+    compact = re.sub(r"\s+", "", stripped)
+    ref = "&&" if compact.endswith("&&") else "&" if compact.endswith("&") else ""
+    parts = [
+        p
+        for p, present in (("const", has_const), ("volatile", has_volatile))
+        if present
+    ]
+    if ref:
+        parts.append(ref)
+    return " ".join(parts)
 
 
 def canonicalize_function_signature_param_type(name: str) -> str:
@@ -402,6 +461,27 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'void ( * )(char *)'
     >>> canonicalize_function_signature_param_type("void (*)(const char *)")
     'void ( * )(char const *)'
+
+    An MSVC/PE calling-convention keyword (``__cdecl``, ``__stdcall``, ...)
+    can also precede a declarator's own sigil -- recognized the identical
+    transparent way, and kept verbatim (it is genuine, distinguishing
+    content, not something dropped). And a pointer-to-member-function's
+    own TRAILING cv/ref-qualifiers -- the ones that follow its parameter
+    list, e.g. ``const`` in ``void (C::*)(int) const`` -- are different
+    from the pointer's own by-value qualifier before the parameter list:
+    they qualify the POINTED-TO member function itself, a genuine,
+    standard-mandated discriminator (``void (C::*)(int) const`` and
+    ``void (C::*)(int)`` are two different, non-interchangeable types), so
+    they are only reordered for cv, never dropped.
+
+    >>> canonicalize_function_signature_param_type("void (__cdecl * const)(int)")
+    'void (__cdecl * )(int)'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) const")
+    'void (C:: * )(int) const'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) volatile const")
+    'void (C:: * )(int) const volatile'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) &&")
+    'void (C:: * )(int) &&'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -413,11 +493,23 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     transparent_parens: list[bool] = []
     last_top_level_sigil = -1
     has_top_level_bracket = False
+    # Once a genuine (opaque) top-level paren has been seen -- the
+    # declarator's own trailing parameter list -- nothing after it is
+    # eligible to become a new "last top-level sigil". Without this, a
+    # trailing ref-qualifier on a pointer-to-member-function
+    # (`void (C::*)(int) &&`) -- itself a `*`/`&`-shaped token sitting at
+    # depth 0, textually after the parameter list closes -- would wrongly
+    # override the declarator's own already-found sigil and corrupt the
+    # prefix/suffix split (Codex review, PR #941, tenth round: caught by
+    # this round's own new ref-qualifier test, not by a reviewer finding).
+    seen_top_level_opaque_paren = False
     for i, ch in enumerate(canonical):
         if ch == "(":
             transparent = _DECLARATOR_GROUP_RE.match(canonical, i + 1) is not None
             transparent_parens.append(transparent)
             if not transparent:
+                if depth == 0:
+                    seen_top_level_opaque_paren = True
                 depth += 1
             continue
         if ch == ")":
@@ -431,7 +523,7 @@ def canonicalize_function_signature_param_type(name: str) -> str:
             depth += 1
         elif ch in ">]":
             depth = max(0, depth - 1)
-        elif ch in "*&" and depth == 0:
+        elif ch in "*&" and depth == 0 and not seen_top_level_opaque_paren:
             last_top_level_sigil = i
     if last_top_level_sigil == -1:
         # No real pointer/reference sigil. An undecayed top-level array
@@ -445,6 +537,31 @@ def canonicalize_function_signature_param_type(name: str) -> str:
             else _strip_cv_tokens_outside_nesting(canonical)
         )
     prefix = canonical[: last_top_level_sigil + 1]
-    suffix = _strip_cv_tokens_outside_nesting(canonical[last_top_level_sigil + 1 :])
-    suffix = _normalize_nested_param_lists(suffix)
+    raw_suffix = canonical[last_top_level_sigil + 1 :]
+    split = _split_at_trailing_param_list(raw_suffix)
+    if split is None:
+        # A bare pointer with no trailing declarator (e.g. "int * const")
+        # -- every depth-0 cv token here is the pointer's own, by-value.
+        suffix = _strip_cv_tokens_outside_nesting(raw_suffix)
+    else:
+        # A declarator's own trailing parameter list is present (a
+        # callback or pointer-to-member-function). Everything BEFORE it is
+        # still the pointer's own by-value qualifier region (stripped);
+        # the parameter list's own contents get the identical nested
+        # by-value treatment; anything AFTER the parameter list's closing
+        # paren is the POINTED-TO member function's own cv/ref qualifiers
+        # -- genuinely distinguishing, only reordered, never stripped.
+        head, params_and_after = split
+        head = _strip_cv_tokens_outside_nesting(head)
+        close = _find_matching_paren(params_and_after, 0)
+        params = _normalize_nested_param_lists(params_and_after[: close + 1])
+        member_quals = _canonicalize_member_qualifiers(params_and_after[close + 1 :])
+        # `head` (a bare pointer-declarator's own closing paren, plus any
+        # by-value cv already stripped out of it) is joined directly onto
+        # `params` -- no separator space -- since `head` always ends in
+        # the declarator group's own ")" immediately followed by the
+        # parameter list's own "(", with nothing to separate.
+        suffix = head + params
+        if member_quals:
+            suffix = f"{suffix} {member_quals}"
     return f"{prefix} {suffix}".rstrip() if suffix else prefix

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -22,11 +22,19 @@ module's own contents are otherwise identity.py's, not a separate design
 decision. See ``docs/contribute/plans/one-semantic-pipeline.md``'s Phase 2
 section for the full history of the several review rounds (Codex, PR #941)
 that grew this from a single ``canonicalize_type_name`` call into the
-dedicated cv/array-decay logic here.
+dedicated cv/array-decay logic here. A second sibling leaf module,
+``declarator_qualifiers.py``, was split out of THIS module in turn once it
+hit the same 800-line cap (fifteenth round) -- it holds the declarator-
+grouping/pointer-to-member/trailing-qualifier machinery that has no
+recursive dependency back into this module's own
+``canonicalize_function_signature_param_type``; see that module's own
+docstring for why the import direction is one-way.
 
 Leaf module: imports only ``name_classification.canonicalize_type_name``
-(a dependency-free sibling), nothing above ``model``, per ADR-063 D10 --
-the same leaf-module contract ``model/identity.py`` itself states.
+(a dependency-free sibling) and its own sibling ``declarator_qualifiers``
+(also a leaf, importing nothing back here), nothing above ``model``, per
+ADR-063 D10 -- the same leaf-module contract ``model/identity.py`` itself
+states.
 """
 
 from __future__ import annotations
@@ -34,92 +42,16 @@ from __future__ import annotations
 import re
 
 from ..name_classification import canonicalize_type_name
+from .declarator_qualifiers import (
+    _canonicalize_member_qualifiers,
+    _find_member_pointer_qualifier,
+    _is_declarator_group,
+    _split_at_trailing_param_list,
+)
 
 __all__ = ["canonicalize_function_signature_param_type"]
 
 _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
-
-# A declarator-grouping paren's content, up to its own sigil: an optional
-# MSVC calling-convention keyword, then either a bare pointer/reference
-# (`*`, `&`) or a pointer-to-member's qualified-name prefix (`C::*`,
-# `ns::C::*`, `C<int>::*` -- one or more `identifier[<template-args>]::`
-# segments) then the sigil. Used to tell a declarator-grouping paren
-# (transparent, not a real nesting level) from a genuine parameter-list
-# paren (opaque): a parameter list's first token is always a type, which
-# can itself start with an identifier, but is never a calling-convention
-# keyword and never immediately followed by `::` then only a bare sigil --
-# both shapes are unique to a declarator (Codex review, PR #941: the
-# ninth round added the qualified-name-prefix form, so `void (C::*
-# const)(int)` -- cv on a pointer-to-member's own outermost sigil -- was
-# found at depth 0; the tenth round added the calling-convention keyword,
-# since a real MSVC/PE calling-convention decoration -- e.g. `void
-# (__cdecl * const)(int)` -- otherwise defeated the same transparency
-# test the identical way; the eleventh round added the template-argument
-# list, since a real nested-name-specifier's segment can itself be a
-# template-id, e.g. `void (C<int>::* const)(int)`, which a plain
-# `identifier::` match can't recognize -- checked with a manual scanner,
-# not a single regex, since a template-argument list can nest arbitrarily
-# deep, `Box<Pair<int, int>>::`, which `re`'s non-recursive matching
-# cannot balance). The convention keyword and any template-argument list
-# are matched, not consumed/erased -- they stay in the returned prefix
-# verbatim, genuine parts of the type, same as the plain qualified-name
-# prefix already does.
-_CALLING_CONVENTIONS = (
-    "__cdecl",
-    "__stdcall",
-    "__fastcall",
-    "__thiscall",
-    "__vectorcall",
-)
-_IDENTIFIER_RE = re.compile(r"[A-Za-z_]\w*")
-
-
-def _is_declarator_group(s: str, start: int) -> bool:
-    """Whether ``s[start:]`` is a declarator-grouping paren's own content
-    (see :data:`_CALLING_CONVENTIONS`'s module-level comment for the full
-    shape) -- called with *start* right after the paren's own ``(``.
-    """
-    n = len(s)
-    i = start
-    while i < n and s[i] == " ":
-        i += 1
-    for conv in _CALLING_CONVENTIONS:
-        if s.startswith(conv, i):
-            i += len(conv)
-            while i < n and s[i] == " ":
-                i += 1
-            break
-    while True:
-        j = i
-        while j < n and s[j] == " ":
-            j += 1
-        m = _IDENTIFIER_RE.match(s, j)
-        if not m:
-            break
-        k = m.end()
-        if k < n and s[k] == "<":
-            depth = 0
-            p = k
-            while p < n:
-                if s[p] == "<":
-                    depth += 1
-                elif s[p] == ">":
-                    depth -= 1
-                    if depth == 0:
-                        p += 1
-                        break
-                p += 1
-            else:
-                return False  # unmatched '<' -- malformed, bail out
-            k = p
-        while k < n and s[k] == " ":
-            k += 1
-        if not s.startswith("::", k):
-            break
-        i = k + 2
-    while i < n and s[i] == " ":
-        i += 1
-    return i < n and s[i] in "*&"
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
@@ -152,49 +84,6 @@ def _strip_cv_tokens_outside_nesting(s: str) -> str:
             out.append(ch)
             i += 1
     return re.sub(r"\s+", " ", "".join(out)).strip()
-
-
-def _extract_top_level_cv(s: str) -> tuple[bool, bool, str]:
-    """Depth-aware sibling of :func:`_strip_cv_tokens_outside_nesting`:
-    finds ``const``/``volatile`` tokens at nesting depth 0 only (outside
-    any ``<...>``/``(...)``/``[...]``), reports which were found, and
-    returns *s* with those depth-0 tokens removed -- a cv-looking word
-    sitting INSIDE a parenthesized region (a ``noexcept(expr)``
-    argument's own text, a template argument) is untouched, since it
-    belongs to that expression, not to this declarator's own trailing
-    qualifier sequence (Codex review, PR #941, thirteenth round: an
-    earlier revision used a plain, depth-blind ``re.search``/``re.sub``
-    over the whole trailing region, which wrongly reached inside a
-    non-literal ``noexcept(expr)``'s own argument, e.g.
-    ``noexcept(Foo<const int>)``).
-    """
-    depth = 0
-    has_const = False
-    has_volatile = False
-    out: list[str] = []
-    i = 0
-    n = len(s)
-    while i < n:
-        ch = s[i]
-        if ch in "<([":
-            depth += 1
-            out.append(ch)
-            i += 1
-        elif ch in ">)]":
-            depth = max(0, depth - 1)
-            out.append(ch)
-            i += 1
-        elif depth == 0 and (m := _CV_WORD_RE.match(s, i)):
-            if m.group() == "const":
-                has_const = True
-            else:
-                has_volatile = True
-            i = m.end()
-        else:
-            out.append(ch)
-            i += 1
-    rest = re.sub(r"\s+", " ", "".join(out)).strip()
-    return has_const, has_volatile, rest
 
 
 def _decay_top_level_array(canonical_type: str) -> str:
@@ -339,124 +228,6 @@ def _normalize_nested_param_lists(s: str) -> str:
     strings).
     """
     return "(" + _normalize_param_list_contents(s[1:-1]) + ")"
-
-
-def _split_at_trailing_param_list(suffix: str) -> tuple[str, str] | None:
-    """If *suffix* (the text after a declarator's own outermost sigil)
-    contains a top-level ``(...)`` group -- the declarator's own trailing
-    parameter list, e.g. the ``(int)`` in ``void (*)(int)`` -- return
-    ``(head, params_and_after)`` split so ``params_and_after`` starts
-    exactly at that paren's ``(``. Returns ``None`` when *suffix* has no
-    top-level ``(`` at all (a bare pointer, with no trailing declarator to
-    split off).
-    """
-    depth = 0
-    for i, ch in enumerate(suffix):
-        if ch == "(" and depth == 0:
-            return suffix[:i], suffix[i:]
-        if ch in "<([":
-            depth += 1
-        elif ch in ">)]":
-            depth = max(0, depth - 1)
-    return None
-
-
-def _canonicalize_member_qualifiers(s: str) -> str:
-    """Canonicalize a pointer-to-member-function's own trailing
-    specifiers -- the cv-qualifiers, ref-qualifier, and (post-C++17)
-    ``noexcept``-specifier that can follow its parameter list, e.g. the
-    ``const`` in ``void (C::*)(int) const`` or the ``noexcept`` in
-    ``void (*)(int) noexcept``. These qualify the POINTED-TO member
-    function itself: genuine, standard-mandated overload/type
-    discriminators (``void (C::*)(int) const`` and ``void (C::*)(int)``
-    are two different, non-interchangeable pointer-to-member types; since
-    C++17 a ``noexcept``/non-``noexcept`` function is likewise a distinct
-    type), unlike the pointer's own by-value qualifier already stripped
-    separately -- so this function only ever REORDERS ``const``/
-    ``volatile`` relative to each other (the same "eliminate ordering by
-    construction" treatment ``entity_id_for_function``'s own
-    ``is_const``/``is_volatile`` booleans already give the outer
-    function's member-cv), while every other specifier -- ref-qualifier,
-    ``noexcept``, and anything else this function does not need to
-    individually name -- passes through verbatim, in its original
-    relative order (Codex review, PR #941, tenth round: an earlier
-    revision blanket-stripped every depth-0 cv token found anywhere after
-    the sigil, which wrongly erased this genuinely-distinguishing trailing
-    region entirely; eleventh round: the fix for that then reconstructed
-    the trailing region from ONLY cv/ref, which silently dropped
-    ``noexcept`` instead -- a second, different over-merge of the same
-    class, `void (*)(int) noexcept` and `void (*)(int)` wrongly collapsing
-    to one identity. `dcl.fct`'s own grammar already fixes cv-qualifier-
-    seq first among these trailing specifiers, so a real producer's
-    placement never needs inferring -- only cv needs reordering relative
-    to itself; everything else keeps whatever order it was already
-    spelled in; twelfth round: preserving ``noexcept`` verbatim was
-    necessary but not sufficient -- since C++17, a function type's
-    exception specification collapses to exactly two kinds for TYPE
-    purposes, "non-throwing" (bare ``noexcept``/``noexcept(true)``) and
-    "potentially-throwing" (no specifier at all, or ``noexcept(false)``),
-    so those pairs are the SAME type and must canonicalize identically,
-    the same "verbatim preservation isn't canonicalization" gap the
-    by-value cv/array-decay fixes each already closed for their own
-    shape. Only the two literal, constant-expression spellings are
-    normalized; any other, non-literal ``noexcept(expr)`` is left
-    completely untouched -- evaluating an arbitrary constant expression is
-    out of scope, the same "don't solve the fully general grammar" limit
-    this module already draws elsewhere; thirteenth round: extracting
-    ``const``/``volatile`` via a plain, depth-blind ``re.search`` over the
-    WHOLE trailing region wrongly reached inside a non-literal
-    ``noexcept(expr)``'s own argument too -- a ``const``/``volatile``
-    token that is part of THAT expression's own text, e.g.
-    ``noexcept(Foo<const int>)``, is not this declarator's own
-    cv-qualifier at all, and extracting it both corrupted the expression
-    (mutating text this function has no business touching, since it
-    cannot evaluate it) and could merge two genuinely different overloads
-    that happen to share a nested "const" by coincidence. Fixed with a
-    depth-aware scan, :func:`_extract_top_level_cv`, mirroring
-    :func:`_strip_cv_tokens_outside_nesting`'s own outside-nesting
-    discipline: only a cv word sitting at depth 0 -- outside any
-    ``(...)``/``<...>``/``[...]`` -- is ever this declarator's own
-    trailing qualifier).
-    """
-    stripped = s.strip()
-    if not stripped:
-        return ""
-    has_const, has_volatile, rest = _extract_top_level_cv(stripped)
-    rest = _canonicalize_noexcept(rest)
-    parts = [
-        p
-        for p, present in (("const", has_const), ("volatile", has_volatile))
-        if present
-    ]
-    if rest:
-        parts.append(rest)
-    return " ".join(parts)
-
-
-_NOEXCEPT_RE = re.compile(r"\bnoexcept\b(?:\s*\(\s*([^()]*)\s*\))?")
-
-
-def _canonicalize_noexcept(s: str) -> str:
-    """Normalize the two constant ``noexcept`` spellings this trailing
-    region can carry: bare ``noexcept``/``noexcept(true)`` (the
-    "non-throwing" type) collapse to the single canonical spelling
-    ``"noexcept"``; ``noexcept(false)`` (equivalent, for type purposes, to
-    no exception-specification at all) is dropped entirely, same as an
-    already-absent specifier. Any other ``noexcept(expr)`` -- a non-
-    literal constant expression this function cannot evaluate -- is left
-    untouched, verbatim.
-    """
-    m = _NOEXCEPT_RE.search(s)
-    if not m:
-        return s
-    arg = m.group(1)
-    if arg is None or arg.strip() == "true":
-        replacement = "noexcept"
-    elif arg.strip() == "false":
-        replacement = ""
-    else:
-        return s
-    return re.sub(r"\s+", " ", s[: m.start()] + replacement + s[m.end() :]).strip()
 
 
 def canonicalize_function_signature_param_type(name: str) -> str:
@@ -697,6 +468,24 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     '(anonymous namespace)::Foo const *'
     >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo *")
     '(anonymous namespace)::Foo *'
+
+    A bare (non-parenthesized) data-member-pointer parameter, e.g.
+    ``int C::*`` (pointer to an ``int`` member of ``C``), has a pointee
+    cv-qualifier that must canonicalize the same regardless of whether it
+    was spelled before or after the base type -- unlike the ordinary
+    pointee case above, ``canonicalize_type_name`` MISPLACES a leading
+    ``const`` across the ``C::`` infix rather than leaving it be, so this
+    needs its own correction (only ``const``/``volatile`` positioning
+    relative to the base type is fixed; if either was already reordered
+    relative to the OTHER, e.g. ``volatile`` vs. ``const volatile``, that
+    residual gap is the same, pre-existing, `canonicalize_type_name`-wide
+    limitation ordinary non-member pointee cv already has -- out of scope
+    here).
+
+    >>> canonicalize_function_signature_param_type("const int C::*")
+    'int const C:: *'
+    >>> canonicalize_function_signature_param_type("int const C::*")
+    'int const C:: *'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -764,6 +553,27 @@ def canonicalize_function_signature_param_type(name: str) -> str:
             else _strip_cv_tokens_outside_nesting(canonical)
         )
     prefix = canonical[: last_top_level_sigil + 1]
+    # A bare (non-parenthesized) data-member-pointer's pointee cv needs
+    # its own independent re-canonicalization -- see
+    # _find_member_pointer_qualifier's own docstring for why. Only applies
+    # when the split-off "base" has no unmatched open paren: a
+    # parenthesized member-function-pointer/-array declarator group
+    # (`(C::*)`) hits this same code path (`(`/`)` don't affect depth,
+    # since they're transparent), and its own "base" (a return type
+    # fragment like `void (`) is not a real standalone type to
+    # re-canonicalize.
+    qualifier_span = _find_member_pointer_qualifier(prefix)
+    if qualifier_span is not None:
+        qualifier_start, qualifier_end = qualifier_span
+        base = prefix[:qualifier_start].rstrip()
+        if base.count("(") == base.count(")"):
+            tail_cv = " ".join(re.findall(r"const|volatile", prefix[qualifier_end:]))
+            combined_base = f"{base} {tail_cv}".strip() if tail_cv else base
+            qualifier_text = prefix[qualifier_start:qualifier_end]
+            sigil_char = prefix[-1]
+            prefix = (
+                f"{canonicalize_type_name(combined_base)} {qualifier_text} {sigil_char}"
+            )
     raw_suffix = canonical[last_top_level_sigil + 1 :]
     split = _split_at_trailing_param_list(raw_suffix)
     if split is None:

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -42,20 +42,27 @@ _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 # A declarator-grouping paren's content, up to its own sigil: an optional
 # MSVC calling-convention keyword, then either a bare pointer/reference
 # (`*`, `&`) or a pointer-to-member's qualified-name prefix (`C::*`,
-# `ns::C::*` -- one or more `identifier::` segments) then the sigil. Used
-# to tell a declarator-grouping paren (transparent, not a real nesting
-# level) from a genuine parameter-list paren (opaque): a parameter list's
-# first token is always a type, which can itself start with an identifier,
-# but is never a calling-convention keyword and never immediately followed
-# by `::` then only a bare sigil -- both shapes are unique to a declarator
-# (Codex review, PR #941: the ninth round added the qualified-name-prefix
-# form, so `void (C::* const)(int)` -- cv on a pointer-to-member's own
-# outermost sigil -- was found at depth 0; the tenth round added the
-# calling-convention keyword, since a real MSVC/PE calling-convention
-# decoration -- e.g. `void (__cdecl * const)(int)` -- otherwise defeated
-# the same transparency test the identical way).  The convention keyword
-# itself is matched, not consumed/erased -- it stays in the returned
-# prefix verbatim, a genuine part of the type, same as the qualified-name
+# `ns::C::*`, `C<int>::*` -- one or more `identifier[<template-args>]::`
+# segments) then the sigil. Used to tell a declarator-grouping paren
+# (transparent, not a real nesting level) from a genuine parameter-list
+# paren (opaque): a parameter list's first token is always a type, which
+# can itself start with an identifier, but is never a calling-convention
+# keyword and never immediately followed by `::` then only a bare sigil --
+# both shapes are unique to a declarator (Codex review, PR #941: the
+# ninth round added the qualified-name-prefix form, so `void (C::*
+# const)(int)` -- cv on a pointer-to-member's own outermost sigil -- was
+# found at depth 0; the tenth round added the calling-convention keyword,
+# since a real MSVC/PE calling-convention decoration -- e.g. `void
+# (__cdecl * const)(int)` -- otherwise defeated the same transparency
+# test the identical way; the eleventh round added the template-argument
+# list, since a real nested-name-specifier's segment can itself be a
+# template-id, e.g. `void (C<int>::* const)(int)`, which a plain
+# `identifier::` match can't recognize -- checked with a manual scanner,
+# not a single regex, since a template-argument list can nest arbitrarily
+# deep, `Box<Pair<int, int>>::`, which `re`'s non-recursive matching
+# cannot balance). The convention keyword and any template-argument list
+# are matched, not consumed/erased -- they stay in the returned prefix
+# verbatim, genuine parts of the type, same as the plain qualified-name
 # prefix already does.
 _CALLING_CONVENTIONS = (
     "__cdecl",
@@ -64,10 +71,55 @@ _CALLING_CONVENTIONS = (
     "__thiscall",
     "__vectorcall",
 )
-_DECLARATOR_GROUP_RE = re.compile(
-    r"\s*(?:(?:" + "|".join(_CALLING_CONVENTIONS) + r")\s*)?"
-    r"(?:[A-Za-z_]\w*\s*::\s*)*[*&]"
-)
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_]\w*")
+
+
+def _is_declarator_group(s: str, start: int) -> bool:
+    """Whether ``s[start:]`` is a declarator-grouping paren's own content
+    (see :data:`_CALLING_CONVENTIONS`'s module-level comment for the full
+    shape) -- called with *start* right after the paren's own ``(``.
+    """
+    n = len(s)
+    i = start
+    while i < n and s[i] == " ":
+        i += 1
+    for conv in _CALLING_CONVENTIONS:
+        if s.startswith(conv, i):
+            i += len(conv)
+            while i < n and s[i] == " ":
+                i += 1
+            break
+    while True:
+        j = i
+        while j < n and s[j] == " ":
+            j += 1
+        m = _IDENTIFIER_RE.match(s, j)
+        if not m:
+            break
+        k = m.end()
+        if k < n and s[k] == "<":
+            depth = 0
+            p = k
+            while p < n:
+                if s[p] == "<":
+                    depth += 1
+                elif s[p] == ">":
+                    depth -= 1
+                    if depth == 0:
+                        p += 1
+                        break
+                p += 1
+            else:
+                return False  # unmatched '<' -- malformed, bail out
+            k = p
+        while k < n and s[k] == " ":
+            k += 1
+        if not s.startswith("::", k):
+            break
+        i = k + 2
+    while i < n and s[i] == " ":
+        i += 1
+    return i < n and s[i] in "*&"
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
@@ -261,40 +313,49 @@ def _split_at_trailing_param_list(suffix: str) -> tuple[str, str] | None:
 
 
 def _canonicalize_member_qualifiers(s: str) -> str:
-    """Canonicalize a pointer-to-member-function's own trailing cv/ref
-    qualifiers -- the ``const``/``volatile``/``&``/``&&`` that can follow
-    its parameter list, e.g. the ``const`` in ``void (C::*)(int) const``.
-    These qualify the POINTED-TO member function itself: a genuine,
-    standard-mandated overload/type discriminator (``void (C::*)(int)
-    const`` and ``void (C::*)(int)`` are two different, non-interchangeable
-    pointer-to-member types), unlike the pointer's own by-value qualifier
-    already stripped separately -- so this function only reorders (never
-    drops) them, the same "eliminate ordering by construction" treatment
-    ``entity_id_for_function``'s own ``is_const``/``is_volatile`` booleans
-    already give the outer function's member-cv (Codex review, PR #941,
-    tenth round: an earlier revision blanket-stripped every depth-0 cv
-    token found anywhere after the sigil, which wrongly erased this
-    genuinely-distinguishing trailing qualifier instead of only the
-    pointer's own by-value one before the parameter list).
+    """Canonicalize a pointer-to-member-function's own trailing
+    specifiers -- the cv-qualifiers, ref-qualifier, and (post-C++17)
+    ``noexcept``-specifier that can follow its parameter list, e.g. the
+    ``const`` in ``void (C::*)(int) const`` or the ``noexcept`` in
+    ``void (*)(int) noexcept``. These qualify the POINTED-TO member
+    function itself: genuine, standard-mandated overload/type
+    discriminators (``void (C::*)(int) const`` and ``void (C::*)(int)``
+    are two different, non-interchangeable pointer-to-member types; since
+    C++17 a ``noexcept``/non-``noexcept`` function is likewise a distinct
+    type), unlike the pointer's own by-value qualifier already stripped
+    separately -- so this function only ever REORDERS ``const``/
+    ``volatile`` relative to each other (the same "eliminate ordering by
+    construction" treatment ``entity_id_for_function``'s own
+    ``is_const``/``is_volatile`` booleans already give the outer
+    function's member-cv), while every other specifier -- ref-qualifier,
+    ``noexcept``, and anything else this function does not need to
+    individually name -- passes through verbatim, in its original
+    relative order (Codex review, PR #941, tenth round: an earlier
+    revision blanket-stripped every depth-0 cv token found anywhere after
+    the sigil, which wrongly erased this genuinely-distinguishing trailing
+    region entirely; eleventh round: the fix for that then reconstructed
+    the trailing region from ONLY cv/ref, which silently dropped
+    ``noexcept`` instead -- a second, different over-merge of the same
+    class, `void (*)(int) noexcept` and `void (*)(int)` wrongly collapsing
+    to one identity. `dcl.fct`'s own grammar already fixes cv-qualifier-
+    seq first among these trailing specifiers, so a real producer's
+    placement never needs inferring -- only cv needs reordering relative
+    to itself; everything else keeps whatever order it was already
+    spelled in).
     """
     stripped = s.strip()
     if not stripped:
         return ""
     has_const = re.search(r"\bconst\b", stripped) is not None
     has_volatile = re.search(r"\bvolatile\b", stripped) is not None
-    # canonicalize_type_name spells "&&" as "& &" (its own established
-    # sigil-spacing convention, same source as "int * const *" -> "int
-    # *const *" elsewhere in this module) -- compare on a whitespace-
-    # collapsed form so a trailing rvalue-ref qualifier is still found.
-    compact = re.sub(r"\s+", "", stripped)
-    ref = "&&" if compact.endswith("&&") else "&" if compact.endswith("&") else ""
+    rest = re.sub(r"\s+", " ", _CV_WORD_RE.sub("", stripped)).strip()
     parts = [
         p
         for p, present in (("const", has_const), ("volatile", has_volatile))
         if present
     ]
-    if ref:
-        parts.append(ref)
+    if rest:
+        parts.append(rest)
     return " ".join(parts)
 
 
@@ -481,7 +542,23 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("void (C::*)(int) volatile const")
     'void (C:: * )(int) const volatile'
     >>> canonicalize_function_signature_param_type("void (C::*)(int) &&")
-    'void (C:: * )(int) &&'
+    'void (C:: * )(int) & &'
+
+    A nested-name-specifier's own segment can itself be a template-id
+    (``C<int>::``), not only a plain identifier -- recognized the same
+    transparent way, to any template-argument nesting depth. And any
+    OTHER trailing specifier this function does not individually name --
+    a ``noexcept``-specifier being the practically important one, since
+    C++17 makes it part of the function type -- passes through verbatim
+    rather than being dropped: only ``const``/``volatile`` are ever
+    reordered here, never anything else.
+
+    >>> canonicalize_function_signature_param_type("void (C<int>::* const)(int)")
+    'void (C<int>:: * )(int)'
+    >>> canonicalize_function_signature_param_type("void (*)(int) noexcept")
+    'void ( * )(int) noexcept'
+    >>> canonicalize_function_signature_param_type("void (C::*)(int) noexcept const")
+    'void (C:: * )(int) const noexcept'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
@@ -505,7 +582,7 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     seen_top_level_opaque_paren = False
     for i, ch in enumerate(canonical):
         if ch == "(":
-            transparent = _DECLARATOR_GROUP_RE.match(canonical, i + 1) is not None
+            transparent = _is_declarator_group(canonical, i + 1)
             transparent_parens.append(transparent)
             if not transparent:
                 if depth == 0:

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -92,6 +92,32 @@ _CALLING_CONVENTION_ATTR_RE = re.compile(
     r"__attribute__\s*\(\(\s*(cdecl|stdcall|fastcall|thiscall|vectorcall)\s*\)\)"
 )
 
+# A leading `::` explicitly requesting GLOBAL-namespace lookup for the
+# scoped name that follows (`::dep::Thing`) names the identical type an
+# unqualified spelling of the same, unambiguous name does (`dep::Thing`)
+# -- direct-clang's own `qualType` preserves this explicit qualifier
+# verbatim (a confirmed real producer spelling: see
+# `tests/test_dumper_scoping_dependency_retention.py::
+# test_globally_qualified_signature_spelling_still_matches`'s own
+# twenty-sixth-round docstring for the identical fact from the *type-
+# matching* side of this codebase), so leaving it in place here fragments
+# one declaration's identity across producers/revisions purely on this
+# spelling choice, the same class of cross-producer-spelling gap this
+# whole module exists to close. Matched by POSITION, not depth: safe to
+# strip only where `::` marks the START of a scoped-name token -- string
+# start, or immediately after whitespace/`(`/`<`/`,`/`*`/`&` (an opening
+# template-argument list, parameter list, or pointer/reference sigil, all
+# places a fresh type name can begin) -- never when `::` follows an
+# identifier character (an ordinary qualified name's own internal
+# separator, e.g. the second `::` in `dep::Thing`, must never be
+# touched) OR anything else, most importantly `)` -- the closing paren of
+# `(anonymous namespace)::Foo`'s own real producer spelling is NOT a
+# fresh-token boundary, and a naive negative-lookbehind-on-identifier-
+# chars-only regex (an earlier draft of this fix) would have wrongly
+# stripped that type's genuine, load-bearing separator, corrupting it to
+# `(anonymous namespace)Foo` (Codex review, PR #941, nineteenth round).
+_GLOBAL_SCOPE_RE = re.compile(r"(?:\A|(?<=[\s(<,*&]))::")
+
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
     """Blank out every ``const``/``volatile``/``restrict`` (any of its
@@ -562,10 +588,34 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'void (__cdecl * )(int)'
     >>> canonicalize_function_signature_param_type("void (C::*)(int) __attribute__((thiscall))")
     'void (__thiscall C:: * )(int)'
+
+    An explicit leading ``::`` (global-namespace lookup) names the
+    identical type an unqualified spelling of that same, unambiguous name
+    does -- direct-clang's own ``qualType`` preserves this qualifier
+    verbatim, a confirmed real producer spelling. A genuine, load-bearing
+    ``::`` separator -- an ordinary qualified name's own internal one, or
+    the one following an anonymous-namespace parenthesized group -- is
+    never touched.
+
+    >>> canonicalize_function_signature_param_type("::dep::Thing *")
+    'dep::Thing *'
+    >>> canonicalize_function_signature_param_type("dep::Thing *")
+    'dep::Thing *'
+    >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo *")
+    '(anonymous namespace)::Foo *'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
+    # An explicit leading `::` (global-namespace lookup) is stripped
+    # unconditionally, unlike restrict/cv -- it is never position-
+    # sensitive (a scoped name resolves to the identical entity whether
+    # or not the lookup was forced global), so this runs once, up front,
+    # rather than being folded into the position-sensitive machinery
+    # below. See `_GLOBAL_SCOPE_RE`'s own comment for why the match is
+    # anchored to specific preceding characters rather than a blanket
+    # "not preceded by an identifier" test.
+    canonical = _GLOBAL_SCOPE_RE.sub("", canonical)
     depth = 0
     # True for a paren currently open on `transparent_parens` that groups a
     # declarator's own sigil (see the docstring above) -- popped, not

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -110,31 +110,42 @@ _CALLING_CONVENTION_KEYWORD_RE = re.compile(
     r"\s*(?:__cdecl|__stdcall|__fastcall|__thiscall|__vectorcall)\b"
 )
 
-# A leading `::` explicitly requesting GLOBAL-namespace lookup for the
-# scoped name that follows (`::dep::Thing`) names the identical type an
-# unqualified spelling of the same, unambiguous name does (`dep::Thing`)
-# -- direct-clang's own `qualType` preserves this explicit qualifier
-# verbatim (a confirmed real producer spelling: see
-# `tests/test_dumper_scoping_dependency_retention.py::
-# test_globally_qualified_signature_spelling_still_matches`'s own
-# twenty-sixth-round docstring for the identical fact from the *type-
-# matching* side of this codebase), so leaving it in place here fragments
-# one declaration's identity across producers/revisions purely on this
-# spelling choice, the same class of cross-producer-spelling gap this
-# whole module exists to close. Matched by POSITION, not depth: safe to
-# strip only where `::` marks the START of a scoped-name token -- string
-# start, or immediately after whitespace/`(`/`<`/`,`/`*`/`&` (an opening
-# template-argument list, parameter list, or pointer/reference sigil, all
-# places a fresh type name can begin) -- never when `::` follows an
-# identifier character (an ordinary qualified name's own internal
-# separator, e.g. the second `::` in `dep::Thing`, must never be
-# touched) OR anything else, most importantly `)` -- the closing paren of
-# `(anonymous namespace)::Foo`'s own real producer spelling is NOT a
-# fresh-token boundary, and a naive negative-lookbehind-on-identifier-
-# chars-only regex (an earlier draft of this fix) would have wrongly
-# stripped that type's genuine, load-bearing separator, corrupting it to
-# `(anonymous namespace)Foo` (Codex review, PR #941, nineteenth round).
-_GLOBAL_SCOPE_RE = re.compile(r"(?:\A|(?<=[\s(<,*&]))::")
+# A leading `::` (explicit global-namespace lookup) is DELIBERATELY left
+# untouched, genuinely distinguishing -- despite a nineteenth-round
+# attempt (`_GLOBAL_SCOPE_RE`, since reverted) to strip it unconditionally
+# on the theory that `::dep::Thing` and `dep::Thing` always name the
+# identical type. That theory is false in general and was falsified by
+# direct compilation, not merely re-derived from principle: given
+#     namespace dep { struct Thing; }
+#     namespace local { namespace dep { struct Thing; } void f(dep::Thing*); }
+# Clang's own `qualType` for `f`'s parameter prints the BARE, unqualified
+# `dep::Thing *` -- with NO leading `::` -- even though it resolves to
+# `local::dep::Thing`, a type that is DISTINCT from the global
+# `::dep::Thing` a sibling declaration `void g(::dep::Thing*)` in the
+# same namespace prints WITH the leading `::` (Codex review, PR #941,
+# twenty-first round, reproduced independently via `clang -Xclang
+# -ast-dump=json` before reverting). Since this module has no scope-tree
+# information -- it operates purely on already-printed type-name text --
+# it cannot tell "a genuinely global entity, spelled either way" apart
+# from "an unqualified name that happens to resolve to a DIFFERENT,
+# locally-shadowing entity of the same spelling"; Clang's own choice to
+# include or omit the leading `::` is exactly the signal that
+# distinguishes them, so erasing it can silently merge two non-
+# interchangeable types. The nineteenth round's own motivating evidence
+# (`tests/test_dumper_scoping_dependency_retention.py::
+# test_globally_qualified_signature_spelling_still_matches`) is for a
+# DIFFERENT subsystem entirely -- matching a signature's type reference
+# against an already-KNOWN declared type's own `qualified_name` within
+# ONE snapshot's dependency-scoping pass -- not for comparing two
+# independently-observed SIGNATURES for cross-producer/cross-revision
+# identity, which is this function's own job; that evidence does not
+# establish that castxml and Clang ever disagree on this leading `::`
+# for one identical real declaration, and no such evidence has been
+# found. Absent that evidence, the conservative, keep-it-distinguishing
+# choice is correct, mirroring how a similarly narrow-scoped generalization
+# mistake in the sixteenth/eighteenth rounds' own restrict handling was
+# corrected the identical way: revert to the position that matches
+# confirmed compiler behavior rather than a plausible-sounding theory.
 
 
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
@@ -520,10 +531,13 @@ def canonicalize_function_signature_param_type(name: str) -> str:
 
     Preserving ``noexcept`` verbatim is necessary but not sufficient: since
     C++17 a function type's exception specification is exactly one of two
-    kinds for TYPE purposes -- "non-throwing" (bare ``noexcept`` or
-    ``noexcept(true)``) and "potentially-throwing" (no specifier at all,
-    or ``noexcept(false)``) -- so those pairs canonicalize identically,
-    not merely both survive. Only the two literal spellings are
+    kinds for TYPE purposes -- "non-throwing" (bare ``noexcept``,
+    ``noexcept(true)``, or ``noexcept(1)`` -- a ``noexcept`` argument is
+    contextually converted to ``bool``, and Clang's own ``qualType``
+    genuinely emits the integer-literal spelling verbatim) and
+    "potentially-throwing" (no specifier at all, ``noexcept(false)``, or
+    ``noexcept(0)``) -- so those pairs canonicalize identically, not
+    merely both survive. Only these four literal spellings are
     recognized; any other, non-literal ``noexcept(expr)`` is left
     untouched (evaluating an arbitrary constant expression is out of
     scope).
@@ -531,6 +545,10 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(true)")
     'void ( * )(int) noexcept'
     >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(false)")
+    'void ( * )(int)'
+    >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(1)")
+    'void ( * )(int) noexcept'
+    >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(0)")
     'void ( * )(int)'
 
     An empty parameter list and a bare ``void`` are the identical "no
@@ -615,33 +633,28 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("my__cdecl_result (*)(int) __attribute__((stdcall))")
     'my__cdecl_result (__stdcall * )(int)'
 
-    An explicit leading ``::`` (global-namespace lookup) names the
-    identical type an unqualified spelling of that same, unambiguous name
-    does -- direct-clang's own ``qualType`` preserves this qualifier
-    verbatim, a confirmed real producer spelling. A genuine, load-bearing
-    ``::`` separator -- an ordinary qualified name's own internal one, or
-    the one following an anonymous-namespace parenthesized group -- is
-    never touched.
+    An explicit leading ``::`` (global-namespace lookup) is left
+    genuinely distinguishing, NOT stripped -- direct compilation confirms
+    Clang's own ``qualType`` can print the bare, unqualified spelling
+    (no leading ``::``) for a type that resolves to a locally-shadowing
+    entity distinct from the true global one a sibling declaration
+    prints WITH the leading ``::`` -- so erasing that qualifier can
+    silently merge two non-interchangeable types. See the module-level
+    comment above (a since-reverted ``_GLOBAL_SCOPE_RE`` once stripped
+    it) for the full worked counterexample.
 
     >>> canonicalize_function_signature_param_type("::dep::Thing *")
-    'dep::Thing *'
+    '::dep::Thing *'
     >>> canonicalize_function_signature_param_type("dep::Thing *")
     'dep::Thing *'
+    >>> canonicalize_function_signature_param_type("::dep::Thing *") != canonicalize_function_signature_param_type("dep::Thing *")
+    True
     >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo *")
     '(anonymous namespace)::Foo *'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
-    # An explicit leading `::` (global-namespace lookup) is stripped
-    # unconditionally, unlike restrict/cv -- it is never position-
-    # sensitive (a scoped name resolves to the identical entity whether
-    # or not the lookup was forced global), so this runs once, up front,
-    # rather than being folded into the position-sensitive machinery
-    # below. See `_GLOBAL_SCOPE_RE`'s own comment for why the match is
-    # anchored to specific preceding characters rather than a blanket
-    # "not preceded by an identifier" test.
-    canonical = _GLOBAL_SCOPE_RE.sub("", canonical)
     depth = 0
     # True for a paren currently open on `transparent_parens` that groups a
     # declarator's own sigil (see the docstring above) -- popped, not

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -40,42 +40,6 @@ __all__ = ["canonicalize_function_signature_param_type"]
 _CV_WORD_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
-def _has_top_level_ptr_or_ref(canonical_type: str) -> bool:
-    """Whether *canonical_type* is pointer-shaped at nesting depth 0 --
-    a ``*``/``&`` sigil, or a top-level ``[`` array declarator (Codex
-    review, PR #941: a function PARAMETER's array type always decays to a
-    pointer, e.g. ``int []`` -> ``int *``, so any cv-qualifier on the
-    element type is pointee-level, exactly like an explicit pointer --
-    ``void f(int[])`` and ``void f(const int[])`` are two distinct,
-    independently-mangled overloads, not one). Either shape means the
-    value itself is a pointer, not merely something passed by value that
-    happens to *contain* one (``Box<int *>``, ``std::function<void(int&)>``,
-    an array *bound inside* a template argument). A minimal, self-
-    contained reimplementation of the identical algorithm
-    ``name_classification._has_top_level_ptr_or_ref`` already applies for
-    a different purpose -- deliberately duplicated rather than imported,
-    since ``name_classification.py`` is a frozen, no-growth legacy module
-    (ADR-061 debt ledger, `architecture/debt.yaml`) that new code must not
-    grow, and the helper it would be imported from is private besides.
-    The array case is added here rather than upstream because this
-    module's fallback signature discriminator is built directly from a
-    caller-supplied *string* that may still spell an array literally
-    (``"int []"``) -- it makes no assumption about whether a given
-    producer's own parsed representation already reflects the decay.
-    """
-    depth = 0
-    for ch in canonical_type:
-        if ch == "[" and depth == 0:
-            return True
-        if ch in "<([":
-            depth += 1
-        elif ch in ">)]":
-            depth = max(0, depth - 1)
-        elif ch in "*&" and depth == 0:
-            return True
-    return False
-
-
 def _strip_cv_tokens_outside_nesting(s: str) -> str:
     """Blank out every ``const``/``volatile`` token in *s* that sits at
     nesting depth 0 (outside any ``<...>``/``(...)``/``[...]``), then
@@ -116,10 +80,10 @@ def _decay_top_level_array(canonical_type: str) -> str:
     element-level cv-qualifier survives verbatim as the decayed pointer's
     pointee cv, e.g. ``const int [3]`` -> ``const int *``). Codex review,
     PR #941: an earlier revision of this module treated a top-level ``[``
-    as "pointer-shaped enough not to strip its cv" (:func:`_has_top_level_
-    ptr_or_ref`) but never performed the decay itself, so ``int []``/
-    ``int [3]``/``int [4]``/``int *`` -- all the identical adjusted
-    parameter type -- still canonicalized to four different strings.
+    as "pointer-shaped enough not to strip its cv" but never performed the
+    decay itself, so ``int []``/``int [3]``/``int [4]``/``int *`` -- all
+    the identical adjusted parameter type -- still canonicalized to four
+    different strings.
 
     Deliberately narrow: a genuinely *multi-dimensional* array parameter
     (``T[][N]``, which adjusts to ``T(*)[N]``, a pointer to an array, not
@@ -265,21 +229,68 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'int [3][4]'
     >>> canonicalize_function_signature_param_type("const int [3][4]")
     'const int [3][4]'
+
+    A parenthesized declarator's own grouping parens (``void (*)(int)``, a
+    pointer to a function; ``int (*)[3]``, a pointer to an array) are
+    transparent for this purpose, not a real nesting level: the ``*``
+    inside them is still the parameter's own outermost, by-value-qualified
+    sigil, exactly like an unparenthesized ``int *``. An opening ``(`` is
+    recognized as declarator grouping (and so does not itself count as
+    nesting depth) whenever the next non-space character is ``*``/``&`` --
+    a real function-parameter-list paren never starts that way, since a
+    parameter list's first token is always a type, not a bare sigil. So
+    ``void f(void (*)(int))`` and ``void f(void (* const)(int))`` name the
+    same function -- the qualifier on the callback parameter's own pointer
+    is by-value, just like ``int *``/``int * const`` (Codex review, PR
+    #941: an earlier revision here treated every ``(`` as opaque, so a
+    parenthesized declarator's own trailing cv-qualifier was silently
+    preserved instead of stripped, fragmenting two spellings of one
+    identical parameter type). This also reaches the previously-unchanged
+    pointer-to-array case (``int (*)[3]``) the same way, for the identical
+    reason -- its own outermost pointer's cv-qualifier, if any, is by-value
+    too; only the trailing array bound inside the parens (the *pointee's*
+    shape) stays untouched, same as always.
+
+    >>> canonicalize_function_signature_param_type("void (*)(int)")
+    'void ( * )(int)'
+    >>> canonicalize_function_signature_param_type("void (* const)(int)")
+    'void ( * )(int)'
     >>> canonicalize_function_signature_param_type("int (*)[3]")
-    'int ( *)[3]'
+    'int ( * )[3]'
+    >>> canonicalize_function_signature_param_type("int (* const)[3]")
+    'int ( * )[3]'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
     depth = 0
+    # True for a paren currently open on `transparent_parens` that groups a
+    # declarator's own sigil (see the docstring above) -- popped, not
+    # depth-counted, so a sigil inside one is still found at depth 0.
+    transparent_parens: list[bool] = []
     last_top_level_sigil = -1
     has_top_level_bracket = False
+    n = len(canonical)
     for i, ch in enumerate(canonical):
+        if ch == "(":
+            j = i + 1
+            while j < n and canonical[j] == " ":
+                j += 1
+            transparent = j < n and canonical[j] in "*&"
+            transparent_parens.append(transparent)
+            if not transparent:
+                depth += 1
+            continue
+        if ch == ")":
+            was_transparent = transparent_parens.pop() if transparent_parens else False
+            if not was_transparent:
+                depth = max(0, depth - 1)
+            continue
         if ch == "[" and depth == 0:
             has_top_level_bracket = True
-        if ch in "<([":
+        if ch in "<[":
             depth += 1
-        elif ch in ">)]":
+        elif ch in ">]":
             depth = max(0, depth - 1)
         elif ch in "*&" and depth == 0:
             last_top_level_sigil = i

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -341,7 +341,19 @@ def _canonicalize_member_qualifiers(s: str) -> str:
     seq first among these trailing specifiers, so a real producer's
     placement never needs inferring -- only cv needs reordering relative
     to itself; everything else keeps whatever order it was already
-    spelled in).
+    spelled in; twelfth round: preserving ``noexcept`` verbatim was
+    necessary but not sufficient -- since C++17, a function type's
+    exception specification collapses to exactly two kinds for TYPE
+    purposes, "non-throwing" (bare ``noexcept``/``noexcept(true)``) and
+    "potentially-throwing" (no specifier at all, or ``noexcept(false)``),
+    so those pairs are the SAME type and must canonicalize identically,
+    the same "verbatim preservation isn't canonicalization" gap the
+    by-value cv/array-decay fixes each already closed for their own
+    shape. Only the two literal, constant-expression spellings are
+    normalized; any other, non-literal ``noexcept(expr)`` is left
+    completely untouched -- evaluating an arbitrary constant expression is
+    out of scope, the same "don't solve the fully general grammar" limit
+    this module already draws elsewhere).
     """
     stripped = s.strip()
     if not stripped:
@@ -349,6 +361,7 @@ def _canonicalize_member_qualifiers(s: str) -> str:
     has_const = re.search(r"\bconst\b", stripped) is not None
     has_volatile = re.search(r"\bvolatile\b", stripped) is not None
     rest = re.sub(r"\s+", " ", _CV_WORD_RE.sub("", stripped)).strip()
+    rest = _canonicalize_noexcept(rest)
     parts = [
         p
         for p, present in (("const", has_const), ("volatile", has_volatile))
@@ -357,6 +370,32 @@ def _canonicalize_member_qualifiers(s: str) -> str:
     if rest:
         parts.append(rest)
     return " ".join(parts)
+
+
+_NOEXCEPT_RE = re.compile(r"\bnoexcept\b(?:\s*\(\s*([^()]*)\s*\))?")
+
+
+def _canonicalize_noexcept(s: str) -> str:
+    """Normalize the two constant ``noexcept`` spellings this trailing
+    region can carry: bare ``noexcept``/``noexcept(true)`` (the
+    "non-throwing" type) collapse to the single canonical spelling
+    ``"noexcept"``; ``noexcept(false)`` (equivalent, for type purposes, to
+    no exception-specification at all) is dropped entirely, same as an
+    already-absent specifier. Any other ``noexcept(expr)`` -- a non-
+    literal constant expression this function cannot evaluate -- is left
+    untouched, verbatim.
+    """
+    m = _NOEXCEPT_RE.search(s)
+    if not m:
+        return s
+    arg = m.group(1)
+    if arg is None or arg.strip() == "true":
+        replacement = "noexcept"
+    elif arg.strip() == "false":
+        replacement = ""
+    else:
+        return s
+    return re.sub(r"\s+", " ", s[: m.start()] + replacement + s[m.end() :]).strip()
 
 
 def canonicalize_function_signature_param_type(name: str) -> str:
@@ -559,6 +598,21 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     'void ( * )(int) noexcept'
     >>> canonicalize_function_signature_param_type("void (C::*)(int) noexcept const")
     'void (C:: * )(int) const noexcept'
+
+    Preserving ``noexcept`` verbatim is necessary but not sufficient: since
+    C++17 a function type's exception specification is exactly one of two
+    kinds for TYPE purposes -- "non-throwing" (bare ``noexcept`` or
+    ``noexcept(true)``) and "potentially-throwing" (no specifier at all,
+    or ``noexcept(false)``) -- so those pairs canonicalize identically,
+    not merely both survive. Only the two literal spellings are
+    recognized; any other, non-literal ``noexcept(expr)`` is left
+    untouched (evaluating an arbitrary constant expression is out of
+    scope).
+
+    >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(true)")
+    'void ( * )(int) noexcept'
+    >>> canonicalize_function_signature_param_type("void (*)(int) noexcept(false)")
+    'void ( * )(int)'
     """
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -69,7 +69,9 @@ __all__ = [
     "is_abi_surface_type_name",
     "is_cxx_runtime_library",
     "canonicalize_type_name",
+    "canonicalize_function_signature_type",
     "cv_qualifiers_only_differ",
+    "func_signature_cv_only_differ",
     "STDLIB_TYPE_NAMESPACE_PREFIXES",
 ]
 
@@ -1256,3 +1258,50 @@ def func_signature_cv_only_differ(old_type: str, new_type: str) -> bool:
     if co == cn:
         return False
     return _strip_cv_qualifiers(co) == _strip_cv_qualifiers(cn)
+
+
+def canonicalize_function_signature_type(name: str) -> str:
+    """The canonical form of a function *parameter* or *return* type, for
+    identity/overload-discriminator purposes -- as opposed to
+    :func:`canonicalize_type_name`, which normalizes only cross-producer
+    spelling differences and deliberately keeps every cv-qualifier,
+    including a top-level by-value one, as real, distinguishing content.
+
+    Drops a top-level BY-VALUE cv-qualifier (``int`` -> ``const int``):
+    per the C++ standard, that qualifier is dropped from the function's
+    own type for linkage/mangling purposes -- ``void f(int)`` and ``void
+    f(const int)`` name the very same function (see
+    :func:`func_signature_cv_only_differ`'s own docstring for the
+    citation). **Deliberately narrower than reusing the private
+    ``_strip_cv_qualifiers`` helper those diff-reporting functions call**:
+    that helper is permissive at the true top level, stripping a
+    *pointee* cv-qualifier too (``const char *`` -> ``char *``) --
+    correct for *"is this an already-matched declaration's param change
+    worth reporting as ABI-breaking"* (``_params_differ``'s own question),
+    but wrong for *this* function's job. A pointee cv-qualifier on a
+    pointer/reference parameter is a genuine, standard-mandated overload
+    discriminator (``void f(char *)`` and ``void f(const char *)`` are two
+    simultaneously-declarable, independently-mangled overloads, not one
+    declaration): collapsing them here would silently merge two distinct
+    functions into one identity, reintroducing exactly the sibling-
+    overload-collision class this whole primitive exists to prevent.
+    So this function strips cv tokens only when *canonicalize_type_name*'s
+    result carries no top-level pointer/reference sigil at all -- the one
+    case where every cv token found is unambiguously by-value, not
+    pointee, cv.
+
+    >>> canonicalize_function_signature_type("int")
+    'int'
+    >>> canonicalize_function_signature_type("const int")
+    'int'
+    >>> canonicalize_function_signature_type("volatile unsigned long long")
+    'unsigned long long'
+    >>> canonicalize_function_signature_type("char const*")
+    'char const *'
+    >>> canonicalize_function_signature_type("const char *")
+    'char const *'
+    """
+    canonical = canonicalize_type_name(name)
+    if _has_top_level_ptr_or_ref(canonical):
+        return canonical
+    return _strip_cv_qualifiers(canonical)

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -69,9 +69,7 @@ __all__ = [
     "is_abi_surface_type_name",
     "is_cxx_runtime_library",
     "canonicalize_type_name",
-    "canonicalize_function_signature_type",
     "cv_qualifiers_only_differ",
-    "func_signature_cv_only_differ",
     "STDLIB_TYPE_NAMESPACE_PREFIXES",
 ]
 
@@ -1258,50 +1256,3 @@ def func_signature_cv_only_differ(old_type: str, new_type: str) -> bool:
     if co == cn:
         return False
     return _strip_cv_qualifiers(co) == _strip_cv_qualifiers(cn)
-
-
-def canonicalize_function_signature_type(name: str) -> str:
-    """The canonical form of a function *parameter* or *return* type, for
-    identity/overload-discriminator purposes -- as opposed to
-    :func:`canonicalize_type_name`, which normalizes only cross-producer
-    spelling differences and deliberately keeps every cv-qualifier,
-    including a top-level by-value one, as real, distinguishing content.
-
-    Drops a top-level BY-VALUE cv-qualifier (``int`` -> ``const int``):
-    per the C++ standard, that qualifier is dropped from the function's
-    own type for linkage/mangling purposes -- ``void f(int)`` and ``void
-    f(const int)`` name the very same function (see
-    :func:`func_signature_cv_only_differ`'s own docstring for the
-    citation). **Deliberately narrower than reusing the private
-    ``_strip_cv_qualifiers`` helper those diff-reporting functions call**:
-    that helper is permissive at the true top level, stripping a
-    *pointee* cv-qualifier too (``const char *`` -> ``char *``) --
-    correct for *"is this an already-matched declaration's param change
-    worth reporting as ABI-breaking"* (``_params_differ``'s own question),
-    but wrong for *this* function's job. A pointee cv-qualifier on a
-    pointer/reference parameter is a genuine, standard-mandated overload
-    discriminator (``void f(char *)`` and ``void f(const char *)`` are two
-    simultaneously-declarable, independently-mangled overloads, not one
-    declaration): collapsing them here would silently merge two distinct
-    functions into one identity, reintroducing exactly the sibling-
-    overload-collision class this whole primitive exists to prevent.
-    So this function strips cv tokens only when *canonicalize_type_name*'s
-    result carries no top-level pointer/reference sigil at all -- the one
-    case where every cv token found is unambiguously by-value, not
-    pointee, cv.
-
-    >>> canonicalize_function_signature_type("int")
-    'int'
-    >>> canonicalize_function_signature_type("const int")
-    'int'
-    >>> canonicalize_function_signature_type("volatile unsigned long long")
-    'unsigned long long'
-    >>> canonicalize_function_signature_type("char const*")
-    'char const *'
-    >>> canonicalize_function_signature_type("const char *")
-    'char const *'
-    """
-    canonical = canonicalize_type_name(name)
-    if _has_top_level_ptr_or_ref(canonical):
-        return canonical
-    return _strip_cv_qualifiers(canonical)

--- a/abicheck/storage/entity_ids.py
+++ b/abicheck/storage/entity_ids.py
@@ -26,16 +26,31 @@ arrangement would have made the two modules a cycle.
 The key encoding lives here too, since it is what makes an identifier an
 identifier: :func:`_packed` length-prefixes every part, so no content a part
 can carry changes how a key parses.
+
+**``EntityKind``/``ObservationKind`` are relocated, not redefined, as of
+ADR-063 Phase 2.** They are domain vocabulary (what kind of thing an
+identity names), not a storage wire concern, so they now live in
+:mod:`abicheck.model.identity` — the leaf module ADR-061's ``storage ->
+model`` import direction requires them to live in, and re-exported here
+under their original names so every existing ``storage.entity_ids.
+EntityKind``/``storage.entity_ids.ObservationKind`` import keeps resolving
+unchanged. ``model.identity`` also defines a second, independent
+``EntityId``/``ScopePath``-based domain identity type of its own; the two
+``EntityId``s are not yet bridged (that is Phase 2's still-open wire-DTO
+work — see that phase's own "not the same claim" note in
+``docs/contribute/plans/one-semantic-pipeline.md``), so this module's
+``EntityId``/``OccurrenceId`` wire pair below is unaffected by the
+relocation beyond the two enum imports.
 """
 
 from __future__ import annotations
 
-import enum
 import functools
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..model.identity import EntityKind, ObservationKind
 from .guards import (
     decision_key as _decision_key,
     enum_member as _enum_member,
@@ -81,37 +96,6 @@ def _packed(*parts: str) -> str:
     no byte a part can contain that changes how the key parses.
     """
     return "".join(f"{len(part)}:{part}" for part in parts)
-
-
-class EntityKind(enum.Enum):
-    """What kind of logical thing an :class:`EntityId` names."""
-
-    FUNCTION = "function"
-    VARIABLE = "variable"
-    TYPE = "type"
-    ENUM = "enum"
-    TYPEDEF = "typedef"
-    CONSTANT = "constant"
-    SYMBOL = "symbol"
-    FIELD = "field"
-    BASE = "base"
-
-
-class ObservationKind(enum.Enum):
-    """Where an :class:`OccurrenceId` was observed.
-
-    This is the axis that makes multiplicity legible: the same logical
-    function observed by Clang, by CastXML, in DWARF, and in the export
-    table is four occurrences of one entity, not four competing answers.
-    """
-
-    AST = "ast"
-    DWARF = "dwarf"
-    PDB = "pdb"
-    EXPORT_TABLE = "export_table"
-    TRANSLATION_UNIT = "translation_unit"
-    SOURCE_LOCATION = "source_location"
-    BUILD_UNIT = "build_unit"
 
 
 def _attribute_pair(pair: Any) -> tuple[str, str]:

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -137,3 +137,10 @@
   are -- only reordered for cv, never dropped, and a trailing `&&`
   ref-qualifier (which `canonicalize_type_name` itself spells `"& &"`) no
   longer corrupts the declarator's own sigil detection.
+  A nested-name-specifier's own segment can now also be a template-id
+  (`void (C<int>::* const)(int)`, to any template-argument nesting depth),
+  recognized as the same declarator-grouping transparency. The
+  pointer-to-member trailing-qualifier handling no longer drops any
+  specifier it doesn't individually name -- a `noexcept`-specifier (part
+  of a C++17 function's type, and previously silently discarded) now
+  survives verbatim alongside order-independent `const`/`volatile`.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -19,11 +19,12 @@
   from parser scope-tracking state, and the still-open "carrier field vs.
   resolved on demand" design question that decision determines).
   `entity_id_for_function` accepts `is_extern_c`/`ref_qualifier`/
-  `is_variadic` alongside `mangled_name`/`param_types`/`cv_qualifiers`, so
-  its discriminator set matches `finding_identity.resolve_function_
-  identity`'s: an `extern "C"` function (mangled_name absent, is_extern_c
-  set) never differentiates by parameter list, and `C::f() &` vs.
-  `C::f() &&` / `void f(int)` vs. `void f(int, ...)` no longer collide.
+  `is_variadic` alongside `mangled_name`/`param_types`/`is_const`/
+  `is_volatile`, so its discriminator set matches `finding_identity.
+  resolve_function_identity`'s: an `extern "C"` function (mangled_name
+  absent, is_extern_c set) never differentiates by parameter list, and
+  `C::f() &` vs. `C::f() &&` / `void f(int)` vs. `void f(int, ...)` no
+  longer collide.
   `LocalToFunction` gained a required `block_ordinal` field alongside
   `owner`, so two same-named locals declared in sibling compound blocks of
   one function no longer collapse onto the same `EntityId` -- the same
@@ -58,3 +59,19 @@
   exported symbol reused for both fields -- so a header/DWARF
   observation's demangled `name` and that export-only observation's raw
   name would otherwise disagree despite an identical, genuine mangling.
+  A new public `name_classification.canonicalize_function_signature_type`
+  drops a top-level BY-VALUE cv-qualifier from a parameter type (`"int"`
+  and `"const int"` now canonicalize the same, matching the C++ standard's
+  own linkage/mangling rule) while deliberately leaving a *pointee*
+  cv-qualifier on a pointer/reference parameter untouched (`"char *"` and
+  `"const char *"` remain genuinely distinct overloads) -- narrower than
+  this codebase's existing `_strip_cv_qualifiers`/
+  `func_signature_cv_only_differ`, which is permissive at the pointee
+  level for a different, diff-reporting question and would have wrongly
+  merged distinct overloads if reused here. `entity_id_for_function`'s
+  `cv_qualifiers: tuple[str, ...]` parameter is replaced by `is_const: bool
+  = False, is_volatile: bool = False` -- matching `resolve_function_
+  identity`'s own two-boolean representation and eliminating a real
+  qualifier-token-order-dependence bug by construction (`("const",
+  "volatile")` vs. `("volatile", "const")` previously collided as two
+  different ids for one identical member-cv qualification).

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -39,10 +39,10 @@
   name (evidence-tier scope availability varies for this case: an export-
   table-only snapshot cannot recover a namespace an `extern "C"` symbol
   was declared in). `param_types` in the signature-fallback branch are now
-  canonicalized via `name_classification.canonicalize_type_name` before
-  joining into `extra`, so CastXML's and Clang's differing spellings of an
-  otherwise-identical parameter type no longer fragment identity across
-  header-AST backends. `entity_id_for_function`'s `mangled` branch also
+  canonicalized (cross-producer spelling, via `name_classification.
+  canonicalize_type_name`) before joining into `extra`, so CastXML's and
+  Clang's differing spellings of an otherwise-identical parameter type no
+  longer fragment identity across header-AST backends. `entity_id_for_function`'s `mangled` branch also
   now returns `scope=()` (matching `resolve_symbol_identity`'s real
   `f"mangled:{real_mangled}"` primary id, which folds in no scope at all)
   -- a genuine mangled name already fully encodes scope, so keeping a
@@ -59,19 +59,34 @@
   exported symbol reused for both fields -- so a header/DWARF
   observation's demangled `name` and that export-only observation's raw
   name would otherwise disagree despite an identical, genuine mangling.
-  A new public `name_classification.canonicalize_function_signature_type`
-  drops a top-level BY-VALUE cv-qualifier from a parameter type (`"int"`
-  and `"const int"` now canonicalize the same, matching the C++ standard's
-  own linkage/mangling rule) while deliberately leaving a *pointee*
-  cv-qualifier on a pointer/reference parameter untouched (`"char *"` and
-  `"const char *"` remain genuinely distinct overloads) -- narrower than
-  this codebase's existing `_strip_cv_qualifiers`/
-  `func_signature_cv_only_differ`, which is permissive at the pointee
-  level for a different, diff-reporting question and would have wrongly
-  merged distinct overloads if reused here. `entity_id_for_function`'s
+  A new module-private `model.identity._canonicalize_function_signature_
+  param_type` additionally drops a top-level BY-VALUE cv-qualifier from a
+  parameter type (`"int"` and `"const int"` now canonicalize the same,
+  matching the C++ standard's own linkage/mangling rule) while
+  deliberately leaving a *pointee* cv-qualifier on a pointer/reference
+  parameter untouched (`"char *"` and `"const char *"` remain genuinely
+  distinct overloads) -- narrower than `name_classification`'s existing
+  `_strip_cv_qualifiers`/`func_signature_cv_only_differ`, which are
+  permissive at the pointee level for a different, diff-reporting
+  question and would have wrongly merged distinct overloads if reused
+  here. Implemented locally in `model/identity.py` (a small,
+  self-contained reimplementation of the top-level-pointer/reference
+  detection those functions use, not an import of it) rather than added
+  to `name_classification.py`, since that module is a frozen, no-growth
+  legacy file under ADR-061's debt ledger. `entity_id_for_function`'s
   `cv_qualifiers: tuple[str, ...]` parameter is replaced by `is_const: bool
   = False, is_volatile: bool = False` -- matching `resolve_function_
   identity`'s own two-boolean representation and eliminating a real
   qualifier-token-order-dependence bug by construction (`("const",
   "volatile")` vs. `("volatile", "const")` previously collided as two
-  different ids for one identical member-cv qualification).
+  different ids for one identical member-cv qualification). The by-value
+  cv fix now also treats a top-level `[` (array declarator) as pointer-
+  shaped: a function parameter's array type always decays to a pointer
+  (`int []` -> `int *`), so `void f(int[])`/`void f(const int[])` are
+  distinct overloads and must not collapse. `entity_id_for_type`/
+  `entity_id_for_enum` gained an opt-in `anonymous_ordinal: int | None =
+  None` keyword, folded into `extra` only when `leaf_name` is empty: two
+  anonymous sibling records/enums previously collided onto one `EntityId`
+  regardless of which is meant, since `ScopePath` names only the
+  containing scope and `Anonymous.ordinal` disambiguates a *descendant's*
+  scope, not the anonymous declaration's own identity.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -41,4 +41,14 @@
   canonicalized via `name_classification.canonicalize_type_name` before
   joining into `extra`, so CastXML's and Clang's differing spellings of an
   otherwise-identical parameter type no longer fragment identity across
-  header-AST backends.
+  header-AST backends. `entity_id_for_function`'s `mangled` branch also
+  now returns `scope=()` (matching `resolve_symbol_identity`'s real
+  `f"mangled:{real_mangled}"` primary id, which folds in no scope at all)
+  -- a genuine mangled name already fully encodes scope, so keeping a
+  caller-supplied `scope` fragmented identity across evidence tiers that
+  differ in whether they can supply one, the same problem the
+  `is_extern_c` branch was fixed for. `entity_id_for_variable` gained the
+  same `is_extern_c` parameter `entity_id_for_function` has, and its
+  `mangled`/`is_extern_c` branches get the identical `scope=()` treatment
+  -- closing the same gap for variables that had no linkage signal at all
+  before this fix.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -59,21 +59,32 @@
   exported symbol reused for both fields -- so a header/DWARF
   observation's demangled `name` and that export-only observation's raw
   name would otherwise disagree despite an identical, genuine mangling.
-  A new module-private `model.identity._canonicalize_function_signature_
-  param_type` additionally drops a top-level BY-VALUE cv-qualifier from a
-  parameter type (`"int"` and `"const int"` now canonicalize the same,
-  matching the C++ standard's own linkage/mangling rule) while
-  deliberately leaving a *pointee* cv-qualifier on a pointer/reference
-  parameter untouched (`"char *"` and `"const char *"` remain genuinely
-  distinct overloads) -- narrower than `name_classification`'s existing
-  `_strip_cv_qualifiers`/`func_signature_cv_only_differ`, which are
-  permissive at the pointee level for a different, diff-reporting
-  question and would have wrongly merged distinct overloads if reused
-  here. Implemented locally in `model/identity.py` (a small,
-  self-contained reimplementation of the top-level-pointer/reference
-  detection those functions use, not an import of it) rather than added
-  to `name_classification.py`, since that module is a frozen, no-growth
-  legacy file under ADR-061's debt ledger. `entity_id_for_function`'s
+  A new `model.signature_normalization.
+  canonicalize_function_signature_param_type` additionally drops a
+  top-level BY-VALUE cv-qualifier from a parameter type (`"int"` and
+  `"const int"` now canonicalize the same, matching the C++ standard's
+  own linkage/mangling rule) while deliberately leaving a *pointee*
+  cv-qualifier on a pointer/reference parameter untouched (`"char *"` and
+  `"const char *"` remain genuinely distinct overloads) -- narrower than
+  `name_classification`'s existing `_strip_cv_qualifiers`/
+  `func_signature_cv_only_differ`, which are permissive at the pointee
+  level for a different, diff-reporting question and would have wrongly
+  merged distinct overloads if reused here. A cv-qualifier trailing the
+  parameter's own outermost pointer sigil (`int * const`) is also now
+  correctly dropped as by-value, while an intermediate pointer level's
+  own qualifier (`int * const *`) stays genuinely distinguishing. An
+  array parameter is decayed to its adjusted pointer type first
+  (`int []`/`int [3]`/`int [4]`/`int *` now all canonicalize identically,
+  the bound plays no part in the real adjusted type), with multi-
+  dimensional arrays and parenthesized declarators (`int (*)[3]`) left
+  as an accepted, documented, unchanged limitation rather than
+  mis-decayed. This whole primitive lives in its own new sibling leaf
+  module, `abicheck/model/signature_normalization.py` (not
+  `name_classification.py`, a frozen, no-growth legacy file under
+  ADR-061's debt ledger; and split out of `model/identity.py` itself once
+  it grew past the AI-readiness gate's 800-line production maximum),
+  with its own dedicated primitive-level test file,
+  `tests/test_signature_normalization.py`. `entity_id_for_function`'s
   `cv_qualifiers: tuple[str, ...]` parameter is replaced by `is_const: bool
   = False, is_volatile: bool = False` -- matching `resolve_function_
   identity`'s own two-boolean representation and eliminating a real

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -144,3 +144,9 @@
   specifier it doesn't individually name -- a `noexcept`-specifier (part
   of a C++17 function's type, and previously silently discarded) now
   survives verbatim alongside order-independent `const`/`volatile`.
+  A `noexcept`-specifier's two constant spellings are now also
+  canonicalized rather than merely preserved: bare `noexcept` and
+  `noexcept(true)` collapse to one canonical form, and `noexcept(false)`
+  is dropped entirely (equivalent, for type purposes, to no specifier at
+  all) -- matching C++17's own function-type rule -- while any other,
+  non-literal `noexcept(expr)` is left genuinely distinguishing.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -62,23 +62,34 @@
   A new `model.signature_normalization.
   canonicalize_function_signature_param_type` additionally drops a
   top-level BY-VALUE cv-qualifier from a parameter type (`"int"` and
-  `"const int"` now canonicalize the same, matching the C++ standard's
-  own linkage/mangling rule) while deliberately leaving a *pointee*
-  cv-qualifier on a pointer/reference parameter untouched (`"char *"` and
-  `"const char *"` remain genuinely distinct overloads) -- narrower than
-  `name_classification`'s existing `_strip_cv_qualifiers`/
-  `func_signature_cv_only_differ`, which are permissive at the pointee
-  level for a different, diff-reporting question and would have wrongly
-  merged distinct overloads if reused here. A cv-qualifier trailing the
-  parameter's own outermost pointer sigil (`int * const`) is also now
-  correctly dropped as by-value, while an intermediate pointer level's
-  own qualifier (`int * const *`) stays genuinely distinguishing. An
-  array parameter is decayed to its adjusted pointer type first
-  (`int []`/`int [3]`/`int [4]`/`int *` now all canonicalize identically,
-  the bound plays no part in the real adjusted type), with multi-
-  dimensional arrays and parenthesized declarators (`int (*)[3]`) left
-  as an accepted, documented, unchanged limitation rather than
-  mis-decayed. This whole primitive lives in its own new sibling leaf
+  `"const int"` now canonicalize the same, per the C++ standard's own
+  parameter-type-adjustment rule -- the qualifier plays no part in the
+  function's type, and is consequently absent from a real ABI's mangled
+  name too, e.g. under the Itanium C++ ABI this codebase targets) while
+  deliberately leaving a *pointee* cv-qualifier on a pointer/reference
+  parameter untouched (`"char *"` and `"const char *"` remain genuinely
+  distinct overloads) -- narrower than `name_classification`'s existing
+  `_strip_cv_qualifiers`/`func_signature_cv_only_differ`, which are
+  permissive at the pointee level for a different, diff-reporting
+  question and would have wrongly merged distinct overloads if reused
+  here. A cv-qualifier trailing the parameter's own outermost pointer
+  sigil (`int * const`) is also now correctly dropped as by-value, while
+  an intermediate pointer level's own qualifier (`int * const *`) stays
+  genuinely distinguishing. An array parameter is decayed to its adjusted
+  pointer type first (`int []`/`int [3]`/`int [4]`/`int *` now all
+  canonicalize identically, the bound plays no part in the real adjusted
+  type); a genuinely multi-dimensional array (`int [3][4]`) is left as an
+  accepted, documented, unchanged limitation, since correctly re-spelling
+  its adjusted type needs declarator-rewriting this primitive doesn't
+  implement. A parenthesized declarator (`int (*)[3]`, "pointer to
+  array") is NOT decayed either (the trailing `[3]` there is the
+  *pointee's* bound, not the parameter's own top-level shape) -- but,
+  unlike the multi-dimensional case, it is not left fully untouched: the
+  later, separate by-value cv-normalization step still treats its
+  grouping parens as transparent and drops a cv-qualifier on its own
+  outermost pointer the identical way (`int (* const)[3]` -> `int (*)[3]`
+  in effect), since that qualifier is by-value regardless of the
+  parenthesization. This whole primitive lives in its own new sibling leaf
   module, `abicheck/model/signature_normalization.py` (not
   `name_classification.py`, a frozen, no-growth legacy file under
   ADR-061's debt ledger; and split out of `model/identity.py` itself once
@@ -117,3 +128,12 @@
   member-function-pointer's parameters, to any nesting depth) -- so
   `void (*)(int)` and `void (*)(const int)` canonicalize identically,
   while a nested parameter's genuine pointee cv still distinguishes.
+  A calling-convention keyword (`__cdecl`/`__stdcall`/`__fastcall`/
+  `__thiscall`/`__vectorcall`) preceding a declarator's own sigil is now
+  recognized too (kept verbatim, not erased), and a pointer-to-member-
+  function's own TRAILING cv/ref-qualifiers (`void (C::*)(int) const`,
+  distinct from the pointer's own by-value qualifier before the parameter
+  list) are now preserved as the genuine, distinguishing type content they
+  are -- only reordered for cv, never dropped, and a trailing `&&`
+  ref-qualifier (which `canonicalize_type_name` itself spells `"& &"`) no
+  longer corrupts the declarator's own sigil detection.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -18,3 +18,14 @@
   doc's own Phase 2 section for what remains (deriving a real `ScopePath`
   from parser scope-tracking state, and the still-open "carrier field vs.
   resolved on demand" design question that decision determines).
+  `entity_id_for_function` accepts `is_extern_c`/`ref_qualifier`/
+  `is_variadic` alongside `mangled_name`/`param_types`/`cv_qualifiers`, so
+  its discriminator set matches `finding_identity.resolve_function_
+  identity`'s: an `extern "C"` function (mangled_name absent, is_extern_c
+  set) never differentiates by parameter list, and `C::f() &` vs.
+  `C::f() &&` / `void f(int)` vs. `void f(int, ...)` no longer collide.
+  `LocalToFunction` gained a required `block_ordinal` field alongside
+  `owner`, so two same-named locals declared in sibling compound blocks of
+  one function no longer collapse onto the same `EntityId` -- the same
+  sibling-collision shape `Anonymous.ordinal` already closes, applied to
+  its own segment kind.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -51,4 +51,10 @@
   same `is_extern_c` parameter `entity_id_for_function` has, and its
   `mangled`/`is_extern_c` branches get the identical `scope=()` treatment
   -- closing the same gap for variables that had no linkage signal at all
-  before this fix.
+  before this fix. Both constructors' `mangled` branch now also ignores
+  `leaf_name` (using `""` instead of the caller-supplied value): a
+  confirmed real code path, `dumper_elf_fallback.py`'s ELF-only fallback,
+  constructs `Function`/`Variable` with `name=sym, mangled=sym` -- the raw
+  exported symbol reused for both fields -- so a header/DWARF
+  observation's demangled `name` and that export-only observation's raw
+  name would otherwise disagree despite an identical, genuine mangling.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -232,3 +232,12 @@
   rather than a blanket "not preceded by an identifier" test, since the
   latter cannot distinguish a genuine leading global-scope marker from
   the anonymous-namespace case's own load-bearing separator.
+  Fixed a related bug in the calling-convention-attribute injection
+  itself: whether a declarator's own leading position already carries a
+  calling-convention keyword was checked with a bare substring test
+  against the whole return-type-plus-declarator prefix, which a
+  coincidentally-named return type defeats (e.g. `my__cdecl_result`
+  contains the substring `__cdecl`). Now matched as a genuine whole
+  token positioned immediately after the declarator's own opening paren,
+  mirroring exactly where the declarator-group recognizer itself looks
+  for a convention keyword.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -101,3 +101,12 @@
   regardless of which is meant, since `ScopePath` names only the
   containing scope and `Anonymous.ordinal` disambiguates a *descendant's*
   scope, not the anonymous declaration's own identity.
+  `model.signature_normalization.canonicalize_function_signature_param_type`
+  now also treats a parenthesized declarator's own grouping parens
+  (`void (* const)(int)`, a callback parameter; `int (* const)[3]`, a
+  pointer to an array) as transparent for by-value cv purposes -- the
+  cv-qualifier on the declarator's own outermost pointer is by-value and
+  dropped, exactly like an unparenthesized `int * const`, while a
+  callback's own parameter types and a pointer-to-array's own trailing
+  bound stay untouched. An unused, dead leftover private helper,
+  `_has_top_level_ptr_or_ref`, was removed from this module.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -219,19 +219,33 @@
   keyword equivalent, so an identical calling-convention-decorated
   declaration observed through Clang's header-AST backend and through
   castxml/DWARF no longer fragments into two different `EntityId`s.
-  An explicit leading `::` (forced global-namespace lookup) is now
-  stripped from a parameter type, unconditionally, so `::dep::Thing *`
-  and `dep::Thing *` -- the identical type when the unqualified name is
-  unambiguous -- canonicalize identically; this is a confirmed real
-  producer spelling (direct-clang's own `qualType` preserves an explicit
-  global-scope qualifier verbatim). An ordinary qualified name's own
-  internal `::` separator, and the one following an anonymous-namespace
-  parenthesized group (`(anonymous namespace)::Foo`), are both left
-  untouched -- the match is anchored to specific preceding characters
-  (string start, or immediately after whitespace/`(`/`<`/`,`/`*`/`&`)
-  rather than a blanket "not preceded by an identifier" test, since the
-  latter cannot distinguish a genuine leading global-scope marker from
-  the anonymous-namespace case's own load-bearing separator.
+  An explicit leading `::` (forced global-namespace lookup) is left
+  genuinely distinguishing, NOT stripped -- direct compilation confirms
+  Clang's own `qualType` can legitimately print the BARE, unqualified
+  spelling (no leading `::`) for a type that resolves to a locally-
+  shadowing entity distinct from the true global one a sibling
+  declaration in the same namespace prints WITH the leading `::` (e.g.
+  a function inside `namespace local { namespace dep { struct Thing; }
+  ... }` prints its `dep::Thing*` parameter unqualified, even though it
+  is `local::dep::Thing`, not `::dep::Thing`). This module has no
+  scope-tree information to distinguish the two cases from text alone,
+  so erasing the leading `::` -- Clang's own signal for the distinction
+  -- can silently merge two non-interchangeable types. (An earlier
+  revision of this fix stripped the leading `::` unconditionally,
+  reasoning it never carries distinguishing meaning; that generalization
+  was itself wrong, caught by direct compiler verification rather than
+  accepted on the strength of a plausible-sounding C++ semantic
+  argument, and is reverted here to the always-preserved behavior
+  above -- the second such self-correction on this primitive, after the
+  restrict-handling one earlier in this same list.)
+  `noexcept`'s argument is contextually converted to `bool`, so
+  `noexcept(1)`/`noexcept(0)` now also canonicalize identically to
+  `noexcept(true)`/`noexcept(false)` respectively -- confirmed both by
+  direct compilation (redefinition errors for each pair) and by Clang's
+  own `qualType`, which genuinely emits these integer-literal spellings
+  verbatim. Deliberately narrow to exactly `1`/`0`; any other integer
+  constant in this position triggers a narrowing-conversion diagnostic in
+  real compilers and is left untouched.
   Fixed a related bug in the calling-convention-attribute injection
   itself: whether a declarator's own leading position already carries a
   calling-convention keyword was checked with a bare substring test

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -219,3 +219,16 @@
   keyword equivalent, so an identical calling-convention-decorated
   declaration observed through Clang's header-AST backend and through
   castxml/DWARF no longer fragments into two different `EntityId`s.
+  An explicit leading `::` (forced global-namespace lookup) is now
+  stripped from a parameter type, unconditionally, so `::dep::Thing *`
+  and `dep::Thing *` -- the identical type when the unqualified name is
+  unambiguous -- canonicalize identically; this is a confirmed real
+  producer spelling (direct-clang's own `qualType` preserves an explicit
+  global-scope qualifier verbatim). An ordinary qualified name's own
+  internal `::` separator, and the one following an anonymous-namespace
+  parenthesized group (`(anonymous namespace)::Foo`), are both left
+  untouched -- the match is anchored to specific preceding characters
+  (string start, or immediately after whitespace/`(`/`<`/`,`/`*`/`&`)
+  rather than a blanket "not preceded by an identifier" test, since the
+  latter cannot distinguish a genuine leading global-scope marker from
+  the anonymous-namespace case's own load-bearing separator.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -28,4 +28,17 @@
   `owner`, so two same-named locals declared in sibling compound blocks of
   one function no longer collapse onto the same `EntityId` -- the same
   sibling-collision shape `Anonymous.ordinal` already closes, applied to
-  its own segment kind.
+  its own segment kind. `LocalToFunction.owner` is now the owning
+  function's own `EntityId` rather than a bare string, so two overloads
+  that each declare a same-named local no longer collide just because
+  both share one bare function name. `entity_id_for_function`'s
+  `is_extern_c` branch now returns `scope=()` regardless of the caller-
+  supplied `scope`, matching `resolve_symbol_identity`'s own choice to
+  base an extern-"C" identity on the raw export rather than a qualified
+  name (evidence-tier scope availability varies for this case: an export-
+  table-only snapshot cannot recover a namespace an `extern "C"` symbol
+  was declared in). `param_types` in the signature-fallback branch are now
+  canonicalized via `name_classification.canonicalize_type_name` before
+  joining into `extra`, so CastXML's and Clang's differing spellings of an
+  otherwise-identical parameter type no longer fragment identity across
+  header-AST backends.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -194,17 +194,24 @@
   (import is strictly one-way, `signature_normalization ->
   declarator_qualifiers`, to avoid a cycle between the two), with its own
   dedicated test file, `tests/test_declarator_qualifiers.py`.
-  `restrict`/`__restrict`/`__restrict__` (a pointer-qualifier with NO
-  effect on the Itanium C++ ABI's mangling at all, unlike `const`/
-  `volatile`) is now stripped from a parameter's type unconditionally, at
-  any position and nesting depth -- not only the parameter's own outermost
-  pointer, unlike a genuine by-value cv-qualifier -- so `int *` and
-  `int *restrict` (in any of its three spellings) now canonicalize
-  identically, including inside a nested callback parameter. This
-  repository already tracks the fact separately on `Param.is_restrict`;
-  without this fix, a restrict addition/removal produced a spurious
-  removal/addition pair here instead of the dedicated compatible
-  parameter-qualifier change it should be.
+  `restrict`/`__restrict`/`__restrict__` now shares the exact same
+  outermost-vs-pointee position discipline `const`/`volatile` already
+  have here: dropped on the parameter's own outermost, by-value pointer
+  position (`int *` and `int *restrict`, in any of its three spellings,
+  including inside a nested callback parameter, now canonicalize
+  identically), while staying genuinely distinguishing on an inner
+  pointer level, exactly like a real pointee cv-qualifier there (`int **`
+  and `int * restrict *` do NOT canonicalize identically) -- verified
+  against real compiler output (`g++ -c`): the outermost pair mangle
+  identically and cannot even be declared together as an overload set,
+  while the inner-pointer pair mangle to two different, simultaneously-
+  declarable Itanium symbols (`_Z1fPPi` vs. `_Z1fPrPi`). This repository
+  already tracks the fact separately on `Param.is_restrict`. (An earlier
+  revision of this same fix stripped restrict unconditionally at every
+  position, reasoning it never affects mangling at all -- that
+  generalization was itself wrong, caught by direct compiler verification
+  rather than by re-reading the finding text a second time, and is
+  corrected here to the position-sensitive behavior above.)
   Clang's own calling-convention spelling for a function-pointer
   declarator -- a trailing `__attribute__((cdecl))`-style attribute after
   the parameter list, rather than MSVC/castxml's leading `__cdecl`-style

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -144,9 +144,32 @@
   specifier it doesn't individually name -- a `noexcept`-specifier (part
   of a C++17 function's type, and previously silently discarded) now
   survives verbatim alongside order-independent `const`/`volatile`.
-  A `noexcept`-specifier's two constant spellings are now also
+  A `noexcept`-specifier's two literal spellings are now also
   canonicalized rather than merely preserved: bare `noexcept` and
   `noexcept(true)` collapse to one canonical form, and `noexcept(false)`
   is dropped entirely (equivalent, for type purposes, to no specifier at
-  all) -- matching C++17's own function-type rule -- while any other,
-  non-literal `noexcept(expr)` is left genuinely distinguishing.
+  all) -- matching C++17's own function-type rule. This is deliberately
+  conservative: only the two literal `true`/`false` spellings are
+  recognized, not the constant expression's actual boolean *value* (C++
+  itself evaluates that value, so e.g. `noexcept(sizeof(int))` is
+  type-equivalent to `noexcept(true)` and `noexcept(1 == 0)` to no
+  specifier at all) -- any other `noexcept(expr)` is left untouched and
+  stays genuinely distinguishing from both canonical forms, which can
+  over-distinguish two constant-expression spellings that a real compiler
+  would treat as the identical type. Evaluating an arbitrary constant
+  expression is out of scope for this primitive.
+  An empty parameter list and a bare `void` (`void (*)()` vs.
+  `void (*)(void)`) now unify to the same canonical form. A
+  `const`/`volatile` token appearing INSIDE a non-literal
+  `noexcept(expr)`'s own argument (e.g. `noexcept(Foo<const int>)`) is no
+  longer mistaken for -- and no longer mutates -- this declarator's own
+  trailing cv-qualifier; extraction is now depth-aware, matching the
+  existing outside-nesting cv-stripping discipline elsewhere in this
+  module.
+  The sigil-lock flag introduced for the trailing-ref-qualifier fix above
+  was itself over-eager: it locked out the parameter's own actual pointer
+  sigil whenever ANY top-level opaque paren appeared, even one preceding
+  that sigil entirely (a real producer spelling,
+  `(anonymous namespace)::Foo const *`) -- wrongly merging pointer-to-const
+  and pointer-to-non-const into one identity. Now only arms once the
+  declarator's own sigil has already been found.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -194,3 +194,14 @@
   (import is strictly one-way, `signature_normalization ->
   declarator_qualifiers`, to avoid a cycle between the two), with its own
   dedicated test file, `tests/test_declarator_qualifiers.py`.
+  `restrict`/`__restrict`/`__restrict__` (a pointer-qualifier with NO
+  effect on the Itanium C++ ABI's mangling at all, unlike `const`/
+  `volatile`) is now stripped from a parameter's type unconditionally, at
+  any position and nesting depth -- not only the parameter's own outermost
+  pointer, unlike a genuine by-value cv-qualifier -- so `int *` and
+  `int *restrict` (in any of its three spellings) now canonicalize
+  identically, including inside a nested callback parameter. This
+  repository already tracks the fact separately on `Param.is_restrict`;
+  without this fix, a restrict addition/removal produced a spurious
+  removal/addition pair here instead of the dedicated compatible
+  parameter-qualifier change it should be.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -1,0 +1,20 @@
+### Changed
+
+- **ADR-063 Phase 2 (first slice), "`EntityId`/`ScopePath` as the one
+  identity primitive"**: added `abicheck.model.identity`, a new leaf module
+  defining the typed `ScopePath` segment vocabulary (`Namespace`, `Record`,
+  `InlineNamespace`, `Anonymous`, `LocalToFunction`, each stating which of
+  its own fields are identity and which are payload) and the corrected
+  `EntityId` shape (`scope`, `kind`, `leaf_name`, `extra` -- never a bare
+  `(scope, kind)`, which collides sibling declarations of the same kind in
+  one scope). `EntityKind`/`ObservationKind` relocate from
+  `storage.entity_ids` into this new module (domain vocabulary belongs in
+  `model`, not the storage wire layer, per ADR-061's `storage -> model`
+  import direction); `storage.entity_ids` now imports rather than redefines
+  them, so exactly one `EntityKind`/`ObservationKind` exists in the
+  repository. Purely additive and internal: nothing outside this module and
+  its own tests constructs a `model.identity.EntityId` yet -- no parser,
+  detector, or storage writer is wired to it in this slice. See the plan
+  doc's own Phase 2 section for what remains (deriving a real `ScopePath`
+  from parser scope-tracking state, and the still-open "carrier field vs.
+  resolved on demand" design question that decision determines).

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -173,3 +173,24 @@
   `(anonymous namespace)::Foo const *`) -- wrongly merging pointer-to-const
   and pointer-to-non-const into one identity. Now only arms once the
   declarator's own sigil has already been found.
+  A bare (non-parenthesized) data-member-pointer parameter's pointee
+  cv-qualifier (`int C::*`, pointer to an `int` member of `C`) now also
+  canonicalizes the same regardless of whether the source spelled it
+  before or after the base type: `canonicalize_type_name` MISPLACES a
+  leading `const` across the `C::` infix rather than leaving it be
+  (`"const int C::*"` becomes `"int C:: const *"`, the cv-word landing
+  where it looks like -- but is not -- the pointer's own by-value
+  qualifier), which this module now corrects. Only `const`/`volatile`
+  positioning relative to the base type is fixed; `canonicalize_type_name`
+  never reorders `volatile` at all, a pre-existing, broader gap affecting
+  every pointee-volatile position in this module (not specific to member
+  pointers), left as an accepted, documented, out-of-scope limitation.
+  This fix's own line-count growth pushed `signature_normalization.py`
+  past the AI-readiness gate's 800-line production maximum a second time,
+  so its declarator-grouping/pointer-to-member/trailing-qualifier
+  machinery -- everything with no recursive dependency back into
+  `canonicalize_function_signature_param_type` itself -- was split into a
+  new sibling leaf module, `abicheck/model/declarator_qualifiers.py`
+  (import is strictly one-way, `signature_normalization ->
+  declarator_qualifiers`, to avoid a cycle between the two), with its own
+  dedicated test file, `tests/test_declarator_qualifiers.py`.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -205,3 +205,10 @@
   without this fix, a restrict addition/removal produced a spurious
   removal/addition pair here instead of the dedicated compatible
   parameter-qualifier change it should be.
+  Clang's own calling-convention spelling for a function-pointer
+  declarator -- a trailing `__attribute__((cdecl))`-style attribute after
+  the parameter list, rather than MSVC/castxml's leading `__cdecl`-style
+  keyword -- now also canonicalizes to the same form as its leading-
+  keyword equivalent, so an identical calling-convention-decorated
+  declaration observed through Clang's header-AST backend and through
+  castxml/DWARF no longer fragments into two different `EntityId`s.

--- a/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
+++ b/changelog.d/1787977821_claude_adr063-phase2-entity-id-scope-path-first-slice.md
@@ -110,3 +110,10 @@
   callback's own parameter types and a pointer-to-array's own trailing
   bound stay untouched. An unused, dead leftover private helper,
   `_has_top_level_ptr_or_ref`, was removed from this module.
+  The same primitive now also recognizes a pointer-to-member-function
+  declarator's qualified-name prefix (`void (C::* const)(int)`) as
+  transparent the identical way, and recursively canonicalizes each
+  parameter of a declarator's own trailing parameter list (a callback or
+  member-function-pointer's parameters, to any nesting depth) -- so
+  `void (*)(int)` and `void (*)(const int)` canonicalize identically,
+  while a nested parameter's genuine pointee cv still distinguishes.

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6577,6 +6577,50 @@ struct that, before this correction, had only one field -- a real
 inconsistency between the stated contract and the actual shape, not just
 prose.
 
+**Correction (2026-08-29, same day, second Codex review round on PR #941,
+commit de0f23e): three more real gaps found and fixed, on top of the two
+already closed above.** (1) `block_ordinal`'s own fix (just above) was
+itself incomplete: `LocalToFunction.owner` stayed a bare `str`, which
+still collides two *overloads* that each declare a same-named local in
+their corresponding block (`f(int) { struct A {}; }` vs. `f(double) {
+struct A {}; }` -- identical `owner="f"` string, identical leaf name).
+Fixed by changing `owner`'s type to `EntityId` -- the owning function's
+*own*, already-overload-disambiguated identity -- rather than widening it
+to yet another bespoke discriminator field; `EntityId` is frozen/hashable,
+so the resulting recursive structure (an `EntityId` whose `scope` may
+contain a `LocalToFunction` whose own `owner` is another `EntityId`) is
+free, not a special case. (2) The `is_extern_c` branch added earlier
+folded the caller-supplied `scope` into the returned `EntityId` unchanged,
+which reintroduces exactly the evidence-tier fragmentation problem
+`resolve_symbol_identity` deliberately avoids for this case: a header/
+DWARF-derived observation of a namespaced `extern "C"` function may supply
+a real `ScopePath`, while an export-table-only snapshot of the identical
+binary symbol knows only the bare exported name (extern "C" linkage means
+the symbol *is* that bare name at the ABI level -- no namespace is even
+recoverable from an export table alone). Fixed by forcing `scope=()` for
+the `is_extern_c` branch specifically, regardless of what `scope` argument
+the caller passed; the `mangled`/`sig` branches are unaffected -- a real
+mangled name already fully and deterministically encodes scope (no
+evidence-tier divergence possible), and a DWARF-only, mangling-free
+function has no comparable across-tier availability problem to guard
+against. (3) The `sig` fallback's `param_types` were joined into `extra`
+as raw, uncanonicalized strings, so CastXML's `"char const*"` and Clang's
+`"char const *"` -- an otherwise-identical parameter type -- would
+fragment identity across the two header-AST backends. Fixed by running
+each `param_types` entry through `name_classification.
+canonicalize_type_name` before joining, mirroring
+`resolve_function_identity`'s own canonicalization of `func.params` for
+the identical reason; `name_classification` is itself a dependency-free
+leaf module already imported by other `model/` modules
+(`model/graph_identity.py`, `model/stdlib_surface.py`), so this does not
+violate this module's own leaf-module contract (ADR-063 D10) -- it is not
+`checker_types`/`diff_*`/`checker`/`compare`/`finding_identity`. Nine new
+tests in `tests/test_model_identity.py` pin all three fixes, including the
+overload-disambiguated-owner case, the export-only-vs-namespaced
+scope-independence case (and that it does not erase `leaf_name`'s own
+discriminating power), that the `mangled`/`sig` branches keep scope as
+given, and the cross-backend canonicalization.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7345,6 +7345,67 @@ New tests: a doctest plus
 correct injected keyword AND non-collision with the convention-free
 form).
 
+**Correction (2026-08-29, same day, twenty-first Codex review round on
+PR #941, commit 05091da): two findings -- one real fix (noexcept
+integer literals), one real REGRESSION in the nineteenth round's own
+global-scope-stripping fix, reverted after direct-compilation
+falsification.**
+
+*Fix 1 (real, implemented):* `noexcept`'s argument is contextually
+converted to `bool`, so `noexcept(1)`/`noexcept(0)` are the identical
+types as `noexcept(true)`/`noexcept(false)` -- confirmed both by direct
+compilation (`g++`: redefinition errors for each pair) and by Clang's
+own `qualType`, which genuinely emits these integer-literal spellings
+verbatim (`clang -Xclang -ast-dump=json`: `void (int) noexcept(1)`).
+`_canonicalize_noexcept` now recognizes `"1"`/`"0"` alongside
+`"true"`/`"false"`, deliberately narrow to exactly these two literals
+(a non-0/1 integer constant in this position triggers a
+narrowing-conversion diagnostic in real compilers and is not a spelling
+this module has confirmed evidence for).
+
+*Fix 2 (self-correction, REVERTED):* the nineteenth round's own
+`_GLOBAL_SCOPE_RE`-based unconditional stripping of a leading `::` was
+itself wrong, falsified by direct compilation before reverting rather
+than accepted on the strength of a plausible-sounding C++ semantic
+argument. Given
+```
+namespace dep { struct Thing; }
+namespace local { namespace dep { struct Thing; } void f(dep::Thing*); }
+```
+Clang's own `qualType` for `f`'s parameter prints the BARE, unqualified
+`dep::Thing *` (no leading `::`) even though it resolves to
+`local::dep::Thing` -- a type DISTINCT from the true global
+`::dep::Thing` a sibling declaration in the SAME namespace prints WITH
+the leading `::` (verified via `clang -Xclang -ast-dump=json` on both
+declarations side by side). This module has no scope-tree information;
+it operates purely on already-printed type-name text, so it cannot tell
+"a genuinely global entity, spelled either way" apart from "an
+unqualified name that happens to resolve to a DIFFERENT, locally-
+shadowing entity of the same spelling" -- Clang's own choice to include
+or omit the leading `::` IS exactly that distinguishing signal, so
+erasing it can silently merge two non-interchangeable types. Separately:
+the nineteenth round's own motivating evidence
+(`tests/test_dumper_scoping_dependency_retention.py::
+test_globally_qualified_signature_spelling_still_matches`) turns out to
+be for a DIFFERENT subsystem entirely -- matching a signature's type
+reference against an already-KNOWN declared type's own `qualified_name`
+within ONE snapshot's dependency-scoping pass, not comparing two
+independently-observed SIGNATURES for cross-producer/cross-revision
+identity (this function's own job) -- and does not establish that
+castxml and Clang ever disagree on this leading `::` for one identical
+real declaration. `_GLOBAL_SCOPE_RE` is removed entirely (not merely
+disabled); `TestLeadingGlobalScopeQualifierIsStripped` in
+`tests/test_signature_normalization.py` is renamed to
+`TestLeadingGlobalScopeQualifierIsPreserved` with every assertion
+flipped from equality to inequality. This is the SECOND self-correction
+on this primitive (the first was the restrict handling, sixteenth ->
+eighteenth rounds) -- the common thread both times is that a plausible-
+sounding cross-producer-normalization generalization was accepted
+without direct-compilation verification first; every future claim about
+what two spellings "mean the same thing" on this primitive gets checked
+against real compiler/AST-dumper output before implementing, not merely
+re-derived from C++ semantics on paper.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6714,7 +6714,7 @@ every cv token found is unambiguously by-value, never pointee, cv. (2)
 unlike `resolve_function_identity`'s own `func.is_const`/
 `func.is_volatile` booleans, a caller-supplied token tuple invites order-
 dependence for one member-cv qualification spelled two ways (`("const",
-"volatile")` vs. `("volatage", "const")` -- caught named literally as
+"volatile")` vs. `("volatile", "const")` -- caught named literally as
 `f() const volatile` vs. `f() volatile const`). Fixed by replacing the
 parameter with `is_const: bool = False, is_volatile: bool = False`,
 matching `resolve_function_identity`'s own representation exactly and
@@ -6779,6 +6779,49 @@ Omitting it (no wired producer yet, same scope boundary this module's own
 docstring already states for `LocalToFunction`/`Anonymous` before their
 producers existed) keeps the pre-existing degenerate-collision behavior,
 not a silent, unrequested change. Six new tests pin both fixes.
+
+**Correction (2026-08-29, same day, seventh Codex review round on PR #941,
+commit b767576): two more real gaps in the by-value/array-decay logic,
+plus a new hard architectural gate the fix itself then had to satisfy.**
+(1) The pointer branch skipped *all* cv processing as soon as it saw any
+top-level `*`/`&`/`[`, so a cv-qualifier trailing the parameter's own
+outermost pointer sigil (`int * const` -- the pointer VALUE itself is
+const, not what it points to) survived unstripped, even though the
+standard drops it exactly like any other top-level parameter qualifier:
+`void f(int *)` and `void f(int * const)` name the same function. Fixed
+by splitting the string at the LAST top-level `*`/`&`: everything up to
+and including it is kept verbatim (an intermediate pointer level's own
+qualifier, e.g. `int * const *`'s middle `const`, is genuinely
+distinguishing and must survive), only the suffix is stripped. (2) The
+earlier `[`-is-pointer-shaped fix stopped `int []`/`const int []` from
+colliding, but never performed the actual array-to-pointer decay, so
+`int []`/`int [3]`/`int [4]`/`int *` -- all one identical adjusted
+parameter type -- still canonicalized to four different strings. Fixed
+with `_decay_top_level_array`, deliberately narrow: multi-dimensional
+arrays (`T[][N]`) and parenthesized declarators (`int (*)[3]`, "pointer to
+array", where the trailing `[3]` is the POINTEE's bound, not the
+parameter's own shape) are left entirely unchanged rather than mis-decayed
+-- an accepted, documented limitation, not a silent gap. **Implementing
+these two together, correctly, in `model/identity.py` pushed that file to
+834 lines, over the AI-readiness gate's 800-line production maximum with
+no debt-ledger entry possible for a brand-new file (`debt-exemption`
+explicitly forbids that) -- a second, different hard architectural
+constraint from the fifth correction's `debt-no-growth` one, caught before
+push this time by running `scripts/check_ai_readiness.py` locally first.**
+Resolved by splitting the whole cv/array-decay block into a new sibling
+leaf module, `abicheck/model/signature_normalization.py` (`identity.py`
+now 586 lines, the new module 299) -- not a design change, purely a file
+split, with `identity.py` importing the one public
+`canonicalize_function_signature_param_type` from it. The new module also
+got its own dedicated primitive-level test file,
+`tests/test_signature_normalization.py` (per AGENTS.md's own convention
+for a new reusable primitive), which caught a genuine bug of its own
+before it shipped: the array-decay path bypassed
+`canonicalize_type_name`'s east-const normalization (its regex never
+matches a bracket-containing string), so `"const int [3]"` and `"const int
+*"` -- the identical adjusted type -- canonicalized to two different
+strings until the decay result was re-canonicalized a second time. Fixed
+in the same commit; `test_element_cv_becomes_pointee_cv` pins it.
 
 ---
 

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6868,6 +6868,45 @@ layer, where the platform's decoration convention is already known, not
 this identity primitive) and out of scope for this "purely additive,
 mirrors the existing resolver" first slice.
 
+**Correction (2026-08-29, same day, ninth Codex review round on PR #941,
+commit 0b7a80a): two more real gaps in the same paren-transparency logic,
+both fixed with a general recursive treatment rather than another one-off
+patch.** (1) A *pointer-to-member-function* declarator (`void (C::*
+const)(int)`) has its own outermost sigil preceded by the member's
+qualified-name prefix (`C::`) rather than a bare sigil -- the eighth
+round's transparency check ("next non-space character after `(` is
+`*`/`&`") never recognized this shape, so its own trailing cv-qualifier
+stayed unstripped. Fixed by generalizing the transparency test to a regex
+(`_DECLARATOR_GROUP_RE`) matching one or more `identifier::` segments
+before the sigil, not only a bare one. (2) A declarator's own trailing
+parameter list (the `(int)` in `void (*)(int)`) is itself exactly as much
+"a function's parameters" as this function's own top-level parameter --
+C++ drops a nested callback parameter's top-level by-value cv from the
+callback's own function type too, so `void (*)(int)` and
+`void (*)(const int)` name the identical adjusted callback type, not two.
+The eighth round's fix left every trailing parameter-list paren entirely
+opaque, so this nested by-value cv was never stripped. Fixed with a real,
+general recursive treatment rather than a narrow special case: every
+top-level `(...)` group found after the declarator's own sigil is now
+comma-split (`_split_top_level_commas`, depth-aware) and each of its own
+parameters is recursively run back through
+`canonicalize_function_signature_param_type` itself
+(`_normalize_nested_param_lists`/`_normalize_param_list_contents`) --
+unlike the array-decay limitations, this is not "unbounded C declarator
+grammar": it is one already-correct function applied to a strictly
+shorter substring at each level, which is what terminates it, and it
+reaches a callback-of-a-callback automatically since each recursive call
+performs the identical treatment on its own nested parameter lists. An
+empty parameter list, a bare `void`, and a variadic `...` marker are left
+untouched (none is itself a parameter type). Ten new tests in
+`tests/test_signature_normalization.py`
+(`TestPointerToMemberOwnCvIsDropped`,
+`TestNestedCallbackParametersAreNormalizedRecursively`, plus two new
+idempotence cases) pin both fixes, including that a nested parameter's
+genuine *pointee* cv still distinguishes, a doubly-nested callback
+normalizes at its innermost level too, and the variadic/void/empty
+special cases pass through unchanged.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7247,6 +7247,46 @@ no-attribute staying unaffected, two different conventions still
 distinguishing, coexistence with a trailing `noexcept`, idempotence, and
 a defensive redundant-both-spellings-at-once case).
 
+**Correction (2026-08-29, same day, eighteenth Codex review round on PR
+#941, commit 06255fc): the sixteenth round's own "restrict never affects
+mangling, strip it everywhere" fix was itself wrong -- a real
+generalization mistake, not a narrow miss.** Fresh evidence, confirmed by
+direct compilation rather than mere assertion (`g++ -c`, inspecting the
+real mangled symbols): `void f(int **)` and `void f(int * restrict *)`
+mangle to two DIFFERENT, simultaneously-declarable Itanium symbols
+(`_Z1fPPi` vs. `_Z1fPrPi`), so restrict on a NON-outermost pointer level
+genuinely IS a standard-mandated, mangling-relevant overload
+discriminator -- the sixteenth round's own unconditional strip wrongly
+collapsed that pair into one identity. Only restrict on the parameter's
+own OUTERMOST, by-value pointer position drops from the mangled name
+(`void f(int *)`/`void f(int * restrict)` mangle identically, and GCC
+even refuses to compile them together as an overload set -- the same
+"can't be a real overload pair" signal a genuine by-value cv-qualifier
+gives). This is exactly the position-sensitivity the SIXTEENTH round's
+own docstring dismissed ("restrict's absence from mangling does not
+depend on where in the declarator it sits") -- which was the actual bug:
+restrict behaves like cv, not like a pure no-op token. Fixed by
+REVERTING the standalone `_RESTRICT_WORD_RE`-based unconditional strip
+entirely and instead folding restrict's three spellings into
+`_CV_WORD_RE` itself, so it goes through the exact same outermost-vs-pointee
+position discipline `const`/`volatile` already have throughout this
+module (`_strip_cv_tokens_outside_nesting`'s existing depth-aware scan,
+applied at exactly the same two safe positions as always -- no new
+logic needed, since the position discipline was already correct for cv
+and restrict needed nothing different from it). Updated tests: `TestRestrictQualifierIsAlwaysStripped` renamed to
+`TestRestrictQualifierSharesCvPositionDiscipline`
+in `tests/test_signature_normalization.py`, with the previously-wrong
+`test_restrict_on_non_outermost_pointer_also_stripped` (asserting
+equality) replaced by
+`test_restrict_on_non_outermost_pointer_still_distinguishes` (asserting
+INequality) plus a new idempotence case for the inner-restrict spelling.
+This is the second consecutive round to revise the SAME primitive's
+restrict handling (sixteenth introduced it, this one corrects its own
+overreach) -- direct compiler verification, not just re-reading the
+finding text, is now the standard for any future ABI-mangling-behavior
+claim in this file before implementing a fix, the same discipline that
+already caught this round's own error.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6724,6 +6724,62 @@ top-level cv non-distinction, pointee cv's continued distinguishing power,
 independent const/volatile discrimination, and that the two booleans'
 call-site order cannot affect the resulting id.
 
+**Correction (2026-08-29, same day): the fifth correction's own new
+primitive landed in the wrong module and had to be relocated before
+push.** `name_classification.canonicalize_function_signature_type` was
+first added directly to `abicheck/name_classification.py` -- but that
+file is a frozen, no-growth legacy module under ADR-061's debt ledger
+(`architecture/debt.yaml`, baseline 1258 lines), and CI's
+`debt-no-growth` architecture check (`scripts/check_architecture.py`)
+correctly failed the push for exceeding it. Relocated the whole primitive
+into `abicheck/model/identity.py` itself as a module-private
+`_canonicalize_function_signature_param_type`, along with a
+self-contained, deliberately-duplicated (not imported) reimplementation
+of the top-level-pointer/reference-sigil detection algorithm
+`name_classification._has_top_level_ptr_or_ref` already applies for a
+different purpose -- duplication here is the correct outcome of the
+no-growth constraint, not an oversight: the alternative (importing a
+private helper from the frozen module) would be worse, and the algorithm
+is small, stable, and independently tested in its new location. This is
+exactly the kind of tension a genuinely completed ADR-061 migration of
+`name_classification.py` would resolve (see that file's own debt-ledger
+entry, "target: see ADR-061 ownership map") -- not attempted here, since
+migrating the whole file is far outside this slice's scope. `git diff
+--stat`/`wc -l` confirm `name_classification.py` is back to exactly 1258
+lines (its original baseline) and `scripts/check_architecture.py`
+reports 0 errors.
+
+**Correction (2026-08-29, same day, sixth Codex review round on PR #941,
+commit 1b3575d): two more real gaps found, both requiring a genuine
+extension rather than reuse.** (1) The by-value-cv fix above left one
+case unhandled: a function PARAMETER's array type always decays to a
+pointer (``int []`` -> ``int *``), so a cv-qualifier on the array's
+element type is pointee-level, exactly like an explicit pointer -- ``void
+f(int[])`` and ``void f(const int[])`` are two distinct, independently-
+mangled overloads, not one. Neither spelling contains a ``*``/``&``
+sigil, so `_has_top_level_ptr_or_ref` (module-private, in
+`model/identity.py`) wrongly treated both as by-value and stripped the
+``const``. Fixed by also treating a top-level ``[`` as pointer-shaped for
+this determination -- the fix landed in this correction's own new
+`model/identity.py` primitive precisely because it was already the
+no-growth-safe location the fifth correction relocated to; there was no
+second relocation needed. (2) `ScopePath` names only the *containing*
+scope, never the leaf declaration (this module's own stated design), so
+two anonymous sibling records/enums both passing `leaf_name=""` collided
+onto one identical `EntityId` regardless of which is meant --
+`Anonymous.ordinal` (a `ScopePath` segment) disambiguates a *descendant's*
+containing scope, not the anonymous declaration's own identity, so it
+does not help here. Fixed by adding an opt-in `anonymous_ordinal: int |
+None = None` keyword to `entity_id_for_type`/`entity_id_for_enum` (the
+two kinds C++ actually allows to be anonymous), folded into `extra` as
+`("anonymous", str(ordinal))` only when `leaf_name` is empty -- mirroring
+`Anonymous.ordinal`'s own deterministic-per-parent-sequence-number
+semantics and identical within-one-parse-only accepted limitation.
+Omitting it (no wired producer yet, same scope boundary this module's own
+docstring already states for `LocalToFunction`/`Anonymous` before their
+producers existed) keeps the pre-existing degenerate-collision behavior,
+not a silent, unrequested change. Six new tests pin both fixes.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7116,6 +7116,73 @@ code (evaluating an arbitrary constant expression remains out of scope).
 Two new tests in `tests/test_signature_normalization.py` pin the
 anonymous-namespace fix, including idempotence.
 
+**Correction (2026-08-29, same day, fifteenth Codex review round on PR
+#941): a bare data-member-pointer's pointee cv-qualifier was misplaced
+across the `ClassName::` infix, plus the fix's own line-count growth
+forced a second module split.** `canonicalize_type_name`'s own east-const
+regex -- unmodifiable, since `name_classification.py` is a frozen,
+no-growth legacy file -- does not know how to normalize a leading
+cv-qualifier across a bare (non-parenthesized) data-member-pointer's own
+`ClassName::` infix, and MISPLACES it depending on which side it started
+on: `"int const C::*"` stays `"int const C:: *"` (matching this
+primitive's own canonical output), but `"const int C::*"` becomes
+`"int C:: const *"` -- the cv-word shoved in between the qualifier and
+the sigil, indistinguishable in that position from the pointer's own
+by-value qualifier. Both spell the identical pointer-to-const-int-member
+type and must canonicalize identically; a first, narrower fix attempt
+(scanning only immediately before the sigil) caught the first
+manifestation but not the second, discovered via direct testing. Fixed
+with a more robust "reliable marker" strategy in the new
+`_find_member_pointer_qualifier`: a member pointer's own qualifier is
+always followed by a single space before whatever comes next
+(`"C:: *"`), unlike ordinary namespace qualification within a type's own
+spelling, which never has a space after `::` (`"ns::Foo"`) -- so the LAST
+`"::` "` marks the qualifier's end reliably, and the caller re-collects
+any cv word found on either side of the qualifier (base-side and
+tail-side) before re-canonicalizing the combined base. A related,
+broader limitation was found and deliberately left out of scope:
+`canonicalize_type_name` never reorders `volatile` at all (only
+`const`), a pre-existing gap affecting every pointee-volatile position in
+this module, not specific to member pointers -- fixing it is a
+substantially larger undertaking than this round's actual Codex finding
+(which named `const` specifically), so it is documented directly in
+`_find_member_pointer_qualifier`'s own docstring and the corresponding
+doctest as an accepted, out-of-scope residual gap rather than silently
+patched over.
+
+Implementing this pushed `signature_normalization.py` to 908 lines, over
+the AI-readiness gate's 800-line production maximum (which has no
+debt-ledger workaround for a file this new) -- the identical situation
+the seventh round's own `identity.py` -> `signature_normalization.py`
+split addressed one level up. Resolved the same way: a second sibling
+leaf module, `abicheck/model/declarator_qualifiers.py`, now holds every
+piece of this module's own machinery that has no *recursive* dependency
+back into `canonicalize_function_signature_param_type` itself --
+`_is_declarator_group` (+ its `_CALLING_CONVENTIONS`/`_IDENTIFIER_RE`
+supporting constants), `_extract_top_level_cv`, the new
+`_find_member_pointer_qualifier` (+ `_MEMBER_POINTER_TAIL_RE`),
+`_split_at_trailing_param_list`, `_canonicalize_member_qualifiers`, and
+`_canonicalize_noexcept` (+ `_NOEXCEPT_RE`). What stays behind in
+`signature_normalization.py` is exactly the machinery that DOES recurse
+back into `canonicalize_function_signature_param_type`
+(`_normalize_param_list_contents`/`_normalize_nested_param_lists`, for a
+callback/member-function-pointer's own nested parameter list) plus the
+top-level by-value cv/array-decay logic and the main function itself --
+so the import is strictly one-way (`signature_normalization ->
+declarator_qualifiers`, never the reverse), avoiding a cycle between the
+two sibling leaf modules. `_CV_WORD_RE` (a trivial one-line regex
+constant) is duplicated in both modules rather than shared, since sharing
+it would need an import in the direction that would create that cycle.
+Both files stay comfortably under the cap after the split (~600 and ~370
+lines respectively). The new module gets its own dedicated
+primitive-level test file, `tests/test_declarator_qualifiers.py`
+(mirroring `test_signature_normalization.py`'s own rationale and
+including its own leaf-module-contract test), alongside new tests in
+`tests/test_signature_normalization.py` pinning the member-pointer fix
+itself (both cv-spelling orderings unifying, an ordinary namespace-
+qualified pointer staying unaffected, the parenthesized member-function-
+pointer case staying unaffected, and idempotence).
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7214,6 +7214,39 @@ non-outermost-pointer restrict, a callback parameter's own restrict, a
 sanity check that a genuine pointee cv-qualifier still distinguishes, and
 idempotence).
 
+**Correction (2026-08-29, same day, seventeenth Codex review round on PR
+#941, commit 2264423): Clang's own trailing calling-convention attribute
+spelling was not recognized, fragmenting identity across header-AST
+backends.** Clang's `ParmVarDecl.type.qualType` renders a calling-
+convention-decorated function-pointer declarator as e.g.
+`void (*)(int) __attribute__((cdecl))` -- the attribute trails the
+parameter list -- rather than MSVC/castxml's leading-keyword spelling,
+`void (__cdecl *)(int)`, which `_is_declarator_group`/
+`_CALLING_CONVENTIONS` already recognized. The two spellings of one
+identical type canonicalized differently, so a template or DWARF-only
+function observed through both backends would fragment. Fixed with a new
+`_CALLING_CONVENTION_ATTR_RE`, matching the same five attribute-node
+kinds `dumper_clang_attributes.py`'s own `_CLANG_ATTR_TOKENS` mapping
+already recognizes for a FunctionDecl's own top-level contract
+attributes (this is the textual, parameter-type-spelling equivalent, for
+the mangling-free signature-fallback identity this module computes): when
+found in the trailing region after a declarator's own parameter list, the
+attribute text is removed and, if the leading `prefix` doesn't already
+carry a calling-convention keyword, the equivalent `__cdecl`-style
+keyword is injected at the same position `_is_declarator_group` looks for
+it -- so both spellings converge on one `prefix` before the ordinary
+member-qualifier canonicalization runs on whatever remains of the
+trailing text. Verified this is a real, internally-corroborated Clang
+spelling (not merely the finding's own claim) via
+`dumper_clang_attributes.py`'s existing, independent handling of the
+identical attribute-node kinds for the top-level FunctionDecl case. New
+tests: `TestClangTrailingCallingConventionAttributeUnifies` in
+`tests/test_signature_normalization.py` (cdecl and stdcall unifying with
+their leading-keyword equivalents, the member-function-pointer case,
+no-attribute staying unaffected, two different conventions still
+distinguishing, coexistence with a trailing `noexcept`, idempotence, and
+a defensive redundant-both-spellings-at-once case).
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6521,6 +6521,62 @@ independently of that work), then (b) migrate `diff_filtering.py`/
 `finding_identity.py` algorithm migration and the storage v2 wire bridge,
 each as their own reviewable slice.
 
+**Correction (2026-08-29, same day, Codex review on PR #941): two real
+discriminator gaps in `entity_id_for_function` fixed, both traced to the
+same root cause -- the constructor accepted a strict subset of the
+dimensions `finding_identity.resolve_function_identity` already treats as
+load-bearing, so a caller reproducing that resolver's own contract through
+this constructor could not.** (1) An `extern "C"` producer follows
+*mangled_name*'s own documented contract and passes `None` for it (its raw
+export spelling is not a genuine mangling) -- with no separate linkage
+signal, that fell through to the signature-based fallback branch, so a
+changed parameter list on a genuinely-non-overloadable C-linkage function
+produced two ids instead of one modification, defeating the name-based
+extern-C fallback the rest of the codebase relies on. Fixed by adding an
+explicit `is_extern_c: bool = False` parameter that takes a third,
+signature-free `("extern_c",)` branch, mirroring `resolve_function_
+identity`'s own `func.is_extern_c` gate. (2) The signature fallback carried
+only `param_types`/`cv_qualifiers`, missing the two dimensions
+`resolve_function_identity` already folds in (`ref_qualifier`,
+`is_variadic`) -- `C::f() &` vs. `C::f() &&`, and `void f(int)` vs.
+`void f(int, ...)`, both collided. Fixed by adding `ref_qualifier: str = ""`
+and `is_variadic: bool | None = None` parameters, folded into the tagged
+`("sig", ...)` tuple; `is_variadic` stays a tri-state (not defaulting to
+`False`) for the same reason `resolve_function_identity` keeps it one --
+"doesn't know" must not silently collapse onto "confirmed non-variadic".
+Both fixes are additive keyword-only parameters with backward-compatible
+defaults; no existing call site changes behavior (there are none outside
+this module's own tests yet). Six new tests in `tests/test_model_identity.py`
+pin each new dimension, the three-way tag disjointness, the tri-state
+`is_variadic`, and that a genuine `mangled_name` still wins outright and
+ignores every other dimension.
+
+**Correction (2026-08-29, same day, CodeRabbit review on PR #941): the
+Design section above states `LocalToFunction(owner)` as a single-field
+segment, but that is an under-specification the same review caught for
+real -- fixed by adding `block_ordinal`, a required second field.**
+`owner` alone disambiguates two same-named locals declared in *different*
+functions, but not two same-named locals in *sibling compound blocks of
+the same function* (`void f() { { struct A {}; } { struct A {}; } }` --
+two distinct declarations, identical `owner`, identical leaf name, so both
+would collapse onto one `EntityId` under the Design section's original
+single-field shape). `block_ordinal` closes this exactly the way
+`Anonymous.ordinal` already closes the structurally identical
+sibling-anonymous-scope case: a deterministic per-function sequence
+number assigned at parse time, stable within one parse only -- the
+identical accepted, documented limitation `Anonymous` already states (an
+inserted or removed earlier local block shifts every later sibling's
+ordinal and therefore its whole `EntityId`, even though nothing about
+those later declarations changed). No default value, matching
+`Anonymous.ordinal`, since nothing constructs a `LocalToFunction` outside
+this module's own tests yet -- a caller must supply a real value rather
+than silently under-specifying identity via an unwired default. The code
+docstring's original "Both fields are identity" language was already
+correct in intent (mirroring `Anonymous`'s own phrasing) but described a
+struct that, before this correction, had only one field -- a real
+inconsistency between the stated contract and the actual shape, not just
+prose.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6618,8 +6618,43 @@ violate this module's own leaf-module contract (ADR-063 D10) -- it is not
 tests in `tests/test_model_identity.py` pin all three fixes, including the
 overload-disambiguated-owner case, the export-only-vs-namespaced
 scope-independence case (and that it does not erase `leaf_name`'s own
-discriminating power), that the `mangled`/`sig` branches keep scope as
-given, and the cross-backend canonicalization.
+discriminating power), that the `sig` branch keeps scope as given, and
+the cross-backend canonicalization. (This section originally also claimed
+the `mangled` branch keeps scope as given, alongside `sig` -- see the next
+correction below for why that claim was itself wrong and has been fixed
+here rather than left standing.)
+
+**Correction (2026-08-29, same day, third Codex review round on PR #941,
+commit e5cbdf2): the previous correction's own claim that the `mangled`
+branch "keeps scope as given... redundant but harmless" was wrong, and
+the identical evidence-tier-fragmentation bug the `is_extern_c` branch
+was fixed for above turned out to reach two more places.** (1)
+`entity_id_for_function`'s *mangled* branch folded the caller-supplied
+`scope` into the returned `EntityId` unchanged. That is not harmless: a
+header/DWARF-derived observation of a mangled function may supply a real
+`ScopePath`, while an export-table-only snapshot of the identical binary
+symbol knows only the bare mangled name -- exactly the same
+evidence-tier-availability mismatch the `is_extern_c` fix already closed,
+just for the mangled case instead of the extern-"C" case.
+`resolve_symbol_identity`'s own real primary id for a genuine mangling is
+`f"mangled:{real_mangled}"` alone, with no scope folded in at all --
+confirming the mangled branch should have matched the `is_extern_c`
+branch's `scope=()` treatment from the start. Fixed by forcing `scope=()`
+for the mangled branch too; only the `sig` fallback -- which has no
+authoritative, scope-independent name to fall back on -- keeps scope as
+given. (2) `entity_id_for_variable` had no `is_extern_c` parameter at all,
+so a namespaced `extern "C"` variable (caller passes `mangled_name=None`
+per that parameter's own contract) had no way to reach a scope-independent
+identity the way the equivalent function case now does, and its own
+*mangled* branch had the identical scope-folding bug as (1). Fixed by
+adding the same `is_extern_c` parameter `entity_id_for_function` has, and
+forcing `scope=()` for both its mangled and its `is_extern_c` branches.
+Six new tests across both constructors pin all of this: mangled-branch
+scope-independence for both functions and variables, the `sig` branch
+still keeping scope as given, the new variable `is_extern_c` path and its
+own tag-disjointness from the pre-existing mangling-free degenerate case,
+and mangled-name-wins-over-`is_extern_c` precedence for variables
+(mirroring the function constructor's own precedence, already tested).
 
 ---
 

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6987,6 +6987,45 @@ positive on a legitimate class-type spelling that happens to end in a
 parenthesized group. Recorded here as an accepted, documented limitation
 rather than silently dropped.
 
+**Correction (2026-08-29, same day, eleventh Codex review round on PR #941,
+commit ea44356): one more real gap in the declarator-transparency test,
+plus a second, more serious self-caught over-merge in the tenth round's
+own trailing-qualifier fix.** (1) `_DECLARATOR_GROUP_RE`'s qualified-name
+loop matched only plain `identifier::` segments, so a template-qualified
+nested-name-specifier -- `void (C<int>::* const)(int)`, a real, common
+C++ shape -- was never recognized as a declarator group, and its own
+by-value cv stayed unstripped. Fixed by replacing the single regex with a
+manual scanner, `_is_declarator_group`: a template-argument list can nest
+arbitrarily deep (`Box<Pair<int, int>>::`), which `re`'s non-recursive
+matching cannot balance, so this needed real character-by-character
+`<`/`>` depth tracking, not a regex extension. (2) The tenth round's
+`_canonicalize_member_qualifiers` fixed the over-merge on trailing
+`const`/`&`/`&&`, but did so by RECONSTRUCTING the whole trailing region
+from only those three tokens -- silently dropping anything else found
+there. The practically important case: a `noexcept`-specifier, which
+C++17 made part of the function type, so `void (*)(int) noexcept` and
+`void (*)(int)` are two different, non-interchangeable types -- and this
+primitive was merging them into one identity, the exact same over-merge
+class the tenth round's own fix existed to close, just relocated rather
+than eliminated. Fixed generally: instead of naming every possible
+trailing specifier and reconstructing from a fixed list, the function now
+only ever removes and reorders the `const`/`volatile` WORDS themselves
+(via `_CV_WORD_RE`, the same primitive `_strip_cv_tokens_outside_nesting`
+already uses) and passes everything else through verbatim, in its
+original relative order -- `dcl.fct`'s own grammar already fixes
+cv-qualifier-seq first among a function's trailing specifiers, so a real
+producer's placement of ref-qualifier/`noexcept`/anything else never
+needs inferring, only cv needs reordering relative to itself. This also
+means the function no longer special-cases the ref-qualifier's `"&&"` ->
+`"& &"` spelling quirk (`canonicalize_type_name` already normalizes that
+upstream, before this function ever sees the string, so passing the
+leftover text through verbatim is already consistent). Eight new tests in
+`tests/test_signature_normalization.py`
+(`TestTemplateQualifiedMemberPointerOwnCvIsDropped`, four new cases in
+`TestPointerToMemberTrailingQualifiersPreserved` for `noexcept`, plus two
+new idempotence cases) pin both fixes, including a nested template
+argument and `noexcept` combined with order-independent cv.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6907,6 +6907,86 @@ genuine *pointee* cv still distinguishes, a doubly-nested callback
 normalizes at its innermost level too, and the variadic/void/empty
 special cases pass through unchanged.
 
+**Correction (2026-08-29, same day, tenth Codex review round on PR #941,
+commit fd715cc): two more real gaps in the same declarator handling, plus
+a self-caught correctness regression from fixing the second one.** (1) The
+paren-transparency regex recognized a bare sigil or a member-pointer's
+qualified-name prefix, but not an MSVC/PE calling-convention keyword
+(`__cdecl`, `__stdcall`, `__fastcall`, `__thiscall`, `__vectorcall`)
+preceding the sigil, so `void (__cdecl * const)(int)` -- confirmed a real,
+reachable shape (this codebase's own PE/PDB-decorated-export handling in
+`diff_platform.py` already deals with `__cdecl`-decorated exports) --
+never found its sigil at depth 0 either. Fixed by widening
+`_DECLARATOR_GROUP_RE` to accept an optional calling-convention keyword
+before the existing qualified-name-prefix loop; the keyword itself is
+matched, not erased, so it stays genuine, distinguishing content in the
+prefix (`void (__cdecl *)(int)` and `void (__stdcall *)(int)` correctly
+stay two different types). (2) A pointer-to-member-function's own
+TRAILING cv/ref-qualifiers -- the ones that follow its parameter list,
+e.g. `const` in `void (C::*)(int) const` -- were wrongly blanket-stripped
+by the same by-value logic that (correctly) strips the pointer's own
+qualifier *before* the parameter list. These are not the same thing: a
+trailing qualifier qualifies the POINTED-TO member function itself, a
+genuine, standard-mandated discriminator (`void (C::*)(int) const` is a
+different, non-interchangeable type from `void (C::*)(int)`), so
+collapsing them together was a real over-merge, the same class of mistake
+this whole primitive exists to prevent, not merely an incompleteness.
+Fixed by splitting the suffix at the declarator's own trailing parameter
+list (`_split_at_trailing_param_list`): everything before it stays the
+pointer's own by-value region (stripped, as before); everything after it
+now goes through a new `_canonicalize_member_qualifiers`, which -- mirroring
+`entity_id_for_function`'s own `is_const`/`is_volatile` two-boolean
+treatment for the identical ordering problem one level up -- only
+reorders `const`/`volatile` into a fixed order and normalizes a ref-
+qualifier (`&`/`&&`), rather than dropping any of it.
+
+**Self-caught regression, found by this round's own new ref-qualifier
+tests before push, not by a reviewer:** implementing fix (2) initially
+broke on `void (C::*)(int) &&`, canonicalizing it as `void (C:: * )(int)
+&&` for `&` but corrupting the `&&` case into `void (C:: * )(int) & &` --
+worse, `canon(...) != canon(...)` on the SAME input, an outright identity
+non-determinism bug. Root cause: `canonicalize_type_name` spells `&&` as
+`"& &"` (its own established sigil-spacing convention, the same source as
+`"int * const *"` -> `"int *const *"` elsewhere in this module), and the
+main sigil-scanning loop records the LAST `*`/`&` found anywhere at depth
+0 as `last_top_level_sigil` -- so the second `&` of the trailing `"& &"`
+ref-qualifier, itself sitting at depth 0 well after the declarator's own
+parameter list had already closed, wrongly overrode the member-pointer's
+own already-found `*`, corrupting the entire prefix/suffix split. Fixed
+at the root: the main loop now tracks whether it has already seen a
+top-level *opaque* paren (the declarator's own trailing parameter list)
+and stops updating `last_top_level_sigil` once it has -- nothing
+`*`/`&`-shaped appearing after a declarator's parameter list closes can
+ever be a NEW top-level sigil, only a ref-qualifier on what came before.
+`_canonicalize_member_qualifiers`'s own ref-qualifier detection was
+likewise fixed to compare against a whitespace-collapsed form so `"& &"`
+is still recognized as `&&`, not two separate `&` tokens. Eleven new tests
+in `tests/test_signature_normalization.py`
+(`TestCallingConventionDeclaratorGroupIsRecognized`,
+`TestPointerToMemberTrailingQualifiersPreserved`, plus two new idempotence
+cases) pin all of this, including the exact `&&`-vs-`& &` regression.
+
+A third finding from the same round -- that a bare, unadjusted function
+*type* used as a parameter (`void(int)`, as opposed to the already-
+adjusted `void (*)(int)`) is returned unchanged rather than decayed to a
+pointer the way an array parameter is -- was investigated and NOT fixed.
+Checked against this codebase's own real header-AST producer output
+(`tests/test_dumper_clang.py`'s and `test_dumper_clang_vtable.py`'s fixed
+`qualType` strings) and confirmed: a real castxml/clang dump always
+already prints the ADJUSTED pointer form for a function-typed parameter
+(`"void (*)(int)"`), never the bare, unadjusted function type -- unlike
+the array case, where the plan's own earlier correction explicitly notes
+this primitive "makes no assumption about whether a given producer's own
+parsed representation already reflects the decay" because an unadjusted
+array spelling genuinely does reach this function from real callers.
+There is no equivalent confirmed real code path supplying an unadjusted
+bare function type here, so implementing a heuristic "is this really an
+unadjusted function type, not some other paren-containing spelling" guess
+would be solving a hypothetical shape, with the attendant risk of a false
+positive on a legitimate class-type spelling that happens to end in a
+parenthesized group. Recorded here as an accepted, documented limitation
+rather than silently dropped.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7055,6 +7055,67 @@ pin this, including that a non-literal expression stays genuinely
 distinguishing rather than being silently (and wrongly) folded into
 either canonical form.
 
+**Correction (2026-08-29, same day, thirteenth Codex review round on PR
+#941, commit 45fd050): one more real under-merge, plus one more real
+over-merge -- this time an actively corrupting one -- in the trailing-
+qualifier and nested-parameter-list handling.** (1)
+`_normalize_param_list_contents` returned an empty parameter list and a
+bare `void` unchanged rather than unifying them, so `void (*)()` and
+`void (*)(void)` -- the identical "no parameters" adjusted type --
+canonicalized to two different strings. Fixed by collapsing both to the
+same canonical empty form. (2) `_canonicalize_member_qualifiers`'s
+`const`/`volatile` extraction used a plain, depth-blind `re.search`/
+`re.sub` over the WHOLE trailing region, which wrongly reached inside a
+non-literal `noexcept(expr)`'s own argument too -- a `const`/`volatile`
+token that is part of THAT expression's own text (e.g.
+`noexcept(Foo<const int>)`) is not this declarator's own cv-qualifier at
+all. This was worse than the earlier over-merges: it didn't just misjudge
+which type two spellings belonged to, it actively MUTATED the nested
+expression's own text (moving the found "const" out to the front,
+leaving the argument reading `Foo< int>`), and could merge two genuinely
+different overloads that happen to share a nested "const" by coincidence.
+Fixed with a depth-aware scan, `_extract_top_level_cv`, mirroring
+`_strip_cv_tokens_outside_nesting`'s own outside-nesting discipline: only
+a cv word sitting at nesting depth 0 -- outside any `(...)`/`<...>`/
+`[...]` -- is ever this declarator's own trailing qualifier. Thirteen new
+tests in `tests/test_signature_normalization.py`
+(`TestCvInsideNoexceptExpressionIsNotExtracted`, a corrected
+`test_empty_and_void_param_lists_unify`, plus two new idempotence cases)
+pin both fixes, including that the nested `const` neither merges with nor
+is corrupted by a real leading `const`.
+
+**Correction (2026-08-29, same day, fourteenth CodeRabbit review round on
+PR #941, commit 45fd050): one more real, serious over-merge in the
+tenth round's `seen_top_level_opaque_paren` flag itself, plus two
+minor cleanups.** (1) That flag was armed on ANY top-level opaque paren,
+regardless of whether the declarator's own sigil had already been found.
+This is wrong for a real, observed producer spelling this codebase
+already handles elsewhere (`tests/test_diff_templates.py`'s own
+`"(anonymous namespace)::T"`): `(anonymous namespace)::Foo const *`
+starts with an opaque paren (`_is_declarator_group` correctly rejects it
+-- it's not a declarator group) that precedes the parameter's own actual
+pointer sigil entirely, not a trailing parameter list. Arming the flag
+there locked out that LATER real sigil, so the whole type fell through to
+the by-value-strip branch and wrongly merged `Foo const *` with `Foo *`
+-- pointer-to-const vs. pointer-to-non-const, two genuinely
+non-interchangeable types. Fixed by only arming the flag once
+`last_top_level_sigil != -1` -- an opaque paren before the declarator's
+own sigil is never its trailing parameter list, so it must never lock
+sigil detection out. (2) A tautological test assertion
+(`canon(x) == canon(x)`, which cannot fail for a pure function and pinned
+nothing) was replaced with a real idempotence check. (3) The twelfth
+round's own changelog wording claimed a non-literal `noexcept(expr)`
+"stays genuinely distinguishing", which overclaims: C++ evaluates a
+constant expression's actual boolean VALUE, not its literal spelling, so
+e.g. `noexcept(sizeof(int))` is genuinely type-equivalent to
+`noexcept(true)` while this primitive (which only recognizes the two
+literal `true`/`false` spellings, per its own docstring's already-correct
+hedge) treats them as different -- a real, documented over-splitting
+limitation, corrected in the changelog fragment's wording rather than the
+code (evaluating an arbitrary constant expression remains out of scope).
+Two new tests in `tests/test_signature_normalization.py` pin the
+anonymous-namespace fix, including idempotence.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7183,6 +7183,37 @@ itself (both cv-spelling orderings unifying, an ordinary namespace-
 qualified pointer staying unaffected, the parenthesized member-function-
 pointer case staying unaffected, and idempotence).
 
+**Correction (2026-08-29, same day, sixteenth Codex review round on PR
+#941, commit 932814b): `restrict`/`__restrict`/`__restrict__` was left
+completely unstripped, fragmenting identity across a compatible
+parameter-qualifier change.** `int *` and `int *restrict` canonicalized
+to two different strings, even though restrict has NO effect on the
+Itanium C++ ABI's mangling at all -- this repository already tracks the
+fact separately (`Param.is_restrict`; `dumper_castxml.py`'s own
+extraction comments state the identical thing), so treating a restrict
+addition/removal as an `EntityId` change turned that dedicated compatible
+change into a spurious removal/addition pair instead. The finding as
+reported scoped a fix to only the parameter's own outermost pointer,
+mirroring how a genuine BY-VALUE cv-qualifier is scoped (per this
+primitive's own established, deliberately narrow-scoped-to-review-
+evidence discipline) -- but unlike cv, restrict's absence from mangling
+does not depend on WHERE in the declarator it sits (the C/C++ grammar
+only ever allows it directly after the `*` it qualifies, at any nesting
+depth), so a fix scoped to "outermost only" would leave e.g.
+`int * restrict *` and `int * *` still wrongly distinguishing. Fixed more
+generally than the reported scope: a new `_RESTRICT_WORD_RE` strips every
+`restrict`/`__restrict`/`__restrict__` token from the canonical type
+string unconditionally, before any of the position-sensitive cv/pointer
+logic runs -- so a nested callback parameter's own restrict-qualified
+pointer is covered too, through this function's existing recursion into
+itself for a trailing parameter list's own parameters, with no special-
+casing needed for that case. New tests:
+`TestRestrictQualifierIsAlwaysStripped` in
+`tests/test_signature_normalization.py` (all three spellings, a
+non-outermost-pointer restrict, a callback parameter's own restrict, a
+sanity check that a genuine pointee cv-qualifier still distinguishes, and
+idempotence).
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7026,6 +7026,35 @@ leftover text through verbatim is already consistent). Eight new tests in
 new idempotence cases) pin both fixes, including a nested template
 argument and `noexcept` combined with order-independent cv.
 
+**Correction (2026-08-29, same day, twelfth Codex review round on PR #941,
+commit 509e3f3): the eleventh round's `noexcept` fix preserved the
+specifier verbatim, which was necessary but not sufficient -- preserving
+its exact SPELLING is not the same as canonicalizing it.** Since C++17, a
+function type's exception specification collapses to exactly two kinds
+for TYPE purposes: "non-throwing" (bare `noexcept` or `noexcept(true)`)
+and "potentially-throwing" (no specifier at all, or `noexcept(false)`).
+Those pairs are the SAME type and must canonicalize identically, but the
+eleventh round's fix passed the raw text through unchanged, so
+`void (*)(int) noexcept` and `void (*)(int) noexcept(true)` -- one
+identical adjusted type -- canonicalized to two different strings (an
+under-merge this time, the milder sibling of the over-merges every
+earlier round fixed, but the same underlying principle: "verbatim
+preservation" is not "canonicalization"). Fixed with a new
+`_canonicalize_noexcept`: only the two literal, constant-expression
+spellings (`true`/`false`) are recognized and normalized -- bare
+`noexcept`/`noexcept(true)` collapse to the single canonical spelling
+`"noexcept"`, `noexcept(false)` is dropped entirely (equivalent, for type
+purposes, to an already-absent specifier) -- while any other,
+non-literal `noexcept(expr)` is left completely untouched, since
+evaluating an arbitrary constant expression is out of scope, the same
+"don't solve the fully general grammar" limit this module already draws
+for multi-dimensional arrays and non-literal declarator shapes elsewhere.
+Nine new tests in `tests/test_signature_normalization.py`
+(`TestNoexceptSpellingsCanonicalized`, plus two new idempotence cases)
+pin this, including that a non-literal expression stays genuinely
+distinguishing rather than being silently (and wrongly) folded into
+either canonical form.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6656,6 +6656,28 @@ own tag-disjointness from the pre-existing mangling-free degenerate case,
 and mangled-name-wins-over-`is_extern_c` precedence for variables
 (mirroring the function constructor's own precedence, already tested).
 
+**Correction (2026-08-29, same day, fourth Codex review round on PR #941,
+commit f22ecf7): a fourth, *confirmed* (not merely hypothetical) gap in
+the mangled branch, found by reading the real producer code.** The
+previous correction made the mangled branch's `EntityId.scope` always
+`()`, but left `leaf_name` folded in unchanged. Codex's finding named a
+concrete, real code path proving this still fragments identity:
+`dumper_elf_fallback.py`'s ELF-only (export-table-only) path constructs
+`Function(name=sym, mangled=sym, ...)` and `Variable(name=sym,
+mangled=sym, ...)` -- the raw exported symbol reused for *both* fields,
+confirmed by reading that module directly rather than assumed. A header/
+DWARF observation of the identical symbol supplies the real demangled
+short name for `name` (e.g. `"f"`), while the export-only observation's
+`name` is the raw mangled spelling itself (e.g. `"_Z1fv"`). Since
+`leaf_name` was still part of the mangled branch's `EntityId`, these two
+observations of the *same* symbol -- agreeing on the mangled evidence --
+would not merge. Fixed by ignoring the caller-supplied `leaf_name`
+entirely in the mangled branch (both constructors), using `""` instead:
+the mangled spelling in `extra` already disambiguates every declaration
+losslessly, so nothing is lost. Four new tests (two per constructor) pin
+that a demangled-short-name observation and a raw-symbol-reused-as-name
+observation of the identical mangled symbol now produce one `EntityId`.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7287,6 +7287,38 @@ finding text, is now the standard for any future ABI-mangling-behavior
 claim in this file before implementing a fix, the same discipline that
 already caught this round's own error.
 
+**Correction (2026-08-29, same day, nineteenth Codex review round on PR
+#941, commit 3aeccc2): an explicit leading `::` (forced global-namespace
+lookup) fragmented identity across producers.** `::dep::Thing *` and
+`dep::Thing *` -- the identical type, since `dep` is unambiguous --
+canonicalized differently, because nothing stripped the leading
+qualifier. Confirmed as a real, already-documented producer spelling
+rather than a hypothetical: direct-clang's own `qualType` preserves an
+explicit global-scope qualifier verbatim, the identical fact
+`tests/test_dumper_scoping_dependency_retention.py`'s own twenty-sixth-
+round docstring already states from the *type-matching* side of this
+codebase (`test_globally_qualified_signature_spelling_still_matches`).
+Fixed with a new `_GLOBAL_SCOPE_RE`, applied unconditionally (not
+position-sensitive the way restrict/cv are, since global-vs-unqualified
+lookup never changes which entity a name denotes) up front, before any
+of the position-sensitive machinery runs. The match is anchored to
+SPECIFIC preceding characters (string start, or immediately after
+whitespace/`(`/`<`/`,`/`*`/`&` -- everywhere a fresh type-name token can
+begin) rather than a blanket "not preceded by an identifier character"
+negative lookbehind: a first draft used exactly that blanket test and
+would have wrongly stripped the genuine, load-bearing `::` in
+`(anonymous namespace)::Foo` too (that separator follows a `)`, not an
+identifier character, so the naive test can't tell it apart from a
+genuine leading global-scope marker) -- caught before implementing by
+walking through the anonymous-namespace case as a check, not discovered
+after the fact. New tests:
+`TestLeadingGlobalScopeQualifierIsStripped` in
+`tests/test_signature_normalization.py` (the bare case, the qualifier
+surviving after stripping, inside a template argument, inside a callback
+parameter, an ordinary namespace qualifier staying unaffected, the
+anonymous-namespace regression pin, the member-pointer qualified-name-
+prefix case, idempotence).
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6823,6 +6823,51 @@ matches a bracket-containing string), so `"const int [3]"` and `"const int
 strings until the decay result was re-canonicalized a second time. Fixed
 in the same commit; `test_element_cv_becomes_pointee_cv` pins it.
 
+**Correction (2026-08-29, same day, eighth Codex review round on PR #941,
+commit 572de14): a parenthesized declarator's own outer pointer skipped
+by-value cv stripping entirely.** The sigil-scan treated every `(` as a
+real nesting level, so a cv-qualifier written inside a declarator's own
+grouping parens -- `void (* const)(int)` (a callback parameter: "const
+pointer to a function taking int"), or `int (* const)[3]` (a const
+pointer to an array of 3 ints) -- was never found at depth 0 and so never
+stripped, even though it qualifies the parameter's own outermost pointer
+exactly like an unparenthesized `int * const` does. Fixed by making an
+opening `(` "transparent" (not a real nesting level) whenever the next
+non-space character is `*`/`&` -- the one shape a real function-parameter-
+list paren can never have, since a parameter list's first token is always
+a type, never a bare sigil. This also reaches the previously-unchanged
+pointer-to-array case (`int (*)[3]`) the same way: its own outermost
+pointer's cv-qualifier, once one exists, is by-value too, while the
+trailing array bound inside the parens (the pointee's own shape) stays
+untouched exactly as before. Also removed `_has_top_level_ptr_or_ref`,
+a leftover private helper from an earlier revision of this module that had
+become genuinely dead code -- the array/pointer-shape detection it
+described was already reimplemented inline at each of its two call sites
+during earlier correction rounds, and nothing in this module or its tests
+called it. Four new tests in `tests/test_signature_normalization.py`
+(`TestParenthesizedDeclaratorOwnCvIsDropped`) pin both the fix and that the
+callback/pointee's own inner types stay untouched.
+
+A second finding from the same round -- that a raw, platform-decorated PE
+export name (`_foo@4` for an `extern "C"` `foo`) reaching this module's
+`is_extern_c` branch as `leaf_name` would fragment identity against an
+undecorated header/DWARF observation of the same symbol -- was investigated
+and NOT fixed here. `entity_id_for_function`'s docstring already states
+this branch is deliberately built to mirror `resolve_symbol_identity`'s own
+representation, and that resolver has the identical property: it also
+keys a non-`_Z`/`?` `mangled` value on its literal raw spelling, undecorated
+(`finding_identity.py`'s own `normalized_basis = mangled if (mangled and
+not real_mangled) else qn` never strips a stdcall/cdecl decoration either).
+This module's stated contract is to *match* that resolver's own chosen
+representation for evidence-tier scope/leaf-name handling, not to invent a
+new normalization capability the mirrored function doesn't have -- and no
+PE-decoration-stripping helper exists anywhere else in the codebase to
+reuse. Introducing one is a real, valid gap worth closing, but it is a
+separate design question (most naturally `pe_metadata.py`'s own extraction
+layer, where the platform's decoration convention is already known, not
+this identity primitive) and out of scope for this "purely additive,
+mirrors the existing resolver" first slice.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -7319,6 +7319,32 @@ parameter, an ordinary namespace qualifier staying unaffected, the
 anonymous-namespace regression pin, the member-pointer qualified-name-
 prefix case, idempotence).
 
+**Correction (2026-08-29, same day, twentieth Codex review round on PR
+#941, commit 2a14e2e): the seventeenth round's own "does prefix already
+carry a calling-convention keyword" check used a bare substring test,
+which a coincidentally-named return type defeats.** `any(cc in prefix
+for cc in _CALLING_CONVENTIONS)` matches whenever any of the five
+keyword strings appears ANYWHERE in `prefix` -- but `prefix` also
+contains the return type, which can legitimately CONTAIN one of these
+keywords as a substring of an unrelated identifier, e.g.
+`my__cdecl_result`. For `my__cdecl_result (*)(int)
+__attribute__((stdcall))`, the substring test wrongly concluded a
+convention keyword was already present (matching `__cdecl` inside
+`my__cdecl_result`), which both skipped injecting the REAL `__stdcall`
+keyword AND still stripped the trailing attribute text -- silently
+merging two distinct callback types (one genuinely `__stdcall`, one with
+no calling convention at all) into one identity. Fixed with a new
+`_CALLING_CONVENTION_KEYWORD_RE`, matched as a genuine whole token
+positioned immediately after the declarator's own opening paren
+(allowing leading whitespace, mirroring exactly where
+`_is_declarator_group`/`_CALLING_CONVENTIONS` themselves look for a
+convention keyword) rather than a substring test anywhere in `prefix`.
+New tests: a doctest plus
+`test_return_type_containing_convention_keyword_as_substring` in
+`TestClangTrailingCallingConventionAttributeUnifies` (asserting both the
+correct injected keyword AND non-collision with the convention-free
+form).
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6433,6 +6433,94 @@ exists in the repository after this phase, in `model/identity.py` —
 shows no regression (a net-new suppressed finding from the identity
 change is a Phase 2 bug, not acceptable drift).
 
+**Landed (first slice, 2026-08-29), not the whole phase — read this before
+assuming the Design section above is fully implemented.**
+`abicheck/model/identity.py` is real: the five `ScopeSegment` types
+(`Namespace`, `Record`, `InlineNamespace`, `Anonymous`, `LocalToFunction`)
+with exactly the identity-vs-payload field split the Design section states
+(`Record.access` excluded from equality/hash via `field(compare=False)`,
+every other segment's fields all participate), the corrected `EntityId`
+shape (`scope`, `kind`, `leaf_name`, `extra`), and `entity_id_for_type`/
+`_enum`/`_typedef`/`_constant`/`_variable`/`_function` constructors
+implementing the function/variable discriminator rules (mangled name first
+when the caller has already established it is genuine, normalized
+param-type/cv-qualifier fallback otherwise — both branches tagged
+(`"mangled"`/`"sig"`) so they occupy disjoint regions of `extra`'s value
+space and can never collide with each other by coincidence).
+`EntityKind`/`ObservationKind` are relocated from `storage/entity_ids.py`
+into this module and re-exported from there under their original names, so
+`storage.entity_ids.EntityKind is model.identity.EntityKind` — that one
+acceptance criterion is closed now, ahead of the rest of the phase.
+Primitive-level property tests in `tests/test_model_identity.py` (not
+`tests/test_entity_identity.py` as this phase's own "Tests" section named —
+that file was already taken, by the unrelated ADR-048/G31
+`buildsource.entity_identity` L5 primitive; corrected here rather than
+silently reusing the wrong name) pin: `Record.access` never affects
+equality/hash; `Anonymous`/`InlineNamespace`/`LocalToFunction` are identity
+on every field; a record nested in a record never collides with the same
+bare names nested in a namespace (the exact collision a `qualified_name`-
+only identity cannot distinguish, since both render to `"A::B"`); sibling
+declarations of the same kind in one scope never collide (enums, typedefs,
+constants, and the two function-overload shapes named in the Tests
+section — `f(int)` vs. `f(double)`, `void f()` vs. `void f() const`);
+`extern "C"`-shaped input (a genuine mangled name present) ignores param
+types, matching `finding_identity.resolve_function_identity`'s own
+documented rule; and the relocation itself, including a hashability check
+per segment and a real AST-based (not substring) leaf-module-import check
+per ADR-063 D10. Full fast unit suite green; storage's own existing test
+suite (1421 tests) re-run clean against the relocated enums; `mypy
+abicheck/` and `ruff` both clean.
+
+**What this slice deliberately does not attempt, and why** — both of Phase
+2's own named open design questions are still open, on purpose:
+
+1. *No `ScopePath` is derived from a real parser yet.* Every
+   `entity_id_for_*` constructor takes an already-built `ScopePath` as
+   input; none of them reach into `dumper_clang.py`'s/`dumper_castxml.py`'s
+   `entry.scope` (still a bare `list[str]`, exactly as insufficient as the
+   Design section found it). Widening that parser state is real,
+   separately-reviewable work of its own — this slice does not touch either
+   dumper module.
+2. *The carrier-field question (option (a) vs. (b)) is still unresolved,*
+   because nothing yet needs it resolved: with no real `ScopePath` producer
+   wired up, there is nothing for a post-parse consumer
+   (`diff_filtering.py`'s `_find_opaque_types` and siblings,
+   `type_reachability.py`) to migrate onto yet, so this slice does not touch
+   either of them, and their existing string-based ambiguity-tracking
+   machinery is untouched and still the one working implementation. Per this
+   phase's own acceptance criteria, deleting them now — before either option
+   is chosen and actually wired — would be strictly worse, not a shortcut.
+3. *`finding_identity.py` does not delegate to this module yet.* The
+   "direction of reuse" note above is correct about where the algorithm
+   should end up, but `finding_identity.is_real_mangled_name`/
+   `normalize_mangled_name` (the ~450-line, independently multi-round-
+   reviewed Itanium-mangling-validation machinery that decides whether a
+   caller-supplied `mangled_name` is genuine) has not moved. This slice's
+   `entity_id_for_function`/`entity_id_for_variable` instead take that
+   determination as an already-resolved `mangled_name: str | None` argument
+   from the caller, documented in the module's own docstring as a
+   deliberate scope boundary rather than an oversight. Migrating that
+   validation logic, and turning `resolve_function_identity`/
+   `resolve_variable_identity` into thin wrappers, is real follow-on work
+   this slice intentionally leaves for its own dedicated, independently
+   reviewable pass — not attempted here to keep this slice small enough to
+   review on its own, matching how every other phase's own first slice in
+   this plan has been landed one piece at a time.
+4. *No storage v2 wire-schema bridge (`to_dto`/`from_dto`) exists yet.*
+   `storage.entity_ids.EntityId`/`OccurrenceId` are completely unchanged
+   beyond the two enum imports — `model.identity.EntityId` and
+   `storage.entity_ids.EntityId` are two independent types today, which the
+   Design section's own note names as the accepted, temporary state until a
+   later slice does the `ScopePath`-preserving v2 encoding it specifies.
+
+Next slice, in order: (a) widen `entry.scope` in both dumper modules to a
+typed segment list (this is the fork point for the carrier-field question —
+see the Design section's own framing of why it can't be answered
+independently of that work), then (b) migrate `diff_filtering.py`/
+`type_reachability.py` once a real producer exists, then (c) the
+`finding_identity.py` algorithm migration and the storage v2 wire bridge,
+each as their own reviewable slice.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -6678,6 +6678,52 @@ losslessly, so nothing is lost. Four new tests (two per constructor) pin
 that a demangled-short-name observation and a raw-symbol-reused-as-name
 observation of the identical mangled symbol now produce one `EntityId`.
 
+**Correction (2026-08-29, same day, fifth Codex review round on PR #941,
+commit 4ad03da): two real gaps in the `sig` fallback's own signature
+normalization, one requiring a genuinely new, carefully-scoped
+primitive rather than reuse of an existing one.** (1) `param_types` were
+canonicalized only for cross-producer *spelling* (via
+`canonicalize_type_name`), not for the C++-standard-mandated fact that a
+top-level BY-VALUE cv-qualifier is dropped from a function's own type for
+linkage/mangling purposes -- `void f(int)` and `void f(const int)` name
+the identical function, but `"int"` and `"const int"` canonicalize to
+different strings and collided as two overloads. **The naive fix --
+reusing this codebase's existing `_strip_cv_qualifiers`/
+`func_signature_cv_only_differ` (the primitive an initial attempt reached
+for, since Codex's own finding named it) -- was investigated and found to
+be wrong, not merely reused:** that helper is deliberately permissive at
+the true top level, stripping a *pointee* cv-qualifier too (`"const char
+*"` -> `"char *"`), because its actual job is "is this an already-
+positionally-matched declaration's param change worth reporting as ABI-
+breaking" (`diff_symbols._params_differ`'s question) -- a *different*
+question from this primitive's, "are these the same overload for identity
+purposes." A pointee cv-qualifier on a pointer/reference parameter is a
+genuine, standard-mandated overload discriminator (`void f(char*)` and
+`void f(const char*)` are two simultaneously-declarable, independently-
+mangled overloads), so reusing the permissive helper verbatim would have
+silently merged two distinct functions into one identity -- reintroducing
+exactly the sibling-overload-collision class this whole primitive exists
+to prevent, while fixing the narrower problem Codex actually named. Fixed
+correctly instead: a new, narrower public primitive,
+`name_classification.canonicalize_function_signature_type`, strips a cv
+token only when the canonicalized type carries no top-level pointer/
+reference sigil at all (checked via the same `_has_top_level_ptr_or_ref`
+helper `cv_qualifiers_only_differ` already uses) -- the one case where
+every cv token found is unambiguously by-value, never pointee, cv. (2)
+`cv_qualifiers: tuple[str, ...]` was itself the wrong representation:
+unlike `resolve_function_identity`'s own `func.is_const`/
+`func.is_volatile` booleans, a caller-supplied token tuple invites order-
+dependence for one member-cv qualification spelled two ways (`("const",
+"volatile")` vs. `("volatage", "const")` -- caught named literally as
+`f() const volatile` vs. `f() volatile const`). Fixed by replacing the
+parameter with `is_const: bool = False, is_volatile: bool = False`,
+matching `resolve_function_identity`'s own representation exactly and
+eliminating the ordering question by construction rather than by
+normalizing a tuple after the fact. Six new tests pin both fixes: by-value
+top-level cv non-distinction, pointee cv's continued distinguishing power,
+independent const/volatile discrimination, and that the two booleans'
+call-site order cannot affect the resulting id.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/tests/test_declarator_qualifiers.py
+++ b/tests/test_declarator_qualifiers.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 2: direct primitive-level tests for
+``model.declarator_qualifiers``, the sibling leaf module
+``model.signature_normalization`` was split into (fifteenth Codex/
+CodeRabbit review round on PR #941) once it hit the AI-readiness gate's
+800-line production maximum.
+
+``tests/test_signature_normalization.py`` already exercises every function
+here indirectly through ``canonicalize_function_signature_param_type``'s own
+doctests and test classes; this file pins each moved primitive's own
+contract directly, mirroring ``test_signature_normalization.py``'s own
+"Primitive-level property tests" rationale -- these functions are reusable
+declarator-scanning primitives in their own right, not merely private
+implementation details of one caller.
+"""
+
+from __future__ import annotations
+
+from abicheck.model import declarator_qualifiers
+from abicheck.model.declarator_qualifiers import (
+    _canonicalize_member_qualifiers,
+    _find_member_pointer_qualifier,
+    _is_declarator_group,
+    _split_at_trailing_param_list,
+)
+
+
+class TestIsDeclaratorGroup:
+    """A declarator-grouping paren's content -- an optional calling-
+    convention keyword, then a qualified-name prefix, then a bare
+    ``*``/``&`` sigil -- as opposed to an opaque parameter-list paren."""
+
+    def test_bare_pointer_sigil_is_a_group(self) -> None:
+        assert _is_declarator_group("*)(int)", 0) is True
+
+    def test_bare_reference_sigil_is_a_group(self) -> None:
+        assert _is_declarator_group("&)(int)", 0) is True
+
+    def test_qualified_member_pointer_prefix_is_a_group(self) -> None:
+        assert _is_declarator_group("C::*)(int)", 0) is True
+
+    def test_chained_namespace_prefix_is_a_group(self) -> None:
+        assert _is_declarator_group("ns::C::*)(int)", 0) is True
+
+    def test_template_id_prefix_is_a_group(self) -> None:
+        assert _is_declarator_group("C<int>::*)(int)", 0) is True
+
+    def test_calling_convention_keyword_is_a_group(self) -> None:
+        assert _is_declarator_group("__cdecl *)(int)", 0) is True
+
+    def test_ordinary_parameter_list_is_not_a_group(self) -> None:
+        # A real parameter list's first token is a type, never immediately
+        # followed by "::" then only a bare sigil.
+        assert _is_declarator_group("int, char)", 0) is False
+
+    def test_unmatched_template_bracket_is_not_a_group(self) -> None:
+        assert _is_declarator_group("C<int::*)(int)", 0) is False
+
+
+class TestFindMemberPointerQualifier:
+    """A bare, non-parenthesized data-member-pointer's own qualified-name
+    prefix, detected via the ``":: "`` (colon-colon-space) marker that
+    ``canonicalize_type_name`` uniquely produces for it."""
+
+    def test_simple_class_qualifier_found(self) -> None:
+        span = _find_member_pointer_qualifier("int C:: *")
+        assert span is not None
+        start, end = span
+        assert "int C:: *"[start:end] == "C::"
+
+    def test_chained_namespace_qualifier_found(self) -> None:
+        span = _find_member_pointer_qualifier("int ns::C:: *")
+        assert span is not None
+        start, end = span
+        assert "int ns::C:: *"[start:end] == "ns::C::"
+
+    def test_ordinary_namespace_qualified_pointer_not_found(self) -> None:
+        # No space follows "::" in ordinary namespace-qualified spelling
+        # (e.g. "ns::Foo"), so this must not match.
+        assert _find_member_pointer_qualifier("ns::Foo *") is None
+
+    def test_non_sigil_suffix_not_found(self) -> None:
+        assert _find_member_pointer_qualifier("int C::x") is None
+
+    def test_empty_prefix_not_found(self) -> None:
+        assert _find_member_pointer_qualifier("") is None
+
+
+class TestSplitAtTrailingParamList:
+    def test_splits_at_top_level_paren(self) -> None:
+        assert _split_at_trailing_param_list("(int)") == ("", "(int)")
+
+    def test_splits_with_head_text(self) -> None:
+        assert _split_at_trailing_param_list(" const(int)") == (
+            " const",
+            "(int)",
+        )
+
+    def test_no_top_level_paren_returns_none(self) -> None:
+        assert _split_at_trailing_param_list(" const") is None
+
+
+class TestCanonicalizeMemberQualifiers:
+    def test_empty_stays_empty(self) -> None:
+        assert _canonicalize_member_qualifiers("") == ""
+
+    def test_reorders_cv(self) -> None:
+        assert _canonicalize_member_qualifiers(
+            " volatile const"
+        ) == _canonicalize_member_qualifiers(" const volatile")
+
+    def test_noexcept_preserved(self) -> None:
+        assert _canonicalize_member_qualifiers(" noexcept") == "noexcept"
+
+    def test_noexcept_true_and_bare_unify(self) -> None:
+        assert _canonicalize_member_qualifiers(
+            " noexcept(true)"
+        ) == _canonicalize_member_qualifiers(" noexcept")
+
+    def test_noexcept_false_drops_to_nothing(self) -> None:
+        assert _canonicalize_member_qualifiers(" noexcept(false)") == ""
+
+    def test_non_literal_noexcept_expression_left_untouched(self) -> None:
+        assert (
+            _canonicalize_member_qualifiers(" noexcept(Foo<const int>)")
+            == "noexcept(Foo<const int>)"
+        )
+
+
+def test_module_declares_no_dependency_above_model() -> None:
+    """Leaf-module contract (ADR-063 D10): ``model.declarator_qualifiers``
+    imports nothing from ``checker_types``/``diff_*``/anything above
+    ``model`` -- the same contract ``model.identity`` and
+    ``model.signature_normalization`` themselves state, checked the
+    identical way -- against the module's real ``import``/
+    ``from ... import`` AST nodes, not a substring scan."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(declarator_qualifiers))
+    banned_prefixes = (
+        "checker_types",
+        "diff_",
+        "checker",
+        "compare",
+        "finding_identity",
+    )
+    imported_names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_names.append(node.module)
+    for name in imported_names:
+        bare = name.lstrip(".")
+        assert not bare.startswith(banned_prefixes), name

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -288,6 +288,58 @@ class TestSiblingKindsNeverCollide:
         assert entity_id_for_type(scope, "A") != entity_id_for_constant(scope, "A")
 
 
+class TestAnonymousDeclarationSelfIdentity:
+    """The Codex-flagged gap: ScopePath names only the *containing* scope,
+    never the leaf declaration itself, so two anonymous sibling records/
+    enums both passing leaf_name="" would otherwise collide onto one
+    EntityId regardless of which one is meant -- distinct from
+    Anonymous.ordinal, which disambiguates a *descendant's* containing
+    scope, not the anonymous declaration itself."""
+
+    @given(ordinal_a=_ordinals, ordinal_b=_ordinals)
+    def test_distinct_anonymous_types_never_collide(
+        self, ordinal_a: int, ordinal_b: int
+    ) -> None:
+        if ordinal_a == ordinal_b:
+            return
+        scope = (Namespace("ns"),)
+        a = entity_id_for_type(scope, "", anonymous_ordinal=ordinal_a)
+        b = entity_id_for_type(scope, "", anonymous_ordinal=ordinal_b)
+        assert a != b
+
+    @given(ordinal_a=_ordinals, ordinal_b=_ordinals)
+    def test_distinct_anonymous_enums_never_collide(
+        self, ordinal_a: int, ordinal_b: int
+    ) -> None:
+        if ordinal_a == ordinal_b:
+            return
+        scope = (Namespace("ns"),)
+        a = entity_id_for_enum(scope, "", anonymous_ordinal=ordinal_a)
+        b = entity_id_for_enum(scope, "", anonymous_ordinal=ordinal_b)
+        assert a != b
+
+    def test_without_anonymous_ordinal_still_collides_as_before(self) -> None:
+        # Documented, deliberate: anonymous_ordinal is opt-in (no wired
+        # producer yet, mirroring this module's own scope boundary for
+        # LocalToFunction/Anonymous before their producers existed) -- a
+        # caller that omits it gets the pre-existing degenerate behavior,
+        # not a silent, unrequested change.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_type(scope, "")
+        b = entity_id_for_type(scope, "")
+        assert a == b
+
+    def test_anonymous_ordinal_ignored_for_a_named_declaration(self) -> None:
+        # Only meaningful when leaf_name is empty -- a named declaration
+        # already disambiguates via leaf_name, so a caller that supplies
+        # both must not get a spurious extra discriminator.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_type(scope, "Widget", anonymous_ordinal=0)
+        b = entity_id_for_type(scope, "Widget", anonymous_ordinal=1)
+        assert a == b
+        assert a == entity_id_for_type(scope, "Widget")
+
+
 # --------------------------------------------------------------------------
 # Function overload discrimination
 # --------------------------------------------------------------------------
@@ -543,6 +595,18 @@ class TestFunctionOverloadDiscrimination:
         mutable_ptr = entity_id_for_function(scope, "f", param_types=("char *",))
         const_ptr = entity_id_for_function(scope, "f", param_types=("const char *",))
         assert mutable_ptr != const_ptr
+
+    def test_array_parameter_element_cv_still_distinguishes_overloads(self) -> None:
+        # The Codex-flagged gap: a function PARAMETER's array type always
+        # decays to a pointer (int[] -> int*), so a cv-qualifier on the
+        # element type is pointee-level, exactly like an explicit pointer
+        # -- void f(int[]) and void f(const int[]) are two distinct,
+        # independently-mangled overloads. Neither spelling contains a
+        # "*"/"&" sigil, so this must not be treated as a by-value type.
+        scope = (Namespace("ns"),)
+        mutable_array = entity_id_for_function(scope, "f", param_types=("int []",))
+        const_array = entity_id_for_function(scope, "f", param_types=("const int []",))
+        assert mutable_array != const_array
 
 
 class TestVariableMangledDiscriminator:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 2 (first slice): ``ScopePath``/``EntityId`` primitive.
+
+Note this file is deliberately named ``test_model_identity.py``, not
+``test_entity_identity.py`` as the plan doc's Phase 2 "Tests" section names
+it -- ``tests/test_entity_identity.py`` already exists, for the unrelated
+ADR-048/G31 ``buildsource.entity_identity`` (L5 source-graph, USR-based)
+primitive. The plan doc is corrected to match in the same commit that adds
+this file.
+
+Scope of this slice (see ``abicheck/model/identity.py``'s own module
+docstring for the two open design questions deliberately left for a later
+slice): pins the identity-vs-payload contract for each ``ScopePath``
+segment type, and the "no bare ``(scope, kind)``" collision contract for
+``EntityId`` -- both are correctness properties, not example-shaped
+behavior, so most of this file is Hypothesis-driven per AGENTS.md's
+"Primitive-level property tests" convention rather than fixed examples.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from abicheck.model import identity as model_identity
+from abicheck.model.identity import (
+    Anonymous,
+    EntityKind,
+    InlineNamespace,
+    LocalToFunction,
+    Namespace,
+    ObservationKind,
+    Record,
+    entity_id_for_constant,
+    entity_id_for_enum,
+    entity_id_for_function,
+    entity_id_for_type,
+    entity_id_for_typedef,
+    entity_id_for_variable,
+)
+from abicheck.storage import entity_ids as storage_entity_ids
+
+# --------------------------------------------------------------------------
+# EntityKind/ObservationKind relocation
+# --------------------------------------------------------------------------
+
+
+class TestRelocatedVocabulary:
+    """Exactly one ``EntityKind``/``ObservationKind`` exists in the
+    repository after this slice -- ``storage.entity_ids`` imports rather
+    than redefines them (acceptance criterion from the plan's Phase 2
+    section, testable now even though the rest of that phase is not yet
+    landed)."""
+
+    def test_storage_entity_kind_is_the_same_object(self) -> None:
+        assert storage_entity_ids.EntityKind is EntityKind
+
+    def test_storage_observation_kind_is_the_same_object(self) -> None:
+        assert storage_entity_ids.ObservationKind is ObservationKind
+
+    def test_storage_wire_entity_id_still_works_with_relocated_kind(self) -> None:
+        # storage.entity_ids.EntityId is the pre-existing wire DTO, unrelated
+        # to model.identity.EntityId (this slice does not bridge the two —
+        # see identity.py's module docstring). Confirms the relocation is
+        # purely additive from the wire type's point of view.
+        wire_id = storage_entity_ids.EntityId(
+            kind=EntityKind.FUNCTION, qualified_name="ns::f", discriminator="_Z1fv"
+        )
+        assert wire_id.kind is EntityKind.FUNCTION
+        round_tripped = storage_entity_ids.EntityId.from_dict(wire_id.to_dict())
+        assert round_tripped == wire_id
+
+
+# --------------------------------------------------------------------------
+# Segment identity-vs-payload contracts
+# --------------------------------------------------------------------------
+
+_names = st.text(
+    min_size=1, max_size=12, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
+)
+_accesses = st.sampled_from(["", "public", "protected", "private"])
+_kinds = st.sampled_from(["struct", "union", "enum", "namespace"])
+_ordinals = st.integers(min_value=0, max_value=1000)
+
+
+class TestRecordAccessIsNotIdentity:
+    """``Record.access`` is payload, not identity -- an access-level change
+    alone must never look like a different containing scope."""
+
+    @given(name=_names, access_a=_accesses, access_b=_accesses)
+    def test_equal_regardless_of_access(
+        self, name: str, access_a: str, access_b: str
+    ) -> None:
+        a = Record(name=name, access=access_a)
+        b = Record(name=name, access=access_b)
+        assert a == b
+        assert hash(a) == hash(b)
+
+    @given(name_a=_names, name_b=_names, access=_accesses)
+    def test_distinct_names_never_equal(
+        self, name_a: str, name_b: str, access: str
+    ) -> None:
+        if name_a == name_b:
+            return
+        assert Record(name=name_a, access=access) != Record(name=name_b, access=access)
+
+    def test_access_is_preserved_on_the_instance(self) -> None:
+        # Payload, not identity, but not discarded either — a consumer that
+        # wants to know the access level of a nested scope still can.
+        rec = Record(name="Inner", access="private")
+        assert rec.access == "private"
+
+
+class TestAnonymousOrdinalIsIdentity:
+    """Both fields of ``Anonymous`` are identity -- nothing else
+    disambiguates two sibling anonymous scopes."""
+
+    @given(kind=_kinds, ordinal_a=_ordinals, ordinal_b=_ordinals)
+    def test_distinct_ordinal_never_equal(
+        self, kind: str, ordinal_a: int, ordinal_b: int
+    ) -> None:
+        if ordinal_a == ordinal_b:
+            return
+        assert Anonymous(kind=kind, ordinal=ordinal_a) != Anonymous(
+            kind=kind, ordinal=ordinal_b
+        )
+
+    @given(kind=_kinds, ordinal=_ordinals)
+    def test_same_kind_and_ordinal_equal(self, kind: str, ordinal: int) -> None:
+        assert Anonymous(kind=kind, ordinal=ordinal) == Anonymous(
+            kind=kind, ordinal=ordinal
+        )
+
+
+class TestInlineNamespaceVersionTagIsIdentity:
+    """ADR-025's own versioned-inline-namespace-alias handling keys on
+    ``version_tag`` -- it must stay part of identity here."""
+
+    @given(name=_names, tag_a=_names, tag_b=_names)
+    def test_distinct_version_tag_never_equal(
+        self, name: str, tag_a: str, tag_b: str
+    ) -> None:
+        if tag_a == tag_b:
+            return
+        assert InlineNamespace(name=name, version_tag=tag_a) != InlineNamespace(
+            name=name, version_tag=tag_b
+        )
+
+
+class TestLocalToFunctionOwnerIsIdentity:
+    @given(owner_a=_names, owner_b=_names)
+    def test_distinct_owner_never_equal(self, owner_a: str, owner_b: str) -> None:
+        if owner_a == owner_b:
+            return
+        assert LocalToFunction(owner=owner_a) != LocalToFunction(owner=owner_b)
+
+
+class TestSegmentsAreHashable:
+    """Every segment type is usable as a dict key / set member -- ``scope``
+    lives inside a frozen, hashable ``EntityId``, so every segment it can
+    hold must itself be hashable."""
+
+    def test_all_segment_kinds_hashable(self) -> None:
+        segments = [
+            Namespace(name="ns"),
+            Record(name="C", access="private"),
+            InlineNamespace(name="v1", version_tag="v1"),
+            Anonymous(kind="struct", ordinal=0),
+            LocalToFunction(owner="f"),
+        ]
+        as_set = set(segments)
+        assert len(as_set) == len(segments)
+
+
+# --------------------------------------------------------------------------
+# EntityId: no bare (scope, kind) collision
+# --------------------------------------------------------------------------
+
+
+class TestDistinctScopesNeverCollide:
+    """Two distinct declarations in different namespaces never collide
+    regardless of bare-name overlap."""
+
+    def test_same_leaf_name_different_namespace(self) -> None:
+        a = entity_id_for_type((Namespace("a"),), "Widget")
+        b = entity_id_for_type((Namespace("b"),), "Widget")
+        assert a != b
+
+    def test_record_nested_in_record_vs_namespace(self) -> None:
+        # A record nested in a record vs. the same bare names nested in a
+        # namespace — the exact collision `qualified_name`-only identity
+        # (a `"::".join`) cannot distinguish, since both render to "A::B".
+        in_record = entity_id_for_type((Record("A"), Record("B")), "C")
+        in_namespace = entity_id_for_type((Namespace("A"), Namespace("B")), "C")
+        assert in_record != in_namespace
+
+
+class TestSiblingKindsNeverCollide:
+    """A bare ``(scope, kind)`` id would collide any two sibling
+    declarations of the same kind and scope -- pinned per kind."""
+
+    @given(name_a=_names, name_b=_names)
+    def test_two_enums_same_scope(self, name_a: str, name_b: str) -> None:
+        if name_a == name_b:
+            return
+        scope = (Namespace("ns"),)
+        assert entity_id_for_enum(scope, name_a) != entity_id_for_enum(scope, name_b)
+
+    @given(name_a=_names, name_b=_names)
+    def test_two_typedefs_same_scope(self, name_a: str, name_b: str) -> None:
+        if name_a == name_b:
+            return
+        scope = (Namespace("ns"),)
+        assert entity_id_for_typedef(scope, name_a) != entity_id_for_typedef(
+            scope, name_b
+        )
+
+    @given(name_a=_names, name_b=_names)
+    def test_two_constants_same_scope(self, name_a: str, name_b: str) -> None:
+        if name_a == name_b:
+            return
+        scope = (Namespace("ns"),)
+        assert entity_id_for_constant(scope, name_a) != entity_id_for_constant(
+            scope, name_b
+        )
+
+    def test_different_kinds_same_scope_and_name_never_collide(self) -> None:
+        # ns::A the type vs. ns::A the constant — legal to coexist in some
+        # producer's raw output even if not in valid C++ (a robust identity
+        # scheme should not rely on the source language to keep this safe).
+        scope = (Namespace("ns"),)
+        assert entity_id_for_type(scope, "A") != entity_id_for_constant(scope, "A")
+
+
+# --------------------------------------------------------------------------
+# Function overload discrimination
+# --------------------------------------------------------------------------
+
+
+class TestFunctionOverloadDiscrimination:
+    """The counterexample this design was built to close: two overloads
+    sharing one ``ScopePath`` must always produce distinct ``EntityId``s."""
+
+    def test_f_int_vs_f_double(self) -> None:
+        scope = (Namespace("ns"),)
+        f_int = entity_id_for_function(scope, "f", param_types=("int",))
+        f_double = entity_id_for_function(scope, "f", param_types=("double",))
+        assert f_int != f_double
+
+    def test_const_vs_non_const_overload(self) -> None:
+        scope = (Record("C"),)
+        plain = entity_id_for_function(scope, "f", cv_qualifiers=())
+        const = entity_id_for_function(scope, "f", cv_qualifiers=("const",))
+        assert plain != const
+
+    def test_different_scope_same_name_never_collides_with_mangled_sig_tag(
+        self,
+    ) -> None:
+        # The ("mangled", ...) / ("sig", ...) tag makes the two branches
+        # occupy disjoint regions of `extra`'s value space — a mangled name
+        # that happens to equal some other function's literal param-type
+        # spelling must not collide with it.
+        scope = (Namespace("ns"),)
+        mangled = entity_id_for_function(scope, "f", mangled_name="int")
+        sig = entity_id_for_function(scope, "f", param_types=("int",))
+        assert mangled != sig
+
+    def test_mangled_name_present_ignores_param_types(self) -> None:
+        # extern "C": a changed parameter list is a modification of the one
+        # function, not a different overload, once a genuine mangled name is
+        # known.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_function(scope, "f", mangled_name="f", param_types=("int",))
+        b = entity_id_for_function(
+            scope, "f", mangled_name="f", param_types=("double", "int")
+        )
+        assert a == b
+
+    def test_distinct_mangled_names_never_collide(self) -> None:
+        scope = (Namespace("ns"),)
+        a = entity_id_for_function(scope, "f", mangled_name="_Z1fi")
+        b = entity_id_for_function(scope, "f", mangled_name="_Z1fd")
+        assert a != b
+
+
+class TestVariableMangledDiscriminator:
+    def test_distinct_mangled_names_never_collide(self) -> None:
+        scope = (Namespace("ns"),)
+        a = entity_id_for_variable(scope, "v", mangled_name="_ZN2ns1vE_v1")
+        b = entity_id_for_variable(scope, "v", mangled_name="_ZN2ns1vE_v2")
+        assert a != b
+
+    def test_absent_mangled_name_is_the_documented_degenerate_case(self) -> None:
+        # Two variables sharing scope+leaf name with no mangled evidence at
+        # all collapse to one EntityId — documented, deliberate (mirrors
+        # AGENTS.md's own SymbolIdentityIndex note: "variables enable no
+        # alias tier at all"), not silently accidental.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_variable(scope, "v")
+        b = entity_id_for_variable(scope, "v")
+        assert a == b
+
+
+# --------------------------------------------------------------------------
+# "Computed once" == one algorithm, not cached identity
+# --------------------------------------------------------------------------
+
+
+class TestPureFunctionOfInputs:
+    """Calling a constructor twice with value-equal-but-not-identical
+    inputs produces an equal ``EntityId`` -- "computed once" means one
+    algorithm called the same way everywhere, not a value cached on any
+    object (per this module's own docstring and the plan's framing note)."""
+
+    def test_list_vs_tuple_scope_argument(self) -> None:
+        as_list = [Namespace("a"), Record("B")]
+        as_tuple = (Namespace("a"), Record("B"))
+        assert entity_id_for_type(as_list, "C") == entity_id_for_type(as_tuple, "C")
+
+    def test_two_freshly_constructed_scopes_compare_equal(self) -> None:
+        a = entity_id_for_function(
+            (Namespace("ns"), Record("C")), "f", param_types=("int",)
+        )
+        b = entity_id_for_function(
+            (Namespace("ns"), Record("C")), "f", param_types=("int",)
+        )
+        assert a == b
+        assert hash(a) == hash(b)
+
+
+def test_entity_id_is_hashable() -> None:
+    eid = entity_id_for_function((Namespace("ns"),), "f", param_types=("int",))
+    hash(eid)  # must not raise
+    assert eid in {eid}
+
+
+def test_module_declares_no_dependency_above_model() -> None:
+    """Leaf-module contract (ADR-063 D10): ``model.identity`` imports
+    nothing from ``checker_types``/``diff_*``/anything above ``model`` —
+    checked against the module's real ``import``/``from ... import`` AST
+    nodes, not a substring scan of its source text (which would also match
+    the module's own explanatory prose about what it deliberately avoids)."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(model_identity))
+    banned_prefixes = (
+        "checker_types",
+        "diff_",
+        "checker",
+        "compare",
+        "finding_identity",
+    )
+    imported_names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_names.append(node.module)
+    for name in imported_names:
+        bare = name.lstrip(".")
+        assert not bare.startswith(banned_prefixes), name

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -300,13 +300,22 @@ class TestFunctionOverloadDiscrimination:
         assert mangled != sig
 
     def test_mangled_name_present_ignores_param_types(self) -> None:
-        # extern "C": a changed parameter list is a modification of the one
-        # function, not a different overload, once a genuine mangled name is
-        # known.
+        # A changed parameter list is a modification of the one function,
+        # not a different overload, once a genuine mangled name is known --
+        # the mangled name already disambiguates the declaration losslessly.
+        # Uses a mangled-shaped name ("_Z1fv"), not a bare name equal to
+        # leaf_name -- that degenerate case is exactly what a real
+        # extern "C" producer reports (mangled == name is *not* a genuine
+        # mangling per this module's own contract) and is covered
+        # separately by TestFunctionOverloadDiscrimination's own
+        # test_extern_c_ignores_param_types via is_extern_c, not by
+        # mangled_name (CodeRabbit review, PR #941).
         scope = (Namespace("ns"),)
-        a = entity_id_for_function(scope, "f", mangled_name="f", param_types=("int",))
+        a = entity_id_for_function(
+            scope, "f", mangled_name="_Z1fv", param_types=("int",)
+        )
         b = entity_id_for_function(
-            scope, "f", mangled_name="f", param_types=("double", "int")
+            scope, "f", mangled_name="_Z1fv", param_types=("double", "int")
         )
         assert a == b
 

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -608,6 +608,40 @@ class TestFunctionOverloadDiscrimination:
         const_array = entity_id_for_function(scope, "f", param_types=("const int []",))
         assert mutable_array != const_array
 
+    def test_array_bound_does_not_distinguish_overloads(self) -> None:
+        # Fresh Codex finding: int [], int [3], int [4], and int * are all
+        # the identical adjusted parameter type -- the bound plays no part
+        # in it at all -- so redeclarations spelled with different bounds
+        # must produce ONE EntityId, not four.
+        scope = (Namespace("ns"),)
+        no_bound = entity_id_for_function(scope, "f", param_types=("int []",))
+        bound_3 = entity_id_for_function(scope, "f", param_types=("int [3]",))
+        bound_4 = entity_id_for_function(scope, "f", param_types=("int [4]",))
+        plain_ptr = entity_id_for_function(scope, "f", param_types=("int *",))
+        assert no_bound == bound_3 == bound_4 == plain_ptr
+
+    def test_pointers_own_top_level_cv_does_not_distinguish_overloads(self) -> None:
+        # Fresh Codex finding: a cv-qualifier trailing the pointer's own
+        # outermost sigil qualifies the pointer value itself, not what it
+        # points to -- void f(int *) and void f(int * const) name the
+        # same function, the identical by-value-cv rule generalized to a
+        # pointer parameter instead of a scalar one.
+        scope = (Namespace("ns"),)
+        plain = entity_id_for_function(scope, "f", param_types=("int *",))
+        pointer_const = entity_id_for_function(scope, "f", param_types=("int * const",))
+        assert plain == pointer_const
+
+    def test_non_outermost_pointer_cv_still_distinguishes_overloads(self) -> None:
+        # Contrast with the case above: a cv-qualifier on an INTERMEDIATE
+        # pointer level (not the parameter's own outermost sigil) is
+        # genuinely part of the pointee's type -- "pointer to a
+        # const-qualified pointer to int" is not the same type as
+        # "pointer to pointer to int".
+        scope = (Namespace("ns"),)
+        plain = entity_id_for_function(scope, "f", param_types=("int **",))
+        inner_const = entity_id_for_function(scope, "f", param_types=("int * const *",))
+        assert plain != inner_const
+
 
 class TestVariableMangledDiscriminator:
     def test_distinct_mangled_names_never_collide(self) -> None:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -165,7 +165,28 @@ class TestLocalToFunctionOwnerIsIdentity:
     def test_distinct_owner_never_equal(self, owner_a: str, owner_b: str) -> None:
         if owner_a == owner_b:
             return
-        assert LocalToFunction(owner=owner_a) != LocalToFunction(owner=owner_b)
+        assert LocalToFunction(owner=owner_a, block_ordinal=0) != LocalToFunction(
+            owner=owner_b, block_ordinal=0
+        )
+
+    @given(owner=_names, ordinal_a=_ordinals, ordinal_b=_ordinals)
+    def test_distinct_block_ordinal_never_equal(
+        self, owner: str, ordinal_a: int, ordinal_b: int
+    ) -> None:
+        # CodeRabbit-flagged gap: owner alone doesn't disambiguate two
+        # same-named locals in sibling compound blocks of one function --
+        # the same sibling-collision shape Anonymous.ordinal already closes.
+        if ordinal_a == ordinal_b:
+            return
+        assert LocalToFunction(owner=owner, block_ordinal=ordinal_a) != LocalToFunction(
+            owner=owner, block_ordinal=ordinal_b
+        )
+
+    @given(owner=_names, ordinal=_ordinals)
+    def test_same_owner_and_block_ordinal_equal(self, owner: str, ordinal: int) -> None:
+        assert LocalToFunction(owner=owner, block_ordinal=ordinal) == LocalToFunction(
+            owner=owner, block_ordinal=ordinal
+        )
 
 
 class TestSegmentsAreHashable:
@@ -179,7 +200,7 @@ class TestSegmentsAreHashable:
             Record(name="C", access="private"),
             InlineNamespace(name="v1", version_tag="v1"),
             Anonymous(kind="struct", ordinal=0),
-            LocalToFunction(owner="f"),
+            LocalToFunction(owner="f", block_ordinal=0),
         ]
         as_set = set(segments)
         assert len(as_set) == len(segments)
@@ -294,6 +315,81 @@ class TestFunctionOverloadDiscrimination:
         a = entity_id_for_function(scope, "f", mangled_name="_Z1fi")
         b = entity_id_for_function(scope, "f", mangled_name="_Z1fd")
         assert a != b
+
+    def test_extern_c_ignores_param_types(self) -> None:
+        # The Codex-flagged gap: an extern "C" caller follows mangled_name's
+        # own contract and passes None for it (the raw export spelling is
+        # not a genuine mangling) -- without is_extern_c, that falls
+        # through to the signature branch and a parameter-type change would
+        # wrongly look like a different overload. C has no overload
+        # resolution, so this must collapse to one id, mirroring
+        # resolve_function_identity's func.is_extern_c gate.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_function(scope, "f", is_extern_c=True, param_types=("int",))
+        b = entity_id_for_function(
+            scope, "f", is_extern_c=True, param_types=("double", "int")
+        )
+        assert a == b
+
+    def test_extern_c_tag_never_collides_with_sig_tag(self) -> None:
+        # ("extern_c",) and ("sig", ...) must occupy disjoint regions of
+        # extra's value space, same discipline as ("mangled", ...) vs.
+        # ("sig", ...).
+        scope = (Namespace("ns"),)
+        extern_c = entity_id_for_function(scope, "f", is_extern_c=True)
+        sig = entity_id_for_function(scope, "f")
+        assert extern_c != sig
+
+    def test_ref_qualifier_distinguishes_overloads(self) -> None:
+        # The other Codex-flagged gap: C::f() & vs. C::f() && share scope,
+        # name, param_types, and cv_qualifiers -- only ref_qualifier tells
+        # them apart, mirroring resolve_function_identity's own dimension.
+        scope = (Record("C"),)
+        lvalue = entity_id_for_function(scope, "f", ref_qualifier="&")
+        rvalue = entity_id_for_function(scope, "f", ref_qualifier="&&")
+        assert lvalue != rvalue
+
+    def test_variadic_distinguishes_overloads(self) -> None:
+        # void f(int) vs. void f(int, ...) share identical fixed
+        # parameters -- only is_variadic tells them apart.
+        scope = (Namespace("ns"),)
+        fixed = entity_id_for_function(
+            scope, "f", param_types=("int",), is_variadic=False
+        )
+        variadic = entity_id_for_function(
+            scope, "f", param_types=("int",), is_variadic=True
+        )
+        assert fixed != variadic
+
+    def test_variadic_none_is_distinct_from_confirmed_states(self) -> None:
+        # bool | None: a producer that doesn't know must not silently
+        # collapse onto "confirmed non-variadic", the same tri-state
+        # resolve_function_identity's own f"variadic:{func.is_variadic}"
+        # preserves.
+        scope = (Namespace("ns"),)
+        unknown = entity_id_for_function(scope, "f", is_variadic=None)
+        confirmed_false = entity_id_for_function(scope, "f", is_variadic=False)
+        confirmed_true = entity_id_for_function(scope, "f", is_variadic=True)
+        assert unknown != confirmed_false
+        assert unknown != confirmed_true
+        assert confirmed_false != confirmed_true
+
+    def test_mangled_name_wins_over_extern_c_and_ignores_signature_dims(self) -> None:
+        # When a genuine mangled name is present, it wins outright --
+        # is_extern_c/ref_qualifier/is_variadic are all ignored, matching
+        # the plain param_types/cv_qualifiers precedence already pinned by
+        # test_mangled_name_present_ignores_param_types.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_function(
+            scope,
+            "f",
+            mangled_name="_Z1fv",
+            is_extern_c=True,
+            ref_qualifier="&",
+            is_variadic=True,
+        )
+        b = entity_id_for_function(scope, "f", mangled_name="_Z1fv")
+        assert a == b
 
 
 class TestVariableMangledDiscriminator:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -305,9 +305,27 @@ class TestFunctionOverloadDiscrimination:
 
     def test_const_vs_non_const_overload(self) -> None:
         scope = (Record("C"),)
-        plain = entity_id_for_function(scope, "f", cv_qualifiers=())
-        const = entity_id_for_function(scope, "f", cv_qualifiers=("const",))
+        plain = entity_id_for_function(scope, "f", is_const=False)
+        const = entity_id_for_function(scope, "f", is_const=True)
         assert plain != const
+
+    def test_volatile_vs_non_volatile_overload(self) -> None:
+        scope = (Record("C"),)
+        plain = entity_id_for_function(scope, "f", is_volatile=False)
+        volatile = entity_id_for_function(scope, "f", is_volatile=True)
+        assert plain != volatile
+
+    def test_const_and_volatile_are_independent_dimensions(self) -> None:
+        # is_const/is_volatile are two independent booleans, not an
+        # order-dependent qualifier-token tuple -- "const volatile" and
+        # "volatile const" spell the same member-cv qualification and must
+        # produce one id regardless of which boolean is set "first" (there
+        # is no first/second: this is the whole point of using two
+        # booleans instead of a tuple of tokens; Codex review, PR #941).
+        scope = (Record("C"),)
+        both_a = entity_id_for_function(scope, "f", is_const=True, is_volatile=True)
+        both_b = entity_id_for_function(scope, "f", is_volatile=True, is_const=True)
+        assert both_a == both_b
 
     def test_different_scope_same_name_never_collides_with_mangled_sig_tag(
         self,
@@ -373,8 +391,9 @@ class TestFunctionOverloadDiscrimination:
 
     def test_ref_qualifier_distinguishes_overloads(self) -> None:
         # The other Codex-flagged gap: C::f() & vs. C::f() && share scope,
-        # name, param_types, and cv_qualifiers -- only ref_qualifier tells
-        # them apart, mirroring resolve_function_identity's own dimension.
+        # name, param_types, is_const, and is_volatile -- only
+        # ref_qualifier tells them apart, mirroring
+        # resolve_function_identity's own dimension.
         scope = (Record("C"),)
         lvalue = entity_id_for_function(scope, "f", ref_qualifier="&")
         rvalue = entity_id_for_function(scope, "f", ref_qualifier="&&")
@@ -408,7 +427,7 @@ class TestFunctionOverloadDiscrimination:
     def test_mangled_name_wins_over_extern_c_and_ignores_signature_dims(self) -> None:
         # When a genuine mangled name is present, it wins outright --
         # is_extern_c/ref_qualifier/is_variadic are all ignored, matching
-        # the plain param_types/cv_qualifiers precedence already pinned by
+        # the plain param_types precedence already pinned by
         # test_mangled_name_present_ignores_param_types.
         scope = (Namespace("ns"),)
         a = entity_id_for_function(
@@ -499,6 +518,31 @@ class TestFunctionOverloadDiscrimination:
             scope, "f", param_types=("char const *",)
         )
         assert castxml_spelling == clang_spelling
+
+    def test_by_value_top_level_cv_does_not_distinguish_overloads(self) -> None:
+        # The Codex-flagged gap: void f(int) and void f(const int) name the
+        # same function per the C++ standard -- a top-level BY-VALUE
+        # cv-qualifier is dropped from the function's own type for
+        # linkage/mangling purposes, so these must not collide as two
+        # overloads.
+        scope = (Namespace("ns"),)
+        plain = entity_id_for_function(scope, "f", param_types=("int",))
+        cv_qualified = entity_id_for_function(scope, "f", param_types=("const int",))
+        assert plain == cv_qualified
+
+    def test_pointee_cv_still_distinguishes_overloads(self) -> None:
+        # Contrast with the by-value case above: a POINTEE cv-qualifier on
+        # a pointer/reference parameter is a genuine, standard-mandated
+        # overload discriminator -- void f(char*) and void f(const char*)
+        # are two simultaneously-declarable, independently-mangled
+        # overloads, not one declaration. Collapsing them would silently
+        # merge two distinct functions, reintroducing exactly the
+        # sibling-overload-collision class this primitive exists to
+        # prevent.
+        scope = (Namespace("ns"),)
+        mutable_ptr = entity_id_for_function(scope, "f", param_types=("char *",))
+        const_ptr = entity_id_for_function(scope, "f", param_types=("const char *",))
+        assert mutable_ptr != const_ptr
 
 
 class TestVariableMangledDiscriminator:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -460,6 +460,22 @@ class TestFunctionOverloadDiscrimination:
         assert namespaced == no_scope
         assert namespaced.scope == ()
 
+    def test_mangled_name_identity_is_independent_of_leaf_name(self) -> None:
+        # The confirmed Codex-flagged gap: dumper_elf_fallback.py's
+        # ELF-only path constructs Function(name=sym, mangled=sym) --
+        # the raw exported symbol reused for *both* fields -- while a
+        # header/DWARF observation of the identical symbol supplies the
+        # real demangled short name for `name`. A header observation
+        # (leaf_name="f") and an export-only observation
+        # (leaf_name="_Z1fv", matching that fallback's real behavior)
+        # of the same genuinely mangled symbol must produce one EntityId.
+        demangled_leaf = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        raw_symbol_reused_as_leaf = entity_id_for_function(
+            (), "_Z1fv", mangled_name="_Z1fv"
+        )
+        assert demangled_leaf == raw_symbol_reused_as_leaf
+        assert demangled_leaf.leaf_name == ""
+
     def test_sig_branch_keeps_caller_supplied_scope(self) -> None:
         # Contrast with the mangled/extern-C branches above: a DWARF-only,
         # mangling-free, non-extern-"C" function has no authoritative,
@@ -511,6 +527,18 @@ class TestVariableMangledDiscriminator:
         no_scope = entity_id_for_variable((), "v", mangled_name="_Zv")
         assert namespaced == no_scope
         assert namespaced.scope == ()
+
+    def test_mangled_name_identity_is_independent_of_leaf_name(self) -> None:
+        # Same confirmed Codex-flagged gap as entity_id_for_function's
+        # mangled branch, for the same reason: dumper_elf_fallback.py's
+        # ELF-only path reuses the raw exported symbol for both
+        # Variable.name and Variable.mangled.
+        demangled_leaf = entity_id_for_variable((), "v", mangled_name="_Zv")
+        raw_symbol_reused_as_leaf = entity_id_for_variable(
+            (), "_Zv", mangled_name="_Zv"
+        )
+        assert demangled_leaf == raw_symbol_reused_as_leaf
+        assert demangled_leaf.leaf_name == ""
 
     def test_extern_c_variable_ignores_param_evidence_free_signature(self) -> None:
         # The other Codex-flagged gap: an extern "C" variable caller

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -38,6 +38,7 @@ from hypothesis import given, strategies as st
 from abicheck.model import identity as model_identity
 from abicheck.model.identity import (
     Anonymous,
+    EntityId,
     EntityKind,
     InlineNamespace,
     LocalToFunction,
@@ -160,14 +161,21 @@ class TestInlineNamespaceVersionTagIsIdentity:
         )
 
 
+def _owner(name: str, *param_types: str) -> EntityId:
+    """Build a plausible owning-function ``EntityId`` for ``LocalToFunction``
+    tests -- ``owner`` is the owning function's own identity, not a bare
+    string (Codex review, PR #941: see ``LocalToFunction``'s docstring)."""
+    return entity_id_for_function((), name, param_types=param_types)
+
+
 class TestLocalToFunctionOwnerIsIdentity:
     @given(owner_a=_names, owner_b=_names)
     def test_distinct_owner_never_equal(self, owner_a: str, owner_b: str) -> None:
         if owner_a == owner_b:
             return
-        assert LocalToFunction(owner=owner_a, block_ordinal=0) != LocalToFunction(
-            owner=owner_b, block_ordinal=0
-        )
+        assert LocalToFunction(
+            owner=_owner(owner_a), block_ordinal=0
+        ) != LocalToFunction(owner=_owner(owner_b), block_ordinal=0)
 
     @given(owner=_names, ordinal_a=_ordinals, ordinal_b=_ordinals)
     def test_distinct_block_ordinal_never_equal(
@@ -178,14 +186,28 @@ class TestLocalToFunctionOwnerIsIdentity:
         # the same sibling-collision shape Anonymous.ordinal already closes.
         if ordinal_a == ordinal_b:
             return
-        assert LocalToFunction(owner=owner, block_ordinal=ordinal_a) != LocalToFunction(
-            owner=owner, block_ordinal=ordinal_b
+        o = _owner(owner)
+        assert LocalToFunction(owner=o, block_ordinal=ordinal_a) != LocalToFunction(
+            owner=o, block_ordinal=ordinal_b
         )
 
     @given(owner=_names, ordinal=_ordinals)
     def test_same_owner_and_block_ordinal_equal(self, owner: str, ordinal: int) -> None:
-        assert LocalToFunction(owner=owner, block_ordinal=ordinal) == LocalToFunction(
-            owner=owner, block_ordinal=ordinal
+        o = _owner(owner)
+        assert LocalToFunction(owner=o, block_ordinal=ordinal) == LocalToFunction(
+            owner=o, block_ordinal=ordinal
+        )
+
+    def test_overloaded_owners_never_collide(self) -> None:
+        # The Codex-flagged gap this dimension exists to close: f(int) and
+        # f(double) each declaring the same local struct A in their
+        # (corresponding) block must not merge just because both owners
+        # share the bare function name "f" -- owner carries the *full*
+        # overload-disambiguated identity of the enclosing function.
+        int_overload = _owner("f", "int")
+        double_overload = _owner("f", "double")
+        assert LocalToFunction(owner=int_overload, block_ordinal=0) != LocalToFunction(
+            owner=double_overload, block_ordinal=0
         )
 
 
@@ -200,7 +222,7 @@ class TestSegmentsAreHashable:
             Record(name="C", access="private"),
             InlineNamespace(name="v1", version_tag="v1"),
             Anonymous(kind="struct", ordinal=0),
-            LocalToFunction(owner="f", block_ordinal=0),
+            LocalToFunction(owner=_owner("f"), block_ordinal=0),
         ]
         as_set = set(segments)
         assert len(as_set) == len(segments)
@@ -399,6 +421,54 @@ class TestFunctionOverloadDiscrimination:
         )
         b = entity_id_for_function(scope, "f", mangled_name="_Z1fv")
         assert a == b
+
+    def test_extern_c_identity_is_independent_of_scope(self) -> None:
+        # The other Codex-flagged gap: a header/DWARF observation of a
+        # namespaced extern "C" function may supply a real ScopePath, while
+        # an export-table-only snapshot of the identical binary symbol
+        # knows only the bare exported name -- extern "C" linkage means the
+        # symbol *is* that bare name at the ABI level, so no namespace is
+        # even recoverable from the export table alone. The two must still
+        # produce the same EntityId, mirroring resolve_symbol_identity's
+        # own choice to base an extern-C identity on the raw export rather
+        # than a qualified name for exactly this reason.
+        namespaced = entity_id_for_function((Namespace("ns"),), "foo", is_extern_c=True)
+        export_only = entity_id_for_function((), "foo", is_extern_c=True)
+        assert namespaced == export_only
+        assert namespaced.scope == ()
+
+    def test_extern_c_scope_independence_does_not_erase_leaf_name(self) -> None:
+        # Scope-independence must not go too far -- two different exported
+        # extern "C" names still must not collide just because both were
+        # observed with no scope.
+        foo = entity_id_for_function((), "foo", is_extern_c=True)
+        bar = entity_id_for_function((), "bar", is_extern_c=True)
+        assert foo != bar
+
+    def test_mangled_and_sig_branches_keep_caller_supplied_scope(self) -> None:
+        # Contrast with the extern-C branch above: neither the mangled nor
+        # the sig fallback branch has an evidence-tier scope-availability
+        # problem to guard against, so scope stays exactly as given.
+        ns_a = entity_id_for_function((Namespace("a"),), "f", mangled_name="_Z1fv")
+        ns_b = entity_id_for_function((Namespace("b"),), "f", mangled_name="_Z1fv")
+        assert ns_a != ns_b
+        sig_a = entity_id_for_function((Namespace("a"),), "f")
+        sig_b = entity_id_for_function((Namespace("b"),), "f")
+        assert sig_a != sig_b
+
+    def test_param_types_canonicalized_across_producer_spellings(self) -> None:
+        # CastXML's "char const*" and Clang's "char const *" spell an
+        # otherwise-identical parameter type differently -- without
+        # canonicalization the same declaration observed by the two
+        # backends would get two different EntityIds.
+        scope = (Namespace("ns"),)
+        castxml_spelling = entity_id_for_function(
+            scope, "f", param_types=("char const*",)
+        )
+        clang_spelling = entity_id_for_function(
+            scope, "f", param_types=("char const *",)
+        )
+        assert castxml_spelling == clang_spelling
 
 
 class TestVariableMangledDiscriminator:

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -445,13 +445,27 @@ class TestFunctionOverloadDiscrimination:
         bar = entity_id_for_function((), "bar", is_extern_c=True)
         assert foo != bar
 
-    def test_mangled_and_sig_branches_keep_caller_supplied_scope(self) -> None:
-        # Contrast with the extern-C branch above: neither the mangled nor
-        # the sig fallback branch has an evidence-tier scope-availability
-        # problem to guard against, so scope stays exactly as given.
-        ns_a = entity_id_for_function((Namespace("a"),), "f", mangled_name="_Z1fv")
-        ns_b = entity_id_for_function((Namespace("b"),), "f", mangled_name="_Z1fv")
-        assert ns_a != ns_b
+    def test_mangled_name_identity_is_also_independent_of_scope(self) -> None:
+        # The Codex-flagged gap this corrects: a real mangled name already
+        # fully and deterministically encodes scope, so folding a caller-
+        # supplied scope on top only fragments identity across evidence
+        # tiers that differ in whether they can supply one -- the same
+        # mechanism the is_extern_c branch guards against, not a
+        # different, harmless case (an earlier revision of this test and
+        # the code's own docstring both wrongly assumed it was).
+        namespaced = entity_id_for_function(
+            (Namespace("ns"),), "f", mangled_name="_Z1fv"
+        )
+        no_scope = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        assert namespaced == no_scope
+        assert namespaced.scope == ()
+
+    def test_sig_branch_keeps_caller_supplied_scope(self) -> None:
+        # Contrast with the mangled/extern-C branches above: a DWARF-only,
+        # mangling-free, non-extern-"C" function has no authoritative,
+        # scope-independent name to fall back on, so scope is exactly what
+        # makes two same-named, same-signature sibling declarations in
+        # different scopes distinct.
         sig_a = entity_id_for_function((Namespace("a"),), "f")
         sig_b = entity_id_for_function((Namespace("b"),), "f")
         assert sig_a != sig_b
@@ -486,6 +500,42 @@ class TestVariableMangledDiscriminator:
         scope = (Namespace("ns"),)
         a = entity_id_for_variable(scope, "v")
         b = entity_id_for_variable(scope, "v")
+        assert a == b
+
+    def test_mangled_name_identity_is_independent_of_scope(self) -> None:
+        # Same Codex-flagged gap as entity_id_for_function's mangled
+        # branch: a genuine mangled name already fully encodes scope, so a
+        # header/DWARF observation and an export-only observation of the
+        # identical symbol must produce the same EntityId.
+        namespaced = entity_id_for_variable((Namespace("ns"),), "v", mangled_name="_Zv")
+        no_scope = entity_id_for_variable((), "v", mangled_name="_Zv")
+        assert namespaced == no_scope
+        assert namespaced.scope == ()
+
+    def test_extern_c_variable_ignores_param_evidence_free_signature(self) -> None:
+        # The other Codex-flagged gap: an extern "C" variable caller
+        # follows mangled_name's own contract and passes None for it, but
+        # entity_id_for_variable had no equivalent linkage signal at all --
+        # is_extern_c closes that the same way it does for functions.
+        scope = (Namespace("ns"),)
+        a = entity_id_for_variable(scope, "v", is_extern_c=True)
+        b = entity_id_for_variable((), "v", is_extern_c=True)
+        assert a == b
+        assert a.scope == ()
+
+    def test_extern_c_variable_tag_never_collides_with_degenerate_case(self) -> None:
+        # ("extern_c",) and the bare () degenerate-case tag must occupy
+        # disjoint regions of extra's value space.
+        scope = (Namespace("ns"),)
+        extern_c = entity_id_for_variable(scope, "v", is_extern_c=True)
+        degenerate = entity_id_for_variable(scope, "v")
+        assert extern_c != degenerate
+
+    def test_mangled_name_wins_over_is_extern_c_for_variables(self) -> None:
+        a = entity_id_for_variable(
+            (Namespace("ns"),), "v", mangled_name="_Zv", is_extern_c=True
+        )
+        b = entity_id_for_variable((), "v", mangled_name="_Zv")
         assert a == b
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -319,6 +319,46 @@ class TestClangTrailingCallingConventionAttributeUnifies:
         )
 
 
+class TestLeadingGlobalScopeQualifierIsStripped:
+    """An explicit leading ``::`` (forcing global-namespace lookup) names
+    the identical type an unqualified spelling of that same, unambiguous
+    name does -- direct-clang's own ``qualType`` preserves it verbatim, a
+    confirmed real producer spelling
+    (``tests/test_dumper_scoping_dependency_retention.py``'s own
+    ``test_globally_qualified_signature_spelling_still_matches``)."""
+
+    def test_bare_global_qualifier_stripped(self) -> None:
+        assert canon("::dep::Thing *") == canon("dep::Thing *")
+
+    def test_qualifier_preserved_after_stripping(self) -> None:
+        assert "dep::Thing" in canon("::dep::Thing *")
+
+    def test_template_argument_global_qualifier_stripped(self) -> None:
+        assert canon("Box<::dep::Thing>") == canon("Box<dep::Thing>")
+
+    def test_callback_parameter_global_qualifier_stripped(self) -> None:
+        assert canon("void (*)(::dep::Thing*)") == canon("void (*)(dep::Thing*)")
+
+    def test_ordinary_namespace_qualifier_unaffected(self) -> None:
+        # A plain namespace-qualified name's own internal "::" must never
+        # be touched -- only a LEADING, global-scope one is stripped.
+        assert canon("ns::Foo *") != canon("Foo *")
+
+    def test_anonymous_namespace_separator_unaffected(self) -> None:
+        # Regression pin: the "::" following "(anonymous namespace)" is a
+        # genuine, load-bearing separator, not a global-scope marker --
+        # a naive "not preceded by an identifier character" test would
+        # wrongly strip it too, since ")" isn't an identifier character.
+        assert canon("(anonymous namespace)::Foo *") == "(anonymous namespace)::Foo *"
+
+    def test_member_pointer_qualifier_global_scope_stripped(self) -> None:
+        assert canon("void (::C::*)(int)") == canon("void (C::*)(int)")
+
+    def test_idempotent(self) -> None:
+        once = canon("::dep::Thing *")
+        assert canon(once) == once
+
+
 class TestTemplateQualifiedMemberPointerOwnCvIsDropped:
     """A nested-name-specifier's own segment can itself be a template-id
     (``C<int>::``), not only a plain identifier -- the declarator-group

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -220,6 +220,48 @@ class TestBareDataMemberPointerPointeeCvIsCanonicalized:
         assert canon("void (C::* const)(int)") == canon("void (C::*)(int)")
 
 
+class TestRestrictQualifierIsAlwaysStripped:
+    """``restrict``/``__restrict``/``__restrict__`` never affects the
+    Itanium C++ ABI's mangling, at ANY position -- unlike a genuine
+    by-value cv-qualifier, which is only by-value (and so only safe to
+    strip) on the parameter's own outermost pointer. This repository
+    already tracks the fact separately (``Param.is_restrict``); collapsing
+    it into an unmangled fallback signature's identity would turn that
+    dedicated compatible parameter-qualifier change into a spurious
+    removal/addition pair instead."""
+
+    def test_bare_pointer_restrict_stripped(self) -> None:
+        assert canon("int *restrict") == canon("int *")
+
+    def test_double_underscore_spelling_stripped(self) -> None:
+        assert canon("int *__restrict") == canon("int *")
+
+    def test_double_underscore_trailing_spelling_stripped(self) -> None:
+        assert canon("int *__restrict__") == canon("int *")
+
+    def test_restrict_still_distinguishes_nothing_from_a_genuine_cv_change(
+        self,
+    ) -> None:
+        # Sanity check that this doesn't accidentally strip a REAL,
+        # distinguishing pointee cv-qualifier too.
+        assert canon("int *restrict") != canon("const int *")
+
+    def test_restrict_on_non_outermost_pointer_also_stripped(self) -> None:
+        # Restrict's absence from mangling holds regardless of WHERE in
+        # the declarator it sits -- not only the parameter's own
+        # outermost pointer, unlike a genuine by-value cv-qualifier.
+        assert canon("int * restrict *") == canon("int * *")
+
+    def test_restrict_inside_callback_parameter_stripped(self) -> None:
+        # The recursive nested-parameter-list normalization must also
+        # apply this rule to each of a callback's own parameters.
+        assert canon("void (*)(int *restrict)") == canon("void (*)(int *)")
+
+    def test_idempotent(self) -> None:
+        once = canon("int *restrict")
+        assert canon(once) == once
+
+
 class TestTemplateQualifiedMemberPointerOwnCvIsDropped:
     """A nested-name-specifier's own segment can itself be a template-id
     (``C<int>::``), not only a plain identifier -- the declarator-group

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -262,6 +262,55 @@ class TestRestrictQualifierIsAlwaysStripped:
         assert canon(once) == once
 
 
+class TestClangTrailingCallingConventionAttributeUnifies:
+    """Clang's own ``qualType`` spelling for a calling-convention-decorated
+    function-pointer declarator trails the attribute AFTER the parameter
+    list (``__attribute__((cdecl))``) rather than using the leading
+    ``__cdecl``-style keyword MSVC/castxml spell it with -- both spellings
+    of the identical type must converge on one identity, or two backends
+    observing the same declaration would fragment it."""
+
+    def test_cdecl_attribute_unifies_with_leading_keyword(self) -> None:
+        assert canon("void (*)(int) __attribute__((cdecl))") == canon(
+            "void (__cdecl *)(int)"
+        )
+
+    def test_stdcall_attribute_unifies_with_leading_keyword(self) -> None:
+        assert canon("void (*)(int) __attribute__((stdcall))") == canon(
+            "void (__stdcall *)(int)"
+        )
+
+    def test_member_function_pointer_attribute_unifies(self) -> None:
+        assert canon("void (C::*)(int) __attribute__((thiscall))") == canon(
+            "void (__thiscall C::*)(int)"
+        )
+
+    def test_no_attribute_stays_unaffected(self) -> None:
+        assert canon("void (*)(int)") == "void ( * )(int)"
+
+    def test_different_conventions_still_distinguish(self) -> None:
+        assert canon("void (*)(int) __attribute__((cdecl))") != canon(
+            "void (*)(int) __attribute__((stdcall))"
+        )
+
+    def test_attribute_coexists_with_trailing_noexcept(self) -> None:
+        assert canon("void (*)(int) __attribute__((cdecl)) noexcept") == canon(
+            "void (__cdecl *)(int) noexcept"
+        )
+
+    def test_idempotent(self) -> None:
+        once = canon("void (*)(int) __attribute__((cdecl))")
+        assert canon(once) == once
+
+    def test_redundant_leading_and_trailing_spelling_deduplicates(self) -> None:
+        # An (unrealistic, but defensive) input carrying BOTH spellings at
+        # once must not duplicate the keyword -- the existing leading one
+        # wins and the trailing attribute is simply dropped.
+        assert canon("void (__cdecl *)(int) __attribute__((cdecl))") == canon(
+            "void (__cdecl *)(int)"
+        )
+
+
 class TestTemplateQualifiedMemberPointerOwnCvIsDropped:
     """A nested-name-specifier's own segment can itself be a template-id
     (``C<int>::``), not only a plain identifier -- the declarator-group

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -79,6 +79,23 @@ class TestPointeeCvIsPreserved:
         # different type -- Box<const int> vs. Box<int>.
         assert canon("Box<const int>") != canon("Box<int>")
 
+    def test_anonymous_namespace_qualified_pointee_cv_differs(self) -> None:
+        # Regression pin: a real, observed producer spelling for a type
+        # in an anonymous namespace, "(anonymous namespace)::Foo", starts
+        # with an opaque paren that precedes the parameter's own actual
+        # pointer sigil entirely -- this must not be mistaken for the
+        # declarator's own trailing parameter list (which would wrongly
+        # lock out that later sigil and merge two genuinely different
+        # pointer-to-const-vs-non-const types).
+        assert canon("(anonymous namespace)::Foo const *") != canon(
+            "(anonymous namespace)::Foo *"
+        )
+
+    def test_anonymous_namespace_qualifier_preserved(self) -> None:
+        assert "(anonymous namespace)::Foo" in canon(
+            "(anonymous namespace)::Foo const *"
+        )
+
 
 class TestPointersOwnTopLevelCvIsDropped:
     """A cv-qualifier trailing the pointer's own outermost sigil qualifies
@@ -252,7 +269,8 @@ class TestPointerToMemberTrailingQualifiersPreserved:
         # briefly mistaken for a NEW top-level sigil, overriding the
         # declarator's own already-found "*" and corrupting the
         # prefix/suffix split entirely.
-        assert canon("void (C::*)(int) &&") == canon("void (C::*)(int) &&")
+        once = canon("void (C::*)(int) &&")
+        assert canon(once) == once
         assert "(int)" in canon("void (C::*)(int) &&")
         assert "C" in canon("void (C::*)(int) &&")
 
@@ -318,6 +336,40 @@ class TestNoexceptSpellingsCanonicalized:
         )
 
 
+class TestCvInsideNoexceptExpressionIsNotExtracted:
+    """A ``const``/``volatile`` token appearing INSIDE a non-literal
+    ``noexcept(expr)``'s own argument belongs to that expression, not to
+    this declarator's own trailing cv-qualifier sequence -- it must not
+    be extracted, reordered, or otherwise mutated."""
+
+    def test_const_inside_noexcept_expression_not_extracted(self) -> None:
+        assert canon("void (C::*)(int) noexcept(Foo<const int>)") == canon(
+            "void (C::*)(int) noexcept(Foo<const int>)"
+        )
+
+    def test_const_inside_noexcept_expression_preserved_verbatim(self) -> None:
+        result = canon("void (C::*)(int) noexcept(Foo<const int>)")
+        assert "Foo<const int>" in result
+
+    def test_nested_const_does_not_merge_with_real_leading_const(self) -> None:
+        # Regression pin: a plain, depth-blind search for "const" over
+        # the whole trailing region wrongly found this nested one and
+        # moved it to the front, producing the SAME string as a
+        # genuinely different declaration with a real leading const.
+        assert canon("void (C::*)(int) noexcept(Foo<const int>)") != canon(
+            "void (C::*)(int) const noexcept(Foo<int>)"
+        )
+
+    def test_nested_const_does_not_distinguish_two_genuinely_equal_specs(self) -> None:
+        # The nested const must not itself become a spurious real-cv
+        # signal: two declarations differing only in an irrelevant
+        # detail outside the nested expression should still compare via
+        # their own real qualifiers, not get contaminated by it.
+        assert canon("void (C::*)(int) const noexcept(Foo<const int>)") == canon(
+            "void (C::*)(int) noexcept(Foo<const int>) const"
+        )
+
+
 class TestNestedCallbackParametersAreNormalizedRecursively:
     """A declarator's own trailing parameter list (a callback or
     member-function-pointer's parameters) is exactly as much a function's
@@ -340,9 +392,11 @@ class TestNestedCallbackParametersAreNormalizedRecursively:
         assert canon("void (*)(int, ...)") == canon("void (*)(const int, ...)")
         assert "..." in canon("void (*)(int, ...)")
 
-    def test_empty_and_void_param_lists_untouched(self) -> None:
-        assert canon("void (*)()") == "void ( * )()"
-        assert canon("void (*)(void)") == "void ( * )(void)"
+    def test_empty_and_void_param_lists_unify(self) -> None:
+        # An empty parameter list and a bare "void" are the identical
+        # "no parameters" adjusted type -- must canonicalize identically,
+        # not merely both survive unchanged.
+        assert canon("void (*)()") == canon("void (*)(void)") == "void ( * )()"
 
     def test_doubly_nested_callback_normalized(self) -> None:
         # A callback parameter that itself takes a callback parameter --
@@ -402,6 +456,18 @@ class TestIdempotence:
 
     def test_idempotent_on_non_literal_noexcept(self) -> None:
         once = canon("void (*)(int) noexcept(SOME_CONSTANT)")
+        assert canon(once) == once
+
+    def test_idempotent_on_void_param_list(self) -> None:
+        once = canon("void (*)(void)")
+        assert canon(once) == once
+
+    def test_idempotent_on_const_inside_noexcept_expression(self) -> None:
+        once = canon("void (C::*)(int) noexcept(Foo<const int>)")
+        assert canon(once) == once
+
+    def test_idempotent_on_anonymous_namespace_qualified_pointer(self) -> None:
+        once = canon("(anonymous namespace)::Foo const *")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -332,40 +332,45 @@ class TestClangTrailingCallingConventionAttributeUnifies:
         )
 
 
-class TestLeadingGlobalScopeQualifierIsStripped:
-    """An explicit leading ``::`` (forcing global-namespace lookup) names
-    the identical type an unqualified spelling of that same, unambiguous
-    name does -- direct-clang's own ``qualType`` preserves it verbatim, a
-    confirmed real producer spelling
-    (``tests/test_dumper_scoping_dependency_retention.py``'s own
-    ``test_globally_qualified_signature_spelling_still_matches``)."""
+class TestLeadingGlobalScopeQualifierIsPreserved:
+    """An explicit leading ``::`` (forcing global-namespace lookup) must
+    NOT be stripped -- a nineteenth-round attempt to strip it
+    unconditionally was reverted in the twenty-first round once direct
+    compilation showed Clang's own ``qualType`` can legitimately print
+    the BARE, unqualified spelling for a type that resolves to a
+    locally-shadowing entity distinct from the true global one a sibling
+    declaration prints WITH the leading ``::`` -- so stripping it can
+    silently merge two non-interchangeable types. This primitive has no
+    scope-tree information to tell the two cases apart, so the leading
+    ``::`` -- Clang's own signal for the distinction -- must survive."""
 
-    def test_bare_global_qualifier_stripped(self) -> None:
-        assert canon("::dep::Thing *") == canon("dep::Thing *")
+    def test_leading_qualifier_preserved(self) -> None:
+        assert canon("::dep::Thing *") == "::dep::Thing *"
 
-    def test_qualifier_preserved_after_stripping(self) -> None:
-        assert "dep::Thing" in canon("::dep::Thing *")
+    def test_leading_qualifier_distinguishes_from_unqualified(self) -> None:
+        # The two spellings must NOT collapse -- they can name genuinely
+        # different, locally-shadowing entities.
+        assert canon("::dep::Thing *") != canon("dep::Thing *")
 
-    def test_template_argument_global_qualifier_stripped(self) -> None:
-        assert canon("Box<::dep::Thing>") == canon("Box<dep::Thing>")
+    def test_template_argument_qualifier_preserved(self) -> None:
+        assert canon("Box<::dep::Thing>") != canon("Box<dep::Thing>")
 
-    def test_callback_parameter_global_qualifier_stripped(self) -> None:
-        assert canon("void (*)(::dep::Thing*)") == canon("void (*)(dep::Thing*)")
+    def test_callback_parameter_qualifier_preserved(self) -> None:
+        assert canon("void (*)(::dep::Thing*)") != canon("void (*)(dep::Thing*)")
 
     def test_ordinary_namespace_qualifier_unaffected(self) -> None:
-        # A plain namespace-qualified name's own internal "::" must never
-        # be touched -- only a LEADING, global-scope one is stripped.
+        # A plain namespace-qualified name's own internal "::" was never
+        # touched by the reverted fix either -- only a leading one was.
         assert canon("ns::Foo *") != canon("Foo *")
 
     def test_anonymous_namespace_separator_unaffected(self) -> None:
-        # Regression pin: the "::" following "(anonymous namespace)" is a
-        # genuine, load-bearing separator, not a global-scope marker --
-        # a naive "not preceded by an identifier character" test would
-        # wrongly strip it too, since ")" isn't an identifier character.
+        # The "::" following "(anonymous namespace)" is a genuine,
+        # load-bearing separator, not a global-scope marker -- unrelated
+        # to this reverted fix, but still worth pinning here.
         assert canon("(anonymous namespace)::Foo *") == "(anonymous namespace)::Foo *"
 
-    def test_member_pointer_qualifier_global_scope_stripped(self) -> None:
-        assert canon("void (::C::*)(int)") == canon("void (C::*)(int)")
+    def test_member_pointer_qualifier_preserved(self) -> None:
+        assert canon("void (::C::*)(int)") != canon("void (C::*)(int)")
 
     def test_idempotent(self) -> None:
         once = canon("::dep::Thing *")
@@ -524,6 +529,37 @@ class TestNoexceptSpellingsCanonicalized:
         assert canon("void (C::*)(int) const noexcept(false)") == canon(
             "void (C::*)(int) const"
         )
+
+
+class TestNoexceptIntegerLiteralSpellingsCanonicalized:
+    """A ``noexcept`` argument is contextually converted to ``bool``, so
+    ``noexcept(1)``/``noexcept(0)`` are the identical types as
+    ``noexcept(true)``/``noexcept(false)`` -- confirmed both by direct
+    compilation (redefinition errors) and by Clang's own ``qualType``,
+    which genuinely emits these integer-literal spellings verbatim
+    (``clang -Xclang -ast-dump=json``: ``void (int) noexcept(1)``)."""
+
+    def test_noexcept_1_equals_noexcept_true(self) -> None:
+        assert canon("void (*)(int) noexcept(1)") == canon(
+            "void (*)(int) noexcept(true)"
+        )
+
+    def test_noexcept_0_equals_no_specifier(self) -> None:
+        assert canon("void (*)(int) noexcept(0)") == canon("void (*)(int)")
+
+    def test_noexcept_1_still_distinguishes_from_no_specifier(self) -> None:
+        assert canon("void (*)(int) noexcept(1)") != canon("void (*)(int)")
+
+    def test_other_integer_literal_left_untouched(self) -> None:
+        # Deliberately narrow to exactly 0/1 -- any other integer
+        # constant is not a spelling this module has confirmed evidence
+        # for, and triggers a narrowing-conversion diagnostic in real
+        # compilers, so it is left alone rather than guessed at.
+        assert "noexcept(2)" in canon("void (*)(int) noexcept(2)")
+
+    def test_idempotent_on_integer_literal_spelling(self) -> None:
+        once = canon("void (*)(int) noexcept(1)")
+        assert canon(once) == once
 
 
 class TestCvInsideNoexceptExpressionIsNotExtracted:

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -182,6 +182,44 @@ class TestPointerToMemberOwnCvIsDropped:
         assert "(int)" in canon("void (C::* const)(int)")
 
 
+class TestBareDataMemberPointerPointeeCvIsCanonicalized:
+    """A bare (non-parenthesized) data-member-pointer parameter, e.g.
+    ``int C::*`` (pointer to an int member of C), has a pointee
+    cv-qualifier that must canonicalize consistently regardless of
+    whether the source spelled it before or after the base type --
+    ``canonicalize_type_name`` itself mishandles this across the
+    ``C::`` infix, misplacing (not merely leaving unmoved) a leading
+    ``const``."""
+
+    def test_leading_and_trailing_const_spellings_unify(self) -> None:
+        assert canon("int const C::*") == canon("const int C::*")
+
+    def test_leading_and_trailing_const_still_distinguish_from_unqualified(
+        self,
+    ) -> None:
+        assert canon("int const C::*") != canon("int C::*")
+
+    def test_nested_namespace_qualifier_handled(self) -> None:
+        assert canon("int const ns::C::*") == canon("const int ns::C::*")
+
+    def test_class_qualifier_preserved(self) -> None:
+        assert "C::" in canon("int const C::*")
+
+    def test_ordinary_namespace_qualified_pointer_unaffected(self) -> None:
+        # A plain pointer whose pointee is namespace-qualified must not
+        # be mistaken for a member pointer -- the "::" there is nowhere
+        # near the sigil, unlike a member pointer's own qualifier.
+        assert canon("ns::Foo *") == "ns::Foo *"
+        assert canon("ns::Foo *") != canon("const ns::Foo *")
+
+    def test_parenthesized_member_function_pointer_unaffected(self) -> None:
+        # The parenthesized case (a member-FUNCTION-pointer's own
+        # trailing parameter list) is a structurally different shape,
+        # already handled by TestPointerToMemberOwnCvIsDropped -- this
+        # bare-pointee-cv fix must not interfere with it.
+        assert canon("void (C::* const)(int)") == canon("void (C::*)(int)")
+
+
 class TestTemplateQualifiedMemberPointerOwnCvIsDropped:
     """A nested-name-specifier's own segment can itself be a template-id
     (``C<int>::``), not only a plain identifier -- the declarator-group
@@ -468,6 +506,10 @@ class TestIdempotence:
 
     def test_idempotent_on_anonymous_namespace_qualified_pointer(self) -> None:
         once = canon("(anonymous namespace)::Foo const *")
+        assert canon(once) == once
+
+    def test_idempotent_on_bare_data_member_pointer(self) -> None:
+        once = canon("const int C::*")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -148,6 +148,57 @@ class TestParenthesizedDeclaratorOwnCvIsDropped:
         assert "[3]" in canon("int (* const)[3]")
 
 
+class TestPointerToMemberOwnCvIsDropped:
+    """A pointer-to-member-function declarator's own outermost sigil is
+    preceded by the member's qualified-name prefix (``C::``) inside the
+    same declarator-grouping parens -- its own trailing cv-qualifier is
+    by-value and dropped exactly like a plain function-pointer's."""
+
+    def test_member_pointer_own_const_dropped(self) -> None:
+        assert canon("void (C::* const)(int)") == canon("void (C::*)(int)")
+
+    def test_nested_namespace_member_pointer_own_const_dropped(self) -> None:
+        assert canon("void (ns::C::* const)(int)") == canon("void (ns::C::*)(int)")
+
+    def test_member_pointer_param_list_untouched(self) -> None:
+        assert "(int)" in canon("void (C::*)(int)")
+        assert "(int)" in canon("void (C::* const)(int)")
+
+
+class TestNestedCallbackParametersAreNormalizedRecursively:
+    """A declarator's own trailing parameter list (a callback or
+    member-function-pointer's parameters) is exactly as much a function's
+    parameter list as this function's own top-level one -- the identical
+    by-value cv rule applies to each of ITS parameters too, recursively to
+    any nesting depth."""
+
+    def test_single_nested_param_by_value_cv_dropped(self) -> None:
+        assert canon("void (*)(const int)") == canon("void (*)(int)")
+
+    def test_multiple_nested_params_by_value_cv_dropped(self) -> None:
+        assert canon("void (*)(const int, int)") == canon("void (*)(int, const int)")
+
+    def test_nested_pointee_cv_still_distinguishes(self) -> None:
+        # A nested parameter's POINTEE cv is a genuine, standard-mandated
+        # discriminator, same as at the top level -- must not be dropped.
+        assert canon("void (*)(char *)") != canon("void (*)(const char *)")
+
+    def test_variadic_marker_untouched(self) -> None:
+        assert canon("void (*)(int, ...)") == canon("void (*)(const int, ...)")
+        assert "..." in canon("void (*)(int, ...)")
+
+    def test_empty_and_void_param_lists_untouched(self) -> None:
+        assert canon("void (*)()") == "void ( * )()"
+        assert canon("void (*)(void)") == "void ( * )(void)"
+
+    def test_doubly_nested_callback_normalized(self) -> None:
+        # A callback parameter that itself takes a callback parameter --
+        # the recursion must reach the innermost level too.
+        assert canon("void (*)(void (*)(const int))") == canon(
+            "void (*)(void (*)(int))"
+        )
+
+
 class TestIdempotence:
     """Canonicalizing an already-canonical form is a no-op -- a basic
     sanity property any normalization function should hold."""
@@ -166,6 +217,14 @@ class TestIdempotence:
 
     def test_idempotent_on_function_pointer_type(self) -> None:
         once = canon("void (* const)(int)")
+        assert canon(once) == once
+
+    def test_idempotent_on_member_pointer_type(self) -> None:
+        once = canon("void (C::* const)(int)")
+        assert canon(once) == once
+
+    def test_idempotent_on_nested_callback_type(self) -> None:
+        once = canon("void (*)(const int, void (*)(char *))")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -126,6 +126,28 @@ class TestArrayParameterDecay:
         assert "[3]" in canon("int (*)[3]")
 
 
+class TestParenthesizedDeclaratorOwnCvIsDropped:
+    """A parenthesized declarator's own grouping parens (a function-pointer
+    or pointer-to-array parameter) are transparent for by-value cv
+    purposes -- the cv-qualifier on the declarator's own outermost pointer
+    is by-value and dropped, exactly like an unparenthesized pointer."""
+
+    def test_function_pointer_own_const_dropped(self) -> None:
+        assert canon("void (* const)(int)") == canon("void (*)(int)")
+
+    def test_function_pointer_param_list_untouched(self) -> None:
+        # The callback's OWN parameter types are not this parameter's
+        # by-value qualifiers -- they must survive verbatim either way.
+        assert "(int)" in canon("void (*)(int)")
+        assert "(int)" in canon("void (* const)(int)")
+
+    def test_pointer_to_array_own_const_dropped(self) -> None:
+        assert canon("int (* const)[3]") == canon("int (*)[3]")
+
+    def test_pointer_to_array_bound_untouched(self) -> None:
+        assert "[3]" in canon("int (* const)[3]")
+
+
 class TestIdempotence:
     """Canonicalizing an already-canonical form is a no-op -- a basic
     sanity property any normalization function should hold."""
@@ -140,6 +162,10 @@ class TestIdempotence:
 
     def test_idempotent_on_array_type(self) -> None:
         once = canon("const int [3]")
+        assert canon(once) == once
+
+    def test_idempotent_on_function_pointer_type(self) -> None:
+        once = canon("void (* const)(int)")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -165,6 +165,29 @@ class TestPointerToMemberOwnCvIsDropped:
         assert "(int)" in canon("void (C::* const)(int)")
 
 
+class TestTemplateQualifiedMemberPointerOwnCvIsDropped:
+    """A nested-name-specifier's own segment can itself be a template-id
+    (``C<int>::``), not only a plain identifier -- the declarator-group
+    transparency test must still recognize it and find the sigil, since a
+    real nested-name-specifier commonly looks like this."""
+
+    def test_template_member_pointer_own_const_dropped(self) -> None:
+        assert canon("void (C<int>::* const)(int)") == canon("void (C<int>::*)(int)")
+
+    def test_nested_template_arguments_handled(self) -> None:
+        # A template argument can itself contain another template-id --
+        # the balanced-<...> scan must not stop at the first ">".
+        assert canon("void (Box<Pair<int, int>>::* const)(int)") == canon(
+            "void (Box<Pair<int, int>>::*)(int)"
+        )
+
+    def test_template_member_pointer_param_list_untouched(self) -> None:
+        assert "(int)" in canon("void (C<int>::*)(int)")
+
+    def test_template_argument_content_preserved(self) -> None:
+        assert "C<int>" in canon("void (C<int>::*)(int)")
+
+
 class TestCallingConventionDeclaratorGroupIsRecognized:
     """An MSVC/PE calling-convention keyword (``__cdecl``, ``__stdcall``,
     ...) can precede a declarator's own sigil inside its grouping parens
@@ -232,6 +255,31 @@ class TestPointerToMemberTrailingQualifiersPreserved:
         assert canon("void (C::*)(int) &&") == canon("void (C::*)(int) &&")
         assert "(int)" in canon("void (C::*)(int) &&")
         assert "C" in canon("void (C::*)(int) &&")
+
+    def test_noexcept_distinguishes_from_unqualified(self) -> None:
+        # Regression pin: an earlier revision of the trailing-qualifier
+        # fix reconstructed the whole trailing region from only cv/ref,
+        # silently dropping "noexcept" -- collapsing two genuinely
+        # different, non-interchangeable C++17 function-pointer types
+        # into one identity, the same over-merge class this whole
+        # primitive exists to prevent.
+        assert canon("void (*)(int) noexcept") != canon("void (*)(int)")
+
+    def test_noexcept_still_present(self) -> None:
+        assert "noexcept" in canon("void (*)(int) noexcept")
+
+    def test_noexcept_combines_with_trailing_cv(self) -> None:
+        assert canon("void (C::*)(int) const noexcept") != canon(
+            "void (C::*)(int) const"
+        )
+        assert canon("void (C::*)(int) const noexcept") != canon(
+            "void (C::*)(int) noexcept"
+        )
+
+    def test_cv_still_order_independent_alongside_noexcept(self) -> None:
+        assert canon("void (C::*)(int) const noexcept") == canon(
+            "void (C::*)(int) noexcept const"
+        )
 
 
 class TestNestedCallbackParametersAreNormalizedRecursively:
@@ -302,6 +350,14 @@ class TestIdempotence:
 
     def test_idempotent_on_trailing_member_qualifiers(self) -> None:
         once = canon("void (C::*)(int) volatile const")
+        assert canon(once) == once
+
+    def test_idempotent_on_template_qualified_member_pointer(self) -> None:
+        once = canon("void (C<int>::* const)(int)")
+        assert canon(once) == once
+
+    def test_idempotent_on_noexcept(self) -> None:
+        once = canon("void (C::*)(int) noexcept const")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -220,15 +220,18 @@ class TestBareDataMemberPointerPointeeCvIsCanonicalized:
         assert canon("void (C::* const)(int)") == canon("void (C::*)(int)")
 
 
-class TestRestrictQualifierIsAlwaysStripped:
-    """``restrict``/``__restrict``/``__restrict__`` never affects the
-    Itanium C++ ABI's mangling, at ANY position -- unlike a genuine
-    by-value cv-qualifier, which is only by-value (and so only safe to
-    strip) on the parameter's own outermost pointer. This repository
-    already tracks the fact separately (``Param.is_restrict``); collapsing
-    it into an unmangled fallback signature's identity would turn that
-    dedicated compatible parameter-qualifier change into a spurious
-    removal/addition pair instead."""
+class TestRestrictQualifierSharesCvPositionDiscipline:
+    """``restrict``/``__restrict``/``__restrict__`` is dropped on the
+    parameter's own outermost, by-value pointer position -- exactly like
+    a genuine cv-qualifier there -- but stays genuinely distinguishing on
+    an inner pointer level, ALSO exactly like cv. Verified against real
+    compiler output (``g++ -c``, both GCC and Clang): ``void f(int *)``
+    and ``void f(int * restrict)`` mangle identically and cannot even be
+    declared as an overload pair, but ``void f(int **)`` and
+    ``void f(int * restrict *)`` mangle to two different, simultaneously-
+    declarable symbols (``_Z1fPPi`` vs ``_Z1fPrPi``) -- restrict is NOT
+    unconditionally mangling-inert, contrary to an earlier (reverted)
+    round's own "strip everywhere" fix."""
 
     def test_bare_pointer_restrict_stripped(self) -> None:
         assert canon("int *restrict") == canon("int *")
@@ -246,19 +249,24 @@ class TestRestrictQualifierIsAlwaysStripped:
         # distinguishing pointee cv-qualifier too.
         assert canon("int *restrict") != canon("const int *")
 
-    def test_restrict_on_non_outermost_pointer_also_stripped(self) -> None:
-        # Restrict's absence from mangling holds regardless of WHERE in
-        # the declarator it sits -- not only the parameter's own
-        # outermost pointer, unlike a genuine by-value cv-qualifier.
-        assert canon("int * restrict *") == canon("int * *")
+    def test_restrict_on_non_outermost_pointer_still_distinguishes(self) -> None:
+        # Restrict on an INNER pointer level is a genuine, standard-
+        # mandated (GCC/Clang-confirmed) overload discriminator, just
+        # like a genuine pointee cv-qualifier there -- must NOT collapse.
+        assert canon("int * restrict *") != canon("int * *")
 
     def test_restrict_inside_callback_parameter_stripped(self) -> None:
         # The recursive nested-parameter-list normalization must also
-        # apply this rule to each of a callback's own parameters.
+        # apply the outermost-position rule to each of a callback's own
+        # parameters.
         assert canon("void (*)(int *restrict)") == canon("void (*)(int *)")
 
-    def test_idempotent(self) -> None:
+    def test_idempotent_on_outermost_restrict(self) -> None:
         once = canon("int *restrict")
+        assert canon(once) == once
+
+    def test_idempotent_on_inner_restrict(self) -> None:
+        once = canon("int * restrict *")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -282,6 +282,42 @@ class TestPointerToMemberTrailingQualifiersPreserved:
         )
 
 
+class TestNoexceptSpellingsCanonicalized:
+    """Since C++17, a function type's exception specification collapses
+    to exactly two kinds for TYPE purposes: "non-throwing" (bare
+    ``noexcept``/``noexcept(true)``) and "potentially-throwing" (no
+    specifier at all, or ``noexcept(false)``) -- those pairs are the SAME
+    type and must canonicalize identically, not merely both survive."""
+
+    def test_bare_noexcept_equals_noexcept_true(self) -> None:
+        assert canon("void (*)(int) noexcept") == canon("void (*)(int) noexcept(true)")
+
+    def test_noexcept_false_equals_no_specifier(self) -> None:
+        assert canon("void (*)(int) noexcept(false)") == canon("void (*)(int)")
+
+    def test_noexcept_still_distinguishes_from_no_specifier(self) -> None:
+        assert canon("void (*)(int) noexcept") != canon("void (*)(int)")
+        assert canon("void (*)(int) noexcept(true)") != canon("void (*)(int)")
+
+    def test_non_literal_noexcept_expression_left_untouched(self) -> None:
+        # Evaluating an arbitrary constant expression is out of scope --
+        # this must not be silently (and wrongly) treated as equivalent
+        # to either canonical form.
+        assert "SOME_CONSTANT" in canon("void (*)(int) noexcept(SOME_CONSTANT)")
+        assert canon("void (*)(int) noexcept(SOME_CONSTANT)") != canon(
+            "void (*)(int) noexcept"
+        )
+        assert canon("void (*)(int) noexcept(SOME_CONSTANT)") != canon("void (*)(int)")
+
+    def test_noexcept_normalization_combines_with_trailing_cv(self) -> None:
+        assert canon("void (C::*)(int) const noexcept(true)") == canon(
+            "void (C::*)(int) noexcept const"
+        )
+        assert canon("void (C::*)(int) const noexcept(false)") == canon(
+            "void (C::*)(int) const"
+        )
+
+
 class TestNestedCallbackParametersAreNormalizedRecursively:
     """A declarator's own trailing parameter list (a callback or
     member-function-pointer's parameters) is exactly as much a function's
@@ -358,6 +394,14 @@ class TestIdempotence:
 
     def test_idempotent_on_noexcept(self) -> None:
         once = canon("void (C::*)(int) noexcept const")
+        assert canon(once) == once
+
+    def test_idempotent_on_noexcept_true_spelling(self) -> None:
+        once = canon("void (*)(int) noexcept(true)")
+        assert canon(once) == once
+
+    def test_idempotent_on_non_literal_noexcept(self) -> None:
+        once = canon("void (*)(int) noexcept(SOME_CONSTANT)")
         assert canon(once) == once
 
 

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 2: direct primitive-level tests for
+``model.signature_normalization.canonicalize_function_signature_param_type``.
+
+``tests/test_model_identity.py`` already exercises this primitive through
+``entity_id_for_function``'s own overload-discrimination contract; this
+file pins the primitive's own contract directly, per AGENTS.md's
+"Primitive-level property tests" convention -- a new reusable string-
+normalization primitive gets its own standalone tests, decoupled from any
+one caller's domain logic.
+"""
+
+from __future__ import annotations
+
+from abicheck.model import signature_normalization
+from abicheck.model.signature_normalization import (
+    canonicalize_function_signature_param_type as canon,
+)
+
+
+class TestByValueCvIsDropped:
+    """A top-level BY-VALUE cv-qualifier plays no part in a function's own
+    type for linkage purposes -- void f(int) and void f(const int) name
+    the same function."""
+
+    def test_plain_scalar_unchanged(self) -> None:
+        assert canon("int") == "int"
+
+    def test_leading_const_dropped(self) -> None:
+        assert canon("const int") == canon("int")
+
+    def test_leading_volatile_dropped(self) -> None:
+        assert canon("volatile unsigned long long") == canon("unsigned long long")
+
+    def test_const_volatile_class_type_dropped(self) -> None:
+        assert canon("const std::string") == canon("std::string")
+
+
+class TestCrossProducerSpellingNormalized:
+    """CastXML and Clang spell an otherwise-identical type differently."""
+
+    def test_castxml_vs_clang_pointer_spacing(self) -> None:
+        assert canon("char const*") == canon("char const *")
+
+    def test_leading_vs_trailing_const_spelling(self) -> None:
+        assert canon("const char *") == canon("char const *")
+
+
+class TestPointeeCvIsPreserved:
+    """A pointee cv-qualifier on a pointer/reference parameter is a
+    genuine, standard-mandated overload discriminator -- unlike the
+    by-value case, it must never be dropped."""
+
+    def test_const_pointer_differs_from_mutable(self) -> None:
+        assert canon("char *") != canon("const char *")
+
+    def test_intermediate_pointer_level_cv_differs(self) -> None:
+        # "pointer to a const-qualified pointer to int" vs. "pointer to
+        # pointer to int" -- genuinely different, non-interchangeable
+        # types, even though the qualifier isn't on the outermost sigil.
+        assert canon("int **") != canon("int * const *")
+
+    def test_template_argument_cv_differs(self) -> None:
+        # A cv-qualifier nested in a template argument names a genuinely
+        # different type -- Box<const int> vs. Box<int>.
+        assert canon("Box<const int>") != canon("Box<int>")
+
+
+class TestPointersOwnTopLevelCvIsDropped:
+    """A cv-qualifier trailing the pointer's own outermost sigil qualifies
+    the pointer value itself, not what it points to -- dropped exactly
+    like any other top-level by-value parameter qualifier."""
+
+    def test_pointer_own_const_dropped(self) -> None:
+        assert canon("int * const") == canon("int *")
+
+    def test_pointer_own_const_does_not_erase_pointee_cv(self) -> None:
+        # The pointer's own trailing qualifier is dropped, but a genuine
+        # pointee qualifier earlier in the same string must survive.
+        assert canon("const int * const") == canon("const int *")
+        assert canon("const int * const") != canon("int *")
+
+
+class TestArrayParameterDecay:
+    """A function parameter's array type always decays to a pointer -- the
+    bound plays no part in the adjusted type at all."""
+
+    def test_bound_does_not_distinguish(self) -> None:
+        assert canon("int []") == canon("int [3]") == canon("int [4]") == canon("int *")
+
+    def test_element_cv_becomes_pointee_cv(self) -> None:
+        assert canon("const int []") == canon("const int *")
+        assert canon("const int [3]") != canon("int [3]")
+
+    def test_multi_dimensional_array_left_unchanged(self) -> None:
+        # Documented, accepted limitation: correctly re-spelling T[][N]'s
+        # adjusted type (T(*)[N]) needs declarator-rewriting this
+        # primitive does not implement.
+        assert canon("int [3][4]") == "int [3][4]"
+
+    def test_multi_dimensional_array_element_cv_not_wrongly_stripped(self) -> None:
+        # The accepted limitation must not become an active regression:
+        # a genuinely different element-cv must still compare different,
+        # even though the bound itself isn't normalized away here.
+        assert canon("const int [3][4]") != canon("int [3][4]")
+
+    def test_pointer_to_array_left_unchanged(self) -> None:
+        # int (*)[3] ("pointer to array of 3 ints") already has its own
+        # outermost sigil -- the trailing [3] is the POINTEE's bound, not
+        # the parameter's own top-level shape, and must not be decayed.
+        assert "*" in canon("int (*)[3]")
+        assert "[3]" in canon("int (*)[3]")
+
+
+class TestIdempotence:
+    """Canonicalizing an already-canonical form is a no-op -- a basic
+    sanity property any normalization function should hold."""
+
+    def test_idempotent_on_plain_type(self) -> None:
+        once = canon("const int")
+        assert canon(once) == once
+
+    def test_idempotent_on_pointer_type(self) -> None:
+        once = canon("int * const")
+        assert canon(once) == once
+
+    def test_idempotent_on_array_type(self) -> None:
+        once = canon("const int [3]")
+        assert canon(once) == once
+
+
+def test_module_declares_no_dependency_above_model() -> None:
+    """Leaf-module contract (ADR-063 D10): ``model.signature_normalization``
+    imports nothing from ``checker_types``/``diff_*``/anything above
+    ``model`` — the same contract ``model.identity`` (its only caller)
+    states, checked the identical way -- against the module's real
+    ``import``/``from ... import`` AST nodes, not a substring scan."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(signature_normalization))
+    banned_prefixes = (
+        "checker_types",
+        "diff_",
+        "checker",
+        "compare",
+        "finding_identity",
+    )
+    imported_names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_names.append(node.module)
+    for name in imported_names:
+        bare = name.lstrip(".")
+        assert not bare.startswith(banned_prefixes), name

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -318,6 +318,19 @@ class TestClangTrailingCallingConventionAttributeUnifies:
             "void (__cdecl *)(int)"
         )
 
+    def test_return_type_containing_convention_keyword_as_substring(self) -> None:
+        # A return type that merely CONTAINS a convention keyword as a
+        # substring of an unrelated identifier (e.g. "my__cdecl_result")
+        # must not be mistaken for a declarator that already has one --
+        # the trailing attribute must still be injected as the
+        # declarator's own leading keyword, not silently dropped.
+        assert canon("my__cdecl_result (*)(int) __attribute__((stdcall))") == canon(
+            "my__cdecl_result (__stdcall *)(int)"
+        )
+        assert canon("my__cdecl_result (*)(int) __attribute__((stdcall))") != canon(
+            "my__cdecl_result (*)(int)"
+        )
+
 
 class TestLeadingGlobalScopeQualifierIsStripped:
     """An explicit leading ``::`` (forcing global-namespace lookup) names

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -165,6 +165,75 @@ class TestPointerToMemberOwnCvIsDropped:
         assert "(int)" in canon("void (C::* const)(int)")
 
 
+class TestCallingConventionDeclaratorGroupIsRecognized:
+    """An MSVC/PE calling-convention keyword (``__cdecl``, ``__stdcall``,
+    ...) can precede a declarator's own sigil inside its grouping parens
+    -- the transparency test must still find the sigil at depth 0, and the
+    convention keyword itself must survive verbatim (it is genuine,
+    distinguishing content, not something this primitive erases)."""
+
+    def test_own_const_dropped_with_calling_convention_present(self) -> None:
+        assert canon("void (__cdecl * const)(int)") == canon("void (__cdecl *)(int)")
+
+    def test_calling_convention_keyword_preserved(self) -> None:
+        assert "__cdecl" in canon("void (__cdecl *)(int)")
+
+    def test_different_calling_conventions_still_distinguish(self) -> None:
+        # The convention itself is genuine ABI content -- __cdecl and
+        # __stdcall are two different, non-interchangeable types.
+        assert canon("void (__cdecl *)(int)") != canon("void (__stdcall *)(int)")
+
+
+class TestPointerToMemberTrailingQualifiersPreserved:
+    """A pointer-to-member-function's own trailing cv/ref-qualifiers (the
+    ``const``/``volatile``/``&``/``&&`` that can follow its parameter
+    list) qualify the POINTED-TO member function -- a genuine,
+    standard-mandated discriminator, unlike the pointer's own by-value
+    qualifier -- so they must survive, only reordered, never dropped."""
+
+    def test_trailing_const_distinguishes_from_unqualified(self) -> None:
+        assert canon("void (C::*)(int) const") != canon("void (C::*)(int)")
+
+    def test_trailing_const_still_present(self) -> None:
+        assert "const" in canon("void (C::*)(int) const")
+
+    def test_trailing_qualifier_order_does_not_matter(self) -> None:
+        assert canon("void (C::*)(int) const volatile") == canon(
+            "void (C::*)(int) volatile const"
+        )
+
+    def test_own_by_value_cv_still_dropped_alongside_trailing_qualifier(self) -> None:
+        # The pointer's own by-value cv (before the parameter list) and
+        # the pointed-to function's own trailing cv (after it) are
+        # independent regions -- dropping the former must not affect the
+        # latter surviving.
+        assert canon("void (C::* const)(int) const") == canon("void (C::*)(int) const")
+        assert canon("void (C::* const)(int) const") != canon("void (C::*)(int)")
+
+    def test_trailing_lvalue_ref_qualifier_distinguishes(self) -> None:
+        assert canon("void (C::*)(int) &") != canon("void (C::*)(int)")
+
+    def test_trailing_rvalue_ref_qualifier_distinguishes(self) -> None:
+        # canonicalize_type_name spells "&&" as "& &" internally -- this
+        # must not be mistaken for two separate top-level sigils, and must
+        # not collide with the single-"&" lvalue-ref-qualifier case.
+        assert canon("void (C::*)(int) &&") != canon("void (C::*)(int)")
+        assert canon("void (C::*)(int) &&") != canon("void (C::*)(int) &")
+
+    def test_trailing_cv_and_ref_qualifier_combine(self) -> None:
+        assert canon("void (C::*)(int) const &") != canon("void (C::*)(int) const")
+        assert canon("void (C::*)(int) const &") != canon("void (C::*)(int) &")
+
+    def test_trailing_ref_qualifier_does_not_corrupt_own_sigil(self) -> None:
+        # Regression pin for a self-caught bug: a trailing "&"/"&&" was
+        # briefly mistaken for a NEW top-level sigil, overriding the
+        # declarator's own already-found "*" and corrupting the
+        # prefix/suffix split entirely.
+        assert canon("void (C::*)(int) &&") == canon("void (C::*)(int) &&")
+        assert "(int)" in canon("void (C::*)(int) &&")
+        assert "C" in canon("void (C::*)(int) &&")
+
+
 class TestNestedCallbackParametersAreNormalizedRecursively:
     """A declarator's own trailing parameter list (a callback or
     member-function-pointer's parameters) is exactly as much a function's
@@ -225,6 +294,14 @@ class TestIdempotence:
 
     def test_idempotent_on_nested_callback_type(self) -> None:
         once = canon("void (*)(const int, void (*)(char *))")
+        assert canon(once) == once
+
+    def test_idempotent_on_calling_convention_type(self) -> None:
+        once = canon("void (__cdecl * const)(int)")
+        assert canon(once) == once
+
+    def test_idempotent_on_trailing_member_qualifiers(self) -> None:
+        once = canon("void (C::*)(int) volatile const")
         assert canon(once) == once
 
 


### PR DESCRIPTION
## Summary

Adds `abicheck/model/identity.py` — the first, isolated slice of ADR-063
Phase 2 ("`EntityId`/`ScopePath` as the one identity primitive").

## Motivation

ADR-063 (`docs/contribute/plans/one-semantic-pipeline.md`) calls for one
shared identity primitive to replace the various ad-hoc string-keyed
identity computations scattered across the codebase (dict keys, `name`,
`qualified_name`, synthetic ctor/dtor keys). Phase 2 is that primitive.
This PR lands its first, self-contained piece rather than the whole phase.

## Changes

- New `abicheck/model/identity.py` (leaf module, no dependency on
  `checker_types`/`diff_*`/anything above `model`, per ADR-063 D10):
  - Five typed `ScopeSegment` variants (`Namespace`, `Record`,
    `InlineNamespace`, `Anonymous`, `LocalToFunction`), each stating which
    of its own fields are identity and which are payload (e.g.
    `Record.access` is excluded from equality/hash — an access-level
    change is a modification, not a different scope).
  - The corrected `EntityId` shape (`scope`, `kind`, `leaf_name`, `extra`)
    — never a bare `(scope, kind)` pair, which would collide sibling
    declarations of the same kind in one scope.
  - `entity_id_for_type`/`_enum`/`_typedef`/`_constant`/`_variable`/
    `_function` constructors implementing the function/variable
    discriminator rules (mangled name first when the caller has already
    established it is genuine, normalized param-type/cv-qualifier
    fallback otherwise), mirroring the existing tiered resolution
    `finding_identity.py`/`SymbolIdentityIndex` already establish.
- `EntityKind`/`ObservationKind` relocate from `storage/entity_ids.py`
  into this new module (domain vocabulary belongs in `model`, not the
  storage wire layer, per ADR-061's `storage -> model` import direction).
  `storage.entity_ids` now imports rather than redefines them, so exactly
  one `EntityKind`/`ObservationKind` exists in the repository; every
  existing `storage.entity_ids.EntityKind` import keeps resolving
  unchanged.
- `tests/test_model_identity.py`: primitive-level property tests (per
  AGENTS.md's own convention for a new reusable identity/merge
  primitive) covering the identity-vs-payload field split per segment,
  sibling-declaration collision avoidance across kinds and nesting
  shapes, the function-overload and `extern "C"` discriminator rules,
  and the `EntityKind`/`ObservationKind` relocation itself.
- `docs/contribute/plans/one-semantic-pipeline.md`: records what this
  slice landed and, explicitly, what it does not attempt yet (deriving a
  real `ScopePath` from parser scope-tracking state, the still-open
  carrier-field design question, migrating `finding_identity.py`'s
  mangled-name-validation algorithm, and the storage v2 wire-schema
  bridge) — each named as its own follow-on slice.

This slice is purely additive and internal: nothing outside this module
and its own tests constructs a `model.identity.EntityId` yet. No parser,
detector, or storage writer is wired to it.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (plan doc's own Phase 2 section)
- [x] `mypy abicheck/` clean
- [x] `ruff check`/`ruff format --check` clean on touched files
- [x] Fast unit suite green

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMVXSbfoCefQiyBKPVmQB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured, scope-aware identities for types, enums, variables, functions, and local declarations.
  * Improved identity handling for anonymous declarations, overloads, mangled and `extern "C"` symbols, qualifiers, references, arrays, and variadic functions.
  * Added consistent parameter-signature normalization, including array decay, nested callbacks, calling conventions, member-function qualifiers, and `noexcept` forms.
  * Preserved compatibility for existing entity and observation kind imports.

* **Documentation**
  * Updated identity model documentation and implementation plans.

* **Tests**
  * Added comprehensive coverage for identity stability, collision resistance, hashability, and signature discrimination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->