### PR TITLE
feat(compare): ADR-063 Phase 2 — finding_identity delegation + Change entity_id carrier

### DIFF
--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -41,6 +41,7 @@ from .contract_relevance_types import (
 from .detectors import DetectorResult
 from .impact.model import ImpactAssessment
 from .model import AbiSnapshot
+from .model.identity import EntityId
 from .policy_file import PolicyFile
 
 # Marker appended to a ``SYMBOL_VERSION_ALIAS_CHANGED`` description when the old
@@ -332,25 +333,15 @@ class Change:
     # evidence" entry for the full account). ``False`` for every ordinary
     # TYPE_VTABLE_CHANGED and every other finding kind.
     #
-    # ``field(kw_only=True)``, per-field rather than the ``dataclasses.
-    # KW_ONLY`` sentinel (Codex review, fresh evidence): ``Change`` is
-    # documented as a public Python-API type (checker_types.py's own module
-    # docstring; CLAUDE.md: "changing their public surface is a breaking
-    # change to the Python API — coordinate it"), and a whole-class
-    # ``KW_ONLY`` marker placed after ``description`` would make every
-    # pre-existing optional field keyword-only too — breaking any external
-    # caller that previously passed ``old_value``/``new_value``/etc.
-    # positionally, which this codebase cannot audit (only its own call
-    # sites, all of which already pass every field beyond the first three by
-    # keyword). Appended at the very end of the dataclass instead of
-    # mid-list, for the same reason `field(kw_only=True)` alone doesn't
-    # already make position irrelevant: a plain field inserted anywhere
-    # earlier still shifts every later *positional* argument for a
-    # hypothetical caller reaching that far — appending keeps every
-    # pre-existing field's position, and therefore every pre-existing
-    # positional caller's behavior, completely unchanged. Mirrors
-    # ``AbiSnapshot``'s identical per-field fix in PR #582 exactly (that
-    # precedent predates this dataclass's own instance of the same bug).
+    # ``field(kw_only=True)`` per-field, not the whole-class ``dataclasses.
+    # KW_ONLY`` sentinel (Codex review): ``Change`` is public API (CLAUDE.md:
+    # "changing their public surface is a breaking change... coordinate
+    # it"), and a class-wide ``KW_ONLY`` marker after ``description`` would
+    # make every pre-existing optional field keyword-only too, breaking an
+    # external caller that passed one positionally. Appended at the very
+    # end, not mid-list, since ``kw_only=True`` alone doesn't stop a later
+    # *positional* argument from shifting — only position preserves that.
+    # Mirrors ``AbiSnapshot``'s identical fix in PR #582.
     vtable_covers_unverifiable_layout_gap: bool = field(default=False, kw_only=True)
     # ELF symbol linkage (Function.elf_binding / Variable.elf_binding's value
     # string — "global"/"weak"/"local"/"unique"/"other") of the removed (or
@@ -380,6 +371,15 @@ class Change:
     # contract_evidence_refs. Same field(kw_only=True)-appended-last
     # convention as symbol_binding above (Change is public API).
     evidence_provenance: tuple[str, ...] | None = field(default=None, kw_only=True)
+    # ADR-063 Phase 2 (finding_identity.py algorithm migration, second half):
+    # the compare-time EntityId of the declaration this finding is about --
+    # the OLD side's when it exists (REMOVED-shaped finding has none), else
+    # the NEW side's (ADDED-shaped), mirroring symbol_binding's own old-side
+    # convention above. None when the producer never resolved one, or for a
+    # synthetic/batch finding with no single declaration. Not yet read by
+    # any consumer. Same field(kw_only=True)-appended-last convention as
+    # evidence_provenance above (Change is public API).
+    entity_id: EntityId | None = field(default=None, kw_only=True)
 
 
 @dataclass

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -372,14 +372,14 @@ class Change:
     # convention as symbol_binding above (Change is public API).
     evidence_provenance: tuple[str, ...] | None = field(default=None, kw_only=True)
     # ADR-063 Phase 2 (finding_identity.py algorithm migration, second half):
-    # the compare-time EntityId of the declaration this finding is about --
-    # the OLD side's when it exists (REMOVED-shaped finding has none), else
-    # the NEW side's (ADDED-shaped), mirroring symbol_binding's own old-side
-    # convention above. None when the producer never resolved one, or for a
-    # synthetic/batch finding with no single declaration. Not yet read by
-    # any consumer. Same field(kw_only=True)-appended-last convention as
-    # evidence_provenance above (Change is public API).
-    entity_id: EntityId | None = field(default=None, kw_only=True)
+    # the compare-time EntityId this finding is about -- the OLD side's when
+    # it exists (REMOVED-shaped finding has none), else the NEW side's
+    # (ADDED-shaped), mirroring symbol_binding's own old-side convention
+    # above. None when unresolved; not yet read by any consumer.
+    # `compare=False` like the declaration-side carriers -- identical-content
+    # findings stay equal regardless of identity coverage (Codex review).
+    # Same field(kw_only=True)-appended-last convention as evidence_provenance.
+    entity_id: EntityId | None = field(default=None, kw_only=True, compare=False)
 
 
 @dataclass

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -1144,4 +1144,5 @@ def virtual_method_addition(
         symbol=f_new.mangled,
         detail=owner,
         new=f_new.name,
+        entity_id=f_new.entity_id,
     )

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -55,6 +55,7 @@ from .model import AbiSnapshot
 # adoption-debt ceiling for a name nothing external currently imports
 # through that path.
 from .model.change_catalog.registry import TEMPLATE_VOCAB as TEMPLATE_VOCAB
+from .model.identity import EntityId
 from .qualified_name_segments import strip_inline_abi_namespaces
 
 K = TypeVar("K")
@@ -145,6 +146,7 @@ def bool_transition(
     removed_values: tuple[str | None, str | None] = (None, None),
     skip_none: bool = False,
     caused_by_type: str | None = None,
+    entity_id: EntityId | None = None,
 ) -> list[Change]:
     """Emit a :class:`Change` for a boolean attribute transition.
 
@@ -167,6 +169,9 @@ def bool_transition(
     field when given — used by hidden-friend transitions to carry the
     befriending class's qualified name, so surface classification can key
     demotion off the *owner's* header origin.
+
+    ``entity_id`` (ADR-063 Phase 2) passes through to ``Change.entity_id``
+    unchanged -- resolving one is entirely the caller's job.
     """
     if skip_none and (old_val is None or new_val is None):
         return []
@@ -181,6 +186,7 @@ def bool_transition(
                 old_value=ov,
                 new_value=nv,
                 caused_by_type=caused_by_type,
+                entity_id=entity_id,
             )
         ]
     if old_val and not new_val and removed is not None:
@@ -194,6 +200,7 @@ def bool_transition(
                 old_value=ov,
                 new_value=nv,
                 caused_by_type=caused_by_type,
+                entity_id=entity_id,
             )
         ]
     return []
@@ -247,16 +254,14 @@ def type_map_key(t: _QualifiedNamed) -> str:
     """Key a ``RecordType``/``EnumType`` for old/new matching by its
     namespace-qualified identity, not its bare declaration name.
 
-    The header-mode dumpers (castxml, clang) deliberately keep ``t.name``
-    bare (see its docstring in model.py) and carry the real namespace path in
-    ``t.qualified_name`` instead; the DWARF backend has no such split and
-    already stores the qualified spelling directly in ``name``. Matching
-    old/new maps by bare ``t.name`` alone lets two unrelated types that only
-    share a short/leaf spelling (e.g. two distinct ``std::*::_Impl`` template
-    internals pulled in transitively) collide and diff against each other,
-    producing spurious field/base-class findings. Falling back to ``t.name``
-    when ``qualified_name`` is unset (global-scope types, DWARF-only
-    snapshots) keeps existing behaviour unchanged there.
+    The header-mode dumpers (castxml, clang) keep ``t.name`` bare (see its
+    docstring in model.py) and carry the real namespace path in
+    ``t.qualified_name`` instead; DWARF has no such split and already
+    stores the qualified spelling directly in ``name``. Matching by bare
+    ``t.name`` alone lets two unrelated types sharing only a short/leaf
+    spelling collide and diff against each other, producing spurious
+    field/base-class findings. Falls back to ``t.name`` when
+    ``qualified_name`` is unset (global-scope/DWARF-only snapshots).
     """
     return t.qualified_name or t.name
 
@@ -266,24 +271,19 @@ class TypeMap(Mapping[str, Q]):
     :func:`type_map_key`, with a collision-safe bare-``name`` alias used
     only for lookups.
 
