### PR TITLE
feat(compare): finalize ADR-063 Phase 2's Change.entity_id consumer migration

### DIFF
--- a/abicheck/diff_hidden_friends.py
+++ b/abicheck/diff_hidden_friends.py
@@ -70,6 +70,7 @@ def check_hidden_friend_change(
         ),
         removed_values=("hidden friend", "non-friend"),
         caused_by_type=owner,
+        entity_id=f_old.entity_id or f_new.entity_id,
     )
 
 
@@ -116,6 +117,7 @@ def diff_inline_hidden_friends(
                         symbol=mangled,
                         old=f_old.name,
                         caused_by_type=f_old.hidden_friend_owner,
+                        entity_id=f_old.entity_id,
                     )
                 )
             continue
@@ -132,6 +134,7 @@ def diff_inline_hidden_friends(
                     symbol=mangled,
                     new=f_new.name,
                     caused_by_type=f_new.hidden_friend_owner,
+                    entity_id=f_new.entity_id,
                 )
             )
     return changes

--- a/abicheck/diff_param_qualifiers.py
+++ b/abicheck/diff_param_qualifiers.py
@@ -83,6 +83,7 @@ def param_restrict_changes(
                         old=str(p_old.name or i),
                         old_value=f"restrict={p_old.is_restrict}",
                         new_value=f"restrict={p_new.is_restrict}",
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
     return changes
@@ -137,6 +138,7 @@ def param_va_list_changes(
                         detail=str(p_old.name or i),
                         old_value=p_old.type,
                         new_value="va_list",
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
             elif p_old.is_va_list and not p_new.is_va_list:
@@ -148,6 +150,7 @@ def param_va_list_changes(
                         detail=str(p_old.name or i),
                         old_value="va_list",
                         new_value=p_new.type,
+                        entity_id=f_old.entity_id or f_new.entity_id,
                     )
                 )
     return changes

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1116,6 +1116,7 @@ def _diff_ctor_overload_ambiguity(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
                     symbol=f.mangled,
                     name=cls,
                     new=f"{cls}({', '.join(sig)})",
+                    entity_id=f.entity_id,
                 )
             )
     return changes

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -37,9 +37,9 @@ mangled-primary + name-based extern-C fallback in ``_diff_functions``,
 independently-tested primitive -- following the same "most specific
 available identity, ambiguity-safe fallback" principle ADR-045 already
 established for flat type matching (``diff_helpers.TypeMap``) and ADR-048
-established for L5 source-graph nodes
-(``buildsource/entity_identity.py``). This is the L0-L2 flat-finding
-analogue of those two, not a third independent implementation of the
+established for L5 source-graph nodes (``buildsource/entity_identity.py``).
+This is the L0-L2 flat-finding analogue of those two, not a third
+independent implementation of the
 underlying principle -- and deliberately does not import
 ``buildsource.entity_identity`` (the optional L3-L5 layer must depend on
 this core package, never the other way around).
@@ -57,14 +57,13 @@ this core package, never the other way around).
 That second wiring waited for the piece this module was missing rather than
 for the refactor to get smaller: :func:`resolve_function_identity` resolves
 *one* declaration's identity and has no notion of "this identity is
-ambiguous within its own snapshot, so do not join on it" -- which is the
-whole of what made the ``extern "C"`` fallback safe. :class:`SymbolIdentityIndex`
+ambiguous within its own snapshot, so do not join on it" -- the whole of
+what made the ``extern "C"`` fallback safe. :class:`SymbolIdentityIndex`
 supplies it, so the matching engine states the rule instead of
-re-implementing it. Matching behavior is deliberately unchanged; the
-hand-tuned logic around the join (elf-only-mode, unconfirmed-parameter and
-LLP64 threading, virtual-method-addition, inline transitions, hidden
-friends) is untouched, and the golden/FP-rate/tier-accuracy/detector-oracle
-suites pin that.
+re-implementing it. Matching behavior is deliberately unchanged -- the
+hand-tuned join logic (elf-only-mode, unconfirmed-parameter/LLP64
+threading, virtual-method-addition, inline transitions, hidden friends) is
+untouched, pinned by the golden/FP-rate/tier-accuracy/detector-oracle suites.
 
 NEVER invents a fact a producer did not supply: a tier is only claimed
 when the corresponding input field is actually present.
@@ -1229,9 +1228,8 @@ def _stringify_change_value(value: object) -> str:
 # Only the bit-valued half of each _EQUIVALENT_CHANGE_CATEGORIES size/
 # alignment pair needs converting -- diff_platform.py's byte-valued
 # STRUCT_SIZE_CHANGED/STRUCT_ALIGNMENT_CHANGED are already the target unit.
