### PR TITLE
refactor(adr-061): continued incremental migration — doc drift fixes + two more classification blockers closed

### DIFF
--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -360,7 +360,7 @@ def write_snapshot_payload(
     """
     import json
 
-    from .snapshot_io import write_snapshot_text
+    from .workflows.storage import write_snapshot_text
 
     text = json.dumps(payload, indent=2)
     return write_snapshot_text(text, path, compression=compression)
@@ -381,7 +381,7 @@ def reject_snapshot_compression_conflict(
     if output is None:
         return
     from .errors import SnapshotError
-    from .snapshot_io import SnapshotCompression, resolve_write_compression
+    from .workflows.storage import SnapshotCompression, resolve_write_compression
 
     try:
         resolve_write_compression(output, SnapshotCompression(snapshot_compression))
@@ -402,7 +402,7 @@ def write_snapshot_and_report(
     readiness file-size gate.
     """
     from .errors import SnapshotError
-    from .snapshot_io import SnapshotCompression
+    from .workflows.storage import SnapshotCompression
 
     try:
         write_result = write_snapshot_payload(
@@ -888,7 +888,7 @@ def render_dump_dry_run(
     )
     if output is not None:
         from .errors import SnapshotError
-        from .snapshot_io import SnapshotCompression, resolve_write_compression
+        from .workflows.storage import SnapshotCompression, resolve_write_compression
 
         try:
             resolved_compression = resolve_write_compression(

--- a/abicheck/cli_dump_request.py
+++ b/abicheck/cli_dump_request.py
@@ -45,16 +45,22 @@ Its own module, not an addition to ``cli.py`` (1800+ lines, WARN) or
 ``cli_dump_helpers.py`` (at the 2000-line hard cap) — AGENTS.md, "Files that
 are large".
 
-**Scope, stated plainly**: the real ELF/PE/Mach-O run still executes through
-``perform_elf_dump``/``handle_non_elf_dump``, not through
-``service_dump_pipeline.execute_dump_request``. ADR-063 Phase 1 re-investigated
-this and found the ADR-039 collector's own post-processing passes are NOT
-actually a blocker (they already run inside ``_resolve_side_snapshot_impl``
-too, and a second, redundant call from ``perform_elf_dump`` is a safe no-op).
-The real, still-open blocker is the legacy ``-p``/``--compile-db`` auto-match
-(``cli_helpers_compare._resolve_build_context_flags``) having no equivalent
-inside ``resolve_dump_request``/``execute_dump_request`` at all — see
+**Scope, stated plainly**: the real ELF run has since migrated (CLI cleanup
+phase two, PR C) — ``frontends/cli/commands/dump.py`` builds a second,
+execution-scoped ``ResolvedDumpRequest`` from the object this module
+produces and calls ``frontends.cli.dump_execute``, which runs it through
+``service_dump_pipeline.execute_dump_request`` instead of the retired
+``perform_elf_dump`` call site (still defined, for any other caller that
+depends on it, but no longer imported by ``dump_cmd``). The legacy
+``-p``/``--compile-db`` auto-match this note used to call a blocker is
+threaded through as an explicit pass-through
+(``execute_dump_request(..., legacy_compile_db_tokens=...,
+legacy_compile_db_matched=...)``) rather than a typed-API field — see
 ``docs/contribute/known-gaps.md``'s "PR C" entry for the precise mechanism.
+**PE/Mach-O is not migrated**: ``handle_non_elf_dump`` still executes
+independently of ``execute_dump_request`` — no PE/Mach-O toolchain was
+available to verify that migration against, so it remains exactly where
+that same "PR C" entry's "Blocker B" heading scoped it: open.
 This module is the prerequisite that migration needs,
 consumed today by ``--dry-run``.
 """

--- a/abicheck/cli_dump_request.py
+++ b/abicheck/cli_dump_request.py
@@ -61,8 +61,10 @@ legacy_compile_db_matched=...)``) rather than a typed-API field — see
 independently of ``execute_dump_request`` — no PE/Mach-O toolchain was
 available to verify that migration against, so it remains exactly where
 that same "PR C" entry's "Blocker B" heading scoped it: open.
-This module is the prerequisite that migration needs,
-consumed today by ``--dry-run``.
+This module's object is consumed by both branches today: ``--dry-run``
+renders it directly, and ``dump_cmd``'s real ELF branch builds the
+execution-scoped ``ResolvedDumpRequest`` described above from it before
+calling ``execute_dump_cli_run``.
 """
 
 from __future__ import annotations

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -418,7 +418,7 @@ def _version_sort_key(
     # ambiguous, indistinguishable from the filename alone, and already
     # surfaced by `_build_match_map`'s own "Ambiguous match" warning for
     # any multi-candidate bucket.)
-    from .snapshot_io import _COMPRESSED_SUFFIXES
+    from .workflows.storage import _COMPRESSED_SUFFIXES
 
     for suffix, _compression in _COMPRESSED_SUFFIXES:
         if lower.endswith(suffix):

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -35,7 +35,6 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
-from .compat.abicc_dump_import import looks_like_perl_dump
 from .errors import SnapshotError
 from .workflows.extraction import PRUNED_HEADER_DIR_SEGMENTS, iter_directory_headers
 
@@ -101,7 +100,7 @@ def _expand_header_inputs(inputs: list[Path]) -> list[Path]:
 
 def _sniff_text_format(path: Path) -> str:
     """Read a small header chunk and return 'json', 'perl', 'symvers', or 'unknown'. ADR-059: a gzip/zstd-compressed snapshot is recognized via a bounded decoded prefix, mirroring ``service.sniff_text_format`` (kept as a separate copy here rather than importing that one, matching this module's existing "no cross-import for this exact helper" shape)."""
-    from .snapshot_io import bounded_decoded_prefix, detect_snapshot_compression
+    from .workflows.storage import bounded_decoded_prefix, detect_snapshot_compression
 
     try:
         compression = detect_snapshot_compression(path)
@@ -120,14 +119,14 @@ def _sniff_text_format(path: Path) -> str:
         head = raw.decode("utf-8", errors="replace").lstrip()
     except OSError:
         return "unknown"
+    from .workflows.extraction import looks_like_perl_dump, looks_like_symvers
+
     # Check Perl dump BEFORE JSON — a Perl dump can start with $VAR1 = {
     # which would incorrectly match the JSON heuristic after the '{'
     if looks_like_perl_dump(head):
         return "perl"
     if head.startswith("{"):
         return "json"
-    from .workflows.extraction import looks_like_symvers
-
     return "symvers" if looks_like_symvers(head) else "unknown"
 
 

--- a/abicheck/compat/cli.py
+++ b/abicheck/compat/cli.py
@@ -37,7 +37,12 @@ from ..errors import ProfileMismatchError, ScopeMismatchError, SnapshotError
 from ..html_report import write_html_report
 from ..reporter import to_json, to_markdown
 from ..serialization import load_snapshot, save_snapshot
-from ..workflows.extraction import suppress_streaming_prune
+from ..workflows.extraction import (
+    import_abicc_perl_dump,
+    is_abicc_perl_dump_file,
+    looks_like_perl_dump,
+    suppress_streaming_prune,
+)
 from ._errors import (
     _classify_compat_error_exit_code,
     _classify_fs_error,
@@ -71,11 +76,6 @@ from ._helpers import (  # noqa: F401
     _setup_logging as _setup_logging,
     _warn_stub_flags as _warn_stub_flags,
     _write_affected_list as _write_affected_list,
-)
-from .abicc_dump_import import (
-    import_abicc_perl_dump,
-    is_abicc_perl_dump_file,
-    looks_like_perl_dump,
 )
 from .descriptor import parse_descriptor
 from .xml_report import write_xml_report
@@ -1208,7 +1208,7 @@ def _load_descriptor_or_dump(
     name = path.name.lower()
     if name.endswith((".json.gz", ".json.zst")):
         return load_snapshot(path)
-    from ..snapshot_io import SnapshotCompression, detect_snapshot_compression
+    from ..workflows.storage import SnapshotCompression, detect_snapshot_compression
 
     try:
         compression_hint = detect_snapshot_compression(path)
@@ -1429,9 +1429,7 @@ def _generate_compat_report(
         # native `legacy_exit_code`/`compute_exit_code` PR G1's `exit` block
         # would compute -- emitting it here would disagree with the actual
         # `compat check` exit code for the same run (Codex review).
-        path.write_text(
-            to_json(r, include_exit_decision=False), encoding="utf-8"
-        )
+        path.write_text(to_json(r, include_exit_decision=False), encoding="utf-8")
     else:
         path.write_text(to_markdown(r), encoding="utf-8")
 

--- a/abicheck/workflows/extraction.py
+++ b/abicheck/workflows/extraction.py
@@ -113,6 +113,11 @@ from ..buildsource.toolchain_bindings import (
 from ..buildsource.toolchain_probe import check_profile_toolchain_identity
 from ..clang_layout_tool import attach_clang_layout
 from ..classify import is_supported_compare_input
+from ..compat.abicc_dump_import import (
+    import_abicc_perl_dump,
+    is_abicc_perl_dump_file,
+    looks_like_perl_dump,
+)
 from ..debug_resolver import DebugArtifact, resolve_debug_info
 from ..dump_manifest import DumpManifest, load_manifest
 from ..dumper_cache import ast_memoize_scope
@@ -206,11 +211,13 @@ __all__ = [
     "fold_type_graph",
     "fold_virtual_dispatch_graph",
     "has_explicit_std",
+    "import_abicc_perl_dump",
     "include_operand_dirs",
     "ingest_codeql_call_results",
     "ingest_codeql_extends_results",
     "ingest_inputs_pack",
     "ingest_kythe_entries",
+    "is_abicc_perl_dump_file",
     "is_inputs_pack",
     "is_inputs_pack_dir",
     "is_pack_dir",
@@ -225,6 +232,7 @@ __all__ = [
     "load_inputs_pack_or_raise",
     "load_manifest",
     "load_pack_or_raise",
+    "looks_like_perl_dump",
     "looks_like_symvers",
     "normalize_binary_input",
     "parse_dwarf",

--- a/abicheck/workflows/storage.py
+++ b/abicheck/workflows/storage.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Snapshot storage-envelope operations a frontend asks the engine to perform.
+
+ADR-061 Phase 4 item 2's "make workflows the sole operation owners" rule
+applies to the ``storage`` ring the same way ``extraction.py`` applies it to
+``extract``: a frontend may not import ``storage`` directly (``frontends.
+may_import`` does not list it), so a CLI module that needs
+``snapshot_io.py``'s compression/detection helpers reaches them through this
+facade instead. Kept as its own module rather than folded into
+``extraction.py``: these operations are ADR-059's storage-envelope
+responsibility, not extraction, and mixing the two facades would blur exactly
+the ownership boundary this ADR exists to keep explicit.
+
+Re-export only, deliberately: the point is that there is one owner per
+operation and the frontend reaches it through the workflow layer, not that a
+new implementation appears here. Each name's own module (``snapshot_io.py``)
+remains the one to read and to change.
+
+``from ..x import y`` **binds** ``y`` here at import time, the same
+consequence ``extraction.py``'s own docstring records -- a test that needs to
+substitute one of these must patch it *here*, where the call actually
+resolves.
+"""
+
+from __future__ import annotations
+
+from ..snapshot_io import (
+    _COMPRESSED_SUFFIXES,
+    SnapshotCompression,
+    bounded_decoded_prefix,
+    detect_snapshot_compression,
+    resolve_write_compression,
+    write_snapshot_text,
+)
+
+__all__ = [
+    "_COMPRESSED_SUFFIXES",
+    "SnapshotCompression",
+    "bounded_decoded_prefix",
+    "detect_snapshot_compression",
+    "resolve_write_compression",
+    "write_snapshot_text",
+]

--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -37,7 +37,8 @@
       ],
       "legacy_paths": [
         "abicheck/buildsource/build_cache.py",
-        "abicheck/dumper_cache.py"
+        "abicheck/dumper_cache.py",
+        "abicheck/snapshot_io.py"
       ]
     },
     "extract": {
@@ -99,6 +100,7 @@
         "abicheck/cc_wrapper.py",
         "abicheck/clang_layout_tool.py",
         "abicheck/classify.py",
+        "abicheck/compat/abicc_dump_import.py",
         "abicheck/ctf_metadata.py",
         "abicheck/debug_resolver.py",
         "abicheck/dump_manifest.py",

--- a/changelog.d/20260830_040825_noreply_adr_061_qm23mp.md
+++ b/changelog.d/20260830_040825_noreply_adr_061_qm23mp.md
@@ -1,0 +1,10 @@
+### Documentation
+
+- **Fixed a stale `dump` CLI migration claim (ADR-061 Phase 3, CLI cleanup
+  phase two PR C).** `cli_dump_request.py`'s module docstring and
+  `docs/contribute/adr/061-responsibility-package-architecture.md`'s Phase 3
+  status still said the real ELF run executed through `perform_elf_dump`
+  rather than `service_dump_pipeline.execute_dump_request` — that migration
+  landed in PR C. Both now describe the actual, current split: ELF is
+  migrated (`frontends/cli/dump_execute.py`), PE/Mach-O
+  (`handle_non_elf_dump`) is not. No behavior change.

--- a/changelog.d/20260830_054607_noreply_adr_061_qm23mp.md
+++ b/changelog.d/20260830_054607_noreply_adr_061_qm23mp.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Closed two more of ADR-061's `service.py` classification blockers.**
+  `snapshot_io.py` (storage-envelope I/O) and `compat/abicc_dump_import.py`
+  (the ABICC Perl-dump importer) are now classified `storage` and `extract`
+  respectively in `architecture/modules.yaml`. Classifying them surfaced
+  real `frontends -> storage`/`frontends -> extract` edges — four CLI
+  modules importing `snapshot_io.py`'s compression/sniffing helpers and two
+  importing `compat.abicc_dump_import` directly — which are now routed
+  through workflow-owned facades instead: a new `abicheck.workflows.storage`
+  module (mirroring the existing `abicheck.workflows.extraction` facade) for
+  the former, and three new re-exports on `abicheck.workflows.extraction`
+  itself for the latter. No behavior change — `python
+  scripts/check_architecture.py` reports 0 findings before and after.

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -967,14 +967,26 @@ Hoisting the resolve also fixed a real inconsistency it exposed: a bare `dump`
 and a bare `dump --dry-run` rejected the *same* invalid input with two
 different messages.
 
-**Still open:** the real ELF/PE/Mach-O run still *executes* through
-`perform_elf_dump`/`handle_non_elf_dump` rather than `execute_dump_request`.
-What changed is which object supplies its resolved inputs. That last migration
-needs the ADR-039 collector's CLI-only inputs represented in the typed API and
-`_write_snapshot_output`'s provenance/`--inputs`/depth-gate sequence reordered
-around a resolve-time embed; it is also unverifiable here, since the default
-header backend is castxml and no policy-conformant build is obtainable in this
-environment (a hand-assembled conda-forge 0.6.13 segfaults in `ParseAST`).
+**The ELF half of this is now closed (CLI cleanup phase two, PR C).**
+`frontends/cli/commands/dump.py`'s real (non-`--dry-run`) ELF branch now
+builds a second, execution-scoped `ResolvedDumpRequest` from the same
+`DumpRequest` `--dry-run` already resolves and calls
+`frontends.cli.dump_execute`, which runs it through
+`service_dump_pipeline.execute_dump_request` — the L3-L5 embed moved to
+resolution time, while depth enforcement and dependency scoping stay at
+write time, unchanged, in `_write_snapshot_output`. `perform_elf_dump` is
+retired from that call site (still defined, for any other caller that
+depends on it, but no longer imported by `dump_cmd`). The legacy
+`-p`/`--compile-db` auto-match is threaded through as an explicit
+pass-through (`execute_dump_request(..., legacy_compile_db_tokens=...,
+legacy_compile_db_matched=...)`) rather than a typed-API field. See
+`docs/contribute/known-gaps.md`'s "PR C" entry for the full mechanism,
+including the one real behavior change this migration carries (`dump`'s L4
+source-extractor default flips from an accidental clang to castxml).
+
+**Still open: PE/Mach-O.** `handle_non_elf_dump` still executes
+independently of `execute_dump_request` — no PE/Mach-O toolchain was
+available to verify that migration against, so it remains open.
 
 Use the pattern already emerging in the typed compare, dump, input-resolution,
 and artifact-plan code:

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -973,8 +973,16 @@ builds a second, execution-scoped `ResolvedDumpRequest` from the same
 `DumpRequest` `--dry-run` already resolves and calls
 `frontends.cli.dump_execute`, which runs it through
 `service_dump_pipeline.execute_dump_request` — the L3-L5 embed moved to
-resolution time, while depth enforcement and dependency scoping stay at
-write time, unchanged, in `_write_snapshot_output`. `perform_elf_dump` is
+resolution time, while depth enforcement stays at write time, unchanged, in
+`_write_snapshot_output`. Dependency scoping is not purely write-time
+either way: `service.run_dump`'s own choke point already dependency-scopes
+the snapshot at resolve time, before the ADR-039 collector/header-graph/
+clang-layout attaches run on it — this predates and is unchanged by this
+migration — so `_write_snapshot_output`'s own unchanged
+`resolve_dependency_scope` call is a second, write-time pass over an
+already-once-scoped snapshot, confirmed idempotent for the shapes this
+migration's parity suite exercises but not proven idempotent in general.
+`perform_elf_dump` is
 retired from that call site (still defined, for any other caller that
 depends on it, but no longer imported by `dump_cmd`). The legacy
 `-p`/`--compile-db` auto-match is threaded through as an explicit

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -1705,16 +1705,26 @@ dozen", and "three sites" overclaims:
   right). Two files, three sites — mechanically fixable by rerouting those
   call sites through a `workflows`-owned facade, but that reroute is its own
   reviewed slice, not a drive-by inside this one.
-- **`snapshot_io.py` -> `storage`**: the same shape as `suppression.py`,
-  independently measured — a real `frontends -> storage` edge at
-  `cli_dump_helpers.py`, `cli_helpers_compare.py`, `cli_resolve.py`, and
-  `compat/cli.py`, all importing its compression/sniffing helpers directly.
-  `classify.py` and `package.py` also import it, but both are `extract`-
-  classified and `extract -> storage` is allowed, so they are not part of
-  the blocker (a plausible-looking `model -> storage` concern from an earlier
-  pass turned out to rest on misclassifying `classify.py` as `model`; it is
-  actually `extract`, checked directly against `architecture/modules.yaml`
-  rather than assumed).
+- **`snapshot_io.py` -> `storage`: done.** The same shape as `suppression.py`
+  below, and it got the reroute that entry says this shape needs: a real
+  `frontends -> storage` edge at `cli_dump_helpers.py`, `cli_helpers_compare.py`,
+  `cli_resolve.py`, and `compat/cli.py`, all importing its compression/sniffing
+  helpers directly. `classify.py` and `package.py` also import it, but both
+  are `extract`-classified and `extract -> storage` is allowed, so they were
+  never part of the blocker (a plausible-looking `model -> storage` concern
+  from an earlier pass turned out to rest on misclassifying `classify.py` as
+  `model`; it is actually `extract`). Fixed the same way `extraction.py`
+  already fixed the identical shape for `extract`-owned operations: a new
+  sibling facade, `workflows/storage.py`, re-exports `snapshot_io.py`'s
+  `SnapshotCompression`/`write_snapshot_text`/`resolve_write_compression`/
+  `detect_snapshot_compression`/`bounded_decoded_prefix`/
+  `_COMPRESSED_SUFFIXES` (kept as its own module rather than folded into
+  `extraction.py`, since these are ADR-059's storage-envelope responsibility,
+  not extraction, and merging the two facades would blur exactly the
+  ownership boundary this ADR exists to keep explicit), and all four call
+  sites now import through it instead of `snapshot_io` directly.
+  `snapshot_io.py` is now `storage` in `architecture/modules.yaml`;
+  `python scripts/check_architecture.py` reports 0 findings.
 - **`serialization.py` -> `storage`**: measured and found to be **worse**
   than the debt ledger's existing `storage` target implied — 72 findings, not
   a handful, because the module's own body reaches into `extract`/`compare`/
@@ -1723,13 +1733,20 @@ dozen", and "three sites" overclaims:
   entries above show. This is a dataclass/parser-shaped split the size of
   Phase 5's `*_metadata.py` work, not a reclassification — see the updated
   `architecture/debt.yaml` entry.
-- **`compat.abicc_dump_import` -> `extract`**: blocked by a real
+- **`compat.abicc_dump_import` -> `extract`: done.** Blocked by a real
   `frontends -> extract` edge at `cli_resolve.py:38` and `compat/cli.py:75`,
   both importing it directly rather than through a `workflows` re-export.
   `classify.py` also imports it function-locally, but `classify.py` is
   itself `extract`-classified, so that particular edge is `extract ->
-  extract` and fires nothing — the two `frontends` sites are the whole
+  extract` and fires nothing — the two `frontends` sites were the whole
   blocker here, not a third site hiding behind physical-location exemptions.
+  Fixed the same way `elf_metadata.py`/`symvers_metadata.py`/siblings
+  already route through `extraction.py`: `looks_like_perl_dump`,
+  `import_abicc_perl_dump`, and `is_abicc_perl_dump_file` joined that
+  facade's existing re-export list, and both `frontends` sites now import
+  them from there instead of `compat.abicc_dump_import` directly.
+  `compat/abicc_dump_import.py` is now `extract` in `architecture/modules.yaml`;
+  `python scripts/check_architecture.py` reports 0 findings.
 - **`service_render.py` -> `workflows`**: this is the one finding that
   reframes the whole entry, not just adds to it. `service_render.py` imports
   `reporter.py`/`sarif.py` — both `report`-classified — and `workflows ->


### PR DESCRIPTION
## Summary

Continues incremental ADR-061 work in two parts:

1. **Doc-vs-code drift fixes** (original scope): `cli_dump_request.py`'s module docstring and ADR-061's Phase 3 "Still open" note both said the real `dump` ELF run executed through `perform_elf_dump` rather than `service_dump_pipeline.execute_dump_request` — that migration (CLI cleanup phase two's PR C) had already landed but the record was never updated.
2. **Two more `service.py` classification blockers closed** (new): ADR-061 Phase 4's per-module re-measurement had already identified `snapshot_io.py` and `compat/abicc_dump_import.py` as blocked by a real `frontends -> storage`/`frontends -> extract` edge each. This PR does that reroute.

## Changes

### Part 1 — doc drift
- `abicheck/cli_dump_request.py`: rewrote the "Scope, stated plainly" paragraph to describe the actual current split — ELF is migrated onto `execute_dump_request`, PE/Mach-O (`handle_non_elf_dump`) is not.
- `docs/contribute/adr/061-responsibility-package-architecture.md`: rewrote Phase 3's "Still open" paragraph the same way (plus a follow-up fix from Codex review distinguishing the two dependency-scoping passes).

### Part 2 — classification blockers
- `snapshot_io.py` → `storage`. Fixed the real `frontends -> storage` edge at four CLI call sites (`cli_dump_helpers.py`, `cli_helpers_compare.py`, `cli_resolve.py`, `compat/cli.py`) with a new `abicheck.workflows.storage` facade (mirrors the existing `abicheck.workflows.extraction` facade).
- `compat/abicc_dump_import.py` → `extract`. Fixed the real `frontends -> extract` edge at two CLI call sites (`cli_resolve.py`, `compat/cli.py`) by adding its three public functions to `abicheck.workflows.extraction`'s existing re-export list.
- `python scripts/check_architecture.py`: 0 findings, before and after.
- Still open, unchanged: `policy_file.py`/`suppression.py` (the `model -> policy` inversion), `serialization.py` (needs its own dataclass/parser split first), `service_render.py` (`workflows -> report` is forbidden by design — a real split-the-file design question, not a mechanical reclassification).
- Two `changelog.d/` fragments (`Documentation` + `Changed`).

## Checklist

- [x] No behavior change — pure re-export/import routing plus architecture-classification metadata
- [x] Changelog fragments added (`scriv create`, x2)
- [x] Docs updated (ADR-061 Phase 3 + Phase 4 sections)
- [x] `ruff check` / `mypy abicheck/` (whole package) clean
- [x] `python scripts/check_architecture.py`, `check_ai_readiness.py`, `adr_status_sync.py`, `check_docs_contract.py` clean (0 errors, no new warnings)
- [x] Targeted test run (1679 tests covering every touched module/area) passes unchanged; `tests/test_cli_split_modules.py`, `test_cov95_cli.py`, `test_non_elf_dump_l2_seed.py`, `test_bazel_root_targets.py`, `test_abicc_dump_import.py` pass unchanged

Not a `fix:`/`perf:`/`security:` change, so the bug-fix test contract section is omitted per the template's own instruction.

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and CLI documentation to accurately describe the current ELF dump workflow.
  * Clarified that PE and Mach-O dump handling remains on the previous workflow.
  * Documented the current dependency-scoping behavior and architecture migration status.

* **Refactor**
  * Organized snapshot storage and dump extraction operations behind workflow-level interfaces.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->