### PR TITLE
fix(cli): treat explicit dump --config/--build-query as trusted operator input

### DIFF
--- a/abicheck/frontends/cli/commands/dump.py
+++ b/abicheck/frontends/cli/commands/dump.py
@@ -750,7 +750,11 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         build_config=build_config,
         build_query=build_query,
         build_compile_db=build_compile_db,
-        allow_build_query=allow_build_query,
+        # `allow_build_query` (the deprecated `--allow-build-query` no-op
+        # flag) is NOT this call's trust signal -- see `execute_dump_cli_run`'s
+        # own docstring (Codex review, third regression) for why `True` is
+        # correct here unconditionally.
+        allow_build_query=True,
         legacy_compile_db_tokens=tuple(build_context_flags),
         legacy_compile_db_matched=compile_db_matched,
         # Codex review, two real regressions: `perform_elf_dump` always

--- a/abicheck/frontends/cli/dump_execute.py
+++ b/abicheck/frontends/cli/dump_execute.py
@@ -138,6 +138,24 @@ def execute_dump_cli_run(
     -- matching ``scan``'s own candidate resolution, which passes the
     identical value for the identical reason.
 
+    *allow_build_query* -- the caller passes ``True`` unconditionally here,
+    NOT ``dump_cmd``'s own ``allow_build_query`` local (Codex review, a third
+    regression). That local is the deprecated, always-``False`` no-op
+    ``--allow-build-query`` flag (``cli_options.py``: "Kept as a no-op for
+    backward compatibility"), never a real trust signal for this call.
+    Forwarding it verbatim into ``_gated_build_query_inputs`` -- a Tier-2
+    gate written for a programmatic API caller who must opt in -- nulled an
+    explicit ``--config``/``--build-query`` for this execution step alone,
+    contradicting both flags' own documented CLI contract (``--build-query``:
+    "runs automatically as trusted operator input"; ``--config``: "build.
+    query runs only from an explicit --config") and regressing
+    ``perform_elf_dump``, which forwarded both unchanged with no such gate.
+    ``dump``'s CLI is itself the trust boundary an explicit ``--config``/
+    ``--build-query`` already crossed by being typed here at all -- unlike
+    ``scan``'s config-file-sourced ``build.query``, which needs its own
+    ``resolve_effective_allow_query`` "level-implies-query" decision
+    (ADR-037 D4) precisely because it is not operator-typed.
+
     Raises:
         click.ClickException: If extraction fails (mirrors
             ``perform_elf_dump``'s own ``except`` clause exactly).

--- a/changelog.d/1788020375_claude_dump-cli-execute-dump-request.md
+++ b/changelog.d/1788020375_claude_dump-cli-execute-dump-request.md
@@ -22,11 +22,15 @@
   shared pipeline's own precedence rule rather than dropping it.
   PE/Mach-O `dump` (`handle_non_elf_dump`) is unmigrated — no PE/Mach-O
   toolchain was available to verify a migration against.
-  Two follow-up fixes to the same migration (review, before release): the
+  Three follow-up fixes to the same migration (review, before release): the
   real ELF run now also forwards its resolved collect mode to the L2
   include/compile seed (so a `--sources` tree with no compile database
   still runs its zero-config inferred build query, matching the retired
-  `perform_elf_dump`'s behavior) and always selects L4 source replay's
+  `perform_elf_dump`'s behavior), always selects L4 source replay's
   compiler from the L3 build-context fold once it applies (matching
-  `scan`'s own candidate resolution) — both were silently dropped kwargs
-  in the initial migration, not new behavior.
+  `scan`'s own candidate resolution), and always treats an explicit
+  `--config`/`--build-query` given on the `dump` command line as trusted
+  operator input for this execution step (matching both flags' documented
+  CLI contract) rather than gating them behind the deprecated, always-off
+  `--allow-build-query` no-op flag — all three were silently dropped or
+  misrouted kwargs in the initial migration, not new behavior.

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -3193,6 +3193,26 @@ pipelines a fourth time.
   > reach `execute_dump_request` (verified to fail against the pre-fix code
   > with a `KeyError`, confirming the test catches the exact regression).
 
+  > **A third regression, same review round.** `execute_dump_cli_run`'s call
+  > forwarded `dump_cmd`'s own `allow_build_query` local -- the deprecated,
+  > always-`False` `--allow-build-query` no-op flag (`cli_options.py`: "Kept
+  > as a no-op for backward compatibility") -- straight into
+  > `_gated_build_query_inputs`, a Tier-2 gate written for a programmatic API
+  > caller who must opt in. That silently nulled an explicit `--config`/
+  > `--build-query` for the execution step alone, contradicting both flags'
+  > own documented CLI contract (`--build-query`: "runs automatically as
+  > trusted operator input"; `--config`: "build.query runs only from an
+  > explicit --config") and regressing `perform_elf_dump`, which forwarded
+  > both unchanged with no such gate. `dump`'s CLI is itself the trust
+  > boundary an explicit `--config`/`--build-query` already crossed by being
+  > typed there at all -- unlike `scan`'s config-file-sourced `build.query`,
+  > which needs its own `resolve_effective_allow_query` "level-implies-query"
+  > decision (ADR-037 D4) precisely because it is not operator-typed. Fixed
+  > by passing `allow_build_query=True` unconditionally at this one call
+  > site instead of the CLI local. The same spy test now also asserts
+  > `seen["allow_build_query"] is True` (verified to fail against the
+  > pre-fix code the same way).
+
 `dump --build-query` and `dump --build-compile-db` describe how the *project*
 is built, not what this snapshot is. They are already documented as CLI
 equivalents of the `.abicheck.yml` `build.query` / `build.compile_db` fields,

--- a/tests/test_dump_request_from_cli.py
+++ b/tests/test_dump_request_from_cli.py
@@ -456,6 +456,16 @@ class TestExecutionConsumesTheResolvedPlan:
         # pins to "off" and L4 replay silently uses the pre-fold compiler.
         assert seen["seed_collect_mode"] == resolved.collect_mode
         assert seen["source_frontend_from_folded_context"] is True
+        # Codex review, third real regression: `dump_cmd`'s own
+        # `allow_build_query` local is the deprecated, always-False no-op
+        # `--allow-build-query` flag -- not the trust signal for this
+        # execution step. This invocation passes no `--allow-build-query`,
+        # so `allow_build_query` (the CLI local) is False; `seen`'s value
+        # must be True regardless, or an explicit `--config`/`--build-query`
+        # given on this exact command line would be silently nulled by
+        # `_gated_build_query_inputs` for the execution step alone -- see
+        # `execute_dump_cli_run`'s own docstring for the full contract.
+        assert seen["allow_build_query"] is True
 
     def test_no_parallel_public_header_derivation(self) -> None:
         """``dump_cmd`` must not re-derive the public-header split itself.


### PR DESCRIPTION
## Summary

A third real regression in the just-merged PR C ELF-dump migration (#945, commit `008783a`), found by Codex review, fresh evidence, after that PR merged.

## Motivation

`dump_cmd`'s `execute_dump_cli_run` call forwarded its own `allow_build_query` local — the deprecated, always-`False` `--allow-build-query` no-op flag (`cli_options.py`: "Kept as a no-op for backward compatibility") — as the trust signal into `_gated_build_query_inputs`, a Tier-2 gate written for a programmatic API caller who must opt in.

That silently nulled an explicit `--config`/`--build-query` for the execution step alone, contradicting both flags' own documented CLI contract (`--build-query`: "runs automatically as trusted operator input"; `--config`: "build.query runs only from an explicit --config") and regressing `perform_elf_dump`, which forwarded both unchanged with no such gate. `dump`'s CLI is itself the trust boundary an explicit `--config`/`--build-query` already crossed by being typed there at all — unlike `scan`'s config-file-sourced `build.query`, which needs its own `resolve_effective_allow_query` "level-implies-query" decision (ADR-037 D4) precisely because it is not operator-typed.

## Changes

- `dump.py`'s call to `execute_dump_cli_run` now passes `allow_build_query=True` unconditionally instead of the CLI's own (always-`False`) `allow_build_query` local.
- `dump_execute.py`'s docstring documents the reasoning and the CLI contract this preserves.
- Regression test + changelog + plan-doc update.

## Bug-fix test contract

- Bug class: A shared Tier-2 pipeline parameter that exists for one caller (`scan`) but is silently left at its default (never wired to the right value) for another caller (`dump`'s migrated ELF execution) — the third instance of this exact class in the same migration (siblings `seed_collect_mode`/`source_frontend_from_folded_context`, both already fixed and merged in #945).
- Publicly observable failure: `abicheck dump lib.so --config myproj.abicheck.yml` (or a bare `--build-query "cmake ..."`) silently drops the config/query for the resolve-time L2 seed and resolve-time L3-L5 embed step — the written snapshot has weaker/missing build-derived evidence (missing include dirs, generated headers, compile flags) with no error, even though the identical flags on the pre-migration `perform_elf_dump` path, or on `_write_snapshot_output`'s own write-time fallback embed, honor them.
- Regression test fails on base: Yes — `tests/test_dump_request_from_cli.py::TestExecutionConsumesTheResolvedPlan::test_elf_run_reads_its_plan_fields_off_the_resolved_request`'s new `assert seen["allow_build_query"] is True` fails against the pre-fix code (the pre-fix call site forwards the raw, always-`False` CLI flag).
- Negative control: the same test's neighboring assertions (`seed_collect_mode`, `source_frontend_from_folded_context`, `write_depth`, `resolved.headers`/`lang`/`header_backend`/`public_headers`/etc.) all still pass unchanged, proving the fix is scoped to `allow_build_query` alone and doesn't loosen or otherwise change the surrounding resolution/trust behavior.
- Public-surface test: Yes — the test invokes the real `abicheck dump` CLI via `CliRunner().invoke(main, ["dump", ...])`, spying at the `execute_dump_request` module-level entry point (not an internal helper in isolation).
- Axes covered: this is the third of three sibling plumbing regressions in the same migration (`seed_collect_mode`, `source_frontend_from_folded_context`, `allow_build_query`), all reached by the identical spy test; each is asserted independently so a future re-introduction of any one is caught alone.
- General invariant: every keyword argument `_resolve_side_snapshot_impl`/`execute_dump_request` defines for `scan`'s candidate resolution must also reach `dump`'s migrated real-run call site with the value that reproduces `perform_elf_dump`'s pre-migration behavior — verified by asserting the exact kwarg value `execute_dump_request` receives (an oracle independent of the fix's own assignment, since the assertion reads the call boundary, not a restatement of it).

## Verified

- `mypy abicheck/`, `ruff check`, `python scripts/check_architecture.py`, `python scripts/check_ai_readiness.py`, `python scripts/check_docs_contract.py` — all clean.
- Full fast unit suite: 34,206 passed, 0 regressions (2 pre-existing failures confirmed unrelated, reproduce identically on unmodified `main`).
- Targeted integration suite for this area (dump/scan L3-L4 convergence, typed API parity, legacy compile-db threading, dry-run build-query trust) — all green.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment updated (`changelog.d/1788020375_claude_dump-cli-execute-dump-request.md`)
- [x] Docs updated (plan doc)
- [x] No new `mypy` or `ruff` errors introduced

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011AMFw533KfPSTPzwJtKvzG)_