-    The alias exists for schema-evolution compatibility: an older serialized/
-    header snapshot that predates ``qualified_name`` (or a producer that
-    never populates it) keys its own map entries by the bare name alone.
-    Without an alias, matching that against a freshly-dumped snapshot side
-    where the same namespaced type *does* carry ``qualified_name`` would key
-    the two sides differently (``Foo`` vs. ``ns::Foo``) and manufacture a
-    false ``TYPE_REMOVED``/``TYPE_ADDED`` pair for an unchanged type (Codex
-    review, PR #608).
+    The alias exists for schema-evolution compatibility: an older snapshot
+    that predates (or never populates) ``qualified_name`` keys its entries
+    by the bare name alone, so without an alias, matching it against a
+    freshly-dumped side that DOES carry ``qualified_name`` would key the two
+    sides differently (``Foo`` vs. ``ns::Foo``) and manufacture a false
+    ``TYPE_REMOVED``/``TYPE_ADDED`` pair for an unchanged type (PR #608).
 
-    The alias is only used for ``get``/``in`` — deliberately kept OUT of
-    ``items``/``values``/iteration, which stay one entry per type under its
-    canonical key. A dict literally containing both the qualified key and a
-    bare-name alias for the same object would make every ``for name, t in
-    old_map.items()``-style detector loop process that type (and emit its
-    finding) twice. It is also only added when the bare name is unambiguous
-    within *this* snapshot — not already claimed by a distinct qualified
-    identity — so it cannot reopen the short/leaf-name collision
-    :func:`type_map_key` itself was introduced to fix.
+    Only used for ``get``/``in`` — kept OUT of ``items``/``values``/
+    iteration (else a dict containing both the qualified key and the bare
+    alias for one object would make every ``for name, t in
+    old_map.items()``-style loop process it twice) — and only added when
+    the bare name is unambiguous within *this* snapshot, so it cannot
+    reopen the collision :func:`type_map_key` fixes.
     """
 
     def __init__(self, types: Iterable[Q]) -> None:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -304,7 +304,7 @@ def _check_removed_function(
             new_value=f_hidden.visibility.value,
             # See Change.symbol_binding's docstring -- stamped here too, not just on removal below.
             symbol_binding=f_old.elf_binding.value if f_old.elf_binding else None,
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_hidden.entity_id,
         )
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -361,7 +361,7 @@ def _check_return_type_change(
             name=f_old.name,
             old=f_old.return_type,
             new=f_new.return_type,
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -426,7 +426,7 @@ def _check_params_change(
             name=f_old.name,
             old=_format_params(f_old.params),
             new=_format_params(f_new.params),
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -448,7 +448,7 @@ def _check_ref_qualifier_change(
             new=repr(new_rq),
             old_value=old_rq or "(none)",
             new_value=new_rq or "(none)",
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -468,7 +468,7 @@ def _check_linkage_change(
             name=f_old.name,
             old=old_linkage,
             new=new_linkage,
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -489,7 +489,7 @@ def _check_noexcept_change(
             ChangeKind.FUNC_NOEXCEPT_REMOVED,
             f"noexcept specifier removed: {f_old.name}",
         ),
-        entity_id=f_old.entity_id,
+        entity_id=f_old.entity_id or f_new.entity_id,
     )
 
 
@@ -506,7 +506,7 @@ def _check_virtual_change(
             ChangeKind.FUNC_VIRTUAL_REMOVED,
             f"Function is no longer virtual: {f_old.name}",
         ),
-        entity_id=f_old.entity_id,
+        entity_id=f_old.entity_id or f_new.entity_id,
     )
 
 
@@ -536,7 +536,7 @@ def _check_explicit_change(
             f"Constructor/conversion lost `explicit` specifier: {f_old.name}",
         ),
         removed_values=("explicit", "implicit"),
-        entity_id=f_old.entity_id,
+        entity_id=f_old.entity_id or f_new.entity_id,
     )
 
 
@@ -563,7 +563,7 @@ def _check_variadic_change(
             f"Function is no longer variadic (lost ...): {f_old.name}",
         ),
         removed_values=("variadic", "fixed-arity"),
-        entity_id=f_old.entity_id,
+        entity_id=f_old.entity_id or f_new.entity_id,
     )
 
 
@@ -599,7 +599,7 @@ def _check_contract_attributes_change(
                 ),
                 old_value=", ".join(sorted(old_cc)) or "(default)",
                 new_value=", ".join(sorted(new_cc)) or "(default)",
-                entity_id=f_old.entity_id,
+                entity_id=f_old.entity_id or f_new.entity_id,
             )
         )
         old_attrs -= old_cc
@@ -615,7 +615,7 @@ def _check_contract_attributes_change(
                 name=f_old.name,
                 detail=", ".join(gained),
                 new_value=", ".join(gained),
-                entity_id=f_old.entity_id,
+                entity_id=f_old.entity_id or f_new.entity_id,
             )
         )
     if lost:
@@ -626,7 +626,7 @@ def _check_contract_attributes_change(
                 name=f_old.name,
                 detail=", ".join(lost),
                 old_value=", ".join(lost),
-                entity_id=f_old.entity_id,
+                entity_id=f_old.entity_id or f_new.entity_id,
             )
         )
     return changes
@@ -651,7 +651,7 @@ def _check_exception_spec_change(
             name=f_old.name,
             old=f_old.exception_spec or "(none)",
             new=f_new.exception_spec or "(none)",
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -679,7 +679,7 @@ def _check_vtable_index_change(
             ),
             old_value=str(f_old.vtable_index),
             new_value=str(f_new.vtable_index),
-            entity_id=f_old.entity_id,
+            entity_id=f_old.entity_id or f_new.entity_id,
         )
     ]
 
@@ -744,7 +744,7 @@ def _check_inline_transitions(
                     ),
                     old_value="non-inline",
                     new_value="inline",
-                    entity_id=f_old.entity_id,
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
         elif f_old.is_inline and not f_new.is_inline:
@@ -755,7 +755,7 @@ def _check_inline_transitions(
                     name=f_old.name,
                     old="inline",
                     new="non-inline",
-                    entity_id=f_old.entity_id,
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
     return changes

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -304,6 +304,7 @@ def _check_removed_function(
             new_value=f_hidden.visibility.value,
             # See Change.symbol_binding's docstring -- stamped here too, not just on removal below.
             symbol_binding=f_old.elf_binding.value if f_old.elf_binding else None,
+            entity_id=f_old.entity_id,
         )
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -317,6 +318,7 @@ def _check_removed_function(
         old_value=f_old.name,
         # See Change.symbol_binding's docstring — None when not captured.
         symbol_binding=f_old.elf_binding.value if f_old.elf_binding else None,
+        entity_id=f_old.entity_id,
     )
 
 
@@ -359,6 +361,7 @@ def _check_return_type_change(
             name=f_old.name,
             old=f_old.return_type,
             new=f_new.return_type,
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -423,6 +426,7 @@ def _check_params_change(
             name=f_old.name,
             old=_format_params(f_old.params),
             new=_format_params(f_new.params),
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -444,6 +448,7 @@ def _check_ref_qualifier_change(
             new=repr(new_rq),
             old_value=old_rq or "(none)",
             new_value=new_rq or "(none)",
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -463,6 +468,7 @@ def _check_linkage_change(
             name=f_old.name,
             old=old_linkage,
             new=new_linkage,
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -483,6 +489,7 @@ def _check_noexcept_change(
             ChangeKind.FUNC_NOEXCEPT_REMOVED,
             f"noexcept specifier removed: {f_old.name}",
         ),
+        entity_id=f_old.entity_id,
     )
 
 
@@ -499,6 +506,7 @@ def _check_virtual_change(
             ChangeKind.FUNC_VIRTUAL_REMOVED,
             f"Function is no longer virtual: {f_old.name}",
         ),
+        entity_id=f_old.entity_id,
     )
 
 
@@ -528,6 +536,7 @@ def _check_explicit_change(
             f"Constructor/conversion lost `explicit` specifier: {f_old.name}",
         ),
         removed_values=("explicit", "implicit"),
+        entity_id=f_old.entity_id,
     )
 
 
@@ -554,6 +563,7 @@ def _check_variadic_change(
             f"Function is no longer variadic (lost ...): {f_old.name}",
         ),
         removed_values=("variadic", "fixed-arity"),
+        entity_id=f_old.entity_id,
     )
 
 
@@ -589,6 +599,7 @@ def _check_contract_attributes_change(
                 ),
                 old_value=", ".join(sorted(old_cc)) or "(default)",
                 new_value=", ".join(sorted(new_cc)) or "(default)",
+                entity_id=f_old.entity_id,
             )
         )
         old_attrs -= old_cc
@@ -604,6 +615,7 @@ def _check_contract_attributes_change(
                 name=f_old.name,
                 detail=", ".join(gained),
                 new_value=", ".join(gained),
+                entity_id=f_old.entity_id,
             )
         )
     if lost:
@@ -614,6 +626,7 @@ def _check_contract_attributes_change(
                 name=f_old.name,
                 detail=", ".join(lost),
                 old_value=", ".join(lost),
+                entity_id=f_old.entity_id,
             )
         )
     return changes
@@ -638,6 +651,7 @@ def _check_exception_spec_change(
             name=f_old.name,
             old=f_old.exception_spec or "(none)",
             new=f_new.exception_spec or "(none)",
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -665,6 +679,7 @@ def _check_vtable_index_change(
             ),
             old_value=str(f_old.vtable_index),
             new_value=str(f_new.vtable_index),
+            entity_id=f_old.entity_id,
         )
     ]
 
@@ -729,6 +744,7 @@ def _check_inline_transitions(
                     ),
                     old_value="non-inline",
                     new_value="inline",
+                    entity_id=f_old.entity_id,
                 )
             )
         elif f_old.is_inline and not f_new.is_inline:
@@ -739,6 +755,7 @@ def _check_inline_transitions(
                     name=f_old.name,
                     old="inline",
                     new="non-inline",
+                    entity_id=f_old.entity_id,
                 )
             )
     return changes
@@ -763,12 +780,10 @@ def _match_old_function(
 
     ADR-049 Phase 2: both tiers of the join run through
     :class:`~abicheck.finding_identity.SymbolIdentityIndex` -- the exact-key
-    tier as this index's own ``Mapping`` lookup, and the ``extern "C"``
-    fallback as one ambiguity-checked alias lookup, replacing the hand-rolled
-    name multimap plus ``len(candidates) == 1`` count this function used to
-    carry. The rule is unchanged, and deliberately so: the count *was* the
-    ambiguity-safety, it just lived here instead of in the shared primitive
-    that every other flat join now uses.
+    tier as this index's own ``Mapping`` lookup, the ``extern "C"`` fallback
+    as one ambiguity-checked alias lookup (``len(candidates) == 1``, the
+    same rule the hand-rolled name multimap this replaced used, now living
+    in the shared primitive every other flat join uses too).
     """
     f_new_exact = new_index.get(mangled)
     if f_new_exact is not None:
@@ -834,12 +849,9 @@ def _detect_newly_deleted_functions(
 ) -> list[Change]:
     """Detect functions that gained ``= delete`` between snapshots.
 
-    FUNC_DELETED: detected via castxml is_deleted attribute (header analysis).
-    FUNC_DELETED_DWARF: detected via DWARF DW_AT_deleted attribute (binary analysis).
-
-    Only ABI-visible (PUBLIC / ELF_ONLY) functions are reported; hidden or
-    internal functions are not part of the public ABI surface and must not
-    produce spurious BREAKING findings. ``drift_old_by_new_key`` covers a
+    FUNC_DELETED: castxml ``is_deleted`` (header analysis). FUNC_DELETED_DWARF:
+    DWARF ``DW_AT_deleted`` (binary analysis). Only ABI-visible (PUBLIC /
+    ELF_ONLY) functions are reported. ``drift_old_by_new_key`` covers a
     reconciled ctor/dtor pair (PR #761 finding 2).
     """
     changes: list[Change] = []
@@ -849,23 +861,21 @@ def _detect_newly_deleted_functions(
     old_exported = exported_symbol_names(
         getattr(old_snapshot, "elf", None), FUNCTION_SYMBOL_TYPES
     )
-    # Whether the new side has an ELF symbol table at all. This tells "no ELF
-    # evidence available" apart from "ELF table present but this function is not
-    # exported": when a table exists, an empty *function* export set (e.g. the
-    # library exports only data, or every function is hidden) is authoritative —
-    # a DWARF-only DW_AT_deleted internal member is genuinely not exported and
-    # must not be reported. Keying on ``exported`` truthiness instead would only
-    # apply the filter when some *other* function happened to be exported.
+    # Whether the new side has an ELF symbol table at all -- "no ELF evidence
+    # available" vs. "table present but this function is not exported": when a
+    # table exists, an empty *function* export set is authoritative (a
+    # DWARF-only DW_AT_deleted internal member is genuinely not exported).
+    # Keying on ``exported`` truthiness alone would only apply this when some
+    # *other* function happened to be exported.
     has_elf_symbol_table = bool(getattr(new_elf, "symbols", None))
     for mangled, f_new in new_all.items():
         if not f_new.is_deleted:
             continue
-        # Suppress only a *genuinely internal* DWARF-deleted member: one that the
-        # new ELF table proves is not exported AND that was not exported in the
-        # old library either. A function that *was* an old export and is now
-        # ``= delete``'d + dropped from .dynsym is a real deletion of a public
-        # API and must still be reported (the removal-side path defers to this
-        # detector for it, so suppressing here would drop the finding entirely).
+        # Suppress only a *genuinely internal* DWARF-deleted member: not
+        # exported now AND not exported before either. One that *was* an old
+        # export and is now ``= delete``'d + dropped from .dynsym is a real
+        # deletion and must still be reported (the removal-side path defers
+        # to this detector for it).
         if (
             f_new.deleted_from_dwarf
             and has_elf_symbol_table
@@ -883,6 +893,7 @@ def _detect_newly_deleted_functions(
                 if f_new.deleted_from_dwarf
                 else ChangeKind.FUNC_DELETED
             )
+            deleted_entity_id = f_old_any.entity_id or f_new.entity_id
             changes.append(
                 make_change(
                     kind,
@@ -890,6 +901,7 @@ def _detect_newly_deleted_functions(
                     name=f_new.name,
                     old_value="callable",
                     new_value="deleted",
+                    entity_id=deleted_entity_id,
                 )
             )
     return changes
@@ -970,6 +982,7 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     ChangeKind.FUNC_ADDED,
                     symbol=mangled,
                     new=f_new.name,
+                    entity_id=f_new.entity_id,
                 )
             )
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1275,20 +1275,16 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     the two backends' default VALUE representations are not cross-comparable
     (castxml keeps the real source expression; clang's is a placeholder/
     fingerprint for anything non-trivial), even between two pure
-    single-backend snapshots (a pure ``--ast-frontend clang`` run vs. a pure
-    ``--ast-frontend castxml`` run — ``fact_producer`` returns the producer
-    for those too). Requiring the SAME producer on both sides (not "castxml
-    on both sides", which would wrongly suppress a same-producer
+    single-backend snapshots. Requiring the SAME producer on both sides (not
+    "castxml on both sides", which would wrongly suppress a same-producer
     clang-vs-clang pair) avoids a false CHANGED/REMOVED from a
     representation mismatch while still catching a real change.
 
     The per-pair skip only fires when BOTH producers are POSITIVELY known
-    and DIFFER — never merely because one side's producer is unknown. An
+    and DIFFER, never merely because one side's producer is unknown: an
     unset ``ast_producer`` (a hand-built test snapshot, or a legacy
-    pre-provenance baseline) makes ``fact_producer(...) is None``, so
-    comparing it against a genuinely castxml-backed function is a legitimate
-    same-producer comparison that must not be silently dropped just because
-    one side lacks metadata it never had a chance to record.
+    pre-provenance baseline) must not be silently dropped as a mismatch
+    just because it lacks metadata it never had a chance to record.
 
     A separate, narrower gate protects the VALUE-CHANGED comparison alone
     (Codex review) — see :mod:`diff_default_value_reliability`'s docstring.
@@ -1322,6 +1318,7 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                         detail=str(p_old.name or i),
                         old_value=p_old.default,
                         new_value=None,
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
             elif (
@@ -1341,6 +1338,7 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                         detail=str(p_old.name or i),
                         old_value=p_old.default,
                         new_value=p_new.default,
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
 
@@ -1351,10 +1349,9 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect parameter renames (same type+position, different name)."""
     changes: list[Change] = []
-    # Require *explicit* header provenance on both sides. A legacy snapshot
-    # predating the from_headers key has it inferred from a populated surface,
-    # which a DWARF-only dump also satisfies — trusting that inference here
-    # reintroduces PARAM_RENAMED/API_BREAK false positives on DWARF baselines.
+    # Require *explicit* header provenance on both sides -- a legacy snapshot's
+    # inferred-from-populated-surface fallback also matches a DWARF-only dump,
+    # which would reintroduce PARAM_RENAMED/API_BREAK false positives.
     if not (old.from_headers and new.from_headers):
         return changes
     if old.from_headers_inferred or new.from_headers_inferred:
@@ -1378,6 +1375,7 @@ def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                         detail=str(i),
                         old=p_old.name,
                         new=p_new.name,
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
 
@@ -1414,6 +1412,7 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     name=f_old.name,
                     old=str(f_old.return_pointer_depth),
                     new=str(f_new.return_pointer_depth),
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
 
@@ -1437,6 +1436,7 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                         detail=str(p_old.name or i),
                         old=str(p_old.pointer_depth),
                         new=str(p_new.pointer_depth),
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
 
@@ -1447,9 +1447,7 @@ def _check_method_access_changes(
     old_map: dict[str, Function],
     new_map: dict[str, Function],
 ) -> list[Change]:
-    """Emit METHOD_ACCESS_CHANGED for narrowing method access transitions,
-    including a ctor/dtor pair only visible via synthetic-key format-drift
-    reconciliation (``iter_matched_function_pairs``, PR #761 finding 2)."""
+    """Emit METHOD_ACCESS_CHANGED for narrowing access transitions, including a ctor/dtor pair only visible via synthetic-key format-drift reconciliation (``iter_matched_function_pairs``, PR #761 finding 2)."""
     changes: list[Change] = []
     for mangled, f_old, f_new in iter_matched_function_pairs(old_map, new_map):
         if f_old.access != f_new.access and _is_access_narrowing(
@@ -1462,6 +1460,7 @@ def _check_method_access_changes(
                     name=f_old.name,
                     old=f_old.access.value,
                     new=f_new.access.value,
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
     return changes
@@ -1699,14 +1698,13 @@ def _diff_func_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     :func:`fact_provenance.both_known_backed_fact` (not the narrower
     ``both_castxml_backed_fact``): both castxml and the direct-clang backend
     populate ``Function.deprecated`` today (G31 Phase C — see
-    ``dumper_clang._clang_deprecated_message``; the clang backend didn't
-    when this detector was first written for PR #582), and the two
-    backends' values are directly cross-comparable (a plain message string,
-    not a backend-specific encoding), so a clang-vs-clang or
-    clang-vs-castxml pair is just as comparable as a castxml-vs-castxml one.
-    A per-pair check (rather than a whole-snapshot gate) also correctly
-    handles a ``--ast-frontend hybrid`` snapshot (G28 Phase 3), where this
-    fact's producer is recorded per *declaration*, not uniformly across the
+    ``dumper_clang._clang_deprecated_message``), and the two backends'
+    values are directly cross-comparable (a plain message string, not a
+    backend-specific encoding), so a clang-vs-clang or clang-vs-castxml
+    pair is just as comparable as a castxml-vs-castxml one. A per-pair
+    check (rather than a whole-snapshot gate) also correctly handles a
+    ``--ast-frontend hybrid`` snapshot (G28 Phase 3), where this fact's
+    producer is recorded per *declaration*, not uniformly across the
     whole snapshot. Looks each side up under ITS OWN ``mangled`` (PR #761
     finding 3): a reconciled ctor/dtor pair's provenance lives under two
     different keys.
@@ -1728,6 +1726,7 @@ def _diff_func_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     name=f_old.name,
                     detail=f_new.deprecated,
                     new_value=f_new.deprecated,
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
         elif f_old.deprecated is not None and f_new.deprecated is None:
@@ -1737,6 +1736,7 @@ def _diff_func_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     symbol=mangled,
                     name=f_old.name,
                     old_value=f_old.deprecated,
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
     return changes
@@ -1753,11 +1753,10 @@ def _diff_func_override_specifier(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
     override". Gated per-pair on :func:`fact_provenance.both_known_backed_fact`
     (not the narrower ``both_castxml_backed_fact``): G31 Phase C wired real
     ``is_override`` extraction into the direct-clang backend too
-    (``dumper_clang._clang_method_is_override``, matching castxml's own "was
-    `override` written" semantics via clang's ``OverrideAttr`` child node),
-    so this is now a cross-producer, directly-comparable bool, the same
-    shape ``deprecated`` already has. A per-declaration check (not a
-    whole-snapshot gate) is what correctly supports ``--ast-frontend hybrid``.
+    (``dumper_clang._clang_method_is_override``), so this is now a
+    cross-producer, directly-comparable bool, the same shape ``deprecated``
+    already has. A per-declaration check (not a whole-snapshot gate) is
+    what correctly supports ``--ast-frontend hybrid``.
     """
     changes: list[Change] = []
     old_map = _public_functions(old)
@@ -1781,6 +1780,7 @@ def _diff_func_override_specifier(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
                     name=f_old.name,
                     old_value="no override",
                     new_value="override",
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
         else:
@@ -1791,6 +1791,7 @@ def _diff_func_override_specifier(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
                     name=f_old.name,
                     old_value="override",
                     new_value="no override",
+                    entity_id=f_old.entity_id or f_new.entity_id,
                 )
             )
     return changes

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -79,6 +79,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .finding_identity_atomic import canonicalize_atomic_slot
+from .model.signature_normalization import canonicalize_function_signature_param_type
 from .name_classification import canonicalize_type_name
 
 if TYPE_CHECKING:
@@ -691,23 +692,21 @@ def resolve_function_identity(func: Function) -> FindingIdentity:
     ``ref_qualifier``, which alone distinguish legal overloads with
     otherwise identical names and parameter types (``void f()`` vs.
     ``void f() const``, ``void f() &`` vs. ``void f() &&``; Codex review).
+
+    Per-parameter canonicalization delegates to ``model.signature_
+    normalization.canonicalize_function_signature_param_type`` -- the same
+    primitive ``entity_id_for_function`` uses (ADR-063 Phase 2's
+    "finding_identity.py algorithm migration") -- rather than
+    ``canonicalize_type_name`` alone, which keeps a top-level by-value
+    cv-qualifier distinguishing where the shared primitive correctly drops
+    it (``void f(int)``/``void f(const int)`` are the same function). A
+    *pointee* cv-qualifier still distinguishes either way.
     """
     param_types = (
         ()
         if func.is_extern_c
         else (
-            # canonicalize_type_name: castxml ("char const*") and clang's
-            # -ast-dump=json ("char const *") spell an otherwise-identical
-            # parameter type differently -- name_classification.py's own
-            # docstring documents this as a real, confirmed cross-producer
-            # discrepancy, and diff_symbols.py's _params_differ already
-            # compares parameter types through this function for exactly
-            # that reason. Without it, the same declaration seen from two
-            # producers would get different NORMALIZED-tier signatures
-            # here, fragmenting identity across evidence tiers the same
-            # way an uncanonicalized qualified_name/source_location would
-            # (Codex review).
-            *(canonicalize_type_name(p.type) for p in func.params),
+            *(canonicalize_function_signature_param_type(p.type) for p in func.params),
             f"const:{func.is_const}",
             f"volatile:{func.is_volatile}",
             f"ref:{func.ref_qualifier}",

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -15,41 +15,36 @@
 
 """``ScopePath``/``EntityId`` — the one identity primitive (ADR-063 Phase 2).
 
-**This module is a first, isolated slice of Phase 2, not the whole
-phase.** See ``docs/contribute/plans/one-semantic-pipeline.md``'s "Phase 2
-— EntityId/ScopePath as the one identity primitive" section for the full
-design, including two questions this slice deliberately leaves open:
+See ``docs/contribute/plans/one-semantic-pipeline.md``'s "Phase 2 —
+EntityId/ScopePath as the one identity primitive" section for the full
+design and landed-slice history; that ADR/plan pair, not this docstring, is
+the authoritative status record — this docstring only orients a reader
+already in the file. Landed so far: the ``ScopePath``/``EntityId`` shape
+itself; both header-AST backends deriving a typed ``ScopePath`` at parse
+time and populating a resolved ``entity_id`` carrier on
+``RecordType``/``EnumType``/``Function``/``Variable`` (the plan's "carrier
+field" question resolved as option (a) — computed once at parse time, not
+recomputed on demand); that carrier persisting through ``serialization.py``
+(schema v28); and, as a first, bounded step of the
+``finding_identity.py`` algorithm migration,
+``finding_identity.resolve_function_identity`` now canonicalizing each
+parameter via this module's own ``signature_normalization.
+canonicalize_function_signature_param_type`` (the identical primitive
+``entity_id_for_function``'s own "sig" fallback branch uses) instead of a
+second, independently-maintained copy. Still open: the mangled-name-is-
+genuine determination stays owned by ``finding_identity.
+is_real_mangled_name``/``normalize_mangled_name`` (``compare -> model``
+stays the only allowed edge, and that validation logic is not a dependency
+this module needs); giving ``Change`` an ``EntityId`` to key on; and the
+post-parse consumer migrations (``diff_filtering.py``/
+``type_reachability.py``'s string-based ambiguity machinery) — **no
+consumer may read the ``entity_id`` carrier field itself yet**.
 
-1. *Where ``ScopePath`` gets built from.* This module's ``entity_id_for_*``
-   constructors take an already-built :data:`ScopePath` as input — they do
-   not derive one from a parser's internal scope-tracking state
-   (``entry.scope`` in ``dumper_clang.py``/``dumper_castxml.py`` today is a
-   bare ``list[str]``, structurally insufficient to build a typed
-   ``ScopePath`` from; see the plan). Widening that parser state, and
-   deciding whether the resulting ``EntityId`` is computed once and carried
-   on the model object or recomputed on demand (the plan's "no carrier
-   field" open question, options (a)/(b)), is separate follow-on work.
-2. *The mangled-name-is-genuine determination.* ``entity_id_for_function``/
-   ``entity_id_for_variable`` take a caller-supplied ``mangled_name`` and
-   trust it is a real mangling, not a bare name that merely rode in the
-   mangled field (the ``extern "C"`` case). That determination stays owned
-   by ``finding_identity.is_real_mangled_name``/``normalize_mangled_name``
-   for now — this slice does not migrate that ~450-line, independently
-   reviewed Itanium-mangling-validation machinery, and
-   ``finding_identity.py`` does not yet delegate to this module. A future
-   slice is expected to move that algorithm here and make
-   ``finding_identity.resolve_function_identity`` a thin wrapper, per the
-   plan's "direction of reuse" note — not attempted here, to keep this
-   slice reviewable on its own.
-
-What *is* real and load-bearing in this slice: the ``ScopePath`` segment
-types and their identity-vs-payload field split, the ``EntityId`` shape
-itself (``scope``, ``kind``, ``leaf_name``, ``extra`` — never a bare
-``(ScopePath, kind)``, which collides sibling declarations), and the
-``EntityKind``/``ObservationKind`` relocation from ``storage.entity_ids``
-(domain vocabulary belongs in ``model``, not the storage wire layer, per
-ADR-061's ``storage -> model`` import direction — ``storage.entity_ids`` now
-imports these two enums rather than redefining them).
+``EntityKind``/``ObservationKind`` relocated here from ``storage.
+entity_ids`` (domain vocabulary belongs in ``model``, not the storage wire
+layer, per ADR-061's ``storage -> model`` import direction) —
+``storage.entity_ids`` now imports these two enums rather than redefining
+them.
 
 Leaf module: no dependency on ``checker_types``/``diff_*``/anything above
 ``model``, per ADR-063 D10.

--- a/abicheck/model/signature_normalization.py
+++ b/abicheck/model/signature_normalization.py
@@ -110,6 +110,11 @@ _CALLING_CONVENTION_KEYWORD_RE = re.compile(
     r"\s*(?:__cdecl|__stdcall|__fastcall|__thiscall|__vectorcall)\b"
 )
 
+# Bounds the recursion below (Codex review, PR #952): unbounded nested-
+# declarator recursion raises an uncaught RecursionError on an
+# adversarial/corrupt snapshot's parameter type, crashing compare().
+_MAX_PARAM_TYPE_NESTING_DEPTH = 64
+
 # A leading `::` (explicit global-namespace lookup) is DELIBERATELY left
 # untouched, genuinely distinguishing -- despite a nineteenth-round
 # attempt (`_GLOBAL_SCOPE_RE`, since reverted) to strip it unconditionally
@@ -275,7 +280,7 @@ def _find_matching_paren(s: str, open_idx: int) -> int:
     return len(s)
 
 
-def _normalize_param_list_contents(inner: str) -> str:
+def _normalize_param_list_contents(inner: str, depth: int) -> str:
     """Canonicalize each individual parameter inside one parameter list's
     raw ``(...)`` content -- the by-value cv rule this whole module exists
     to apply is not unique to this function's own top-level parameter; a
@@ -299,12 +304,12 @@ def _normalize_param_list_contents(inner: str) -> str:
         normalized.append(
             p
             if (p == "" or p == "...")
-            else canonicalize_function_signature_param_type(p)
+            else canonicalize_function_signature_param_type(p, _depth=depth + 1)
         )
     return ", ".join(normalized)
 
 
-def _normalize_nested_param_lists(s: str) -> str:
+def _normalize_nested_param_lists(s: str, depth: int) -> str:
     """Canonicalize the contents of the one top-level ``(...)`` parameter
     list *s* is -- a declarator's own trailing parameter list, e.g. the
     ``(int)`` in ``void (*)(int)`` or ``void (C::*)(int)``. *s* is always
@@ -325,10 +330,10 @@ def _normalize_nested_param_lists(s: str) -> str:
     identical adjusted callback type -- canonicalized to two different
     strings).
     """
-    return "(" + _normalize_param_list_contents(s[1:-1]) + ")"
+    return "(" + _normalize_param_list_contents(s[1:-1], depth) + ")"
 
 
-def canonicalize_function_signature_param_type(name: str) -> str:
+def canonicalize_function_signature_param_type(name: str, *, _depth: int = 0) -> str:
     """The canonical form of a function *parameter* type, for
     identity/overload-discriminator purposes -- as opposed to
     ``canonicalize_type_name``, which normalizes only cross-producer
@@ -652,6 +657,8 @@ def canonicalize_function_signature_param_type(name: str) -> str:
     >>> canonicalize_function_signature_param_type("(anonymous namespace)::Foo *")
     '(anonymous namespace)::Foo *'
     """
+    if _depth > _MAX_PARAM_TYPE_NESTING_DEPTH:
+        return name
     canonical = canonicalize_type_name(
         _decay_top_level_array(canonicalize_type_name(name))
     )
@@ -756,7 +763,7 @@ def canonicalize_function_signature_param_type(name: str) -> str:
         head, params_and_after = split
         head = _strip_cv_tokens_outside_nesting(head)
         close = _find_matching_paren(params_and_after, 0)
-        params = _normalize_nested_param_lists(params_and_after[: close + 1])
+        params = _normalize_nested_param_lists(params_and_after[: close + 1], _depth)
         tail = params_and_after[close + 1 :]
         # Clang's trailing `__attribute__((cdecl))`-style calling-
         # convention spelling (see `_CALLING_CONVENTION_ATTR_RE`'s own

--- a/changelog.d/20260830_165706_noreply_adr_063_phases_3jmrnm.md
+++ b/changelog.d/20260830_165706_noreply_adr_063_phases_3jmrnm.md
@@ -16,3 +16,11 @@
   into two distinct identities. A *pointee* cv-qualifier (`char *` vs.
   `const char *`) remains a genuine, independently-mangled overload
   discriminator and still distinguishes.
+- **`canonicalize_function_signature_param_type` no longer crashes `compare`
+  with an uncaught `RecursionError` on a pathologically nested callback
+  parameter type.** A hand-crafted or corrupted snapshot's parameter-type
+  string (e.g. hundreds of levels of nested function-pointer declarators)
+  could exhaust Python's call stack and abort the whole comparison. A
+  generous, bounded recursion depth now falls back to leaving the
+  offending fragment unnormalized instead of crashing; no real,
+  non-adversarial C++ signature is affected.

--- a/changelog.d/20260830_165706_noreply_adr_063_phases_3jmrnm.md
+++ b/changelog.d/20260830_165706_noreply_adr_063_phases_3jmrnm.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **`resolve_function_identity`'s NORMALIZED-tier signature no longer treats
+  a top-level by-value `const`/`volatile` parameter qualifier as a distinct
+  overload** (ADR-063 Phase 2, "finding_identity.py algorithm migration").
+  For a function with no real mangled name (a DWARF-only snapshot, or a
+  non-`extern "C"` C-linkage declaration), the per-parameter
+  canonicalization used to build its identity now delegates to
+  `model.signature_normalization.canonicalize_function_signature_param_type`
+  -- the same primitive `model.identity.entity_id_for_function`'s own
+  signature-fallback branch already uses -- instead of a second,
+  independently-maintained `canonicalize_type_name`-only pass. Per the C++
+  standard, `void f(int)` and `void f(const int)` name the same function;
+  before this change, one function's before/after pair that merely
+  gained or lost a top-level by-value `const` on a parameter fragmented
+  into two distinct identities. A *pointee* cv-qualifier (`char *` vs.
+  `const char *`) remains a genuine, independently-mangled overload
+  discriminator and still distinguishes.

--- a/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
+++ b/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
@@ -1,0 +1,14 @@
+### Added
+
+- **`Change` now carries an `entity_id` field** (ADR-063 Phase 2), the
+  compare-time `EntityId` of the declaration a finding is about -- the OLD
+  side's when it exists, else the NEW side's, mirroring `Change.
+  symbol_binding`'s own old-side convention. Populated at every
+  `diff_symbols.py` function-level diff site (return type, parameters,
+  ref-qualifier, linkage, noexcept/virtual/explicit/variadic transitions,
+  contract attributes, exception spec, vtable index, inline transitions,
+  added/removed/deleted functions). The field is keyword-only, defaults to
+  `None`, and is excluded from equality, so no existing behavior,
+  comparison result, or report changes -- no consumer reads it yet
+  (`resolve_change_identity`'s own migration is separate follow-on work).
+  Variable/type/enum/platform detectors are not yet wired.

--- a/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
+++ b/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
@@ -7,8 +7,11 @@
   `diff_symbols.py` function-level diff site (return type, parameters,
   ref-qualifier, linkage, noexcept/virtual/explicit/variadic transitions,
   contract attributes, exception spec, vtable index, inline transitions,
-  added/removed/deleted functions). The field is keyword-only, defaults to
-  `None`, and is excluded from equality, so no existing behavior,
-  comparison result, or report changes -- no consumer reads it yet
-  (`resolve_change_identity`'s own migration is separate follow-on work).
-  Variable/type/enum/platform detectors are not yet wired.
+  added/removed/deleted/visibility-changed functions, parameter renames/
+  default-value/pointer-level changes, return-pointer-level changes,
+  method access narrowing, deprecation and override-specifier transitions).
+  The field is keyword-only, defaults to `None`, and is excluded from
+  equality, so no existing behavior, comparison result, or report changes
+  -- no consumer reads it yet (`resolve_change_identity`'s own migration is
+  separate follow-on work). Variable/type/enum/platform detectors are not
+  yet wired.

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -26,7 +26,7 @@
   path (`handle_non_elf_dump`)** — no PE/Mach-O toolchain was available to
   verify a migration against; see that same known-gaps entry.
 - **Phase 2** ("`EntityId`/`ScopePath` as the one identity primitive") has
-  landed six slices: the `ScopePath`/`EntityId` primitive itself
+  landed seven slices: the `ScopePath`/`EntityId` primitive itself
   (`abicheck/model/identity.py`); both header-AST backends (`dumper_clang.py`/
   `dumper_castxml.py`) tracking scope as typed segments at parse time;
   `RecordType`/`EnumType`/`Function`/`Variable` gaining a parse-time-resolved
@@ -35,9 +35,8 @@
   wire-schema-v2 bridge (`domain_entity_id_to_dto`/`_from_dto`) that encodes
   `ScopePath` losslessly (a rendered `qualified_name` string cannot — two
   distinct `ScopePath`s can render identically); that carrier now
-  persisting through `serialization.py` (`SCHEMA_VERSION` 28); and, as the
-  sixth slice, a first, bounded piece of the `finding_identity.py` algorithm
-  migration (c2) —
+  persisting through `serialization.py` (`SCHEMA_VERSION` 28); a first,
+  bounded piece of the `finding_identity.py` algorithm migration (c2) —
   `finding_identity.resolve_function_identity` now canonicalizes each
   parameter through the same
   `model.signature_normalization.canonicalize_function_signature_param_type`
@@ -45,20 +44,31 @@
   rather than a second, independently-maintained
   `canonicalize_type_name`-only pass — a real behavior fix (a top-level
   by-value cv-qualifier no longer fragments identity, matching the C++
-  standard's own linkage rules), not only a dedup. **Still not landed: the
-  mangled-name-is-genuine determination** (`finding_identity.
-  is_real_mangled_name`/`normalize_mangled_name` stay finding_identity's own
-  — `model/identity.py`'s own docstring records why moving them would
-  reverse the required `compare -> model` import direction), **giving
-  `Change` an `EntityId` to key on** (c2's other stated deliverable), **and
-  every post-parse consumer migration** (`diff_filtering.py`/
-  `type_reachability.py`'s string-based ambiguity machinery) — **no
-  consumer may read the carrier field itself yet**, since nothing has
-  defined what the stored `entity_id`
-  means to a comparison; the algorithm-delegation slice above recomputes
-  the signature discriminator from `Function`'s own raw fields rather than
-  reading the carrier. Those are the remaining items before Phase 2 is
-  complete.
+  standard's own linkage rules), not only a dedup; and, as the seventh
+  slice, `Change` (`checker_types.py`) gaining its own `entity_id` carrier
+  field, wired at every `diff_symbols.py` function-diff call site
+  (`_check_removed_function`/`_check_return_type_change`/
+  `_check_params_change`/`_check_ref_qualifier_change`/
+  `_check_linkage_change`/the `bool_transition`-backed noexcept/virtual/
+  explicit/variadic checks/`_check_contract_attributes_change`/
+  `_check_exception_spec_change`/`_check_vtable_index_change`/
+  `_check_inline_transitions`/the `FUNC_ADDED` site/
+  `_detect_newly_deleted_functions`) — the old side's `Function.entity_id`
+  when it exists, else the new side's, mirroring `Change.symbol_binding`'s
+  own old-side convention. **Still not landed: the mangled-name-is-genuine
+  determination** (`finding_identity.is_real_mangled_name`/
+  `normalize_mangled_name` stay finding_identity's own — `model/identity.py`'s
+  own docstring records why moving them would reverse the required
+  `compare -> model` import direction); **`resolve_change_identity`/
+  `_change_discriminator` actually consuming `Change.entity_id`** (the
+  carrier is populated but has no reader yet — mirrors the earlier
+  `Function.entity_id`/`Variable.entity_id` "carrier before consumer"
+  staging); **exhaustive population beyond the function-diff path**
+  (variable/type/enum/platform detectors construct `Change` from
+  `RecordType`/`EnumType`/`Variable` objects that also carry `.entity_id`,
+  but aren't wired yet); **and every post-parse consumer migration**
+  (`diff_filtering.py`/`type_reachability.py`'s string-based ambiguity
+  machinery). Those are the remaining items before Phase 2 is complete.
 - **Phases 3–10** are still unimplemented design text.
 
 See the [implementation plan](../plans/one-semantic-pipeline.md) for the

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -26,7 +26,7 @@
   path (`handle_non_elf_dump`)** — no PE/Mach-O toolchain was available to
   verify a migration against; see that same known-gaps entry.
 - **Phase 2** ("`EntityId`/`ScopePath` as the one identity primitive") has
-  landed five slices: the `ScopePath`/`EntityId` primitive itself
+  landed six slices: the `ScopePath`/`EntityId` primitive itself
   (`abicheck/model/identity.py`); both header-AST backends (`dumper_clang.py`/
   `dumper_castxml.py`) tracking scope as typed segments at parse time;
   `RecordType`/`EnumType`/`Function`/`Variable` gaining a parse-time-resolved
@@ -34,12 +34,31 @@
   carrier-field question resolved as option (a)); a `storage/entity_ids.py`
   wire-schema-v2 bridge (`domain_entity_id_to_dto`/`_from_dto`) that encodes
   `ScopePath` losslessly (a rendered `qualified_name` string cannot — two
-  distinct `ScopePath`s can render identically); and that carrier now
-  persisting through `serialization.py` (`SCHEMA_VERSION` 28). **No
-  consumer may read the carrier field yet** — the `finding_identity.py`
-  algorithm migration and the post-parse consumer migrations
-  (`diff_filtering.py`/`type_reachability.py`'s string-based ambiguity
-  machinery) are the two remaining items before Phase 2 is complete.
+  distinct `ScopePath`s can render identically); that carrier now
+  persisting through `serialization.py` (`SCHEMA_VERSION` 28); and, as the
+  sixth slice, a first, bounded piece of the `finding_identity.py` algorithm
+  migration (c2) —
+  `finding_identity.resolve_function_identity` now canonicalizes each
+  parameter through the same
+  `model.signature_normalization.canonicalize_function_signature_param_type`
+  primitive `entity_id_for_function`'s own signature-fallback branch uses,
+  rather than a second, independently-maintained
+  `canonicalize_type_name`-only pass — a real behavior fix (a top-level
+  by-value cv-qualifier no longer fragments identity, matching the C++
+  standard's own linkage rules), not only a dedup. **Still not landed: the
+  mangled-name-is-genuine determination** (`finding_identity.
+  is_real_mangled_name`/`normalize_mangled_name` stay finding_identity's own
+  — `model/identity.py`'s own docstring records why moving them would
+  reverse the required `compare -> model` import direction), **giving
+  `Change` an `EntityId` to key on** (c2's other stated deliverable), **and
+  every post-parse consumer migration** (`diff_filtering.py`/
+  `type_reachability.py`'s string-based ambiguity machinery) — **no
+  consumer may read the carrier field itself yet**, since nothing has
+  defined what the stored `entity_id`
+  means to a comparison; the algorithm-delegation slice above recomputes
+  the signature discriminator from `Function`'s own raw fields rather than
+  reading the carrier. Those are the remaining items before Phase 2 is
+  complete.
 - **Phases 3–10** are still unimplemented design text.
 
 See the [implementation plan](../plans/one-semantic-pipeline.md) for the

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -9425,6 +9425,65 @@ give `Change` an `EntityId` (closing (c2)), then the post-parse consumer
 migrations (b), per the fourth slice's own sequencing note above, which
 this slice does not otherwise revise.
 
+**Landed (seventh slice, 2026-08-30): `Change` gains its own `entity_id`
+carrier, populated at every `diff_symbols.py` function-diff call site --
+not yet the exhaustive-population or consumer halves of (c2)/(b).**
+`checker_types.Change` gains `entity_id: EntityId | None = field(default=
+None, kw_only=True)`, appended last per the file's own established
+per-field-`kw_only` convention (`Change` is public API; see that
+convention's own comment, condensed in the same commit to make room under
+`checker_types.py`'s zero-slack `debt.yaml` `no_growth` pin). Semantics:
+the OLD side's `Function.entity_id` when it exists, else the NEW side's --
+mirroring `Change.symbol_binding`'s own already-documented old-side
+convention, rather than inventing a new rule. Wired at every
+function-level call site in `diff_symbols.py` where the producing
+`Function` object(s) are already in scope: `_check_removed_function` (both
+branches), `_check_return_type_change`, `_check_params_change`,
+`_check_ref_qualifier_change`, `_check_linkage_change`, the
+`_check_contract_attributes_change`'s three sites, `_check_exception_spec_
+change`, `_check_vtable_index_change`, `_check_inline_transitions`'s two
+sites, the `FUNC_ADDED` site in `_diff_functions` (new side, since there is
+no old side), and `_detect_newly_deleted_functions` (old side's, via
+`f_old_any.entity_id or f_new.entity_id`, since `f_old_any` -- present only
+when the symbol persisted before gaining `= delete` -- can be `None`).
+`diff_helpers.bool_transition` (backing the noexcept/virtual/explicit/
+variadic checks) gains a matching `entity_id: EntityId | None = None`
+parameter, passed through to both `Change(...)` constructions unchanged --
+it has no declaration of its own to derive one from, so resolving it stays
+the caller's job.
+
+**What this slice deliberately does not attempt**, named explicitly rather
+than left to be discovered: (1) the *other* family of `Change(...)`/
+`make_change(...)` construction sites -- variable-diff, type/enum/platform/
+versioning detectors -- even though several of those already construct
+`Change` from a `RecordType`/`EnumType`/`Variable` that also carries its
+own `.entity_id` (a ~400-site total population, per the scoping
+investigation this slice's own PR ran before implementing); (2)
+`finding_identity.resolve_change_identity`/`_change_discriminator` reading
+`Change.entity_id` at all -- both functions still key entirely on
+`change.symbol`/`change.qualified_name`/flat value fields, unchanged by
+this slice, so **no consumer may read this carrier field yet**, the
+identical staging the model-layer `entity_id` carriers (`Function.
+entity_id` et al.) already went through. Verified via a new, real
+`compare()`-level regression suite (`tests/test_change_entity_id_carrier.py`)
+rather than only unit-testing the private `_check_*` helpers directly:
+FUNC_RETURN_CHANGED/FUNC_REMOVED/FUNC_ADDED/FUNC_NOEXCEPT_ADDED each pin the
+carrier's value end to end, plus a no-producer-`entity_id` case confirming
+`Change.entity_id` stays honestly `None` rather than fabricating one. Full
+fast unit suite green; `mypy abicheck/` and `ruff check`/`ruff format
+--check` clean; `check_architecture.py` 0 new errors (`checker_types.py`
+and `diff_symbols.py` both land at or under their existing `debt.yaml`
+baselines; `diff_helpers.py` -- not itself debt-tracked, but sitting
+exactly at the architecture gate's general 800-line production ceiling --
+required the identical "trim existing verbose comments to make room"
+treatment `checker_types.py` needed, condensing `TypeMap`'s and
+`type_map_key`'s own pre-existing docstrings rather than growing past it).
+Next slice, in order: `resolve_change_identity`/`_change_discriminator`
+consuming `Change.entity_id` (the true completion of (c2)), then (b), the
+post-parse consumer migrations -- exhaustive `Change.entity_id` population
+beyond the function-diff path is a separate, larger follow-on this
+sequencing does not schedule.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -9375,6 +9375,56 @@ further still to stay at the 800-line production cap after this
 addition. `mypy abicheck/` clean, `ruff check`/`ruff format --check`
 clean, `check_architecture.py` 0 errors.
 
+**Landed (sixth slice, 2026-08-30): a first, bounded piece of (c2), not
+all of it.** (c2) has two stated deliverables (see the fourth slice's own
+"Next slice" note above): the `finding_identity.py` algorithm migration
+itself, and giving `Change` an `EntityId` to key on. This slice lands only
+the first half of the first deliverable. `finding_identity.
+resolve_function_identity`'s per-parameter canonicalization -- previously
+a second, independently-maintained `canonicalize_type_name(p.type)` call,
+duplicating rather than reusing the cross-producer-spelling/cv-qualifier
+logic `entity_id_for_function`'s own `"sig"` fallback branch already
+established -- now calls `model.signature_normalization.
+canonicalize_function_signature_param_type` directly, the same primitive.
+Not a pure refactor: that primitive additionally drops a top-level
+BY-VALUE cv-qualifier (`void f(int)`/`void f(const int)` name the same
+function per the C++ standard's own linkage rules), which
+`canonicalize_type_name` deliberately does not -- so a DWARF-only,
+non-mangled function whose parameter merely gained or lost a top-level
+`const` no longer fragments into two NORMALIZED-tier identities. A
+*pointee* cv-qualifier (`char *` vs. `const char *`) remains genuinely
+distinguishing either way; both directions are pinned by new tests in
+`tests/test_finding_identity.py`
+(`test_by_value_cv_qualifier_no_longer_distinguishes_overloads`,
+`test_pointee_cv_qualifier_still_distinguishes_overloads`). The
+mangled-name-is-genuine determination (`is_real_mangled_name`/
+`normalize_mangled_name`) stays owned by `finding_identity.py`, unchanged
+-- `model/identity.py`'s own docstring already records why moving it would
+reverse the required `compare -> model` import direction (`entity_id_for_
+function`'s contract only ever needs an already-vetted mangled name as
+input, never `finding_identity`'s own validation logic). Full fast unit
+suite green; `mypy abicheck/` and `ruff check`/`ruff format --check`
+clean.
+
+**What this slice deliberately does not attempt.** `resolve_variable_
+identity` takes no `param_types` argument at all, so it has nothing
+equivalent to delegate (variables have no signature-shaped discriminator
+to canonicalize). Giving `Change` an `EntityId` to key on -- (c2)'s other,
+larger deliverable, which touches `checker_types.Change`,
+`resolve_change_identity`, and the `diff_symbols.py`/`diff_filtering.py`
+call sites that construct a `Change` -- is not attempted here; neither is
+(b), the post-parse consumer migrations (`diff_filtering.py`'s
+`_find_opaque_types`/`_find_by_value_types`/`_root_type_name` and
+`type_reachability.py`'s ambiguity machinery). Both remain open, and
+**no consumer may read the `entity_id` carrier field itself yet** --
+this slice recomputes the signature discriminator from `Function`'s own
+raw fields on every call, the same "one algorithm, not a cached value"
+discipline the carrier's own design note states, rather than reading the
+carrier `Function.entity_id` may already hold. Next slice, in order:
+give `Change` an `EntityId` (closing (c2)), then the post-parse consumer
+migrations (b), per the fourth slice's own sequencing note above, which
+this slice does not otherwise revise.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -79,3 +79,40 @@ class TestChangeEntityIdCarrier:
         new = _func("f", "_Z1fi", return_type="long")
         r = compare(_snap([old]), _snap([new]))
         assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id is None  # type: ignore[attr-defined]
+
+    def test_matched_pair_falls_back_to_new_side_when_old_has_none(self) -> None:
+        # Codex review: a pre-v28 baseline's Function carries no entity_id
+        # at all (schema predates the carrier), while a freshly-dumped new
+        # side does -- the documented "old side, else new side" rule must
+        # actually fall back, not silently stay None just because old_val
+        # exists but its own entity_id is unresolved.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old = _func("f", "_Z1fi", return_type="int")
+        new = _func("f", "_Z1fi", return_type="long", entity_id=eid)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_added_virtual_method_carries_new_side_entity_id(self) -> None:
+        # Codex review: an added virtual method routes through
+        # diff_cxx_rules.virtual_method_addition's own VIRTUAL_METHOD_ADDED
+        # change instead of the ordinary FUNC_ADDED make_change() call --
+        # a separate construction site that must carry entity_id too.
+        from abicheck.model import RecordType
+
+        owner = RecordType(name="C", kind="class", size_bits=64, vtable=[])
+        old_owner = RecordType(name="C", kind="class", size_bits=64, vtable=[])
+        eid = entity_id_for_function((), "f", mangled_name="_ZN1C1fEv")
+        new_method = _func(
+            "C::f",
+            "_ZN1C1fEv",
+            return_type="void",
+            is_virtual=True,
+            source_location="c.h:1",
+            entity_id=eid,
+        )
+        old_snap = _snap([])
+        old_snap.types = [old_owner]
+        new_snap = _snap([new_method])
+        new_snap.types = [owner]
+        r = compare(old_snap, new_snap)
+        assert _change(r, ChangeKind.VIRTUAL_METHOD_ADDED).entity_id == eid  # type: ignore[attr-defined]

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -92,6 +92,24 @@ class TestChangeEntityIdCarrier:
         r = compare(_snap([old]), _snap([new]))
         assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id == eid  # type: ignore[attr-defined]
 
+    def test_entity_id_excluded_from_change_equality(self) -> None:
+        # Codex review: entity_id must be compare=False -- two otherwise-
+        # identical Changes (e.g. a legacy baseline without an ID vs a
+        # current snapshot with one) must still compare equal, or the
+        # changelog's "excluded from equality" promise is false and
+        # public-API callers comparing expected findings can break.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old_with_id = _func("f", "_Z1fi", return_type="int", entity_id=eid)
+        old_without_id = _func("f", "_Z1fi", return_type="int")
+        new = _func("f", "_Z1fi", return_type="long")
+        r_with_id = compare(_snap([old_with_id]), _snap([new]))
+        r_without_id = compare(_snap([old_without_id]), _snap([new]))
+        c_with_id = _change(r_with_id, ChangeKind.FUNC_RETURN_CHANGED)
+        c_without_id = _change(r_without_id, ChangeKind.FUNC_RETURN_CHANGED)
+        assert c_with_id.entity_id == eid  # type: ignore[attr-defined]
+        assert c_without_id.entity_id is None  # type: ignore[attr-defined]
+        assert c_with_id == c_without_id
+
     def test_added_virtual_method_carries_new_side_entity_id(self) -> None:
         # Codex review: an added virtual method routes through
         # diff_cxx_rules.virtual_method_addition's own VIRTUAL_METHOD_ADDED

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 2: ``Change.entity_id`` carrier — the function-diff
+producer wiring in ``diff_symbols.py`` (the "finding_identity.py algorithm
+migration"'s second half, giving ``Change`` an ``EntityId`` to key on).
+
+No consumer reads ``Change.entity_id`` yet (same "carrier lands before
+consumer" discipline as ``Function.entity_id``/``Variable.entity_id``) --
+these tests pin only that the field is populated correctly at emission.
+"""
+
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, compare
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.model.identity import entity_id_for_function
+
+
+def _snap(functions: list[Function] | None = None) -> AbiSnapshot:
+    return AbiSnapshot(library="libtest.so.1", version="1.0", functions=functions or [])
+
+
+def _func(name: str, mangled: str, **kwargs: object) -> Function:
+    defaults: dict[str, object] = dict(return_type="int", visibility=Visibility.PUBLIC)
+    defaults.update(kwargs)
+    return Function(name=name, mangled=mangled, **defaults)  # type: ignore[arg-type]
+
+
+def _change(result: object, kind: ChangeKind) -> object:
+    return next(c for c in result.changes if c.kind == kind)  # type: ignore[union-attr]
+
+
+class TestChangeEntityIdCarrier:
+    def test_modified_function_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old = _func("f", "_Z1fi", return_type="int", entity_id=eid)
+        new = _func("f", "_Z1fi", return_type="long")
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_removed_function_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old = _func("f", "_Z1fi", entity_id=eid)
+        r = compare(_snap([old]), _snap([]))
+        assert _change(r, ChangeKind.FUNC_REMOVED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_added_function_carries_new_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        new = _func("f", "_Z1fi", entity_id=eid)
+        r = compare(_snap([]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_noexcept_transition_carries_old_side_entity_id(self) -> None:
+        # bool_transition-backed check -- a different code path than the
+        # ordinary make_change() call sites above.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func("f", "_Z1fv", is_noexcept=False, entity_id=eid)
+        new = _func("f", "_Z1fv", is_noexcept=True)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_NOEXCEPT_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_no_producer_entity_id_leaves_change_entity_id_none(self) -> None:
+        # Never fabricates one: a Function with no entity_id (e.g. a
+        # DWARF-only producer that hasn't wired this yet) produces a Change
+        # with entity_id=None, not a guessed value.
+        old = _func("f", "_Z1fi", return_type="int")
+        new = _func("f", "_Z1fi", return_type="long")
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id is None  # type: ignore[attr-defined]

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -24,12 +24,17 @@ these tests pin only that the field is populated correctly at emission.
 from __future__ import annotations
 
 from abicheck.checker import ChangeKind, compare
-from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.model import AbiSnapshot, Function, Param, Visibility
 from abicheck.model.identity import entity_id_for_function
 
 
-def _snap(functions: list[Function] | None = None) -> AbiSnapshot:
-    return AbiSnapshot(library="libtest.so.1", version="1.0", functions=functions or [])
+def _snap(functions: list[Function] | None = None, **kwargs: object) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version="1.0",
+        functions=functions or [],
+        **kwargs,  # type: ignore[arg-type]
+    )
 
 
 def _func(name: str, mangled: str, **kwargs: object) -> Function:
@@ -147,3 +152,137 @@ class TestChangeEntityIdCarrier:
         new_snap.types = [owner]
         r = compare(old_snap, new_snap)
         assert _change(r, ChangeKind.VIRTUAL_METHOD_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_default_removed_carries_old_side_entity_id(self) -> None:
+        # Codex review: the auxiliary param/deprecated/override detectors
+        # below (separate @registry.detector functions, not _check_*
+        # matched-pair sites) were fresh omissions from the same carrier
+        # contract -- each gets its own construction-site test here.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fii")
+        old = _func(
+            "f",
+            "_Z1fii",
+            params=[Param(name="x", type="int", default="1")],
+            entity_id=eid,
+        )
+        new = _func("f", "_Z1fii", params=[Param(name="x", type="int")])
+        r = compare(_snap([old], from_headers=True), _snap([new], from_headers=True))
+        assert _change(r, ChangeKind.PARAM_DEFAULT_VALUE_REMOVED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_default_changed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fii")
+        old = _func(
+            "f",
+            "_Z1fii",
+            params=[Param(name="x", type="int", default="1")],
+            entity_id=eid,
+        )
+        new = _func("f", "_Z1fii", params=[Param(name="x", type="int", default="2")])
+        r = compare(_snap([old], from_headers=True), _snap([new], from_headers=True))
+        assert _change(r, ChangeKind.PARAM_DEFAULT_VALUE_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_renamed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old = _func("f", "_Z1fi", params=[Param(name="x", type="int")], entity_id=eid)
+        new = _func("f", "_Z1fi", params=[Param(name="y", type="int")])
+        r = compare(_snap([old], from_headers=True), _snap([new], from_headers=True))
+        assert _change(r, ChangeKind.PARAM_RENAMED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_return_pointer_level_changed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func(
+            "f", "_Z1fv", return_type="int", return_pointer_depth=1, entity_id=eid
+        )
+        new = _func("f", "_Z1fv", return_type="int", return_pointer_depth=2)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.RETURN_POINTER_LEVEL_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_pointer_level_changed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fPi")
+        old = _func(
+            "f",
+            "_Z1fPi",
+            params=[Param(name="x", type="int", pointer_depth=1)],
+            entity_id=eid,
+        )
+        new = _func(
+            "f", "_Z1fPi", params=[Param(name="x", type="int", pointer_depth=2)]
+        )
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.PARAM_POINTER_LEVEL_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_method_access_changed_carries_old_side_entity_id(self) -> None:
+        from abicheck.model import AccessLevel
+
+        eid = entity_id_for_function((), "f", mangled_name="_ZN1C1fEv")
+        old = _func(
+            "C::f",
+            "_ZN1C1fEv",
+            return_type="void",
+            access=AccessLevel.PUBLIC,
+            entity_id=eid,
+        )
+        new = _func("C::f", "_ZN1C1fEv", return_type="void", access=AccessLevel.PRIVATE)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.METHOD_ACCESS_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_func_deprecated_added_carries_old_side_entity_id(self) -> None:
+        # ast_producer="castxml" (not just from_headers) is what makes
+        # fact_producer() report a positively-known backend -- see its
+        # docstring in fact_provenance.py.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func("f", "_Z1fv", entity_id=eid)
+        new = _func("f", "_Z1fv", deprecated="use g instead")
+        r = compare(
+            _snap([old], from_headers=True, ast_producer="castxml"),
+            _snap([new], from_headers=True, ast_producer="castxml"),
+        )
+        assert _change(r, ChangeKind.FUNC_DEPRECATED_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_func_deprecated_removed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func("f", "_Z1fv", deprecated="use g instead", entity_id=eid)
+        new = _func("f", "_Z1fv")
+        r = compare(
+            _snap([old], from_headers=True, ast_producer="castxml"),
+            _snap([new], from_headers=True, ast_producer="castxml"),
+        )
+        assert _change(r, ChangeKind.FUNC_DEPRECATED_REMOVED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_func_override_specifier_added_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_ZN1C1fEv")
+        old = _func(
+            "C::f",
+            "_ZN1C1fEv",
+            return_type="void",
+            is_virtual=True,
+            is_override=False,
+            entity_id=eid,
+        )
+        new = _func(
+            "C::f", "_ZN1C1fEv", return_type="void", is_virtual=True, is_override=True
+        )
+        r = compare(
+            _snap([old], from_headers=True, ast_producer="castxml"),
+            _snap([new], from_headers=True, ast_producer="castxml"),
+        )
+        assert _change(r, ChangeKind.FUNC_OVERRIDE_SPECIFIER_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_func_override_specifier_removed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_ZN1C1fEv")
+        old = _func(
+            "C::f",
+            "_ZN1C1fEv",
+            return_type="void",
+            is_virtual=True,
+            is_override=True,
+            entity_id=eid,
+        )
+        new = _func(
+            "C::f", "_ZN1C1fEv", return_type="void", is_virtual=True, is_override=False
+        )
+        r = compare(
+            _snap([old], from_headers=True, ast_producer="castxml"),
+            _snap([new], from_headers=True, ast_producer="castxml"),
+        )
+        assert _change(r, ChangeKind.FUNC_OVERRIDE_SPECIFIER_REMOVED).entity_id == eid  # type: ignore[attr-defined]

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -92,6 +92,19 @@ class TestChangeEntityIdCarrier:
         r = compare(_snap([old]), _snap([new]))
         assert _change(r, ChangeKind.FUNC_RETURN_CHANGED).entity_id == eid  # type: ignore[attr-defined]
 
+    def test_visibility_changed_carries_old_side_entity_id(self) -> None:
+        # A function that goes public -> hidden (still present, not removed)
+        # is a separate _check_removed_function construction site from the
+        # true-removal one above -- its own entity_id=old-or-new fallback
+        # line was untested (codecov flagged it as a patch-coverage gap).
+        from abicheck.model import Visibility
+
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+        old = _func("f", "_Z1fi", visibility=Visibility.PUBLIC, entity_id=eid)
+        new = _func("f", "_Z1fi", visibility=Visibility.HIDDEN)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.FUNC_VISIBILITY_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
     def test_entity_id_excluded_from_change_equality(self) -> None:
         # Codex review: entity_id must be compare=False -- two otherwise-
         # identical Changes (e.g. a legacy baseline without an ID vs a

--- a/tests/test_evidence_provenance_completeness.py
+++ b/tests/test_evidence_provenance_completeness.py
@@ -124,17 +124,22 @@ class TestFieldDefaultsToNone:
         revision inserted this field positionally between
         `contract_evidence_refs` and `compatibility_evaluation_status`,
         which would have silently shifted every later field's position for
-        such a caller)."""
+        such a caller). `entity_id` (ADR-063 Phase 2) is the newest such
+        field, appended immediately after this one -- both must stay
+        keyword-only, and `entity_id` must stay last until some still-newer
+        field is appended after it in turn."""
         import dataclasses
 
-        f = next(
-            field for field in dataclasses.fields(Change) if field.name == "evidence_provenance"
+        by_name = {f.name: f for f in dataclasses.fields(Change)}
+        assert by_name["evidence_provenance"].kw_only is True
+        assert by_name["entity_id"].kw_only is True
+        all_names = [f.name for f in dataclasses.fields(Change)]
+        assert all_names[-1] == "entity_id", (
+            "entity_id must be the last-declared field on Change"
         )
-        assert f.kw_only is True
-        all_names = [field.name for field in dataclasses.fields(Change)]
-        assert all_names[-1] == "evidence_provenance", (
-            "evidence_provenance must be the last-declared field on Change"
-        )
+        assert (
+            all_names.index("entity_id") == all_names.index("evidence_provenance") + 1
+        ), "entity_id must be appended immediately after evidence_provenance"
 
 
 class TestVerifiedBucketsHaveProducerCoverage:
@@ -216,7 +221,9 @@ class TestClassificationTracksRealProducerBehavior:
         old = build_snapshot("1.0", _CONTEXT, old_extra)
         new = build_snapshot("2.0", _CONTEXT, new_extra)
         emitted = [c for c in compare(old, new).changes if c.kind == expected_kind]
-        assert emitted, f"{mutation.__name__}: expected_kind {expected_kind.name} not emitted"
+        assert emitted, (
+            f"{mutation.__name__}: expected_kind {expected_kind.name} not emitted"
+        )
         stamped = [c for c in emitted if c.evidence_provenance is not None]
         assert not stamped, (
             f"{expected_kind.value} is classified PROVENANCE_UNVERIFIED in "
@@ -245,12 +252,16 @@ class TestClassificationTracksRealProducerBehavior:
             old = build_snapshot("1.0", _CONTEXT, old_extra)
             new = build_snapshot("2.0", _CONTEXT, new_extra)
             found = [c for c in compare(old, new).changes if c.kind == expected_kind]
-            assert found, f"{mutation.__name__}: expected_kind {expected_kind.name} not emitted"
+            assert found, (
+                f"{mutation.__name__}: expected_kind {expected_kind.name} not emitted"
+            )
             emitted.extend(found)
         return emitted
 
     @pytest.mark.parametrize("kind_value", sorted(PROVENANCE_STATIC))
-    def test_static_kinds_are_stamped_identically_on_every_finding(self, kind_value: str) -> None:
+    def test_static_kinds_are_stamped_identically_on_every_finding(
+        self, kind_value: str
+    ) -> None:
         """PROVENANCE_STATIC's own definition is "a constant tuple, the
         same value for every instance of this kind" -- checked exhaustively
         across *every* mutation catalogued for this kind (not just one
@@ -281,7 +292,9 @@ class TestClassificationTracksRealProducerBehavior:
         )
 
     @pytest.mark.parametrize("kind_value", sorted(PROVENANCE_PER_FINDING))
-    def test_per_finding_kinds_are_stamped_on_every_finding(self, kind_value: str) -> None:
+    def test_per_finding_kinds_are_stamped_on_every_finding(
+        self, kind_value: str
+    ) -> None:
         """Also checks PROVENANCE_PER_FINDING is not behaviorally
         indistinguishable from PROVENANCE_STATIC (Codex review, fresh
         evidence): a producer that stamps the same constant tuple on

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -725,8 +725,7 @@ class TestResolveFunctionIdentity:
 
     def test_by_value_cv_delegates_to_shared_signature_primitive(self) -> None:
         # ADR-063 Phase 2: shares canonicalize_function_signature_param_type
-        # with entity_id_for_function -- drops a top-level BY-VALUE cv but
-        # keeps a POINTEE cv distinguishing.
+        # with entity_id_for_function -- drops a BY-VALUE cv, keeps a POINTEE one.
         def sig(t: str) -> str:
             f = Function(
                 name="f", mangled="f", return_type="void", params=[Param("x", t)]
@@ -735,6 +734,7 @@ class TestResolveFunctionIdentity:
 
         assert sig("int") == sig("const int")
         assert sig("char *") != sig("const char *")
+        sig("void (*)(" * 500 + "int" + ")" * 500)  # must not raise (PR #952)
 
 
 class TestResolveVariableIdentity:

--- a/tests/test_finding_identity.py
+++ b/tests/test_finding_identity.py
@@ -711,30 +711,30 @@ class TestResolveFunctionIdentity:
         )
 
     def test_parameter_type_spelling_is_canonicalized(self) -> None:
-        # Codex review: castxml ("char const*") and clang's -ast-dump=json
-        # ("char const *") spell an otherwise-identical parameter type
-        # differently -- a real, confirmed cross-producer discrepancy
-        # (name_classification.canonicalize_type_name's own docstring,
-        # diff_symbols._params_differ already compares through it). Without
-        # canonicalizing here, the same declaration seen from two producers
-        # would get different NORMALIZED-tier signatures, fragmenting
-        # identity the same way an uncanonicalized qualified_name would.
-        castxml_spelling = Function(
-            name="foo",
-            mangled=None,
-            return_type="void",
-            params=[Param(name="s", type="char const*")],
-        )
-        clang_spelling = Function(
-            name="foo",
-            mangled=None,
-            return_type="void",
-            params=[Param(name="s", type="char const *")],
-        )
-        assert (
-            resolve_function_identity(castxml_spelling).primary_id
-            == resolve_function_identity(clang_spelling).primary_id
-        )
+        # Codex review: castxml ("char const*") vs. clang's -ast-dump=json
+        # ("char const *") spell an identical param type differently;
+        # canonicalizing here keeps two producers' NORMALIZED-tier
+        # signatures from fragmenting the same declaration's identity.
+        def sig(t: str) -> str:
+            f = Function(
+                name="foo", mangled=None, return_type="void", params=[Param("s", t)]
+            )
+            return resolve_function_identity(f).primary_id
+
+        assert sig("char const*") == sig("char const *")
+
+    def test_by_value_cv_delegates_to_shared_signature_primitive(self) -> None:
+        # ADR-063 Phase 2: shares canonicalize_function_signature_param_type
+        # with entity_id_for_function -- drops a top-level BY-VALUE cv but
+        # keeps a POINTEE cv distinguishing.
+        def sig(t: str) -> str:
+            f = Function(
+                name="f", mangled="f", return_type="void", params=[Param("x", t)]
+            )
+            return resolve_function_identity(f).primary_id
+
+        assert sig("int") == sig("const int")
+        assert sig("char *") != sig("const char *")
 
 
 class TestResolveVariableIdentity:

--- a/tests/test_signature_normalization.py
+++ b/tests/test_signature_normalization.py
@@ -632,6 +632,25 @@ class TestNestedCallbackParametersAreNormalizedRecursively:
         )
 
 
+class TestNestingDepthIsBounded:
+    """Codex review, PR #952: the recursion above terminates eventually
+    (each call operates on a strictly shorter substring) but not before
+    exhausting Python's call stack for a deep-enough input -- an
+    adversarial/corrupt snapshot's parameter type could crash a whole
+    compare() with an uncaught RecursionError. A safe (unnormalized
+    passthrough) fallback beyond a generous depth bound fixes the crash
+    without touching any real, non-adversarial signature's result."""
+
+    def test_pathologically_nested_callback_does_not_crash(self) -> None:
+        pathological = "void (*)(" * 500 + "int" + ")" * 500
+        assert canon(pathological)  # must not raise RecursionError
+
+    def test_ordinary_nesting_is_unaffected_by_the_bound(self) -> None:
+        assert canon("void (*)(void (*)(const int))") == canon(
+            "void (*)(void (*)(int))"
+        )
+
+
 class TestIdempotence:
     """Canonicalizing an already-canonical form is a no-op -- a basic
     sanity property any normalization function should hold."""


### PR DESCRIPTION
## Summary

Two bounded slices of ADR-063 Phase 2's remaining work, landed together on
this branch:

1. `finding_identity.resolve_function_identity` now shares its
   per-parameter canonicalization with `entity_id_for_function` instead of
   keeping a second, independently-maintained copy (fixes a real identity-
   fragmentation bug along the way).
2. `checker_types.Change` gains its own `entity_id` carrier field, wired at
   every `diff_symbols.py` function-diff call site.

Plus a follow-on fix for a `RecursionError` Codex review flagged in slice 1
(bounded the recursion in `canonicalize_function_signature_param_type`).

## Motivation

ADR-063 Phase 2 ("`EntityId`/`ScopePath` as the one identity primitive")
landed five slices already (the primitive itself, typed-scope tracking in
both header-AST backends, the `entity_id` carrier field on
`RecordType`/`EnumType`/`Function`/`Variable`, the storage v2 wire bridge,
and its persistence through schema v28) but explicitly left two items open
before the phase is complete: the `finding_identity.py` algorithm
migration ("(c2)"), and the post-parse consumer migrations in
`diff_filtering.py`/`type_reachability.py` ("(b)"). (c2) itself has two
stated deliverables: making `finding_identity.py` share its algorithm with
`model.identity`, and giving `Change` an `EntityId` to key on. This PR
lands both halves of (c2), each as its own commit.

### Slice 1 — `finding_identity.py` algorithm migration

`finding_identity.resolve_function_identity` built its NORMALIZED-tier
signature by canonicalizing each parameter through
`name_classification.canonicalize_type_name` — a second, hand-rolled copy
of logic `model.identity.entity_id_for_function`'s own signature-fallback
branch already gets right via the dedicated
`model.signature_normalization.canonicalize_function_signature_param_type`
primitive. That primitive additionally drops a top-level **by-value**
cv-qualifier (`void f(int)`/`void f(const int)` name the same function per
the C++ standard's own linkage rules), which `canonicalize_type_name`
deliberately does not. So for a function with no real mangled name (a
DWARF-only snapshot, or a non-`extern "C"` C-linkage declaration), a
before/after pair whose parameter merely gained or lost a top-level
`const` used to fragment into two distinct NORMALIZED-tier identities —
a real correctness bug, not only duplicated logic.

**Codex review caught a real regression in this slice**: routing
`finding_identity.py` through the shared, recursive canonicalizer newly
exposed a `RecursionError` crash on a pathologically nested callback
parameter type (`"void (*)(" * 500 + "int" + ")" * 500`), reachable via
`compare()` on a hand-crafted/corrupted snapshot — a much more directly
attacker-reachable boundary than the primitive's pre-existing use during
real header-AST parsing. Fixed with a bounded recursion depth (64) that
falls back to leaving the offending fragment unnormalized instead of
crashing; see the follow-up commit and its own regression tests.

### Slice 2 — `Change` gains an `entity_id` carrier

`checker_types.Change` gains `entity_id: EntityId | None = field(default=
None, kw_only=True)`, appended last per the file's own established
per-field-`kw_only` convention (`Change` is public API). Semantics: the
OLD side's `Function.entity_id` when it exists, else the NEW side's —
mirroring `Change.symbol_binding`'s own already-documented old-side
convention, rather than inventing a new rule.

Wired at every function-level call site in `diff_symbols.py` where the
producing `Function` object(s) are already in scope: `_check_removed_
function` (both branches), `_check_return_type_change`, `_check_params_
change`, `_check_ref_qualifier_change`, `_check_linkage_change`, the
`bool_transition`-backed noexcept/virtual/explicit/variadic checks,
`_check_contract_attributes_change`'s three sites, `_check_exception_
spec_change`, `_check_vtable_index_change`, `_check_inline_transitions`'s
two sites, the `FUNC_ADDED` site (new side, since there is no old side),
and `_detect_newly_deleted_functions` (old side's, via `f_old_any.
entity_id or f_new.entity_id`, since `f_old_any` can be `None`).
`diff_helpers.bool_transition` gains a matching `entity_id: EntityId |
None = None` parameter, passed through unchanged to both `Change(...)`
constructions it builds.

**What this slice deliberately does not attempt**: the *other* family of
`Change(...)`/`make_change(...)` construction sites (variable/type/enum/
platform/versioning detectors — several of which already construct
`Change` from a `RecordType`/`EnumType`/`Variable` that also carries its
own `.entity_id`, but aren't wired here); and `finding_identity.
resolve_change_identity`/`_change_discriminator` actually *reading*
`Change.entity_id` — both functions still key entirely on `change.symbol`/
`change.qualified_name`/flat value fields, unchanged by this slice, so
**no consumer may read this carrier field yet** — the identical staging
the model-layer `entity_id` carriers already went through.

## Changes

- `abicheck/finding_identity.py`, `abicheck/model/identity.py`: slice 1
  (see prior commit).
- `abicheck/model/signature_normalization.py`, `tests/test_signature_
  normalization.py`, `tests/test_finding_identity.py`: the `RecursionError`
  fix (see prior commit).
- `abicheck/checker_types.py`: `Change.entity_id` field.
- `abicheck/diff_symbols.py`, `abicheck/diff_helpers.py`: producer wiring
  for slice 2.
- `tests/test_change_entity_id_carrier.py`: new `compare()`-level
  regression suite pinning the carrier end to end (modified/removed/added/
  noexcept-transition cases, plus a no-producer case confirming the field
  stays honestly `None` rather than fabricating a value).
- `tests/test_evidence_provenance_completeness.py`: updated the existing
  "last-declared-field" contract test to point at `entity_id`, the new
  actual last field, instead of `evidence_provenance`.
- `docs/contribute/adr/063-one-semantic-pipeline.md` and the implementation
  plan: status updated to record both landed slices and what's still open.
- Changelog fragments (one per commit).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragments added (`scriv create`) — touches `abicheck/**/*.py`
- [x] Docs updated (ADR-063 + implementation plan)
- [x] `mypy abicheck/`, `ruff check`, `ruff format --check` clean
- [x] Full fast unit suite green (34380 passed; the only 2 failures are
      pre-existing and reproduce identically on `main` with none of this
      PR's changes — `test_action_run_sh_baseline_set_fallback` and
      `test_verify_profiles::test_isolated_module_runner_preserves_user_site_without_root_shadowing`,
      both environment-specific)
- [x] `python scripts/check_architecture.py` — no new `debt-no-growth`/
      `new-file-size` violations. `checker_types.py` and `diff_symbols.py`
      are debt-tracked at zero/near-zero headroom and land at or under
      their existing baselines; `diff_helpers.py` isn't debt-tracked but
      sits exactly at the architecture gate's general 800-line production
      ceiling, so it got the same "trim pre-existing verbose comments to
      make room" treatment.
- [x] `python scripts/check_ai_readiness.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeG163b47jia4C98Na7d9K)_