-# Used only by _change_discriminator's canonicalize_values=True path to
-# fold a category-collapsed kind's old/new into the discriminator in a
-# unit that agrees regardless of which detector supplied the finding
+# Used only by _change_discriminator's canonicalize_values=True path, so a
+# category-collapsed kind's old/new agree regardless of the detector
 # (Codex review, fresh evidence -- see that call site's own comment).
 _CATEGORY_VALUE_UNIT_DIVISOR = {
     "type_size_changed": 8,
@@ -1301,12 +1299,10 @@ def _change_discriminator(
     ``description`` embeds the arbitrary sampled symbol via its
     ``description_template`` (``diff_platform_elf_symbols.py``'s
     ``_check_gained_gnu_unique``: ``"Symbol binding became GNU_UNIQUE:
-    {name} ..."`` where ``name`` is the sample). Clearing
-    ``entity_symbol`` alone (see :func:`resolve_change_identity`) is not
-    enough, since ``description`` still varies with the sample even
-    though ``old_value``/``new_value`` do not (Codex review: verified
-    changing only the sampled export still produced a different synthetic
-    primary id).
+    {name} ..."`` where ``name`` is the sample). Clearing ``entity_symbol``
+    alone is not enough, since ``description`` still varies with the sample
+    even though ``old_value``/``new_value`` do not (Codex review: verified
+    changing only the sampled export still produced a different id).
 
     ``canonicalize_values=True`` -- used only by
     :func:`report_canonical_finding_id`'s call into
@@ -1328,17 +1324,13 @@ def _change_discriminator(
     ``type_field_type_changed`` -- embed a per-item identity, such as a
     field name, in ``description`` via ``change_registry``'s ``{detail}``
     template placeholder, with no other structured field carrying it;
-    dropping description collapsed two distinct findings on the same
-    symbol/kind/old/new differing only by which field/parameter changed).
-    Canonicalizing the whole description sentence for an allowlisted kind
-    is safe rather than corrupting: :func:`canonicalize_type_name`'s
-    struct/const-prefix rewrites only ever match at the very start of the
-    string, and its pointer/reference-sigil spacing pass only touches
-    ``*``/``&`` characters -- neither construct appears in an ordinary
-    field/parameter name, so the identifying part of the sentence survives
-    untouched while any embedded raw type spelling (e.g.
-    ``struct_field_type_changed``'s own template embeds ``{old} → {new}``)
-    normalizes the same way ``old_value``/``new_value`` do.
+    dropping description collapsed two distinct findings differing only by
+    which field/parameter changed). Canonicalizing the whole sentence for
+    an allowlisted kind is safe rather than corrupting: ``canonicalize_
+    type_name``'s struct/const-prefix rewrites only match at the string's
+    start, and its pointer/reference-sigil pass only touches ``*``/``&`` --
+    neither appears in an ordinary field/parameter name, so any embedded
+    raw type spelling normalizes the same way ``old_value``/``new_value`` do.
     """
     category = _EQUIVALENT_CHANGE_CATEGORIES.get(kind_value)
     if category is not None:
@@ -1481,21 +1473,23 @@ def resolve_change_identity(
     (which identify one *entity*, so a bare mangled name is already
     unambiguous), this identifies one *finding* -- two distinct findings
     routinely share a symbol. :func:`_change_discriminator` is folded into
-    ``primary_id`` at every tier, including CANONICAL, mirroring the
-    discriminator ``reporter_markdown._finding_id`` already established as
-    the minimal set that disambiguates one finding from another on the same
-    symbol (Codex review: a bare ``mangled:<symbol>`` canonical id would
-    collapse unrelated findings and violate this module's stated dedup-key
+    ``primary_id`` at every tier, including CANONICAL, mirroring
+    ``reporter_markdown._finding_id``'s own established minimal
+    disambiguating set (Codex review: a bare ``mangled:<symbol>`` canonical
+    id would collapse unrelated findings, violating this module's dedup-key
     contract).
 
     ``canonicalize_values=False`` (the default) preserves this function's
     pre-existing, exact-value discriminator for its established callers
     (``diff_filtering.py``'s cross-detector dedup, ``aggregate_findings.py``,
-    ``contract_evaluation.py``) -- none of which need, or were verified
-    against, a type-spelling-insensitive comparison. Pass ``True`` only for
-    a genuinely cross-backend use (:func:`report_canonical_finding_id`),
-    where :func:`_change_discriminator`'s own docstring explains why the
-    raw value must not leak into a "backend-independent" identity.
+    ``contract_evaluation.py``) -- none verified against a type-spelling-
+    insensitive comparison. Pass ``True`` only for a genuinely cross-backend
+    use (:func:`report_canonical_finding_id`), where
+    :func:`_change_discriminator`'s own docstring explains why the raw
+    value must not leak into a "backend-independent" identity.
+
+    ``change.entity_id``, when set, folds in as an additional ``entity:``
+    alias (ADR-063 Phase 2) -- additive, never ``primary_id``/tier.
     """
     kind_value = str(getattr(change.kind, "value", change.kind))
     is_batch = _is_batch_shaped_change(change, kind_value)
@@ -1525,6 +1519,9 @@ def resolve_change_identity(
     # would still make the supposedly library-level identity change
     # whenever the sampled export's file changes.
     source_location = None if is_batch else change.source_location
+    # Same is_batch guard as the three fields above, defensively -- no
+    # producer sets entity_id on a batch-shaped Change today.
+    entity_id = None if is_batch else change.entity_id
     is_symbol_level = _is_symbol_level_kind(kind_value) and not is_batch
     # For a symbol-level change, `entity_symbol` (the raw exported name) is
     # the more tier-stable NORMALIZED-tier basis than `qualified_name` --
@@ -1564,11 +1561,10 @@ def resolve_change_identity(
     # Every alias below is qualified with `discriminator`, matching `primary`/
     # `sig`: a bare `mangled:<x>`/`symbol:<x>`/`qualified:<x>` alias would
     # identify the *entity*, not this *finding* -- two distinct findings on
-    # the same entity (e.g. a return-type change and a param-type change on
-    # the same function) would then share every entity-scoped alias despite
-    # being unrelated changes, and a future alias-match reconciliation tier
-    # (this field's documented purpose) would wrongly pair them whenever
-    # each side has only one candidate (Codex review).
+    # the same entity (e.g. a return-type and a param-type change on the
+    # same function) would share every entity-scoped alias, and a future
+    # alias-match reconciliation tier would wrongly pair them whenever each
+    # side has only one candidate (Codex review).
     aliases: list[str] = []
     if real_mangled:
         aliases.append(f"mangled:{real_mangled}\x1f{discriminator}")
@@ -1579,6 +1575,11 @@ def resolve_change_identity(
     aliases.append(sig)
     if source_location:
         aliases.append(f"relsrc:{rel}\x1f{discriminator}")
+    if entity_id is not None:
+        # ADR-063 Phase 2: first real read of Change.entity_id. Additive
+        # only -- EntityId.key isn't yet proven stable across releases
+        # enough to replace what stored suppression rules key against.
+        aliases.append(f"entity:{entity_id.key}\x1f{discriminator}")
 
     if real_mangled:
         primary = f"mangled:{real_mangled}\x1f{discriminator}"

--- a/abicheck/model/identity.py
+++ b/abicheck/model/identity.py
@@ -15,34 +15,28 @@
 
 """``ScopePath``/``EntityId`` — the one identity primitive (ADR-063 Phase 2).
 
-See ``docs/contribute/plans/one-semantic-pipeline.md``'s "Phase 2 —
-EntityId/ScopePath as the one identity primitive" section for the full
-design and landed-slice history; that ADR/plan pair, not this docstring, is
-the authoritative status record — this docstring only orients a reader
-already in the file. Landed so far: the ``ScopePath``/``EntityId`` shape
-itself; both header-AST backends deriving a typed ``ScopePath`` at parse
-time and populating a resolved ``entity_id`` carrier on
-``RecordType``/``EnumType``/``Function``/``Variable`` (the plan's "carrier
-field" question resolved as option (a) — computed once at parse time, not
-recomputed on demand); that carrier persisting through ``serialization.py``
-(schema v28); and, as a first, bounded step of the
-``finding_identity.py`` algorithm migration,
-``finding_identity.resolve_function_identity`` now canonicalizing each
-parameter via this module's own ``signature_normalization.
-canonicalize_function_signature_param_type`` (the identical primitive
-``entity_id_for_function``'s own "sig" fallback branch uses) instead of a
-second, independently-maintained copy. Still open: the mangled-name-is-
-genuine determination stays owned by ``finding_identity.
-is_real_mangled_name``/``normalize_mangled_name`` (``compare -> model``
-stays the only allowed edge, and that validation logic is not a dependency
-this module needs); giving ``Change`` an ``EntityId`` to key on; and the
-post-parse consumer migrations (``diff_filtering.py``/
-``type_reachability.py``'s string-based ambiguity machinery) — **no
-consumer may read the ``entity_id`` carrier field itself yet**.
+See ``docs/contribute/plans/one-semantic-pipeline.md``'s "Phase 2" section
+for the full design and landed-slice history -- that ADR/plan pair, not
+this docstring, is the authoritative status record. Landed: the
+``ScopePath``/``EntityId`` shape; both header-AST backends populating a
+parse-time ``entity_id`` carrier on ``RecordType``/``EnumType``/
+``Function``/``Variable``, persisted through ``serialization.py`` (schema
+v28); ``finding_identity.resolve_function_identity`` sharing this module's
+own signature canonicalization; ``Change`` gaining its own ``entity_id``
+carrier, populated across the function-diff path; and, as this module's own
+``EntityId.key`` property, the first read of that carrier by a real
+consumer (``finding_identity.resolve_change_identity``'s new alias --
+additive only, no existing primary/canonical id changes). Still open:
+the mangled-name-is-genuine determination stays owned by
+``finding_identity.is_real_mangled_name``/``normalize_mangled_name``
+(``compare -> model`` stays the only allowed edge); exhaustive
+``entity_id`` population beyond the function-diff path; and the post-parse
+consumer migrations (``diff_filtering.py``/``type_reachability.py``'s
+string-based ambiguity machinery).
 
 ``EntityKind``/``ObservationKind`` relocated here from ``storage.
 entity_ids`` (domain vocabulary belongs in ``model``, not the storage wire
-layer, per ADR-061's ``storage -> model`` import direction) —
+layer, per ADR-061's ``storage -> model`` import direction) --
 ``storage.entity_ids`` now imports these two enums rather than redefining
 them.
 
@@ -184,11 +178,9 @@ class Anonymous:
     whole ``EntityId``, even though nothing about those later declarations
     changed. No stable across-snapshot discriminator is adopted here -- see
     the plan's Phase 2 Design section for why (a source-location anchor and
-    a structural fingerprint of the anonymous scope's own members were both
-    considered and are each independently documented elsewhere in this
-    codebase's AGENTS.md as unreliable for this exact purpose). This is an
-    accepted, documented limitation of ``Anonymous`` identity specifically,
-    not a silent gap.
+    a structural fingerprint were both considered and are each documented
+    elsewhere in AGENTS.md as unreliable for this purpose). Accepted,
+    documented limitation of ``Anonymous`` identity, not a silent gap.
     """
 
     kind: str
@@ -199,33 +191,22 @@ class Anonymous:
 class LocalToFunction:
     """A scope local to one function body.
 
-    Both fields are identity, deliberately, for exactly the reason
-    :class:`Anonymous` gives for its own ``ordinal``: ``owner`` alone
-    disambiguates two same-named locals across *different* functions, but
-    not two same-named locals in *sibling compound blocks of the same
-    function* (``void f() { { struct A {}; } { struct A {}; } }`` -- two
-    distinct declarations, same ``owner``, same leaf name). ``block_ordinal``
-    closes that gap the same way ``Anonymous.ordinal`` closes its sibling
-    case: a deterministic per-function sequence number assigned at parse
-    time, stable *within one parse*, not across revisions -- the identical
-    accepted, documented limitation :class:`Anonymous` already states (an
-    edit that adds or removes an earlier local block shifts every later
-    sibling's ordinal and therefore its whole ``EntityId``, even though
-    nothing about those later declarations changed). No default is given,
-    matching :class:`Anonymous.ordinal` for the same reason: a caller must
-    supply a real value rather than silently under-specifying identity by
-    relying on an unwired default.
+    Both fields are identity. ``owner`` alone disambiguates two same-named
+    locals across *different* functions, but not two in *sibling compound
+    blocks of the same function* (``void f() { { struct A {}; } { struct A
+    {}; } }`` -- two distinct declarations, same ``owner``, same leaf name);
+    ``block_ordinal`` closes that gap the same way ``Anonymous.ordinal``
+    closes its sibling case -- same per-parse-only stability, same no-default
+    rule, see that class's own docstring rather than restating both here.
 
     ``owner`` is the *owning function's own* :class:`EntityId`, not a bare
     string -- a plain function name collides two overloads that each
     declare a same-named local in their (corresponding) block
     (``f(int) { struct A {}; }`` vs. ``f(double) { struct A {}; }`` --
-    identical ``owner="f"`` string, identical leaf name, so the two locals
-    would wrongly merge under an unconstrained-string owner; Codex review,
-    PR #941). Recursion is intentional and safe: `EntityId` is frozen/
-    hashable, so an `EntityId` naming a function whose own scope path
-    happens to include an outer `LocalToFunction` nests exactly as deep as
-    the real declaration does, with no special-casing needed here.
+    identical ``owner="f"`` string, identical leaf name; Codex review, PR
+    #941). Recursion is intentional and safe: ``EntityId`` is frozen/
+    hashable, so one naming a function whose own scope path includes an
+    outer ``LocalToFunction`` nests exactly as deep as the real declaration.
     """
 
     owner: EntityId
@@ -263,14 +244,49 @@ class EntityId:
     leaf_name: str
     extra: tuple[str, ...] = ()
 
+    @property
+    def key(self) -> str:
+        """Flat, collision-safe string (ADR-063 Phase 2, closing (c2)'s
+        ``resolve_change_identity`` consumer step) -- length-prefixed parts
+        (``_packed``, a local duplicate of ``storage.entity_ids.EntityId.
+        key``'s own audited scheme, since this module may not import
+        ``storage``), excluding every ``compare=False`` field (``Record.
+        access``) so two ``==`` segments produce the same key. Stable only
+        within one process's lifetime (``Anonymous``/``LocalToFunction``'s
+        own ordinals aren't cross-revision)."""
+        return _packed(
+            *(_segment_key(s) for s in self.scope),
+            self.kind.value,
+            self.leaf_name,
+            *self.extra,
+        )
+
+
+def _packed(*parts: str) -> str:
+    """Length-prefix each part (``"<len>:<part>"``); nesting is safe since a
+    ``_packed`` result is just another opaque part. Local dup of ``storage.
+    entity_ids._packed`` (``storage -> model`` is the only allowed edge)."""
+    return "".join(f"{len(part)}:{part}" for part in parts)
+
+
+def _segment_key(segment: ScopeSegment) -> str:
+    """``EntityId.key``'s per-segment encoder -- one tagged part per variant
+    so no two sharing a bare field can collide."""
+    if isinstance(segment, Namespace):
+        return _packed("ns", segment.name)
+    if isinstance(segment, Record):
+        return _packed("rec", segment.name)
+    if isinstance(segment, InlineNamespace):
+        return _packed("ins", segment.name, segment.version_tag)
+    if isinstance(segment, Anonymous):
+        return _packed("anon", segment.kind, str(segment.ordinal))
+    return _packed("local", segment.owner.key, str(segment.block_ordinal))
+
 
 def _scope_path(scope: ScopePath) -> ScopePath:
-    """Normalize *scope* to a real ``tuple`` regardless of what iterable a
-    caller passed, so two calls built from value-equal-but-not-identical
-    scope sequences (e.g. a list vs. a tuple) produce ``EntityId``s that
-    compare equal -- "computed once" here means one algorithm producing one
-    answer for one input, not object identity of the scope argument.
-    """
+    """Normalize *scope* to a real ``tuple`` regardless of the iterable a
+    caller passed, so value-equal-but-not-identical scope sequences (a list
+    vs. a tuple) produce ``EntityId``s that compare equal."""
     return tuple(scope)
 
 
@@ -378,17 +394,14 @@ def entity_id_for_variable(
 
     When either *mangled_name* or *is_extern_c* applies, the resulting
     ``EntityId.scope`` is always ``()``, regardless of the caller-supplied
-    *scope*. A genuine mangled name already fully and deterministically
-    encodes scope, so folding a caller-supplied *scope* in on top adds
-    nothing when it is available and actively fragments identity when it
-    is not: a header/DWARF-derived observation may supply a real
-    ``ScopePath`` for the identical symbol an export-table-only snapshot
-    observes with no scope at all (Codex review, PR #941 -- the same
-    evidence-tier-fragmentation mechanism :func:`entity_id_for_function`'s
-    own *is_extern_c* branch already guards against, generalized here to
-    every name-based -- as opposed to signature-based -- discriminator,
-    mangled included). Only the genuinely mangling-free, non-``extern
-    "C"`` degenerate case keeps *scope* as given.
+    *scope*: a genuine mangled name already fully encodes scope, so folding
+    a caller-supplied one in adds nothing when available and fragments
+    identity when not (an export-table-only observation of the identical
+    symbol has no scope at all -- Codex review, PR #941, the same
+    evidence-tier mechanism :func:`entity_id_for_function`'s *is_extern_c*
+    branch guards against, generalized to every name-based discriminator).
+    Only the genuinely mangling-free, non-``extern "C"`` case keeps *scope*
+    as given.
 
     When *mangled_name* is present, *leaf_name* is likewise ignored, for
     a confirmed, not merely hypothetical, reason: the ELF-only fallback
@@ -585,30 +598,21 @@ def entity_id_for_function(
     function's ``extra`` tuple is unchanged byte-for-byte.
 
     Both the *mangled* and *is_extern_c* branches' resulting
-    ``EntityId.scope`` are always ``()``, regardless of *scope*.
-    ``resolve_symbol_identity`` deliberately bases a real-mangled or
-    extern-"C" identity on the raw name alone (``mangled:...``) rather
-    than a qualified name, precisely because scope availability varies by
-    evidence tier -- a header/DWARF-derived observation of a namespaced
-    function (mangled or ``extern "C"``) may supply a real ``ScopePath``,
-    while an export-table-only snapshot of the identical binary symbol
-    knows only the bare exported/mangled name. Folding a caller-supplied
-    *scope* into the id would fragment one entity's identity across those
-    two evidence tiers even though the name already, on its own,
-    unambiguously identifies the declaration -- for a genuine mangled
-    name this holds losslessly (the mangling itself fully encodes scope);
-    for ``extern "C"`` it holds because the symbol *is* that bare name at
-    the ABI level, so no namespace is even recoverable from an export
-    table alone. (An earlier revision of this docstring claimed the
-    *mangled* branch's redundant `scope` was merely harmless rather than
-    actively fragmenting -- Codex review on PR #941 caught that this is
-    the identical mechanism the *is_extern_c* branch already guards
-    against, not a different, safe case; corrected here.) The *sig*
-    fallback is the one branch that keeps *scope* as given -- a DWARF-only,
-    mangling-free, non-``extern "C"`` function has no authoritative,
-    scope-independent name to fall back on, and scope is exactly what
-    makes two same-named, same-signature sibling declarations in
-    different scopes distinct.
+    ``EntityId.scope`` are always ``()``, regardless of *scope* --
+    mirroring ``resolve_symbol_identity``'s own raw-name-only
+    (``mangled:...``) basis, since scope availability varies by evidence
+    tier (a header/DWARF observation may supply a real ``ScopePath``; an
+    export-table-only one knows only the bare name) and folding a
+    caller-supplied *scope* in would fragment one entity's identity across
+    tiers even though the name alone already, losslessly, identifies it
+    (for ``extern "C"`` because the symbol *is* that bare name at the ABI
+    level -- Codex review, PR #941, correcting an earlier revision that
+    called the *mangled* branch's redundant ``scope`` merely harmless
+    rather than the identical fragmentation the *is_extern_c* branch
+    already guards against). The *sig* fallback is the one branch that
+    keeps *scope* as given -- a DWARF-only, mangling-free, non-``extern
+    "C"`` function has no scope-independent name to fall back on, and scope
+    is exactly what makes two same-named, same-signature siblings distinct.
 
     *param_types* are canonicalized via the sibling
     ``signature_normalization.canonicalize_function_signature_param_type``

--- a/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
+++ b/changelog.d/20260830_225244_noreply_adr_063_phases_3jmrnm.md
@@ -4,14 +4,16 @@
   compare-time `EntityId` of the declaration a finding is about -- the OLD
   side's when it exists, else the NEW side's, mirroring `Change.
   symbol_binding`'s own old-side convention. Populated at every
-  `diff_symbols.py` function-level diff site (return type, parameters,
-  ref-qualifier, linkage, noexcept/virtual/explicit/variadic transitions,
-  contract attributes, exception spec, vtable index, inline transitions,
-  added/removed/deleted/visibility-changed functions, parameter renames/
-  default-value/pointer-level changes, return-pointer-level changes,
-  method access narrowing, deprecation and override-specifier transitions).
-  The field is keyword-only, defaults to `None`, and is excluded from
-  equality, so no existing behavior, comparison result, or report changes
-  -- no consumer reads it yet (`resolve_change_identity`'s own migration is
-  separate follow-on work). Variable/type/enum/platform detectors are not
-  yet wired.
+  function-level diff site across `diff_symbols.py` and its sibling
+  split-out modules (return type, parameters, ref-qualifier, linkage,
+  noexcept/virtual/explicit/variadic transitions, contract attributes,
+  exception spec, vtable index, inline transitions, added/removed/
+  deleted/visibility-changed functions, parameter renames/default-value/
+  pointer-level/restrict/va_list changes, return-pointer-level changes,
+  method access narrowing, deprecation and override-specifier
+  transitions, hidden-friend transitions, constructor overload-ambiguity
+  risk). The field is keyword-only, defaults to `None`, and is excluded
+  from equality, so no existing behavior, comparison result, or report
+  changes -- no consumer reads it yet (`resolve_change_identity`'s own
+  migration is separate follow-on work). Variable/type/enum/platform
+  detectors are not yet wired.

--- a/changelog.d/20260831_020948_noreply_adr_063_phase2_followup_3jmrnm.md
+++ b/changelog.d/20260831_020948_noreply_adr_063_phase2_followup_3jmrnm.md
@@ -1,0 +1,13 @@
+### Added
+
+- **`finding_identity.resolve_change_identity` now reads `Change.entity_id`**
+  (ADR-063 Phase 2, closing the true completion of (c2)), folding it in as
+  a new `entity:<key>` alias qualified with the existing discriminator --
+  additive only, never promoted to `primary_id`/tier, so every existing
+  suppression rule and canonical finding ID is unchanged. `EntityId` gains
+  a new `.key` property (`model/identity.py`) producing a flat,
+  collision-safe string form for this purpose. The same `entity_id`
+  old-else-new fallback now also reaches every remaining function-backed
+  `Change` construction site: `diff_hidden_friends.py`,
+  `diff_param_qualifiers.py`, constructor overload-ambiguity risk, and the
+  auxiliary parameter/deprecation/override-specifier detectors.

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -55,20 +55,28 @@
   `_check_inline_transitions`/the `FUNC_ADDED` site/
   `_detect_newly_deleted_functions`) — the old side's `Function.entity_id`
   when it exists, else the new side's, mirroring `Change.symbol_binding`'s
-  own old-side convention. **Still not landed: the mangled-name-is-genuine
-  determination** (`finding_identity.is_real_mangled_name`/
-  `normalize_mangled_name` stay finding_identity's own — `model/identity.py`'s
-  own docstring records why moving them would reverse the required
-  `compare -> model` import direction); **`resolve_change_identity`/
-  `_change_discriminator` actually consuming `Change.entity_id`** (the
-  carrier is populated but has no reader yet — mirrors the earlier
-  `Function.entity_id`/`Variable.entity_id` "carrier before consumer"
-  staging); **exhaustive population beyond the function-diff path**
+  own old-side convention; an eighth slice extended that wiring to every
+  remaining function-backed site (`diff_hidden_friends.py`,
+  `diff_param_qualifiers.py`, `_diff_ctor_overload_ambiguity`, and the
+  auxiliary param/deprecated/override-specifier detectors), and gave
+  `EntityId` its own `.key` property (`model/identity.py`, a flat,
+  collision-safe string) so `finding_identity.resolve_change_identity`
+  could fold `Change.entity_id` in as a new `entity:` alias — the first
+  real consumer read, additive only, never promoted to `primary_id`/tier
+  (existing suppression-rule/canonical-id compatibility is unaffected).
+  **Still not landed: the mangled-name-is-genuine determination**
+  (`finding_identity.is_real_mangled_name`/`normalize_mangled_name` stay
+  finding_identity's own — `model/identity.py`'s own docstring records why
+  moving them would reverse the required `compare -> model` import
+  direction); **exhaustive population beyond the function-diff path**
   (variable/type/enum/platform detectors construct `Change` from
   `RecordType`/`EnumType`/`Variable` objects that also carry `.entity_id`,
   but aren't wired yet); **and every post-parse consumer migration**
   (`diff_filtering.py`/`type_reachability.py`'s string-based ambiguity
-  machinery). Those are the remaining items before Phase 2 is complete.
+  machinery, plus actually promoting the new `entity:` alias into a real
+  alias-match reconciliation tier once `EntityId.key`'s cross-release
+  stability is established). Those are the remaining items before Phase 2
+  is complete.
 - **Phases 3–10** are still unimplemented design text.
 
 See the [implementation plan](../plans/one-semantic-pipeline.md) for the

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -9484,6 +9484,63 @@ post-parse consumer migrations -- exhaustive `Change.entity_id` population
 beyond the function-diff path is a separate, larger follow-on this
 sequencing does not schedule.
 
+**Landed (eighth slice, 2026-08-31): exhaustive function-diff population,
+plus `resolve_change_identity` consuming `Change.entity_id` -- the true
+completion of (c2).** Two parts, landed together since the first is what
+made the second worth doing. First, the same old-else-new `entity_id`
+fallback reached every remaining function-backed `Change` construction
+site the seventh slice's own scoping investigation had found but not yet
+wired: `diff_hidden_friends.py` (`HIDDEN_FRIEND_ADDED`/`REMOVED`, both the
+matched-pair `bool_transition` call and the two single-sided `make_change()`
+sites), `diff_param_qualifiers.py` (`PARAM_RESTRICT_CHANGED`,
+`PARAM_BECAME_VA_LIST`/`LOST_VA_LIST`), `diff_symbols.py`'s own
+`_diff_ctor_overload_ambiguity` (`CTOR_OVERLOAD_AMBIGUITY_RISK`, a
+single-sided new-side-only site), and the auxiliary
+`param_defaults`/`param_renames`/`pointer_levels`/`method_access`/
+`func_deprecated`/`func_override_specifier` detectors -- ten sites in
+total, found and fixed across four review rounds (each fix drew a fresh
+"still missing a sibling site" finding until a full audit of every
+`make_change()`/`Change()` call in `diff_symbols.py` and its split-out
+sibling modules, not just the named sites, actually closed the class).
+Second, `EntityId` gained its own `.key` property (`model/identity.py`) --
+a flat, collision-safe string (`_packed`, a local duplicate of
+`storage.entity_ids._packed`'s own audited length-prefixing scheme, since
+`model` may not import `storage`), excluding every `compare=False` payload
+field (`Record.access`) so two `==` segments produce the same key.
+`finding_identity.resolve_change_identity` folds `change.entity_id.key` in
+as a new `entity:<key>\x1f<discriminator>` alias, qualified with the
+discriminator like every other alias there so two distinct findings on the
+same entity never collide -- **additive only**: never promoted to
+`primary_id`/tier, so every existing suppression rule and canonical finding
+ID is bit-for-bit unchanged (`tests/test_canonical_finding_id*.py` pin
+that). Deliberately conservative rather than replacing the CANONICAL tier's
+mangled-name basis outright: `EntityId.key`'s cross-release stability is
+not yet established the way a persisted wire identity would need to be
+(`Anonymous`/`LocalToFunction`'s own ordinals are parse-order-only, not
+cross-revision, by their own documented design), so promoting it to
+`primary_id` now would risk silently reshaping every stored suppression
+rule's matching behavior -- exactly the class of risk this slice's own
+scoping investigation flagged as needing a separate, explicit design
+decision rather than a rushed migration. Tests: `tests/
+test_model_identity.py::TestEntityIdKey` (collision-safety across sibling
+scope-segment variants, the `extra`-tuple boundary-forgery case in the same
+spirit as `storage.entity_ids`'s own audited collision test, `Record.
+access` exclusion, `LocalToFunction` recursion) and `tests/
+test_change_entity_id_carrier.py::TestResolveChangeIdentityConsumesEntityId`
+(the alias's presence/absence and non-collision, through `compare()` +
+`resolve_change_identity` end to end) plus one regression test per newly-
+wired site in `tests/test_change_entity_id_carrier.py`, each confirmed to
+fail against the pre-fix code. Full fast unit suite green; `mypy
+abicheck/` and `ruff check`/`ruff format --check` clean;
+`check_architecture.py` 0 errors (`finding_identity.py`, `diff_symbols.py`,
+and `model/identity.py` all land at or under their `debt.yaml`/general
+800-line baselines, each requiring the same "condense existing verbose
+docstrings to make room" treatment prior slices needed). Remaining Phase 2
+items unchanged by this slice: exhaustive `entity_id` population beyond
+the function-diff path, the post-parse consumer migrations, and promoting
+the new `entity:` alias into a real alias-match reconciliation tier once
+`EntityId.key`'s stability question above is resolved.
+
 ---
 
 ### Phase 3 — public surface as a graph query over one evidence graph (D5)

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -14,16 +14,23 @@
 
 """ADR-063 Phase 2: ``Change.entity_id`` carrier — the function-diff
 producer wiring in ``diff_symbols.py`` (the "finding_identity.py algorithm
-migration"'s second half, giving ``Change`` an ``EntityId`` to key on).
-
-No consumer reads ``Change.entity_id`` yet (same "carrier lands before
-consumer" discipline as ``Function.entity_id``/``Variable.entity_id``) --
-these tests pin only that the field is populated correctly at emission.
+migration"'s second half, giving ``Change`` an ``EntityId`` to key on) --
+and, as of ``TestResolveChangeIdentityConsumesEntityId`` below, the first
+real consumer read: ``finding_identity.resolve_change_identity`` folds it
+in as an additional ``entity:`` alias (additive only, never promoted to
+``primary_id``/tier). Every other test in this file still pins only that
+the carrier is populated correctly at emission, the same "carrier lands
+before consumer" discipline ``Function.entity_id``/``Variable.entity_id``
+went through first.
 """
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from abicheck.checker import ChangeKind, compare
+from abicheck.checker_types import Change
+from abicheck.finding_identity import IDENTITY_TIER_CANONICAL, resolve_change_identity
 from abicheck.model import AbiSnapshot, Function, Param, Visibility
 from abicheck.model.identity import entity_id_for_function
 
@@ -362,3 +369,29 @@ class TestChangeEntityIdCarrier:
         new_snap.types = [owner]
         r = compare(old_snap, new_snap, scope_to_public_surface=False)
         assert _change(r, ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK).entity_id == eid  # type: ignore[attr-defined]
+
+
+class TestResolveChangeIdentityConsumesEntityId:
+    """ADR-063 Phase 2, the true completion of (c2): the first real
+    consumer read of ``Change.entity_id``, via ``resolve_change_identity``'s
+    new ``entity:`` alias -- additive only (qualified with the discriminator
+    like every other alias there), never promoted to ``primary_id``/tier."""
+
+    _eid = entity_id_for_function((), "f", mangled_name="_Z1fi")
+    _ret = Change(ChangeKind.FUNC_RETURN_CHANGED, "_Z1fi", "c", "int", "long")
+    _params = Change(ChangeKind.FUNC_PARAMS_CHANGED, "_Z1fi", "c", "(int)", "(long)")
+
+    def test_entity_id_alias_present_iff_entity_id_set(self) -> None:
+        a = resolve_change_identity(replace(self._ret, entity_id=self._eid))
+        b = resolve_change_identity(self._ret)
+        assert any(x.startswith(f"entity:{self._eid.key}\x1f") for x in a.aliases)
+        assert not any(x.startswith("entity:") for x in b.aliases)
+        assert a.primary_id == b.primary_id
+        assert a.tier == b.tier == IDENTITY_TIER_CANONICAL
+
+    def test_entity_id_alias_distinguishes_findings_on_same_entity(self) -> None:
+        a = resolve_change_identity(replace(self._ret, entity_id=self._eid))
+        b = resolve_change_identity(replace(self._params, entity_id=self._eid))
+        ea = {x for x in a.aliases if x.startswith("entity:")}
+        eb = {x for x in b.aliases if x.startswith("entity:")}
+        assert ea and eb and ea.isdisjoint(eb)

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -286,3 +286,79 @@ class TestChangeEntityIdCarrier:
             _snap([new], from_headers=True, ast_producer="castxml"),
         )
         assert _change(r, ChangeKind.FUNC_OVERRIDE_SPECIFIER_REMOVED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_hidden_friend_added_transition_carries_old_side_entity_id(self) -> None:
+        # Codex review (2nd round): diff_hidden_friends.py/diff_param_qualifiers.py
+        # are separate modules from diff_symbols.py's own detectors -- the
+        # same carrier omission, in files split out for the file-size cap.
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func("f", "_Z1fv", is_hidden_friend=False, entity_id=eid)
+        new = _func("f", "_Z1fv", is_hidden_friend=True)
+        r = compare(_snap([old]), _snap([new]))
+        assert _change(r, ChangeKind.HIDDEN_FRIEND_ADDED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_hidden_friend_removed_with_symbol_carries_old_side_entity_id(self) -> None:
+        # diff_inline_hidden_friends' own single-sided removal path (symbol
+        # gone entirely, not just a flag flip on a matched pair).
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fv")
+        old = _func("f", "_Z1fv", is_hidden_friend=True, entity_id=eid)
+        r = compare(_snap([old]), _snap([]))
+        assert _change(r, ChangeKind.HIDDEN_FRIEND_REMOVED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_restrict_changed_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fPi")
+        old = _func(
+            "f",
+            "_Z1fPi",
+            params=[Param(name="x", type="int*", is_restrict=False)],
+            entity_id=eid,
+        )
+        new = _func(
+            "f", "_Z1fPi", params=[Param(name="x", type="int*", is_restrict=True)]
+        )
+        r = compare(_snap([old], from_headers=True), _snap([new], from_headers=True))
+        assert _change(r, ChangeKind.PARAM_RESTRICT_CHANGED).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_param_became_va_list_carries_old_side_entity_id(self) -> None:
+        eid = entity_id_for_function((), "f", mangled_name="_Z1fz")
+        old = _func(
+            "f",
+            "_Z1fz",
+            params=[Param(name="x", type="...", is_va_list=False)],
+            entity_id=eid,
+        )
+        new = _func(
+            "f", "_Z1fz", params=[Param(name="x", type="va_list", is_va_list=True)]
+        )
+        r = compare(
+            _snap([old], from_headers=True, ast_producer="clang"),
+            _snap([new], from_headers=True, ast_producer="clang"),
+        )
+        assert _change(r, ChangeKind.PARAM_BECAME_VA_LIST).entity_id == eid  # type: ignore[attr-defined]
+
+    def test_ctor_overload_ambiguity_risk_carries_entity_id(self) -> None:
+        # Single-sided (new-side-only) construction site -- no old/new
+        # fallback pair, just the new ctor's own entity_id.
+        from abicheck.model import RecordType
+
+        eid = entity_id_for_function((), "C::C", mangled_name="_ZN1CC1Ej")
+        owner = RecordType(name="C", kind="class", size_bits=64)
+        old_ctor = _func(
+            "C::C", "_ZN1CC1Ei", params=[Param(name="x", type="int")], is_explicit=False
+        )
+        new_ctor1 = _func(
+            "C::C", "_ZN1CC1Ei", params=[Param(name="x", type="int")], is_explicit=False
+        )
+        new_ctor2 = _func(
+            "C::C",
+            "_ZN1CC1Ej",
+            params=[Param(name="x", type="unsigned int")],
+            is_explicit=False,
+            entity_id=eid,
+        )
+        old_snap = _snap([old_ctor])
+        old_snap.types = [owner]
+        new_snap = _snap([new_ctor1, new_ctor2])
+        new_snap.types = [owner]
+        r = compare(old_snap, new_snap, scope_to_public_surface=False)
+        assert _change(r, ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK).entity_id == eid  # type: ignore[attr-defined]

--- a/tests/test_model_identity.py
+++ b/tests/test_model_identity.py
@@ -710,6 +710,80 @@ class TestVariableMangledDiscriminator:
 
 
 # --------------------------------------------------------------------------
+# EntityId.key -- the first real consumer read (ADR-063 Phase 2, closing
+# (c2)'s finding_identity.resolve_change_identity consumer step)
+# --------------------------------------------------------------------------
+
+
+class TestEntityIdKey:
+    """``EntityId.key``'s own contract: a pure function of the object's
+    identity fields, collision-safe the same way ``storage.entity_ids.
+    EntityId.key`` is audited to be (this module may not import that one,
+    so ``_packed``/``_segment_key`` are a local duplicate of the algorithm,
+    not the object)."""
+
+    @given(name_a=_names, name_b=_names)
+    def test_distinct_scopes_never_collide(self, name_a: str, name_b: str) -> None:
+        if name_a == name_b:
+            return
+        a = entity_id_for_type((Namespace(name_a),), "Widget")
+        b = entity_id_for_type((Namespace(name_b),), "Widget")
+        assert a.key != b.key
+
+    def test_record_nested_in_record_vs_namespace(self) -> None:
+        # Mirrors TestDistinctScopesNeverCollide's own object-equality case,
+        # through .key specifically -- both scopes render to the identical
+        # "A::B" qualified-name string, so a naive string-based key would
+        # collide them.
+        in_record = entity_id_for_type((Record("A"), Record("B")), "C")
+        in_namespace = entity_id_for_type((Namespace("A"), Namespace("B")), "C")
+        assert in_record.key != in_namespace.key
+
+    def test_sibling_segment_variants_never_collide(self) -> None:
+        # Same bare name, different segment kind at the same position --
+        # _segment_key's own per-variant tag is what this pins.
+        keys = {
+            entity_id_for_type((Namespace("a"),), "X").key,
+            entity_id_for_type((Record("a"),), "X").key,
+            entity_id_for_type((InlineNamespace("a"),), "X").key,
+        }
+        assert len(keys) == 3
+
+    def test_record_access_does_not_change_key(self) -> None:
+        # access is compare=False (payload, not identity) -- .key must
+        # honor that exclusion or an alias join could miss a real match
+        # between two snapshots that only differ in a member's access.
+        public = entity_id_for_type((Record("A", access="public"),), "B")
+        private = entity_id_for_type((Record("A", access="private"),), "B")
+        assert public == private
+        assert public.key == private.key
+
+    def test_extra_tuple_boundary_does_not_collide_with_leaf_name(self) -> None:
+        # Adversarial case in the same spirit as the storage module's own
+        # audited _packed collision test: two EntityIds whose (leaf_name,
+        # extra) split differently but might concatenate to the same raw
+        # text must still produce distinct keys.
+        a = entity_id_for_function((), "f", mangled_name="ab")
+        b = entity_id_for_function((), "fa", mangled_name="b")
+        assert a.key != b.key
+
+    def test_local_to_function_recursion_terminates_and_differs(self) -> None:
+        owner_f = entity_id_for_function((), "f", param_types=("int",))
+        owner_g = entity_id_for_function((), "g", param_types=("int",))
+        a = entity_id_for_type((LocalToFunction(owner_f, 0),), "A")
+        b = entity_id_for_type((LocalToFunction(owner_g, 0),), "A")
+        c = entity_id_for_type((LocalToFunction(owner_f, 1),), "A")
+        assert a.key != b.key  # different owning function
+        assert a.key != c.key  # same owner, different sibling block
+
+    @given(name=_names, kind=_kinds, ordinal=_ordinals)
+    def test_key_never_raises(self, name: str, kind: str, ordinal: int) -> None:
+        scope = (Namespace(name), Anonymous(kind, ordinal))
+        key = entity_id_for_type(scope, name).key
+        assert isinstance(key, str) and key
+
+
+# --------------------------------------------------------------------------
 # "Computed once" == one algorithm, not cached identity
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #952, which merged before its last fix landed on that branch,
now extended to close ADR-063 Phase 2's (c2) item entirely: a real consumer
now reads `Change.entity_id`.

### Producer wiring (first commit)

Codex flagged three more function-backed `Change` construction sites
missing the `entity_id` carrier, in the `diff_symbols.py` sibling modules
split out for the file-size cap:

- `diff_hidden_friends.py`: `HIDDEN_FRIEND_ADDED`/`REMOVED` — both the
  matched-pair `bool_transition` call in `check_hidden_friend_change` and
  the two single-sided `make_change()` sites in `diff_inline_hidden_friends`.
- `diff_param_qualifiers.py`: `PARAM_RESTRICT_CHANGED`,
  `PARAM_BECAME_VA_LIST`/`LOST_VA_LIST`.
- `diff_symbols.py`'s own `_diff_ctor_overload_ambiguity`
  (`CTOR_OVERLOAD_AMBIGUITY_RISK`) — a single-sided, new-side-only site.

I also audited the rest of the function-backed `diff_*.py` surface for the
same gap; the remaining sites construct type/pattern/Python-API-level
`Change`s, not function-diff ones, so they're out of this slice's scope.

### Consumer migration (second commit)

The true completion of (c2): previous slices gave `Change` an `entity_id`
carrier but no consumer read it.

- `EntityId` gains a `.key` property (`model/identity.py`): a flat,
  collision-safe string (a local duplicate of `storage.entity_ids`'s own
  audited length-prefixing scheme, since `model` may not import `storage`),
  excluding every `compare=False` payload field (`Record.access`) so two
  `==` segments produce the same key.
- `finding_identity.resolve_change_identity` folds `change.entity_id.key`
  in as a new `entity:<key>` alias, qualified with the existing
  discriminator like every other alias — **additive only**, never promoted
  to `primary_id`/tier, so no existing suppression rule or canonical
  finding ID changes. `EntityId.key`'s cross-release stability isn't yet
  established (`Anonymous`/`LocalToFunction`'s ordinals are parse-order
  only), so promoting it to the CANONICAL basis is deliberately deferred to
  a separate, explicit design decision rather than rushed here.

## Changes

- `abicheck/diff_hidden_friends.py`, `abicheck/diff_param_qualifiers.py`,
  `abicheck/diff_symbols.py`: `entity_id=` wiring at the remaining sites.
- `abicheck/model/identity.py`: `EntityId.key`.
- `abicheck/finding_identity.py`: `resolve_change_identity`'s new alias.
- `tests/test_change_entity_id_carrier.py`,
  `tests/test_model_identity.py`: one regression test per newly-wired
  site, each confirmed to fail against the pre-fix code, plus
  `TestEntityIdKey`/`TestResolveChangeIdentityConsumesEntityId`.
- `docs/contribute/adr/063-one-semantic-pipeline.md`,
  `docs/contribute/plans/one-semantic-pipeline.md`: status updated.
- Changelog fragments.

## Checklist

- [x] Tests added / updated for new behaviour, each confirmed to fail
      pre-fix
- [x] Changelog fragments added (touches `abicheck/**/*.py`)
- [x] `mypy abicheck/`, `ruff check`, `ruff format --check` clean
- [x] `python scripts/check_architecture.py` — 0 errors
- [x] `python scripts/check_ai_readiness.py` — 0 errors introduced by this
      change (3 pre-existing errors on `main`, unrelated — stale ADR
      `**Verified:**` receipts on ADR-037/044/046, confirmed via `git diff
      origin/main -- <those files>` showing no changes from this branch)
- [x] `tests/test_canonical_finding_id*.py` unaffected — confirms the
      additive-only design holds
- [x] Full fast unit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeG163b47jia4C98Na7d9K)_