### PR TITLE
fix: normalize closure spellings on load; recover corroborated added-side rename evidence

### DIFF
--- a/abicheck/compare/rename_ambiguity.py
+++ b/abicheck/compare/rename_ambiguity.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Added-side ambiguity resolution for ``diff_symbols_renames.
+find_namespace_move_groups`` (ADR-061 D1: new rename-matching logic routes
+to ``compare/``, not the debt-baselined flat ``diff_symbols_renames.py``).
+
+That function already resolves cross-position ambiguity via global-support
+corroboration when ONE removed symbol has multiple candidate added targets
+(``removed_id_to_added_symbols``) -- one candidate key independently reused
+by a DIFFERENT removed symbol is real corroborating evidence the other
+candidate lacks. This module runs the mirror test for the symmetric case:
+ONE added symbol claimed by multiple distinct removed identities
+(``added_id_to_removed_symbols``), previously rejected outright,
+unconditionally. That asymmetry silently dropped a well-supported
+namespace-move batch member -- or, when the collateral loss dropped a group
+below its 2+-pair threshold, an entire batch -- whenever an unrelated,
+uncorroborated removed identity happened to coincidentally collide with one
+of the batch's own added targets.
+
+This CANNOT reuse the removed-side test's exact shape: there, every
+competing key belongs to the SAME symbol (its own alternate masking
+positions), so subtracting that one ``symbol_id`` from a key's supporter set
+is enough to ask "does anyone ELSE back this option". Here, each competing
+key belongs to a DIFFERENT removed identity, and that competitor may itself
+never have resolved THIS SPECIFIC added identity to any single key at all --
+exactly the round-4 scenario ``TestFindNamespaceMoveGroupsRetainsLocally
+AmbiguousCandidatesGlobally`` (``tests/test_batch_rename_namespace_move.py``)
+pins: a removed symbol stuck between two candidates at its only masking
+position never gets an ``entries`` row for either, and remains a live,
+irreducible threat, not a dismissible coincidence.
+
+A competitor is therefore scoped per (competitor, added_id) pair (Codex
+review, fresh evidence) -- NOT merely "did the competitor resolve to any key
+anywhere": a removed symbol can have several masking positions, each
+possibly targeting a DIFFERENT added identity. A competitor resolved
+cleanly at one position (an unrelated added identity) is not thereby vouched
+for at ANOTHER position where its candidacy toward THIS added identity was
+itself locally ambiguous and never got its own ``entries`` row -- checking
+"has any resolved key at all" let an unrelated, resolved claim dismiss a
+genuinely live, unresolved threat on the target actually in question,
+fabricating a batch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+
+
+def added_side_ambiguity_resolver(
+    entries: Sequence[tuple[tuple[str, ...], list[str], int, list[str]]],
+    added_id_to_removed_symbols: Mapping[str, set[str]],
+    raw_symbol_key_targets: Mapping[tuple[str, tuple[str, str]], set[str]],
+) -> tuple[
+    dict[tuple[str, str], set[str]], Callable[[str, str, tuple[str, str]], bool]
+]:
+    """Build ``key_support`` (which removed symbol(s) raised each
+    ``(old_segment, new_segment)`` key via *entries*) and the
+    ``is_acceptable(symbol_id, added_id, key)`` predicate
+    ``find_namespace_move_groups``'s Phase 2 gates each entry's added-side
+    ambiguity on. Returns both since the caller's own removed-side
+    corroboration check (right after the added-side one) reuses
+    ``key_support`` too, rather than rebuilding it a second time.
+
+    *entries* is that function's Phase 1 output (masked context, removed
+    scope components, differing position, added scope components) --
+    already-computed, locally-unambiguous candidacies only.
+    *added_id_to_removed_symbols*/*raw_symbol_key_targets* are the caller's
+    raw, pre-Phase-2 candidacy trackers (populated from every raw candidacy,
+    including one a masking position's own local ambiguity check discards
+    from *entries*). ``raw_added_key_targets`` (this module's own added-
+    identity-keyed mirror of *raw_symbol_key_targets*) is derived here by
+    inverting it, rather than asking the caller to also build and pass a
+    second raw tracker: every ``(symbol_id, key) -> {cand_id, ...}`` entry
+    *raw_symbol_key_targets* carries names exactly the same raw candidacies
+    an added-identity-keyed ``(cand_id, key) -> {symbol_id, ...}`` view
+    needs, just grouped the other way.
+    """
+    raw_added_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
+    for (symbol_id, rkey), cand_ids in raw_symbol_key_targets.items():
+        for cand_id in cand_ids:
+            raw_added_key_targets.setdefault((cand_id, rkey), set()).add(symbol_id)
+
+    # key_support: which removed symbol(s) raised each key via `entries`.
+    # resolved_added_claims: (symbol_id, added_id) -> the key this exact
+    # pairing resolved to via `entries` -- i.e. this removed identity's claim
+    # on THIS SPECIFIC added identity survived its own local per-position
+    # ambiguity check. A competitor with no entry here for the added_id in
+    # question never resolved that specific rivalry and must always veto.
+    key_support: dict[tuple[str, str], set[str]] = {}
+    resolved_added_claims: dict[tuple[str, str], tuple[str, str]] = {}
+    for _masked, r_comps, i, a_comps in entries:
+        sid = "::".join(r_comps)
+        aid = "::".join(a_comps)
+        k = (r_comps[i], a_comps[i])
+        key_support.setdefault(k, set()).add(sid)
+        resolved_added_claims[(sid, aid)] = k
+
+    def _competitor_is_dismissible(competitor_id: str, added_id: str) -> bool:
+        resolved_key = resolved_added_claims.get((competitor_id, added_id))
+        if resolved_key is None:
+            return False
+        # Resolved on this target; dismissible only if that key carries no
+        # support from anyone besides this competitor itself.
+        return not (key_support.get(resolved_key, set()) - {competitor_id})
+
+    def is_acceptable(symbol_id: str, added_id: str, key: tuple[str, str]) -> bool:
+        if len(added_id_to_removed_symbols[added_id]) == 1:
+            return True
+        # This key itself may be reachable from >1 distinct removed symbol
+        # for this SAME added identity (the added-side mirror of the
+        # caller's repeated-segment collision guard) -- reject before
+        # considering corroboration.
+        if len(raw_added_key_targets[(added_id, key)]) != 1:
+            return False
+        if not key_support[key] - {symbol_id}:
+            return False
+        competitors = added_id_to_removed_symbols[added_id] - {symbol_id}
+        return all(_competitor_is_dismissible(c, added_id) for c in competitors)
+
+    return key_support, is_acceptable

--- a/abicheck/compare/rename_ambiguity.py
+++ b/abicheck/compare/rename_ambiguity.py
@@ -52,6 +52,18 @@ itself locally ambiguous and never got its own ``entries`` row -- checking
 "has any resolved key at all" let an unrelated, resolved claim dismiss a
 genuinely live, unresolved threat on the target actually in question,
 fabricating a batch.
+
+A second, narrower gap of the same shape (Codex review, second round): even
+an ``entries`` row for the exact ``(competitor, added_id)`` pair is not
+proof the competitor is uniquely spoken for -- two DIFFERENT masking
+positions of the SAME removed symbol can share the identical
+``(old_segment, new_segment)`` key tokens while targeting two DIFFERENT
+added identities (e.g. ``Q::Q::f`` reaching both ``Q::new::f`` at position 1
+and ``new::Q::f`` at position 0 via the same key ``("Q", "new")``). Checking
+only that this one pairing resolved ignores that the competitor's own claim
+under that key is itself multi-target, so ``_competitor_is_dismissible``
+also requires the competitor's raw ``(competitor_id, resolved_key)`` target
+set to name only this ``added_id``.
 """
 
 from __future__ import annotations
@@ -111,6 +123,16 @@ def added_side_ambiguity_resolver(
     def _competitor_is_dismissible(competitor_id: str, added_id: str) -> bool:
         resolved_key = resolved_added_claims.get((competitor_id, added_id))
         if resolved_key is None:
+            return False
+        # The competitor's OWN candidacy under that key must itself be
+        # unambiguous and point only at this added_id -- the same removed
+        # symbol can reach a different added identity through an equally
+        # "resolved" entry sharing the identical key tokens (one masking
+        # position per differing scope segment), so an entry existing here
+        # is not yet proof this competitor is uniquely spoken for.
+        if raw_symbol_key_targets.get((competitor_id, resolved_key), set()) != {
+            added_id
+        }:
             return False
         # Resolved on this target; dismissible only if that key carries no
         # support from anyone besides this competitor itself.

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -1056,6 +1056,31 @@ def find_namespace_move_groups(
     # 0) AND "old::new::f" (position 1) both key as ("old", "new") -- a
     # shared key must not be treated as agreement. Keyed by (symbol_id, key), not merged into `raw_symbol_keys`, so a single-target key is unaffected.
     raw_symbol_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
+    # Added-side mirrors of `raw_symbol_keys`/`raw_symbol_key_targets`
+    # (item 6 follow-up): the corroboration logic Phase 2 already applies
+    # when ONE removed symbol has multiple candidate added targets
+    # (`removed_id_to_added_symbols`) was never extended to the symmetric
+    # case -- ONE added symbol claimed by multiple distinct removed
+    # identities (`added_id_to_removed_symbols`) was rejected outright,
+    # unconditionally, with no attempt to see whether one of the competing
+    # claims is corroborated elsewhere in the same comparison while the
+    # other is an isolated coincidence. Real-world effect: a genuine
+    # namespace-move batch that is overwhelmingly well-supported can still
+    # lose a handful of its own members purely because an unrelated,
+    # uncorroborated removed identity happens to coincidentally collide
+    # with one of the batch's added targets -- those members' underlying
+    # evidence is silently dropped from the group's supporting-pairs list
+    # even though the roll-up they belong to is real (`emit_namespace_move_
+    # batches`'s "additive" per-symbol removals/additions still cover the
+    # symbol elsewhere, but the batch's own supporting-pairs count and
+    # description under-represent it). `raw_added_keys`/
+    # `raw_added_key_targets` are keyed by ADDED identity exactly the way
+    # `raw_symbol_keys`/`raw_symbol_key_targets` are keyed by removed
+    # identity, so an analogous corroboration test can run in this
+    # direction too -- see Phase 2 below for why it cannot be the exact
+    # same test, just mirrored.
+    raw_added_keys: dict[str, set[tuple[str, str]]] = {}
+    raw_added_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
     for r_sym in sorted(removed):
         r_resolved = _scope_components(r_sym)
         if r_resolved is None:
@@ -1080,6 +1105,8 @@ def find_namespace_move_groups(
                 rkey = (r_comps[i], cand_comps[i])
                 raw_symbol_keys.setdefault(symbol_id, set()).add(rkey)
                 raw_symbol_key_targets.setdefault((symbol_id, rkey), set()).add(cand_id)
+                raw_added_keys.setdefault(cand_id, set()).add(rkey)
+                raw_added_key_targets.setdefault((cand_id, rkey), set()).add(symbol_id)
             # Reject an AMBIGUOUS substitution at the source (Codex review,
             # fresh evidence): when the SAME masked context (this removed
             # symbol's scope chain with position `i` blanked out) matches
@@ -1169,19 +1196,72 @@ def find_namespace_move_groups(
     # come from `raw_symbol_keys` instead, so a key raised at a
     # locally-ambiguous position still counts as a competitor even without
     # its own entry. A genuine tie (both/neither corroborated) still rejects.
+    #
+    # The SAME idea -- don't let an unresolved-but-uncorroborated coincidence
+    # veto a well-supported pairing -- also applies on the added side (item 6
+    # follow-up): `added_id_to_removed_symbols[added_id] > 1` -- this added
+    # declaration is claimed by more than one distinct removed identity --
+    # used to be rejected outright, unconditionally, unlike its removed-side
+    # mirror just above. That asymmetry silently dropped a well-supported
+    # namespace-move batch member whenever an unrelated, uncorroborated
+    # removed identity happened to coincidentally collide with one of the
+    # batch's own added targets: the real member's evidence never reached
+    # `groups[key]` even though the substitution it supports is otherwise
+    # heavily corroborated elsewhere in the same comparison.
+    #
+    # This CANNOT reuse the removed-side test's exact shape, though: there,
+    # every competing key belongs to the SAME symbol (its own alternate
+    # masking positions), so subtracting that one `symbol_id` from a key's
+    # supporter set is enough to ask "does anyone ELSE back this option".
+    # Here, each competing key belongs to a DIFFERENT removed identity, and
+    # that competitor may itself never have resolved to any single key at
+    # all -- exactly the round-4 scenario `TestFindNamespaceMoveGroupsRetains
+    # LocallyAmbiguousCandidatesGlobally` pins (`p1::old::f` is itself stuck
+    # between two candidates at its only masking position and so never gets
+    # an `entries` row for either): such a competitor is a live, irreducible
+    # threat, not a dismissible coincidence, and must still veto -- there is
+    # no key of its own whose support could be checked. Only a competitor
+    # that DID resolve to its own key(s) (via `entries`) can be assessed and
+    # potentially dismissed, and only when NONE of ITS resolved keys carry
+    # support from anyone other than that competitor itself.
     key_support: dict[tuple[str, str], set[str]] = {}
+    symbol_entries_keys: dict[str, set[tuple[str, str]]] = {}
     for masked, r_comps, i, a_comps in entries:
         sid = "::".join(r_comps)
         k = (r_comps[i], a_comps[i])
         key_support.setdefault(k, set()).add(sid)
+        symbol_entries_keys.setdefault(sid, set()).add(k)
+
+    def _added_side_competitor_is_dismissible(competitor_id: str) -> bool:
+        resolved_keys = symbol_entries_keys.get(competitor_id)
+        if not resolved_keys:
+            # Never resolved to any key of its own -- an irreducible,
+            # unresolved rival that cannot be ruled out. Always vetoes.
+            return False
+        # Resolved, but only dismissible if NONE of its own keys are
+        # independently backed by anyone besides itself.
+        return not any(
+            key_support.get(ok, set()) - {competitor_id} for ok in resolved_keys
+        )
+
     for masked, r_comps, i, a_comps in entries:
         if len(masked_to_old_segments[masked]) != 1:
             continue
         added_id = "::".join(a_comps)
         symbol_id = "::".join(r_comps)
-        if len(added_id_to_removed_symbols[added_id]) != 1:
-            continue
         key = (r_comps[i], a_comps[i])
+        if len(added_id_to_removed_symbols[added_id]) != 1:
+            # This key itself may be reachable from >1 distinct removed
+            # symbol for this SAME added identity (the added-side mirror of
+            # raw_symbol_key_targets's repeated-segment collision, just
+            # below) -- reject before considering corroboration.
+            if len(raw_added_key_targets[(added_id, key)]) != 1:
+                continue
+            if not key_support[key] - {symbol_id}:
+                continue
+            competitors = added_id_to_removed_symbols[added_id] - {symbol_id}
+            if not all(_added_side_competitor_is_dismissible(c) for c in competitors):
+                continue
         if len(removed_id_to_added_symbols[symbol_id]) != 1:
             # This key itself may resolve to >1 distinct target for this
             # symbol (see raw_symbol_key_targets's docstring) -- reject

--- a/abicheck/diff_symbols_renames.py
+++ b/abicheck/diff_symbols_renames.py
@@ -36,6 +36,7 @@ from .binary_fingerprint import (
 )
 from .checker_policy import ChangeKind
 from .checker_types import Change
+from .compare.rename_ambiguity import added_side_ambiguity_resolver
 from .demangle import demangle, demangle_batch
 from .detector_registry import registry
 from .diff_cxx_rules import (
@@ -1056,31 +1057,6 @@ def find_namespace_move_groups(
     # 0) AND "old::new::f" (position 1) both key as ("old", "new") -- a
     # shared key must not be treated as agreement. Keyed by (symbol_id, key), not merged into `raw_symbol_keys`, so a single-target key is unaffected.
     raw_symbol_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
-    # Added-side mirrors of `raw_symbol_keys`/`raw_symbol_key_targets`
-    # (item 6 follow-up): the corroboration logic Phase 2 already applies
-    # when ONE removed symbol has multiple candidate added targets
-    # (`removed_id_to_added_symbols`) was never extended to the symmetric
-    # case -- ONE added symbol claimed by multiple distinct removed
-    # identities (`added_id_to_removed_symbols`) was rejected outright,
-    # unconditionally, with no attempt to see whether one of the competing
-    # claims is corroborated elsewhere in the same comparison while the
-    # other is an isolated coincidence. Real-world effect: a genuine
-    # namespace-move batch that is overwhelmingly well-supported can still
-    # lose a handful of its own members purely because an unrelated,
-    # uncorroborated removed identity happens to coincidentally collide
-    # with one of the batch's added targets -- those members' underlying
-    # evidence is silently dropped from the group's supporting-pairs list
-    # even though the roll-up they belong to is real (`emit_namespace_move_
-    # batches`'s "additive" per-symbol removals/additions still cover the
-    # symbol elsewhere, but the batch's own supporting-pairs count and
-    # description under-represent it). `raw_added_keys`/
-    # `raw_added_key_targets` are keyed by ADDED identity exactly the way
-    # `raw_symbol_keys`/`raw_symbol_key_targets` are keyed by removed
-    # identity, so an analogous corroboration test can run in this
-    # direction too -- see Phase 2 below for why it cannot be the exact
-    # same test, just mirrored.
-    raw_added_keys: dict[str, set[tuple[str, str]]] = {}
-    raw_added_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
     for r_sym in sorted(removed):
         r_resolved = _scope_components(r_sym)
         if r_resolved is None:
@@ -1105,8 +1081,6 @@ def find_namespace_move_groups(
                 rkey = (r_comps[i], cand_comps[i])
                 raw_symbol_keys.setdefault(symbol_id, set()).add(rkey)
                 raw_symbol_key_targets.setdefault((symbol_id, rkey), set()).add(cand_id)
-                raw_added_keys.setdefault(cand_id, set()).add(rkey)
-                raw_added_key_targets.setdefault((cand_id, rkey), set()).add(symbol_id)
             # Reject an AMBIGUOUS substitution at the source (Codex review,
             # fresh evidence): when the SAME masked context (this removed
             # symbol's scope chain with position `i` blanked out) matches
@@ -1196,72 +1170,17 @@ def find_namespace_move_groups(
     # come from `raw_symbol_keys` instead, so a key raised at a
     # locally-ambiguous position still counts as a competitor even without
     # its own entry. A genuine tie (both/neither corroborated) still rejects.
-    #
-    # The SAME idea -- don't let an unresolved-but-uncorroborated coincidence
-    # veto a well-supported pairing -- also applies on the added side (item 6
-    # follow-up): `added_id_to_removed_symbols[added_id] > 1` -- this added
-    # declaration is claimed by more than one distinct removed identity --
-    # used to be rejected outright, unconditionally, unlike its removed-side
-    # mirror just above. That asymmetry silently dropped a well-supported
-    # namespace-move batch member whenever an unrelated, uncorroborated
-    # removed identity happened to coincidentally collide with one of the
-    # batch's own added targets: the real member's evidence never reached
-    # `groups[key]` even though the substitution it supports is otherwise
-    # heavily corroborated elsewhere in the same comparison.
-    #
-    # This CANNOT reuse the removed-side test's exact shape, though: there,
-    # every competing key belongs to the SAME symbol (its own alternate
-    # masking positions), so subtracting that one `symbol_id` from a key's
-    # supporter set is enough to ask "does anyone ELSE back this option".
-    # Here, each competing key belongs to a DIFFERENT removed identity, and
-    # that competitor may itself never have resolved to any single key at
-    # all -- exactly the round-4 scenario `TestFindNamespaceMoveGroupsRetains
-    # LocallyAmbiguousCandidatesGlobally` pins (`p1::old::f` is itself stuck
-    # between two candidates at its only masking position and so never gets
-    # an `entries` row for either): such a competitor is a live, irreducible
-    # threat, not a dismissible coincidence, and must still veto -- there is
-    # no key of its own whose support could be checked. Only a competitor
-    # that DID resolve to its own key(s) (via `entries`) can be assessed and
-    # potentially dismissed, and only when NONE of ITS resolved keys carry
-    # support from anyone other than that competitor itself.
-    key_support: dict[tuple[str, str], set[str]] = {}
-    symbol_entries_keys: dict[str, set[tuple[str, str]]] = {}
-    for masked, r_comps, i, a_comps in entries:
-        sid = "::".join(r_comps)
-        k = (r_comps[i], a_comps[i])
-        key_support.setdefault(k, set()).add(sid)
-        symbol_entries_keys.setdefault(sid, set()).add(k)
-
-    def _added_side_competitor_is_dismissible(competitor_id: str) -> bool:
-        resolved_keys = symbol_entries_keys.get(competitor_id)
-        if not resolved_keys:
-            # Never resolved to any key of its own -- an irreducible,
-            # unresolved rival that cannot be ruled out. Always vetoes.
-            return False
-        # Resolved, but only dismissible if NONE of its own keys are
-        # independently backed by anyone besides itself.
-        return not any(
-            key_support.get(ok, set()) - {competitor_id} for ok in resolved_keys
-        )
-
+    key_support, is_added_side_acceptable = added_side_ambiguity_resolver(
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets
+    )
     for masked, r_comps, i, a_comps in entries:
         if len(masked_to_old_segments[masked]) != 1:
             continue
         added_id = "::".join(a_comps)
         symbol_id = "::".join(r_comps)
         key = (r_comps[i], a_comps[i])
-        if len(added_id_to_removed_symbols[added_id]) != 1:
-            # This key itself may be reachable from >1 distinct removed
-            # symbol for this SAME added identity (the added-side mirror of
-            # raw_symbol_key_targets's repeated-segment collision, just
-            # below) -- reject before considering corroboration.
-            if len(raw_added_key_targets[(added_id, key)]) != 1:
-                continue
-            if not key_support[key] - {symbol_id}:
-                continue
-            competitors = added_id_to_removed_symbols[added_id] - {symbol_id}
-            if not all(_added_side_competitor_is_dismissible(c) for c in competitors):
-                continue
+        if not is_added_side_acceptable(symbol_id, added_id, key):
+            continue
         if len(removed_id_to_added_symbols[symbol_id]) != 1:
             # This key itself may resolve to >1 distinct target for this
             # symbol (see raw_symbol_key_targets's docstring) -- reject

--- a/abicheck/qualified_name_segments.py
+++ b/abicheck/qualified_name_segments.py
@@ -729,6 +729,62 @@ def defer_closure_identity_renumbering() -> _Iterator[None]:
         _defer_renumber.active = previous
 
 
+def _lambda_identity_containers_and_strings(
+    snapshot: object,
+) -> tuple[list[object], list[str]] | None:
+    """Collect :data:`_LAMBDA_IDENTITY_FIELDS`' containers and every string
+    reachable from them, or ``None`` as soon as none of those strings even
+    mentions ``"(lambda"``/``"(unnamed "`` -- the cheap, shared no-op gate
+    both :func:`renumber_anonymous_closure_identities` and
+    :func:`rewrite_anonymous_type_spellings` use, factored out so the two
+    don't each walk *snapshot* separately when a caller runs both back to
+    back (as ``serialization.snapshot_from_dict`` does)."""
+    containers = [getattr(snapshot, name) for name in _LAMBDA_IDENTITY_FIELDS]
+    strings: list[str] = []
+    for container in containers:
+        _collect_strings(container, strings)
+    if not any("(lambda" in s or "(unnamed " in s for s in strings):
+        return None
+    return containers, strings
+
+
+def rewrite_anonymous_type_spellings(
+    snapshot: _SnapshotT, rewrite: _Callable[[str], str]
+) -> _SnapshotT:
+    """Apply *rewrite* to every string reachable from the same
+    :data:`_LAMBDA_IDENTITY_FIELDS` :func:`renumber_anonymous_closure_
+    identities` scans, mutating *snapshot* in place. Returns *snapshot*
+    unchanged (for chaining at a call site's own ``return`` statement), and
+    is a cheap no-op under the identical fast-path gate that function uses.
+
+    Exists so a caller needing a normalization pass BEFORE renumbering --
+    :func:`~abicheck.name_classification.strip_anonymous_type_location`,
+    applied to a snapshot just loaded from disk that may still carry a
+    closure marker in its raw, un-stripped ``(lambda at
+    <path>:<line>:<col>)`` form -- can drive that normalization over the
+    identical field set without this module importing the normalizer
+    itself (this module stays a leaf, no imports from the rest of
+    ``abicheck`` -- see its own module docstring; the normalizer is passed
+    in by the caller instead). *rewrite* must be idempotent on text it has
+    already normalized, the same way ``strip_anonymous_type_location`` is a
+    no-op on a marker that no longer contains ``" at "`` -- this function
+    applies it unconditionally to every matched string, including one that
+    needs no change, so a repeat call (or a call on an already-normalized
+    snapshot) must stay safe.
+    """
+    if getattr(_defer_renumber, "active", False):
+        return snapshot
+    collected = _lambda_identity_containers_and_strings(snapshot)
+    if collected is None:
+        return snapshot
+    containers, _strings = collected
+    for field_name, container in zip(_LAMBDA_IDENTITY_FIELDS, containers):
+        new_container = _walk_rewrite_strings(container, rewrite)
+        if new_container is not container:
+            setattr(snapshot, field_name, new_container)
+    return snapshot
+
+
 def renumber_anonymous_closure_identities(snapshot: _SnapshotT) -> _SnapshotT:
     """Replace each castxml/clang closure marker's ``:<line>:<col>``
     discriminator with a stable ordinal among same-header, same-kind
@@ -746,6 +802,19 @@ def renumber_anonymous_closure_identities(snapshot: _SnapshotT) -> _SnapshotT:
     ``getattr(snapshot, field)`` rather than importing ``AbiSnapshot``, to
     keep this module import-free -- see its own docstring.
 
+    ``serialization.snapshot_from_dict`` calls
+    :func:`rewrite_anonymous_type_spellings` with
+    ``name_classification.strip_anonymous_type_location`` right before this
+    function, so a snapshot loaded from disk always reaches this function
+    with any raw ``(lambda at <path>:<line>:<col>)`` spelling already
+    reduced to the stripped ``(lambda:<basename>:<line>:<col>)`` form this
+    function's own marker regex requires -- this function's regex never
+    matched the raw ``" at "`` spelling on its own (fixed after being found
+    to leave a pre-strip-era on-disk baseline's closures completely
+    unrenumbered on load, silently comparing them against a freshly-dumped
+    snapshot's ordinal-form spellings as if the two were unrelated
+    declarations).
+
     Known, accepted residual (Codex review, fresh evidence): a snapshot
     written by a version of abicheck *older* than this function's own
     introduction never carries an ordinal-form marker, and a reader
@@ -756,23 +825,22 @@ def renumber_anonymous_closure_identities(snapshot: _SnapshotT) -> _SnapshotT:
     signal that the identity format it's comparing against differs from
     what its own dumper would have produced. The reverse direction (an
     older-format on-disk baseline compared by a current reader) is closed
-    by ``snapshot_from_dict``'s unconditional renumber-on-load. Closing
-    this direction too needs a real schema bump, which ripples into
-    ``docs/`` (the doc-count-sync AI-readiness check) and every test
-    fixture pinning the current schema version -- a real, separate change,
-    not folded into this fix.
+    by ``snapshot_from_dict``'s unconditional strip-and-renumber-on-load
+    (see above). Closing the "older reader, newer baseline" direction too
+    needs a real schema bump, which ripples into ``docs/`` (the
+    doc-count-sync AI-readiness check) and every test fixture pinning the
+    current schema version -- a real, separate change, not folded into this
+    fix.
 
     A no-op, returning *snapshot* untouched, inside
     :func:`defer_closure_identity_renumbering`'s context.
     """
     if getattr(_defer_renumber, "active", False):
         return snapshot
-    containers = [getattr(snapshot, name) for name in _LAMBDA_IDENTITY_FIELDS]
-    strings: list[str] = []
-    for container in containers:
-        _collect_strings(container, strings)
-    if not any("(lambda" in s or "(unnamed " in s for s in strings):
+    collected = _lambda_identity_containers_and_strings(snapshot)
+    if collected is None:
         return snapshot
+    containers, strings = collected
     ordinals = collect_anonymous_type_ordinals(strings)
     if not ordinals:
         return snapshot

--- a/abicheck/qualified_name_segments.py
+++ b/abicheck/qualified_name_segments.py
@@ -732,13 +732,9 @@ def defer_closure_identity_renumbering() -> _Iterator[None]:
 def _lambda_identity_containers_and_strings(
     snapshot: object,
 ) -> tuple[list[object], list[str]] | None:
-    """Collect :data:`_LAMBDA_IDENTITY_FIELDS`' containers and every string
-    reachable from them, or ``None`` as soon as none of those strings even
-    mentions ``"(lambda"``/``"(unnamed "`` -- the cheap, shared no-op gate
-    both :func:`renumber_anonymous_closure_identities` and
-    :func:`rewrite_anonymous_type_spellings` use, factored out so the two
-    don't each walk *snapshot* separately when a caller runs both back to
-    back (as ``serialization.snapshot_from_dict`` does)."""
+    """Collect :data:`_LAMBDA_IDENTITY_FIELDS`' containers and strings, or
+    ``None`` once none mentions ``"(lambda"``/``"(unnamed "`` -- shared with
+    ``storage.snapshot_load_normalization``, an importer of this helper."""
     containers = [getattr(snapshot, name) for name in _LAMBDA_IDENTITY_FIELDS]
     strings: list[str] = []
     for container in containers:
@@ -746,43 +742,6 @@ def _lambda_identity_containers_and_strings(
     if not any("(lambda" in s or "(unnamed " in s for s in strings):
         return None
     return containers, strings
-
-
-def rewrite_anonymous_type_spellings(
-    snapshot: _SnapshotT, rewrite: _Callable[[str], str]
-) -> _SnapshotT:
-    """Apply *rewrite* to every string reachable from the same
-    :data:`_LAMBDA_IDENTITY_FIELDS` :func:`renumber_anonymous_closure_
-    identities` scans, mutating *snapshot* in place. Returns *snapshot*
-    unchanged (for chaining at a call site's own ``return`` statement), and
-    is a cheap no-op under the identical fast-path gate that function uses.
-
-    Exists so a caller needing a normalization pass BEFORE renumbering --
-    :func:`~abicheck.name_classification.strip_anonymous_type_location`,
-    applied to a snapshot just loaded from disk that may still carry a
-    closure marker in its raw, un-stripped ``(lambda at
-    <path>:<line>:<col>)`` form -- can drive that normalization over the
-    identical field set without this module importing the normalizer
-    itself (this module stays a leaf, no imports from the rest of
-    ``abicheck`` -- see its own module docstring; the normalizer is passed
-    in by the caller instead). *rewrite* must be idempotent on text it has
-    already normalized, the same way ``strip_anonymous_type_location`` is a
-    no-op on a marker that no longer contains ``" at "`` -- this function
-    applies it unconditionally to every matched string, including one that
-    needs no change, so a repeat call (or a call on an already-normalized
-    snapshot) must stay safe.
-    """
-    if getattr(_defer_renumber, "active", False):
-        return snapshot
-    collected = _lambda_identity_containers_and_strings(snapshot)
-    if collected is None:
-        return snapshot
-    containers, _strings = collected
-    for field_name, container in zip(_LAMBDA_IDENTITY_FIELDS, containers):
-        new_container = _walk_rewrite_strings(container, rewrite)
-        if new_container is not container:
-            setattr(snapshot, field_name, new_container)
-    return snapshot
 
 
 def renumber_anonymous_closure_identities(snapshot: _SnapshotT) -> _SnapshotT:
@@ -802,35 +761,20 @@ def renumber_anonymous_closure_identities(snapshot: _SnapshotT) -> _SnapshotT:
     ``getattr(snapshot, field)`` rather than importing ``AbiSnapshot``, to
     keep this module import-free -- see its own docstring.
 
-    ``serialization.snapshot_from_dict`` calls
-    :func:`rewrite_anonymous_type_spellings` with
-    ``name_classification.strip_anonymous_type_location`` right before this
-    function, so a snapshot loaded from disk always reaches this function
-    with any raw ``(lambda at <path>:<line>:<col>)`` spelling already
-    reduced to the stripped ``(lambda:<basename>:<line>:<col>)`` form this
-    function's own marker regex requires -- this function's regex never
-    matched the raw ``" at "`` spelling on its own (fixed after being found
-    to leave a pre-strip-era on-disk baseline's closures completely
-    unrenumbered on load, silently comparing them against a freshly-dumped
-    snapshot's ordinal-form spellings as if the two were unrelated
-    declarations).
+    The marker regex requires the stripped spelling, never a raw
+    ``(lambda at <path>:<line>:<col>)`` one --
+    ``storage.snapshot_load_normalization`` strips it first on load.
 
-    Known, accepted residual (Codex review, fresh evidence): a snapshot
-    written by a version of abicheck *older* than this function's own
-    introduction never carries an ordinal-form marker, and a reader
-    *older* than this function that later loads a snapshot written by a
-    *newer* abicheck (which already carries the ordinal form) has no code
-    path that renumbers it back -- ``serialization.SCHEMA_VERSION`` was not
-    bumped for this representation change, so that older reader has no
-    signal that the identity format it's comparing against differs from
-    what its own dumper would have produced. The reverse direction (an
-    older-format on-disk baseline compared by a current reader) is closed
-    by ``snapshot_from_dict``'s unconditional strip-and-renumber-on-load
-    (see above). Closing the "older reader, newer baseline" direction too
-    needs a real schema bump, which ripples into ``docs/`` (the
-    doc-count-sync AI-readiness check) and every test fixture pinning the
-    current schema version -- a real, separate change, not folded into this
-    fix.
+    Known, accepted residual (Codex review, fresh evidence): a reader
+    *older* than this function that loads a snapshot written by a *newer*
+    abicheck (already in ordinal form) has no code path renumbering it
+    back -- ``serialization.SCHEMA_VERSION`` was not bumped for this
+    representation change, so that older reader has no signal the identity
+    format differs from what its own dumper would produce. The reverse
+    direction (an older-format baseline, current reader) is closed by the
+    strip-then-renumber load path above; closing this one too needs a real
+    schema bump, rippling into ``docs/`` and every fixture pinning the
+    schema version -- separate, not folded into this fix.
 
     A no-op, returning *snapshot* untouched, inside
     :func:`defer_closure_identity_renumbering`'s context.

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -46,7 +46,6 @@ from .model import (
     Variable,
     Visibility,
 )
-from .name_classification import strip_anonymous_type_location
 from .storage.entity_id_codec import decode_entity_ids, encode_entity_ids
 from .storage.enum_codec import encode_platform_enums
 from .storage.fact_codec import (
@@ -54,6 +53,10 @@ from .storage.fact_codec import (
     decode_fact,
     decode_record_facts,
     encode_fact_fields,
+)
+from .storage.snapshot_load_normalization import (
+    backfill_missing_elf_binding,
+    normalize_anonymous_type_spellings_on_load,
 )
 from .storage.surface_graph_codec import decode_surface_graph, encode_surface_graph
 
@@ -799,41 +802,6 @@ def _sub_block(parser: Callable[[dict[str, Any]], _T], raw: Any) -> _T | None:
     one guard keeps a dozen call sites from each spelling it out.
     """
     return parser(raw) if isinstance(raw, dict) else None
-
-
-def _backfill_missing_elf_binding(snap: AbiSnapshot) -> None:
-    """Backfill Function/Variable.elf_binding from an already-loaded
-    ``elf.symbols`` for a snapshot serialized before this field existed
-    (Codex review, fresh evidence).
-
-    A pre-this-PR snapshot's own ``elf`` block already carries the exact
-    same fact ``dumper_elf_symbols._populate_elf_visibility`` reads it
-    from at dump time -- only the newer per-declaration ``elf_binding``
-    key was never written at serialization time, so loading it as ``None``
-    (the ordinary missing-key convention) would make a fresh ``binding:``
-    suppression selector fail closed against *every* already-archived
-    baseline, not just genuinely-unknown-binding cases, until each one is
-    regenerated -- which is not always possible for an archived release.
-    Only fills a ``None``: an explicitly serialized value from a v16+
-    writer is preserved untouched, never recomputed.
-
-    Deliberately scoped to ``elf_binding`` alone -- ``elf_visibility`` has
-    the identical legacy-backfill gap but predates this PR, is unrelated to
-    the field this PR adds, and is left as it already was.
-    """
-    if snap.elf is None:
-        return
-    sym_map = snap.elf.symbol_map
-    for func in snap.functions:
-        if func.elf_binding is None:
-            elf_sym = sym_map.get(func.mangled)
-            if elf_sym is not None:
-                func.elf_binding = elf_sym.binding
-    for var in snap.variables:
-        if var.elf_binding is None:
-            elf_sym = sym_map.get(var.mangled)
-            if elf_sym is not None:
-                var.elf_binding = elf_sym.binding
 
 
 def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
@@ -1644,19 +1612,8 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             stacklevel=2,
         )
 
-    _backfill_missing_elf_binding(snap)
-    # A baseline written by a pre-normalization abicheck can still carry a
-    # closure/anonymous-type marker in its raw ``(lambda at
-    # <path>:<line>:<col>)`` form -- the two header-mode dumpers only ever
-    # call strip_anonymous_type_location at extraction time, never on this
-    # load path, so without this step renumber_anonymous_closure_identities
-    # below (whose marker regex requires the already-stripped
-    # ``(lambda:<basename>:<line>:<col>)`` spelling) leaves such a baseline's
-    # closures completely unrenumbered, comparing them against a freshly
-    # dumped snapshot's ordinal-form spellings as if unrelated declarations.
-    qualified_name_segments.rewrite_anonymous_type_spellings(
-        snap, strip_anonymous_type_location
-    )
+    backfill_missing_elf_binding(snap)
+    normalize_anonymous_type_spellings_on_load(snap)
     return qualified_name_segments.renumber_anonymous_closure_identities(snap)
 
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -46,6 +46,7 @@ from .model import (
     Variable,
     Visibility,
 )
+from .name_classification import strip_anonymous_type_location
 from .storage.entity_id_codec import decode_entity_ids, encode_entity_ids
 from .storage.enum_codec import encode_platform_enums
 from .storage.fact_codec import (
@@ -1644,6 +1645,18 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         )
 
     _backfill_missing_elf_binding(snap)
+    # A baseline written by a pre-normalization abicheck can still carry a
+    # closure/anonymous-type marker in its raw ``(lambda at
+    # <path>:<line>:<col>)`` form -- the two header-mode dumpers only ever
+    # call strip_anonymous_type_location at extraction time, never on this
+    # load path, so without this step renumber_anonymous_closure_identities
+    # below (whose marker regex requires the already-stripped
+    # ``(lambda:<basename>:<line>:<col>)`` spelling) leaves such a baseline's
+    # closures completely unrenumbered, comparing them against a freshly
+    # dumped snapshot's ordinal-form spellings as if unrelated declarations.
+    qualified_name_segments.rewrite_anonymous_type_spellings(
+        snap, strip_anonymous_type_location
+    )
     return qualified_name_segments.renumber_anonymous_closure_identities(snap)
 
 

--- a/abicheck/storage/snapshot_load_normalization.py
+++ b/abicheck/storage/snapshot_load_normalization.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-load snapshot migrations for legacy-format documents.
+
+``serialization.snapshot_from_dict`` calls these right after a document is
+parsed, before the result reaches any detector or index. Kept out of
+``serialization.py`` itself (ADR-061 D1: ``storage/`` is the canonical owner
+of a snapshot format's schemas and migrations; that file is debt-baselined
+at its adoption ceiling, so new load-time migration logic belongs here, with
+only a thin call left at the call site). ``abicheck.qualified_name_segments``
+is a ``public_root_surfaces`` entry (its own docstring already frames it as
+a stable, dependency-free leaf shared across detectors), the same exemption
+``abicheck.serialization`` itself already uses.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..name_classification import strip_anonymous_type_location
+from ..qualified_name_segments import (
+    _LAMBDA_IDENTITY_FIELDS,
+    _lambda_identity_containers_and_strings,
+    _walk_rewrite_strings,
+)
+
+if TYPE_CHECKING:
+    from ..model.snapshot import AbiSnapshot
+
+
+def normalize_anonymous_type_spellings_on_load(snapshot: AbiSnapshot) -> AbiSnapshot:
+    """Strip a checkout-dependent path out of any closure/anonymous-type
+    marker still in its raw ``(lambda at <path>:<line>:<col>)`` form,
+    mutating *snapshot* in place. Returns *snapshot* unchanged (for
+    chaining at the call site's own ``return``).
+
+    A baseline written before ``strip_anonymous_type_location`` existed (or
+    by a header-mode dumper build that never called it) still carries that
+    raw spelling on disk -- the two header-mode dumpers only ever call it at
+    extraction time, never on this load path. Without this step,
+    ``qualified_name_segments.renumber_anonymous_closure_identities``'s own
+    marker regex (which requires the already-stripped
+    ``(lambda:<basename>:<line>:<col>)`` form) leaves such a baseline's
+    closures completely unrenumbered, comparing them against a freshly
+    dumped snapshot's ordinal-form spellings as if the two were unrelated
+    declarations. Idempotent: ``strip_anonymous_type_location`` is a no-op
+    on text with no ``" at "`` left to strip, so this is safe to call
+    unconditionally on every load, including an already-normalized one.
+    """
+    collected = _lambda_identity_containers_and_strings(snapshot)
+    if collected is None:
+        return snapshot
+    containers, _strings = collected
+    for field_name, container in zip(_LAMBDA_IDENTITY_FIELDS, containers):
+        new_container = _walk_rewrite_strings(container, strip_anonymous_type_location)
+        if new_container is not container:
+            setattr(snapshot, field_name, new_container)
+    return snapshot
+
+
+def backfill_missing_elf_binding(snap: AbiSnapshot) -> None:
+    """Backfill Function/Variable.elf_binding from an already-loaded
+    ``elf.symbols`` for a snapshot serialized before this field existed
+    (Codex review, fresh evidence).
+
+    A pre-this-PR snapshot's own ``elf`` block already carries the exact
+    same fact ``dumper_elf_symbols._populate_elf_visibility`` reads it
+    from at dump time -- only the newer per-declaration ``elf_binding``
+    key was never written at serialization time, so loading it as ``None``
+    (the ordinary missing-key convention) would make a fresh ``binding:``
+    suppression selector fail closed against *every* already-archived
+    baseline, not just genuinely-unknown-binding cases, until each one is
+    regenerated -- which is not always possible for an archived release.
+    Only fills a ``None``: an explicitly serialized value from a v16+
+    writer is preserved untouched, never recomputed.
+
+    Deliberately scoped to ``elf_binding`` alone -- ``elf_visibility`` has
+    the identical legacy-backfill gap but predates this PR, is unrelated to
+    the field this PR adds, and is left as it already was.
+    """
+    if snap.elf is None:
+        return
+    sym_map = snap.elf.symbol_map
+    for func in snap.functions:
+        if func.elf_binding is None:
+            elf_sym = sym_map.get(func.mangled)
+            if elf_sym is not None:
+                func.elf_binding = elf_sym.binding
+    for var in snap.variables:
+        if var.elf_binding is None:
+            elf_sym = sym_map.get(var.mangled)
+            if elf_sym is not None:
+                var.elf_binding = elf_sym.binding

--- a/abicheck/storage/snapshot_load_normalization.py
+++ b/abicheck/storage/snapshot_load_normalization.py
@@ -59,6 +59,23 @@ def normalize_anonymous_type_spellings_on_load(snapshot: AbiSnapshot) -> AbiSnap
     declarations. Idempotent: ``strip_anonymous_type_location`` is a no-op
     on text with no ``" at "`` left to strip, so this is safe to call
     unconditionally on every load, including an already-normalized one.
+
+    Known, accepted limitation shared with ``renumber_anonymous_closure_
+    identities`` (Codex review; see ``docs/contribute/known-gaps.md``'s "The
+    L5 source graph's own node identities are never renumbered..." entry,
+    Codex review on PR #868): this only rewrites
+    :data:`~abicheck.qualified_name_segments._LAMBDA_IDENTITY_FIELDS` on the
+    flat snapshot. A schema-v29+ document's ``AbiSnapshot.surface_graph`` is
+    decoded earlier in ``snapshot_from_dict`` (``decode_surface_graph``) and
+    is not touched here, so a loaded raw-marker baseline's attached graph
+    keeps its own un-stripped node/edge identities even after the flat
+    fields are normalized -- the identical flat-vs-graph mismatch the
+    existing entry documents for dump-time renumbering, now also reachable
+    from this load-time path. Not fixed here for the same reason: closing it
+    needs the graph's own node/edge strings folded into the same
+    strip-and-renumber pass, verified against a case mixing flat-visible and
+    graph-only closures -- a real, cross-cutting change, not a same-PR
+    reactive patch.
     """
     collected = _lambda_identity_containers_and_strings(snapshot)
     if collected is None:

--- a/architecture/modules.yaml
+++ b/architecture/modules.yaml
@@ -394,6 +394,7 @@
     "abicheck.contract_gating",
     "abicheck.dumper_contract",
     "abicheck.errors",
+    "abicheck.qualified_name_segments",
     "abicheck.reclassify",
     "abicheck.serialization"
   ],

--- a/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
+++ b/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
@@ -21,11 +21,10 @@ it should read in CHANGELOG.md. Delete the other sections.
   manufactured a spurious `type_removed`/`func_removed` plus
   `type_added`/`func_added` pair purely from the encoding difference.
   `snapshot_from_dict` now calls the new
-  `qualified_name_segments.rewrite_anonymous_type_spellings` with
-  `name_classification.strip_anonymous_type_location` immediately before
-  renumbering, closing the "raw pre-strip baseline vs. fresh dump" gap in
-  the `scan --against`/`publish-baseline` workflow this tool exists to
-  serve.
+  `storage.snapshot_load_normalization.normalize_anonymous_type_spellings_on_load`
+  immediately before renumbering, closing the "raw pre-strip baseline vs.
+  fresh dump" gap in the `scan --against`/`publish-baseline` workflow this
+  tool exists to serve.
 - **A namespace-move batch (`SYMBOL_RENAMED_BATCH`) could silently drop a
   well-supported member, or fall entirely below its 2+-pair reporting
   threshold, whenever an unrelated, isolated removed symbol happened to

--- a/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
+++ b/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
@@ -41,4 +41,9 @@ it should read in CHANGELOG.md. Delete the other sections.
   different symbol rather than the same one's alternate positions): an
   unresolved competitor still always vetoes, but a competitor that resolved
   to its own key with no support beyond itself is dismissed instead of
-  blocking a real, well-supported substitution.
+  blocking a real, well-supported substitution. A competitor is also not
+  dismissible when its own raw candidacy under the resolved key reaches more
+  than one added identity (two masking positions of the same removed symbol
+  sharing identical key tokens but targeting different added identities) --
+  an `entries` row for the exact pairing in question is not by itself proof
+  the competitor is uniquely spoken for.

--- a/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
+++ b/changelog.d/20260831_202301_noreply_behavioral_drift_fixes_status_fxq0ej.md
@@ -1,0 +1,45 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **A baseline persisted before `strip_anonymous_type_location` existed (or
+  by a header-mode dumper build that never called it) had its closure/
+  anonymous-type markers left completely unrenumbered on load.**
+  `strip_anonymous_type_location` was only ever applied at header-extraction
+  time; `serialization.snapshot_from_dict` called
+  `qualified_name_segments.renumber_anonymous_closure_identities` directly,
+  whose marker regex requires the already-stripped
+  `(lambda:<basename>:<line>:<col>)` spelling and never matched the raw
+  `(lambda at <path>:<line>:<col>)` form. Comparing such a baseline against
+  a freshly dumped snapshot of the identical, unedited declaration
+  manufactured a spurious `type_removed`/`func_removed` plus
+  `type_added`/`func_added` pair purely from the encoding difference.
+  `snapshot_from_dict` now calls the new
+  `qualified_name_segments.rewrite_anonymous_type_spellings` with
+  `name_classification.strip_anonymous_type_location` immediately before
+  renumbering, closing the "raw pre-strip baseline vs. fresh dump" gap in
+  the `scan --against`/`publish-baseline` workflow this tool exists to
+  serve.
+- **A namespace-move batch (`SYMBOL_RENAMED_BATCH`) could silently drop a
+  well-supported member, or fall entirely below its 2+-pair reporting
+  threshold, whenever an unrelated, isolated removed symbol happened to
+  coincidentally collide with one of the batch's own added targets.**
+  `diff_symbols_renames.find_namespace_move_groups` already resolved this
+  class of cross-position ambiguity via global-support corroboration when
+  ONE removed symbol had multiple candidate added targets
+  (`removed_id_to_added_symbols`), but rejected the exact mirror
+  unconditionally — ONE added symbol claimed by multiple distinct removed
+  identities (`added_id_to_removed_symbols`) — with no attempt to
+  distinguish a genuinely corroborated rival from an isolated coincidence.
+  The added-side gate now runs the same corroboration test (scoped per
+  competing removed identity, since each competing claim belongs to a
+  different symbol rather than the same one's alternate positions): an
+  unresolved competitor still always vetoes, but a competitor that resolved
+  to its own key with no support beyond itself is dismissed instead of
+  blocking a real, well-supported substitution.

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -5256,6 +5256,19 @@ looked like the obvious fix and wasn't.
   and graph-only closures in one header -- a real, cross-cutting change
   to two independently-evolving modules, not a same-PR reactive patch.
 
+  **Same gap, also reachable from the load path (Codex review, fresh
+  evidence).** `storage.snapshot_load_normalization.normalize_anonymous_
+  type_spellings_on_load` (added to close a sibling bug: a raw pre-strip
+  on-disk baseline was left completely unrenumbered on load, see this
+  file's own git history) rewrites the identical flat
+  `_LAMBDA_IDENTITY_FIELDS` only, called after `snapshot_from_dict` has
+  already decoded a schema-v29+ document's `AbiSnapshot.surface_graph` --
+  so a loaded raw-marker baseline's attached graph keeps its own
+  un-stripped node/edge identities even once the flat fields are
+  normalized. Not fixed here, for the same reason as above: it needs the
+  same graph-aware widening this entry already calls for, not a second,
+  independent patch on the load side.
+
 - ~~Neither `scan`'s dry-run report validates `--abi3` applicability before
   reporting success~~ **Fixed (CLI cleanup phase two, PR 5 follow-up).**
   Both `frontends.cli.scan_dry_run.render_scan_dry_run` (single-binary) and

--- a/tests/test_lambda_identity_ordinal.py
+++ b/tests/test_lambda_identity_ordinal.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import pytest
+from hypothesis import given, settings, strategies as st
 
 from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
 from abicheck.buildsource.pack import BuildSourcePack
@@ -62,6 +63,7 @@ from abicheck.qualified_name_segments import (
     apply_anonymous_type_ordinals,
     collect_anonymous_type_ordinals,
     renumber_anonymous_closure_identities,
+    rewrite_anonymous_type_spellings,
 )
 from abicheck.serialization import snapshot_from_dict
 
@@ -492,6 +494,220 @@ class TestLegacyPersistedSnapshotsAreRenumberedOnLoad:
         }
         loaded = snapshot_from_dict(already_ordinal)
         assert loaded.types[0].name == "raii_guard<(lambda:task_group.h#1)>"
+
+
+def _raw_closure(
+    header: str, line: int, col: int, root: str = "/home/build/src"
+) -> str:
+    """A genuinely RAW, pre-``strip_anonymous_type_location`` closure marker
+    -- what a baseline written before that normalizer existed (or one
+    produced by a dumper build that predates it) actually carries on disk,
+    unlike this file's own ``_closure`` helper above which already applies
+    the strip before the fixture is ever built."""
+    return f"(lambda at {root}/{header}:{line}:{col})"
+
+
+class TestRawPreStripBaselinesAreNormalizedOnLoad:
+    """A baseline persisted by an abicheck build from *before*
+    ``strip_anonymous_type_location`` existed (or a dumper build that never
+    called it) still carries the fully raw ``(lambda at
+    <checkout-root>/<header>:<line>:<col>)`` spelling on disk -- not the
+    intermediate ``(lambda:<basename>:<line>:<col>)`` form every other
+    "legacy" fixture in this file already starts from.
+
+    Bug: ``renumber_anonymous_closure_identities``'s own marker regex
+    (``_ANON_TYPE_MARKER_PREFIX_RE = r"\\((lambda|unnamed\\s+\\w+):"``)
+    requires the colon that only the STRIPPED spelling has right after the
+    marker keyword -- ``"(lambda at "`` never matches it. Since
+    ``strip_anonymous_type_location`` was called only from the two
+    header-mode dumpers' extraction-time code paths and never from
+    ``snapshot_from_dict``, loading such a baseline left its closures
+    completely unrenumbered: still absolute-path-and-line-tainted, while a
+    freshly dumped snapshot of the identical, unedited declaration is
+    fully stripped and ordinal-renumbered -- a spurious
+    type/func removed+added pair purely from where/when the baseline was
+    produced, not from any real ABI change. Fixed by
+    ``snapshot_from_dict`` calling ``rewrite_anonymous_type_spellings(snap,
+    strip_anonymous_type_location)`` immediately before renumbering.
+    """
+
+    def _raw_legacy_dict(
+        self, line: int, header: str = "task_group.h", root: str = "/home/build/src"
+    ) -> dict:
+        owner = f"tbb::detail::d1::raii_guard<{_raw_closure(header, line, 26, root)}>"
+        return {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [
+                {
+                    "name": owner.rsplit("::", 1)[-1],
+                    "qualified_name": owner,
+                    "kind": "class",
+                    "size_bits": 8,
+                }
+            ],
+            "functions": [
+                {
+                    "name": "raii_guard::raii_guard",
+                    "mangled": f"__abicheck_ctor__{owner}()",
+                    "return_type": "void",
+                }
+            ],
+        }
+
+    def test_loading_a_raw_pre_strip_snapshot_strips_and_renumbers_it(self) -> None:
+        loaded = snapshot_from_dict(self._raw_legacy_dict(522))
+        qualified = loaded.types[0].qualified_name
+        assert qualified is not None
+        assert "#" in qualified
+        assert " at " not in qualified
+        assert "/home/build/src" not in qualified
+        assert ":522:" not in qualified
+
+    def test_raw_pre_strip_baseline_agrees_with_a_fresh_dump_across_line_and_root_drift(
+        self,
+    ) -> None:
+        legacy_baseline = snapshot_from_dict(self._raw_legacy_dict(522))
+
+        # A fresh dump: checked out to a DIFFERENT root, with an unrelated
+        # earlier edit shifting the same, unedited closure to a new line --
+        # exactly what the real dumper produces (strip, then renumber),
+        # simulated the same way this file's own `_closure` helper does for
+        # the intermediate-form fixtures above.
+        fresh_bare_name = (
+            "raii_guard<"
+            f"{_raw_closure('task_group.h', 539, 26, root='/ci/checkout/src')}>"
+        )
+        fresh_owner = f"tbb::detail::d1::{fresh_bare_name}"
+        fresh = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(fresh_bare_name, qualified=fresh_owner)],
+            functions=[
+                Function(
+                    name="raii_guard::raii_guard",
+                    mangled=f"__abicheck_ctor__{fresh_owner}()",
+                    return_type="void",
+                )
+            ],
+        )
+        rewrite_anonymous_type_spellings(fresh, strip_anonymous_type_location)
+        renumber_anonymous_closure_identities(fresh)
+
+        assert legacy_baseline.types[0].qualified_name == fresh.types[0].qualified_name
+        assert legacy_baseline.functions[0].mangled == fresh.functions[0].mangled
+
+        result = compare(legacy_baseline, fresh)
+        noisy_kinds = {
+            ChangeKind.FUNC_REMOVED,
+            ChangeKind.FUNC_ADDED,
+            ChangeKind.TYPE_REMOVED,
+            ChangeKind.TYPE_ADDED,
+        }
+        assert not ({c.kind for c in result.changes} & noisy_kinds)
+
+    @given(
+        old_line=st.integers(min_value=1, max_value=5000),
+        new_line=st.integers(min_value=1, max_value=5000),
+        old_root=st.sampled_from(["/home/build/src", "/home/alice/onetbb", "/a"]),
+        new_root=st.sampled_from(["/ci/checkout/src", "/home/bob/onetbb-2", "/b/c/d"]),
+        header=st.sampled_from(["task_group.h", "flow_graph.h", "concurrent_queue.h"]),
+    )
+    @settings(max_examples=50)
+    def test_property_no_phantom_findings_for_any_line_or_root_drift(
+        self, old_line: int, new_line: int, old_root: str, new_root: str, header: str
+    ) -> None:
+        """General invariant (not just the one reported line/root pair
+        above): a raw pre-strip baseline compared against a fresh dump of
+        the identical, unedited closure-parameterized declaration must
+        never manufacture a removed/added pair, regardless of which lines
+        or checkout roots either side happens to use."""
+        owner_old = f"raii_guard<{_raw_closure(header, old_line, 26, old_root)}>"
+        legacy_dict = {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [{"name": owner_old, "kind": "class", "size_bits": 8}],
+        }
+        legacy_baseline = snapshot_from_dict(legacy_dict)
+
+        owner_new = f"raii_guard<{_raw_closure(header, new_line, 26, new_root)}>"
+        fresh = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(owner_new)],
+        )
+        rewrite_anonymous_type_spellings(fresh, strip_anonymous_type_location)
+        renumber_anonymous_closure_identities(fresh)
+
+        assert legacy_baseline.types[0].name == fresh.types[0].name
+
+        result = compare(legacy_baseline, fresh)
+        noisy_kinds = {ChangeKind.TYPE_REMOVED, ChangeKind.TYPE_ADDED}
+        assert not ({c.kind for c in result.changes} & noisy_kinds)
+
+    def test_rewrite_is_idempotent_on_an_already_stripped_snapshot(self) -> None:
+        """`rewrite_anonymous_type_spellings` is applied unconditionally on
+        every load, including a snapshot that was already fully normalized
+        (the overwhelmingly common case) -- it must be a true no-op there,
+        not just harmless-by-luck."""
+        already_stripped = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(f"raii_guard<{_closure('task_group.h', 539, 26)}>")],
+        )
+        before = already_stripped.types[0].name
+        rewrite_anonymous_type_spellings(
+            already_stripped, strip_anonymous_type_location
+        )
+        assert already_stripped.types[0].name == before
+
+        already_ordinal = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record("raii_guard<(lambda:task_group.h#1)>")],
+        )
+        before = already_ordinal.types[0].name
+        rewrite_anonymous_type_spellings(already_ordinal, strip_anonymous_type_location)
+        assert already_ordinal.types[0].name == before
+
+    def test_multiple_raw_lambdas_in_one_header_still_get_distinct_ordinals(
+        self,
+    ) -> None:
+        """Mirrors the real report's shape (thousands of raw markers in one
+        baseline, not just one): several distinct raw closures in the same
+        header must each survive stripping with their own identity and
+        still be renumbered by RELATIVE SOURCE ORDER, exactly as a snapshot
+        that was already stripped at dump time would be."""
+        raw_names = [
+            f"raii_guard<{_raw_closure('task_group.h', line, 26)}>"
+            for line in (522, 520, 539, 528)
+        ]
+        legacy_dict = {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [{"name": n, "kind": "class"} for n in raw_names],
+        }
+        loaded = snapshot_from_dict(legacy_dict)
+        loaded_names = [t.name for t in loaded.types]
+
+        stripped_then_renumbered = [
+            f"raii_guard<{_closure('task_group.h', line, 26)}>"
+            for line in (522, 520, 539, 528)
+        ]
+        expected_snapshot = AbiSnapshot(
+            library="libtbb.so",
+            version="2021.13.0",
+            types=[_record(n) for n in stripped_then_renumbered],
+        )
+        renumber_anonymous_closure_identities(expected_snapshot)
+        expected_names = [t.name for t in expected_snapshot.types]
+
+        assert loaded_names == expected_names
+        # Every entry actually got an ordinal -- none left in :line:col form.
+        assert all("#" in n for n in loaded_names)
 
 
 class TestKnownLimitationDifferentFilesSharingABasename:

--- a/tests/test_lambda_identity_ordinal.py
+++ b/tests/test_lambda_identity_ordinal.py
@@ -39,12 +39,10 @@ identical ordinal to the identical closure.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import pytest
-from hypothesis import given, settings, strategies as st
 
 from abicheck.buildsource.graph_facts import GraphEdge, GraphNode
 from abicheck.buildsource.pack import BuildSourcePack
@@ -64,9 +62,8 @@ from abicheck.qualified_name_segments import (
     apply_anonymous_type_ordinals,
     collect_anonymous_type_ordinals,
     renumber_anonymous_closure_identities,
-    rewrite_anonymous_type_spellings,
 )
-from abicheck.serialization import load_snapshot, snapshot_from_dict
+from abicheck.serialization import snapshot_from_dict
 
 
 # Frozen/mutable fixtures for TestFrozenDataclassesReachableFromTheWalkAreRebuilt
@@ -495,240 +492,6 @@ class TestLegacyPersistedSnapshotsAreRenumberedOnLoad:
         }
         loaded = snapshot_from_dict(already_ordinal)
         assert loaded.types[0].name == "raii_guard<(lambda:task_group.h#1)>"
-
-
-def _raw_closure(
-    header: str, line: int, col: int, root: str = "/home/build/src"
-) -> str:
-    """A genuinely RAW, pre-``strip_anonymous_type_location`` closure marker
-    -- what a baseline written before that normalizer existed (or one
-    produced by a dumper build that predates it) actually carries on disk,
-    unlike this file's own ``_closure`` helper above which already applies
-    the strip before the fixture is ever built."""
-    return f"(lambda at {root}/{header}:{line}:{col})"
-
-
-class TestRawPreStripBaselinesAreNormalizedOnLoad:
-    """A baseline persisted by an abicheck build from *before*
-    ``strip_anonymous_type_location`` existed (or a dumper build that never
-    called it) still carries the fully raw ``(lambda at
-    <checkout-root>/<header>:<line>:<col>)`` spelling on disk -- not the
-    intermediate ``(lambda:<basename>:<line>:<col>)`` form every other
-    "legacy" fixture in this file already starts from.
-
-    Bug: ``renumber_anonymous_closure_identities``'s own marker regex
-    (``_ANON_TYPE_MARKER_PREFIX_RE = r"\\((lambda|unnamed\\s+\\w+):"``)
-    requires the colon that only the STRIPPED spelling has right after the
-    marker keyword -- ``"(lambda at "`` never matches it. Since
-    ``strip_anonymous_type_location`` was called only from the two
-    header-mode dumpers' extraction-time code paths and never from
-    ``snapshot_from_dict``, loading such a baseline left its closures
-    completely unrenumbered: still absolute-path-and-line-tainted, while a
-    freshly dumped snapshot of the identical, unedited declaration is
-    fully stripped and ordinal-renumbered -- a spurious
-    type/func removed+added pair purely from where/when the baseline was
-    produced, not from any real ABI change. Fixed by
-    ``snapshot_from_dict`` calling ``rewrite_anonymous_type_spellings(snap,
-    strip_anonymous_type_location)`` immediately before renumbering.
-    """
-
-    def _raw_legacy_dict(
-        self, line: int, header: str = "task_group.h", root: str = "/home/build/src"
-    ) -> dict:
-        owner = f"tbb::detail::d1::raii_guard<{_raw_closure(header, line, 26, root)}>"
-        return {
-            "library": "libtbb.so",
-            "version": "2021.13.0",
-            "schema_version": 25,
-            "types": [
-                {
-                    "name": owner.rsplit("::", 1)[-1],
-                    "qualified_name": owner,
-                    "kind": "class",
-                    "size_bits": 8,
-                }
-            ],
-            "functions": [
-                {
-                    "name": "raii_guard::raii_guard",
-                    "mangled": f"__abicheck_ctor__{owner}()",
-                    "return_type": "void",
-                }
-            ],
-        }
-
-    def test_loading_a_raw_pre_strip_snapshot_strips_and_renumbers_it(self) -> None:
-        loaded = snapshot_from_dict(self._raw_legacy_dict(522))
-        qualified = loaded.types[0].qualified_name
-        assert qualified is not None
-        assert "#" in qualified
-        assert " at " not in qualified
-
-    def test_loading_a_raw_pre_strip_snapshot_from_a_real_json_file_on_disk(
-        self, tmp_path: Path
-    ) -> None:
-        """Same fixture as above, but through the REAL public loading
-        boundary (`load_snapshot` -> `snapshot_io.read_snapshot_text` ->
-        `json.loads` -> `snapshot_from_dict`) against an actual file on
-        disk, not a hand-built Python dict handed directly to the internal
-        function -- the exact "real dependency" gap ADR-059 SS12 warns
-        about for a serialization-boundary fix (a test against only the
-        in-memory shortcut can pass identically before and after the bug)."""
-        path = tmp_path / "onetbb_old.abi.json"
-        path.write_text(json.dumps(self._raw_legacy_dict(522)), encoding="utf-8")
-
-        loaded = load_snapshot(path)
-
-        qualified = loaded.types[0].qualified_name
-        assert qualified is not None
-        assert "#" in qualified
-        assert " at " not in qualified
-        assert "/home/build/src" not in qualified
-        assert ":522:" not in qualified
-
-    def test_raw_pre_strip_baseline_agrees_with_a_fresh_dump_across_line_and_root_drift(
-        self,
-    ) -> None:
-        legacy_baseline = snapshot_from_dict(self._raw_legacy_dict(522))
-
-        # A fresh dump: checked out to a DIFFERENT root, with an unrelated
-        # earlier edit shifting the same, unedited closure to a new line --
-        # exactly what the real dumper produces (strip, then renumber),
-        # simulated the same way this file's own `_closure` helper does for
-        # the intermediate-form fixtures above.
-        fresh_bare_name = (
-            "raii_guard<"
-            f"{_raw_closure('task_group.h', 539, 26, root='/ci/checkout/src')}>"
-        )
-        fresh_owner = f"tbb::detail::d1::{fresh_bare_name}"
-        fresh = AbiSnapshot(
-            library="libtbb.so",
-            version="2022.3.0",
-            types=[_record(fresh_bare_name, qualified=fresh_owner)],
-            functions=[
-                Function(
-                    name="raii_guard::raii_guard",
-                    mangled=f"__abicheck_ctor__{fresh_owner}()",
-                    return_type="void",
-                )
-            ],
-        )
-        rewrite_anonymous_type_spellings(fresh, strip_anonymous_type_location)
-        renumber_anonymous_closure_identities(fresh)
-
-        assert legacy_baseline.types[0].qualified_name == fresh.types[0].qualified_name
-        assert legacy_baseline.functions[0].mangled == fresh.functions[0].mangled
-
-        result = compare(legacy_baseline, fresh)
-        noisy_kinds = {
-            ChangeKind.FUNC_REMOVED,
-            ChangeKind.FUNC_ADDED,
-            ChangeKind.TYPE_REMOVED,
-            ChangeKind.TYPE_ADDED,
-        }
-        assert not ({c.kind for c in result.changes} & noisy_kinds)
-
-    @given(
-        old_line=st.integers(min_value=1, max_value=5000),
-        new_line=st.integers(min_value=1, max_value=5000),
-        old_root=st.sampled_from(["/home/build/src", "/home/alice/onetbb", "/a"]),
-        new_root=st.sampled_from(["/ci/checkout/src", "/home/bob/onetbb-2", "/b/c/d"]),
-        header=st.sampled_from(["task_group.h", "flow_graph.h", "concurrent_queue.h"]),
-    )
-    @settings(max_examples=50)
-    def test_property_no_phantom_findings_for_any_line_or_root_drift(
-        self, old_line: int, new_line: int, old_root: str, new_root: str, header: str
-    ) -> None:
-        """General invariant (not just the one reported line/root pair
-        above): a raw pre-strip baseline compared against a fresh dump of
-        the identical, unedited closure-parameterized declaration must
-        never manufacture a removed/added pair, regardless of which lines
-        or checkout roots either side happens to use."""
-        owner_old = f"raii_guard<{_raw_closure(header, old_line, 26, old_root)}>"
-        legacy_dict = {
-            "library": "libtbb.so",
-            "version": "2021.13.0",
-            "schema_version": 25,
-            "types": [{"name": owner_old, "kind": "class", "size_bits": 8}],
-        }
-        legacy_baseline = snapshot_from_dict(legacy_dict)
-
-        owner_new = f"raii_guard<{_raw_closure(header, new_line, 26, new_root)}>"
-        fresh = AbiSnapshot(
-            library="libtbb.so",
-            version="2022.3.0",
-            types=[_record(owner_new)],
-        )
-        rewrite_anonymous_type_spellings(fresh, strip_anonymous_type_location)
-        renumber_anonymous_closure_identities(fresh)
-
-        assert legacy_baseline.types[0].name == fresh.types[0].name
-
-        result = compare(legacy_baseline, fresh)
-        noisy_kinds = {ChangeKind.TYPE_REMOVED, ChangeKind.TYPE_ADDED}
-        assert not ({c.kind for c in result.changes} & noisy_kinds)
-
-    def test_rewrite_is_idempotent_on_an_already_stripped_snapshot(self) -> None:
-        """`rewrite_anonymous_type_spellings` is applied unconditionally on
-        every load, including a snapshot that was already fully normalized
-        (the overwhelmingly common case) -- it must be a true no-op there,
-        not just harmless-by-luck."""
-        already_stripped = AbiSnapshot(
-            library="libtbb.so",
-            version="2022.3.0",
-            types=[_record(f"raii_guard<{_closure('task_group.h', 539, 26)}>")],
-        )
-        before = already_stripped.types[0].name
-        rewrite_anonymous_type_spellings(
-            already_stripped, strip_anonymous_type_location
-        )
-        assert already_stripped.types[0].name == before
-
-        already_ordinal = AbiSnapshot(
-            library="libtbb.so",
-            version="2022.3.0",
-            types=[_record("raii_guard<(lambda:task_group.h#1)>")],
-        )
-        before = already_ordinal.types[0].name
-        rewrite_anonymous_type_spellings(already_ordinal, strip_anonymous_type_location)
-        assert already_ordinal.types[0].name == before
-
-    def test_multiple_raw_lambdas_in_one_header_still_get_distinct_ordinals(
-        self,
-    ) -> None:
-        """Mirrors the real report's shape (thousands of raw markers in one
-        baseline, not just one): several distinct raw closures in the same
-        header must each survive stripping with their own identity and
-        still be renumbered by RELATIVE SOURCE ORDER, exactly as a snapshot
-        that was already stripped at dump time would be."""
-        raw_names = [
-            f"raii_guard<{_raw_closure('task_group.h', line, 26)}>"
-            for line in (522, 520, 539, 528)
-        ]
-        legacy_dict = {
-            "library": "libtbb.so",
-            "version": "2021.13.0",
-            "schema_version": 25,
-            "types": [{"name": n, "kind": "class"} for n in raw_names],
-        }
-        loaded = snapshot_from_dict(legacy_dict)
-        loaded_names = [t.name for t in loaded.types]
-
-        stripped_then_renumbered = [
-            f"raii_guard<{_closure('task_group.h', line, 26)}>"
-            for line in (522, 520, 539, 528)
-        ]
-        expected_snapshot = AbiSnapshot(
-            library="libtbb.so",
-            version="2021.13.0",
-            types=[_record(n) for n in stripped_then_renumbered],
-        )
-        renumber_anonymous_closure_identities(expected_snapshot)
-        expected_names = [t.name for t in expected_snapshot.types]
-
-        assert loaded_names == expected_names
-        # Every entry actually got an ordinal -- none left in :line:col form.
-        assert all("#" in n for n in loaded_names)
 
 
 class TestKnownLimitationDifferentFilesSharingABasename:

--- a/tests/test_lambda_identity_ordinal.py
+++ b/tests/test_lambda_identity_ordinal.py
@@ -39,6 +39,7 @@ identical ordinal to the identical closure.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -65,7 +66,7 @@ from abicheck.qualified_name_segments import (
     renumber_anonymous_closure_identities,
     rewrite_anonymous_type_spellings,
 )
-from abicheck.serialization import snapshot_from_dict
+from abicheck.serialization import load_snapshot, snapshot_from_dict
 
 
 # Frozen/mutable fixtures for TestFrozenDataclassesReachableFromTheWalkAreRebuilt
@@ -558,6 +559,26 @@ class TestRawPreStripBaselinesAreNormalizedOnLoad:
 
     def test_loading_a_raw_pre_strip_snapshot_strips_and_renumbers_it(self) -> None:
         loaded = snapshot_from_dict(self._raw_legacy_dict(522))
+        qualified = loaded.types[0].qualified_name
+        assert qualified is not None
+        assert "#" in qualified
+        assert " at " not in qualified
+
+    def test_loading_a_raw_pre_strip_snapshot_from_a_real_json_file_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """Same fixture as above, but through the REAL public loading
+        boundary (`load_snapshot` -> `snapshot_io.read_snapshot_text` ->
+        `json.loads` -> `snapshot_from_dict`) against an actual file on
+        disk, not a hand-built Python dict handed directly to the internal
+        function -- the exact "real dependency" gap ADR-059 SS12 warns
+        about for a serialization-boundary fix (a test against only the
+        in-memory shortcut can pass identically before and after the bug)."""
+        path = tmp_path / "onetbb_old.abi.json"
+        path.write_text(json.dumps(self._raw_legacy_dict(522)), encoding="utf-8")
+
+        loaded = load_snapshot(path)
+
         qualified = loaded.types[0].qualified_name
         assert qualified is not None
         assert "#" in qualified

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -312,3 +312,39 @@ class TestAddedSideCrossPositionAmbiguityAlsoResolvesViaGlobalSupport:
         assert groups.get(("old", "new")) == [("R::old::h", "R::new::h")]
         changes = emit_namespace_move_batches(groups)
         assert changes == []
+
+    def test_a_competitor_resolved_elsewhere_does_not_dismiss_an_unrelated_unresolved_claim(
+        self,
+    ) -> None:
+        """Code review (fresh evidence): the first version of this fix
+        scoped dismissibility per COMPETITOR only ("did this removed
+        symbol resolve to any key at all"), not per (competitor, added
+        identity) pair. `Q::old::f` has TWO masking positions: position 0
+        resolves cleanly to `S::old::f` (key ("Q", "S"), uncorroborated but
+        genuinely resolved -- an entirely unrelated target), while
+        position 1 -- its actual competing claim on `Q::new::f`, the
+        target `P::new::f` wants -- is itself locally ambiguous (it
+        matches BOTH `Q::new::f` and `Q::alt::f`) and never gets its own
+        `entries` row. The unrelated, resolved ("Q", "S") claim must not
+        vouch for the unresolved, still-live ("old", "new") rivalry on
+        `Q::new::f` -- doing so fabricated a 2-pair `P` -> `Q` batch that
+        should not exist (the `Q::old::f` -> `Q::new::f` question is
+        genuinely unresolved, exactly the round-4 scenario's shape, just
+        with the unresolved claim now hidden behind a red-herring resolved
+        one on a different target)."""
+        removed = {
+            "_ZN1P3new1fEv",
+            "_ZN1P3new1gEv",
+            "_ZN1Q3old1fEv",
+        }
+        added = {
+            "_ZN1Q3new1fEv",
+            "_ZN1Q3new1gEv",
+            "_ZN1Q3alt1fEv",
+            "_ZN1S3old1fEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert ("P::new::f", "Q::new::f") not in groups.get(("P", "Q"), [])
+        assert groups.get(("P", "Q")) == [("P::new::g", "Q::new::g")]
+        changes = emit_namespace_move_batches(groups)
+        assert changes == [], "a red-herring resolved claim fabricated a batch"

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -30,11 +30,13 @@ alongside this fix).
 
 from __future__ import annotations
 
+from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind
 from abicheck.diff_symbols_renames import (
     emit_namespace_move_batches,
     find_namespace_move_groups,
 )
+from abicheck.model import AbiSnapshot, Function, Visibility
 
 
 class TestCrossPositionAmbiguityResolvesViaGlobalSupport:
@@ -161,3 +163,152 @@ class TestCrossPositionAmbiguityResolvesViaGlobalSupport:
         groups = find_namespace_move_groups(removed, added)
         assert groups == {}
         assert emit_namespace_move_batches(groups) == []
+
+
+class TestAddedSideCrossPositionAmbiguityAlsoResolvesViaGlobalSupport:
+    """Follow-up to a later code-review report's own item 6: the corroboration
+    test above (``removed_id_to_added_symbols`` ambiguity -- ONE removed
+    symbol with multiple candidate added targets) was never extended to its
+    exact mirror -- ``added_id_to_removed_symbols`` ambiguity, ONE added
+    symbol claimed by multiple distinct removed identities. That asymmetry
+    silently dropped a real batch member (or, in the case below, an entire
+    batch under its 2+-pair threshold) whenever an unrelated, isolated,
+    uncorroborated removed identity happened to coincidentally collide with
+    one of the batch's own added targets -- reported as "batch still cites
+    7 of 15" against a real oneTBB comparison.
+
+    The fix cannot just reuse the removed-side test's shape: there, every
+    competing key belongs to the SAME removed symbol (its own alternate
+    masking positions), so subtracting that one symbol from a key's
+    supporter set is enough to ask "does anyone else back this option". On
+    the added side, each competing key belongs to a DIFFERENT removed
+    identity, and that competitor may itself never have resolved to any
+    single key at all (see
+    ``TestFindNamespaceMoveGroupsRetainsLocallyAmbiguousCandidatesGlobally``
+    in ``test_batch_rename_namespace_move.py`` -- confirmed unaffected by
+    this fix) -- an unresolved competitor is a live, irreducible threat and
+    must still veto. Only a competitor that DID resolve to its own key can
+    be assessed, and only dismissed when that key carries no support from
+    anyone besides the competitor itself.
+    """
+
+    def test_a_real_batch_below_threshold_is_recovered(self) -> None:
+        """Without the fix: `P::new::f` -> `Q::new::f` is unconditionally
+        rejected because `Q::new::f` is ALSO claimed by the coincidental,
+        single-member `Q::old::f` (an unrelated, uncorroborated "old" ->
+        "new" leaf rename) -- dropping the real "P" -> "Q" substitution to
+        a single supporting pair (`P::new::g` -> `Q::new::g` alone), below
+        `emit_namespace_move_batches`' 2+-pair threshold, so the whole
+        batch silently never gets reported at all."""
+        removed = {"_ZN1P3new1fEv", "_ZN1P3new1gEv", "_ZN1Q3old1fEv"}
+        added = {"_ZN1Q3new1fEv", "_ZN1Q3new1gEv"}
+        groups = find_namespace_move_groups(removed, added)
+        assert groups.get(("P", "Q")) == [
+            ("P::new::f", "Q::new::f"),
+            ("P::new::g", "Q::new::g"),
+        ]
+        # The isolated coincidence itself never forms its own group -- its
+        # own key has no corroboration beyond itself either.
+        assert ("old", "new") not in groups
+
+        changes = emit_namespace_move_batches(groups)
+        assert len(changes) == 1
+        assert changes[0].kind is ChangeKind.SYMBOL_RENAMED_BATCH
+
+    def test_a_real_batch_below_threshold_is_recovered_through_compare(self) -> None:
+        """The same scenario as
+        `test_a_real_batch_below_threshold_is_recovered` above, but through
+        the real public entry point (`compare`), the same way
+        `test_batch_rename_namespace_move.py`'s own end-to-end tests do."""
+        old = AbiSnapshot(
+            library="libfoo.so",
+            version="1.0",
+            functions=[
+                Function(
+                    name="P::new::f",
+                    mangled="_ZN1P3new1fEv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(
+                    name="P::new::g",
+                    mangled="_ZN1P3new1gEv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(
+                    name="Q::old::f",
+                    mangled="_ZN1Q3old1fEv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+        )
+        new = AbiSnapshot(
+            library="libfoo.so",
+            version="2.0",
+            functions=[
+                Function(
+                    name="Q::new::f",
+                    mangled="_ZN1Q3new1fEv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(
+                    name="Q::new::g",
+                    mangled="_ZN1Q3new1gEv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+        )
+        result = compare(old, new)
+        batch = [c for c in result.changes if c.kind is ChangeKind.SYMBOL_RENAMED_BATCH]
+        assert batch, "the 'P' -> 'Q' namespace move produced no batch roll-up"
+        assert "P" in batch[0].description and "Q" in batch[0].description
+
+    def test_a_repeated_segment_collision_on_the_added_side_still_rejects(
+        self,
+    ) -> None:
+        """The added-side mirror of `raw_symbol_key_targets`'s
+        repeated-segment guard: `old::new::f` (masked at position 0:
+        "old" -> "new") and `new::old::f` (masked at position 1:
+        "old" -> "new") both key as the IDENTICAL text ("old", "new") AND
+        both converge on the SAME added declaration `new::new::f` -- an
+        irresolvable ambiguity about which removed declaration is the real
+        source, not real corroboration, so this must reject entirely."""
+        removed = {"_ZN3old3new1fEv", "_ZN3new3old1fEv"}
+        added = {"_ZN3new3new1fEv"}
+        groups = find_namespace_move_groups(removed, added)
+        assert groups == {}
+
+    def test_a_genuine_added_side_tie_still_rejects(self) -> None:
+        """When the competing removed identity (`Q::old::f`, proposing an
+        unrelated "old" -> "new" leaf substitution for the SAME added
+        target `Q::new::f` the "P" -> "Q" batch wants) is ITSELF
+        independently corroborated by another member (`R::old::h` ->
+        `R::new::h`, also "old" -> "new"), the ambiguity is real and
+        neither side yields for the contested pair: it drops out of BOTH
+        candidate groups, leaving each at a single, unambiguous
+        supporting pair -- correctly below the 2+-pair batch-emission
+        threshold, not a fabricated 2-pair batch on either side."""
+        removed = {
+            "_ZN1P3new1fEv",
+            "_ZN1P3new1gEv",
+            "_ZN1Q3old1fEv",
+            "_ZN1R3old1hEv",
+        }
+        added = {
+            "_ZN1Q3new1fEv",
+            "_ZN1Q3new1gEv",
+            "_ZN1R3new1hEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        # The contested pair joins neither group...
+        assert ("P::new::f", "Q::new::f") not in groups.get(("P", "Q"), [])
+        assert ("Q::old::f", "Q::new::f") not in groups.get(("old", "new"), [])
+        # ...but each side's own unambiguous, unrelated member still does.
+        assert groups.get(("P", "Q")) == [("P::new::g", "Q::new::g")]
+        assert groups.get(("old", "new")) == [("R::old::h", "R::new::h")]
+        changes = emit_namespace_move_batches(groups)
+        assert changes == []

--- a/tests/test_namespace_move_cross_position_ambiguity.py
+++ b/tests/test_namespace_move_cross_position_ambiguity.py
@@ -348,3 +348,33 @@ class TestAddedSideCrossPositionAmbiguityAlsoResolvesViaGlobalSupport:
         assert groups.get(("P", "Q")) == [("P::new::g", "Q::new::g")]
         changes = emit_namespace_move_batches(groups)
         assert changes == [], "a red-herring resolved claim fabricated a batch"
+
+    def test_a_competitor_with_two_targets_under_the_same_key_still_vetoes(
+        self,
+    ) -> None:
+        """Codex review, second round: `_competitor_is_dismissible` treated
+        ANY `entries` row for the exact (competitor, added_id) pair as proof
+        the competitor was uniquely resolved -- but `Q::Q::f` has TWO
+        masking positions that happen to share the IDENTICAL key tokens
+        ("Q", "new"): position 1 targets `Q::new::f` and position 0 targets
+        `new::Q::f`. An entry existing for `(Q::Q::f, Q::new::f)` does not
+        mean `Q::Q::f`'s candidacy under key ("Q", "new") is unambiguous --
+        it also reaches `new::Q::f` under that same key, so it must still
+        veto `P::new::f -> Q::new::f` rather than being dismissed as an
+        uncorroborated coincidence (which would also let `Q::Q::f` resolve
+        to both `Q::new::f` and the single-claimant `new::Q::f` at once)."""
+        removed = {
+            "_ZN1P3new1fEv",
+            "_ZN1P3new1gEv",
+            "_ZN1Q1Q1fEv",
+        }
+        added = {
+            "_ZN1Q3new1fEv",
+            "_ZN1Q3new1gEv",
+            "_ZN3new1Q1fEv",
+        }
+        groups = find_namespace_move_groups(removed, added)
+        assert ("P::new::f", "Q::new::f") not in groups.get(("P", "Q"), [])
+        assert groups.get(("P", "Q")) == [("P::new::g", "Q::new::g")]
+        changes = emit_namespace_move_batches(groups)
+        assert changes == [], "a multi-target competitor key fabricated a batch"

--- a/tests/test_raw_pre_strip_snapshot_normalization.py
+++ b/tests/test_raw_pre_strip_snapshot_normalization.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A closure's identity must survive a genuinely RAW, pre-strip on-disk
+baseline, not just the already-stripped "legacy" shape
+``tests/test_lambda_identity_ordinal.py`` covers.
+
+Split out of that file (Codex review: the added block pushed it past the
+architecture gate's 1200-line test-file cap) rather than folded into it --
+same fixture family, same closure-identity invariant, but exercising the
+``storage.snapshot_load_normalization`` on-load migration specifically.
+
+Reported: ``strip_anonymous_type_location`` is only ever applied at
+header-extraction time (the two header-mode dumpers' own parsing code), never
+on the ``snapshot_from_dict`` load path. A baseline written before that
+normalizer existed -- or by a dumper build that never called it -- still
+carries the fully raw ``(lambda at <checkout-root>/<header>:<line>:<col>)``
+spelling on disk. ``renumber_anonymous_closure_identities``'s own marker
+regex requires the colon that only the STRIPPED spelling has right after the
+marker keyword, so loading such a baseline left its closures completely
+unrenumbered: still absolute-path-and-line-tainted, while a freshly dumped
+snapshot of the identical, unedited declaration is fully stripped and
+ordinal-renumbered -- a spurious type/func removed+added pair purely from
+where/when the baseline was produced, not from any real ABI change. Fixed by
+``snapshot_from_dict`` calling ``storage.snapshot_load_normalization.
+normalize_anonymous_type_spellings_on_load`` immediately before renumbering.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hypothesis import given, settings, strategies as st
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.model import AbiSnapshot, Function, RecordType
+from abicheck.name_classification import strip_anonymous_type_location
+from abicheck.qualified_name_segments import renumber_anonymous_closure_identities
+from abicheck.serialization import load_snapshot, snapshot_from_dict
+from abicheck.storage.snapshot_load_normalization import (
+    normalize_anonymous_type_spellings_on_load,
+)
+
+
+def _closure(header: str, line: int, col: int) -> str:
+    """Already-stripped closure marker, matching a freshly dumped snapshot's
+    own spelling (the dumpers strip at extraction time, before this text
+    would ever reach a snapshot field)."""
+    return strip_anonymous_type_location(f"(lambda at /src/x/{header}:{line}:{col})")
+
+
+def _record(name: str, qualified: str | None = None) -> RecordType:
+    return RecordType(name=name, kind="class", qualified_name=qualified, size_bits=8)
+
+
+def _raw_closure(
+    header: str, line: int, col: int, root: str = "/home/build/src"
+) -> str:
+    """A genuinely RAW, pre-``strip_anonymous_type_location`` closure marker
+    -- what a baseline written before that normalizer existed (or one
+    produced by a dumper build that predates it) actually carries on disk,
+    unlike this module's own ``_closure`` helper above which already applies
+    the strip before the fixture is ever built."""
+    return f"(lambda at {root}/{header}:{line}:{col})"
+
+
+class TestRawPreStripBaselinesAreNormalizedOnLoad:
+    """A baseline persisted by an abicheck build from *before*
+    ``strip_anonymous_type_location`` existed (or a dumper build that never
+    called it) still carries the fully raw ``(lambda at
+    <checkout-root>/<header>:<line>:<col>)`` spelling on disk -- not the
+    intermediate ``(lambda:<basename>:<line>:<col>)`` form every "legacy"
+    fixture in ``test_lambda_identity_ordinal.py`` already starts from.
+    """
+
+    def _raw_legacy_dict(
+        self, line: int, header: str = "task_group.h", root: str = "/home/build/src"
+    ) -> dict:
+        owner = f"tbb::detail::d1::raii_guard<{_raw_closure(header, line, 26, root)}>"
+        return {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [
+                {
+                    "name": owner.rsplit("::", 1)[-1],
+                    "qualified_name": owner,
+                    "kind": "class",
+                    "size_bits": 8,
+                }
+            ],
+            "functions": [
+                {
+                    "name": "raii_guard::raii_guard",
+                    "mangled": f"__abicheck_ctor__{owner}()",
+                    "return_type": "void",
+                }
+            ],
+        }
+
+    def test_loading_a_raw_pre_strip_snapshot_strips_and_renumbers_it(self) -> None:
+        loaded = snapshot_from_dict(self._raw_legacy_dict(522))
+        qualified = loaded.types[0].qualified_name
+        assert qualified is not None
+        assert "#" in qualified
+        assert " at " not in qualified
+
+    def test_loading_a_raw_pre_strip_snapshot_from_a_real_json_file_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """Same fixture as above, but through the REAL public loading
+        boundary (`load_snapshot` -> `snapshot_io.read_snapshot_text` ->
+        `json.loads` -> `snapshot_from_dict`) against an actual file on
+        disk, not a hand-built Python dict handed directly to the internal
+        function -- the exact "real dependency" gap ADR-059 SS12 warns
+        about for a serialization-boundary fix (a test against only the
+        in-memory shortcut can pass identically before and after the bug)."""
+        path = tmp_path / "onetbb_old.abi.json"
+        path.write_text(json.dumps(self._raw_legacy_dict(522)), encoding="utf-8")
+
+        loaded = load_snapshot(path)
+
+        qualified = loaded.types[0].qualified_name
+        assert qualified is not None
+        assert "#" in qualified
+        assert " at " not in qualified
+        assert "/home/build/src" not in qualified
+        assert ":522:" not in qualified
+
+    def test_raw_pre_strip_baseline_agrees_with_a_fresh_dump_across_line_and_root_drift(
+        self,
+    ) -> None:
+        legacy_baseline = snapshot_from_dict(self._raw_legacy_dict(522))
+
+        # A fresh dump: checked out to a DIFFERENT root, with an unrelated
+        # earlier edit shifting the same, unedited closure to a new line --
+        # exactly what the real dumper produces (strip, then renumber),
+        # simulated the same way this module's own `_closure` helper does
+        # for the intermediate-form fixtures above.
+        fresh_bare_name = (
+            "raii_guard<"
+            f"{_raw_closure('task_group.h', 539, 26, root='/ci/checkout/src')}>"
+        )
+        fresh_owner = f"tbb::detail::d1::{fresh_bare_name}"
+        fresh = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(fresh_bare_name, qualified=fresh_owner)],
+            functions=[
+                Function(
+                    name="raii_guard::raii_guard",
+                    mangled=f"__abicheck_ctor__{fresh_owner}()",
+                    return_type="void",
+                )
+            ],
+        )
+        normalize_anonymous_type_spellings_on_load(fresh)
+        renumber_anonymous_closure_identities(fresh)
+
+        assert legacy_baseline.types[0].qualified_name == fresh.types[0].qualified_name
+        assert legacy_baseline.functions[0].mangled == fresh.functions[0].mangled
+
+        result = compare(legacy_baseline, fresh)
+        noisy_kinds = {
+            ChangeKind.FUNC_REMOVED,
+            ChangeKind.FUNC_ADDED,
+            ChangeKind.TYPE_REMOVED,
+            ChangeKind.TYPE_ADDED,
+        }
+        assert not ({c.kind for c in result.changes} & noisy_kinds)
+
+    @given(
+        old_line=st.integers(min_value=1, max_value=5000),
+        new_line=st.integers(min_value=1, max_value=5000),
+        old_root=st.sampled_from(["/home/build/src", "/home/alice/onetbb", "/a"]),
+        new_root=st.sampled_from(["/ci/checkout/src", "/home/bob/onetbb-2", "/b/c/d"]),
+        header=st.sampled_from(["task_group.h", "flow_graph.h", "concurrent_queue.h"]),
+    )
+    @settings(max_examples=50)
+    def test_property_no_phantom_findings_for_any_line_or_root_drift(
+        self, old_line: int, new_line: int, old_root: str, new_root: str, header: str
+    ) -> None:
+        """General invariant (not just the one reported line/root pair
+        above): a raw pre-strip baseline compared against a fresh dump of
+        the identical, unedited closure-parameterized declaration must
+        never manufacture a removed/added pair, regardless of which lines
+        or checkout roots either side happens to use."""
+        owner_old = f"raii_guard<{_raw_closure(header, old_line, 26, old_root)}>"
+        legacy_dict = {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [{"name": owner_old, "kind": "class", "size_bits": 8}],
+        }
+        legacy_baseline = snapshot_from_dict(legacy_dict)
+
+        owner_new = f"raii_guard<{_raw_closure(header, new_line, 26, new_root)}>"
+        fresh = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(owner_new)],
+        )
+        normalize_anonymous_type_spellings_on_load(fresh)
+        renumber_anonymous_closure_identities(fresh)
+
+        assert legacy_baseline.types[0].name == fresh.types[0].name
+
+        result = compare(legacy_baseline, fresh)
+        noisy_kinds = {ChangeKind.TYPE_REMOVED, ChangeKind.TYPE_ADDED}
+        assert not ({c.kind for c in result.changes} & noisy_kinds)
+
+    def test_rewrite_is_idempotent_on_an_already_stripped_snapshot(self) -> None:
+        """The on-load normalization is applied unconditionally on every
+        load, including a snapshot that was already fully normalized (the
+        overwhelmingly common case) -- it must be a true no-op there, not
+        just harmless-by-luck."""
+        already_stripped = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record(f"raii_guard<{_closure('task_group.h', 539, 26)}>")],
+        )
+        before = already_stripped.types[0].name
+        normalize_anonymous_type_spellings_on_load(already_stripped)
+        assert already_stripped.types[0].name == before
+
+        already_ordinal = AbiSnapshot(
+            library="libtbb.so",
+            version="2022.3.0",
+            types=[_record("raii_guard<(lambda:task_group.h#1)>")],
+        )
+        before = already_ordinal.types[0].name
+        normalize_anonymous_type_spellings_on_load(already_ordinal)
+        assert already_ordinal.types[0].name == before
+
+    def test_multiple_raw_lambdas_in_one_header_still_get_distinct_ordinals(
+        self,
+    ) -> None:
+        """Mirrors the real report's shape (thousands of raw markers in one
+        baseline, not just one): several distinct raw closures in the same
+        header must each survive stripping with their own identity and
+        still be renumbered by RELATIVE SOURCE ORDER, exactly as a snapshot
+        that was already stripped at dump time would be."""
+        raw_names = [
+            f"raii_guard<{_raw_closure('task_group.h', line, 26)}>"
+            for line in (522, 520, 539, 528)
+        ]
+        legacy_dict = {
+            "library": "libtbb.so",
+            "version": "2021.13.0",
+            "schema_version": 25,
+            "types": [{"name": n, "kind": "class"} for n in raw_names],
+        }
+        loaded = snapshot_from_dict(legacy_dict)
+        loaded_names = [t.name for t in loaded.types]
+
+        stripped_then_renumbered = [
+            f"raii_guard<{_closure('task_group.h', line, 26)}>"
+            for line in (522, 520, 539, 528)
+        ]
+        expected_snapshot = AbiSnapshot(
+            library="libtbb.so",
+            version="2021.13.0",
+            types=[_record(n) for n in stripped_then_renumbered],
+        )
+        renumber_anonymous_closure_identities(expected_snapshot)
+        expected_names = [t.name for t in expected_snapshot.types]
+
+        assert loaded_names == expected_names
+        # Every entry actually got an ordinal -- none left in :line:col form.
+        assert all("#" in n for n in loaded_names)

--- a/tests/test_rename_ambiguity_properties.py
+++ b/tests/test_rename_ambiguity_properties.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Primitive-level property tests for
+``compare.rename_ambiguity.added_side_ambiguity_resolver`` (CLAUDE.md's
+"Primitive-level property tests" convention, `abicheck/compare/AGENTS.md`'s
+own "gets its own standalone property-test class" rule for a new matching
+primitive here — Codex review, PR abicheck/abicheck#970).
+
+``tests/test_namespace_move_cross_position_ambiguity.py`` already exercises
+this resolver through its one real caller, ``find_namespace_move_groups``,
+with hand-picked mangled-name scenarios. This file states the resolver's own
+contract as invariants, generated over its actual input shapes directly
+(never through a caller), the way ``test_diff_namespaces.py``'s
+``TestPairedStableIndicesProperties`` does for its own merge primitive.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from abicheck.compare.rename_ambiguity import added_side_ambiguity_resolver
+
+_Entry = tuple[tuple[str, ...], list[str], int, list[str]]
+
+#: Small, disjoint token alphabet -- large enough to build multi-symbol
+#: scenarios without every draw colliding, small enough that Hypothesis
+#: explores real collisions/sharing rather than always drawing distinct
+#: tokens by chance.
+_TOKENS = ("p", "q", "r", "s", "t", "u")
+
+
+def _scopes() -> st.SearchStrategy[tuple[str, ...]]:
+    """A removed/added identity's own full scope chain -- 2 or 3 distinct
+    segments, mirroring a real mangled name's parsed component list."""
+    return st.lists(st.sampled_from(_TOKENS), min_size=2, max_size=3, unique=True).map(
+        tuple
+    )
+
+
+def _build(
+    symbol_and_substitutions: list[tuple[tuple[str, ...], list[tuple[int, str]]]],
+) -> tuple[
+    list[_Entry],
+    dict[str, set[str]],
+    dict[tuple[str, tuple[str, str]], set[str]],
+]:
+    """Replay ``find_namespace_move_groups``'s own Phase 1 bookkeeping for a
+    hand-specified set of (symbol scope, [(position, new_token), ...])
+    entries, producing a self-consistent ``(entries,
+    added_id_to_removed_symbols, raw_symbol_key_targets)`` triple -- exactly
+    the three inputs the caller threads through unchanged from its own raw
+    candidacy loop into :func:`added_side_ambiguity_resolver`.
+    """
+    entries: list[_Entry] = []
+    added_id_to_removed_symbols: dict[str, set[str]] = {}
+    raw_symbol_key_targets: dict[tuple[str, tuple[str, str]], set[str]] = {}
+    for scope, substitutions in symbol_and_substitutions:
+        r_comps = list(scope)
+        symbol_id = "::".join(r_comps)
+        for i, new_token in substitutions:
+            a_comps = list(r_comps)
+            a_comps[i] = new_token
+            added_id = "::".join(a_comps)
+            key = (r_comps[i], new_token)
+            entries.append(((), r_comps, i, a_comps))
+            added_id_to_removed_symbols.setdefault(added_id, set()).add(symbol_id)
+            raw_symbol_key_targets.setdefault((symbol_id, key), set()).add(added_id)
+    return entries, added_id_to_removed_symbols, raw_symbol_key_targets
+
+
+@st.composite
+def _random_scenarios(
+    draw: st.DrawFn,
+) -> tuple[
+    list[_Entry],
+    dict[str, set[str]],
+    dict[tuple[str, tuple[str, str]], set[str]],
+]:
+    """A random, internally-consistent scenario: several symbols, each with
+    zero or more (position, new_token) substitutions -- i.e. an entry per
+    masking position that resolved to a candidate, the shape Phase 1 hands
+    to Phase 2. Symbols may coincidentally share tokens/positions, so
+    genuine corroboration and collision cases both arise by construction."""
+    scopes = draw(st.lists(_scopes(), min_size=1, max_size=4, unique=True))
+    spec: list[tuple[tuple[str, ...], list[tuple[int, str]]]] = []
+    for scope in scopes:
+        subs = []
+        for i in range(len(scope) - 1):
+            if draw(st.booleans()):
+                new_token = draw(
+                    st.sampled_from(_TOKENS).filter(lambda t: t != scope[i])
+                )
+                subs.append((i, new_token))
+        spec.append((scope, subs))
+    return _build(spec)
+
+
+class TestAddedSideAmbiguityResolverProperties:
+    @given(scenario=_random_scenarios())
+    def test_permutation_independence(self, scenario) -> None:
+        """Shuffling `entries`' order must not change `key_support` or any
+        `is_acceptable` verdict -- the resolver groups by dict/set, so its
+        answer must depend only on which entries exist, never on the order
+        they were built or handed in."""
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets = scenario
+        key_support_a, is_acceptable_a = added_side_ambiguity_resolver(
+            entries, added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        key_support_b, is_acceptable_b = added_side_ambiguity_resolver(
+            list(reversed(entries)), added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        assert key_support_a == key_support_b
+        for _masked, r_comps, i, a_comps in entries:
+            symbol_id = "::".join(r_comps)
+            added_id = "::".join(a_comps)
+            key = (r_comps[i], a_comps[i])
+            assert is_acceptable_a(symbol_id, added_id, key) == is_acceptable_b(
+                symbol_id, added_id, key
+            )
+
+    @given(scenario=_random_scenarios())
+    def test_single_claimant_is_always_accepted(self, scenario) -> None:
+        """An added identity claimed by exactly one distinct removed
+        identity is never ambiguous on the added side -- the fast path must
+        accept it unconditionally, regardless of what else is going on
+        elsewhere in the same comparison."""
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets = scenario
+        _key_support, is_acceptable = added_side_ambiguity_resolver(
+            entries, added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        for _masked, r_comps, i, a_comps in entries:
+            symbol_id = "::".join(r_comps)
+            added_id = "::".join(a_comps)
+            key = (r_comps[i], a_comps[i])
+            if len(added_id_to_removed_symbols[added_id]) == 1:
+                assert is_acceptable(symbol_id, added_id, key)
+
+    def test_unresolved_competitor_always_vetoes(self) -> None:
+        """A competitor claimed via `added_id_to_removed_symbols` but that
+        never resolved its OWN candidacy toward this specific added
+        identity into any `entries` row (round-4 scenario,
+        `TestFindNamespaceMoveGroupsRetainsLocallyAmbiguousCandidatesGlobally`)
+        is a live, irreducible threat -- built directly at the primitive
+        level here, not through the caller's mangled-name machinery."""
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets = _build(
+            [
+                (("p", "q", "x"), [(0, "z")]),  # p::q::x -> z::q::x
+                (("r", "q", "x"), [(0, "y")]),  # r::q::x -> y::q::x (unrelated)
+            ]
+        )
+        # A phantom competitor claims the SAME added identity ("z::q::x")
+        # that "p::q::x" resolved to, but never itself appears in `entries`
+        # for that target -- exactly "claimed, never resolved here".
+        added_id_to_removed_symbols["z::q::x"].add("ghost::q::x")
+
+        _key_support, is_acceptable = added_side_ambiguity_resolver(
+            entries, added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        assert not is_acceptable("p::q::x", "z::q::x", ("p", "z"))
+        # The unrelated pairing, sharing no added identity with the ghost,
+        # is untouched.
+        assert is_acceptable("r::q::x", "y::q::x", ("r", "y"))
+
+    def test_a_resolved_uncorroborated_competitor_is_dismissible(self) -> None:
+        """A competitor that DID resolve its own candidacy toward this
+        added identity, but whose resolved key carries no support beyond
+        itself, is a dismissible coincidence -- the well-supported rival
+        claim must still be accepted (the exact fix for the fabricated-
+        batch regression this resolver replaced an unconditional reject
+        with)."""
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets = _build(
+            [
+                (("p", "new", "f"), [(0, "q")]),  # p::new::f -> q::new::f
+                (("p", "new", "g"), [(0, "q")]),  # p::new::g -> q::new::g
+                (("q", "old", "f"), [(1, "new")]),  # q::old::f -> q::new::f
+            ]
+        )
+        _key_support, is_acceptable = added_side_ambiguity_resolver(
+            entries, added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        # "q::new::f" is contested by "p::new::f" (key ("p","q"), backed by
+        # the sibling "g" pair) and "q::old::f" (key ("old","new"), backed
+        # by nothing else) -- the isolated claim must not block the
+        # well-supported one.
+        assert is_acceptable("p::new::f", "q::new::f", ("p", "q"))
+        # "q::old::f"'s own claim has no corroboration of its own key either
+        # -- it is not accepted as a group member (checked by the caller's
+        # separate corroboration test, not this resolver), but it must not
+        # be treated as blocking the other side, which this call alone
+        # already confirms above.

--- a/tests/test_rename_ambiguity_properties.py
+++ b/tests/test_rename_ambiguity_properties.py
@@ -201,3 +201,35 @@ class TestAddedSideAmbiguityResolverProperties:
         # separate corroboration test, not this resolver), but it must not
         # be treated as blocking the other side, which this call alone
         # already confirms above.
+
+    def test_a_competitor_reaching_two_targets_under_the_same_key_still_vetoes(
+        self,
+    ) -> None:
+        """Codex review, second round (`tests/test_namespace_move_cross_
+        position_ambiguity.py`'s caller-level sibling of this test): an
+        `entries` row existing for the exact (competitor, added_id) pair is
+        not proof the competitor is uniquely resolved -- two DIFFERENT
+        masking positions of the SAME removed symbol can share the
+        IDENTICAL key tokens while targeting two DIFFERENT added
+        identities. `"q::q::f"` reaches both `"q::new::f"` (position 1) and
+        `"new::q::f"` (position 0) via the same key `("q", "new")`; an entry
+        exists for `("q::q::f", "q::new::f")`, but `"q::q::f"`'s own claim
+        under `("q", "new")` is not confined to that target, so it must
+        still veto `"p::new::f" -> "q::new::f"` rather than being dismissed
+        as an uncorroborated coincidence."""
+        entries, added_id_to_removed_symbols, raw_symbol_key_targets = _build(
+            [
+                (("p", "new", "f"), [(0, "q")]),  # p::new::f -> q::new::f
+                (("p", "new", "g"), [(0, "q")]),  # p::new::g -> q::new::g
+                (
+                    ("q", "q", "f"),
+                    [(1, "new"), (0, "new")],  # q::q::f -> q::new::f / new::q::f
+                ),
+            ]
+        )
+        _key_support, is_acceptable = added_side_ambiguity_resolver(
+            entries, added_id_to_removed_symbols, raw_symbol_key_targets
+        )
+        assert not is_acceptable("p::new::f", "q::new::f", ("p", "q"))
+        # The single-claimant target is untouched by the other's rejection.
+        assert is_acceptable("q::q::f", "new::q::f", ("q", "new"))

--- a/tests/test_symbol_binding_field.py
+++ b/tests/test_symbol_binding_field.py
@@ -113,15 +113,25 @@ class TestSerializationRoundTrip:
 
     def test_missing_elf_binding_stays_none_when_no_matching_symbol(self) -> None:
         # elf block present, but no .dynsym entry for this declaration's
-        # mangled name -- nothing to backfill from either.
+        # mangled name -- nothing to backfill from either. Covers the
+        # variable branch too (`backfill_missing_elf_binding` walks
+        # functions and variables separately) -- previously exercised only
+        # for functions.
         func = Function(name="f", mangled="_Z1fv", return_type="void")
+        var = Variable(name="g", mangled="g", type="int")
         snap = AbiSnapshot(
-            library="lib.so", version="1.0", functions=[func], elf=ElfMetadata(symbols=[])
+            library="lib.so",
+            version="1.0",
+            functions=[func],
+            variables=[var],
+            elf=ElfMetadata(symbols=[]),
         )
         d = snapshot_to_dict(snap)
         d["functions"][0].pop("elf_binding", None)
+        d["variables"][0].pop("elf_binding", None)
         loaded = snapshot_from_dict(d)
         assert loaded.functions[0].elf_binding is None
+        assert loaded.variables[0].elf_binding is None
 
     def test_explicit_elf_binding_is_not_overwritten_by_backfill(self) -> None:
         # An already-serialized non-None value must be preserved untouched,

--- a/tests/unit/storage/adr062_scope.py
+++ b/tests/unit/storage/adr062_scope.py
@@ -46,7 +46,10 @@ import pathlib
 #: Phase 3's `surface_graph_codec`, the identical shape for
 #: `AbiSnapshot.surface_graph`) — a third, independent body of work in this
 #: package, unrelated to either ADR-062's Phase 0 primitives or G40's
-#: container.
+#: container. `snapshot_load_normalization` is a fourth, equally unrelated
+#: body of work: `serialization.snapshot_from_dict`'s on-load legacy-format
+#: migrations (ADR-061 D1's storage-owns-migrations rule), not a Phase 0
+#: identity/availability/versioning primitive.
 NON_ADR062_MODULES = frozenset(
     {
         "bundle_archive",
@@ -59,6 +62,7 @@ NON_ADR062_MODULES = frozenset(
         "enum_codec",
         "entity_id_codec",
         "surface_graph_codec",
+        "snapshot_load_normalization",
     }
 )
 


### PR DESCRIPTION
## Summary

Two independent, previously-open correctness gaps in the ABI-comparison pipeline: (1) an on-disk baseline predating closure-marker normalization was left unrenumbered on load, and (2) the namespace-move rename batch's added-side ambiguity gate rejected corroborated evidence unconditionally (and, after two rounds of review, had two independent per-competitor scoping bugs of its own).

## Motivation

Both were flagged as open items in a behavioral-drift audit of this repo. Item 9 (new): `strip_anonymous_type_location` is only ever applied at header-extraction time, never on the `snapshot_from_dict` load path, so a baseline written before that normalizer existed — or with a raw `(lambda at ::)` spelling — was never renumbered, silently comparing as unrelated to a freshly-dumped snapshot of the identical declaration. Item 6: `find_namespace_move_groups` already resolves cross-position ambiguity via global-support corroboration when *one removed symbol* has multiple candidate added targets, but rejected the exact mirror — *one added symbol* claimed by multiple removed identities — unconditionally, letting an isolated coincidence silently drop a well-supported batch member (or an entire batch below its 2-pair threshold).

## Changes

- `abicheck/storage/snapshot_load_normalization.py` (new): `normalize_anonymous_type_spellings_on_load()`, called by `serialization.snapshot_from_dict` immediately before renumbering; also houses the pre-existing `backfill_missing_elf_binding` (moved here as the same kind of on-load legacy-format migration, per ADR-061's storage-owns-migrations rule, and to keep `serialization.py` from growing past its debt-baselined adoption ceiling).
- `abicheck/qualified_name_segments.py`: factored the shared "has any anonymous/lambda marker" fast-path gate into `_lambda_identity_containers_and_strings()`, reused by both `renumber_anonymous_closure_identities` and the new storage module; corrected that function's docstring, which previously (falsely) claimed the reverse direction was already closed.
- `abicheck/compare/rename_ambiguity.py` (new): `added_side_ambiguity_resolver()` — the added-side mirror of `find_namespace_move_groups`'s existing removed-side corroboration test (item 6), moved here per ADR-061 (new `compare/` logic routes here, not the debt-baselined flat `diff_symbols_renames.py`). Scoped per `(competitor, added_id)` pair rather than per competitor — an earlier version of this fix scoped it per competitor only and was shown (Codex review) to fabricate a batch when a competitor resolved cleanly at an unrelated target while its actual rivalry on the target in question stayed unresolved. A second Codex review round found a narrower gap of the same shape: an `entries` row for the exact `(competitor, added_id)` pair is not by itself proof the competitor is uniquely resolved, since two different masking positions of the same removed symbol can share identical key tokens while targeting two different added identities — `_competitor_is_dismissible` now also requires the competitor's raw `(competitor_id, resolved_key)` target set to name only this `added_id`.
- `architecture/modules.yaml`: `qualified_name_segments` joined `public_root_surfaces` (the same exemption `serialization.py` itself already uses) so the new storage module can import its shared closure-identity helpers.
- `docs/contribute/known-gaps.md`: extended the existing "L5 source graph identities aren't renumbered" entry to note the new load-time normalization path has the identical, deliberately-deferred flat-vs-graph mismatch (Codex review) — not fixed here, same reasoning as the existing dump-time entry.
- Regression tests: `tests/test_raw_pre_strip_snapshot_normalization.py` (new), `tests/test_namespace_move_cross_position_ambiguity.py` (extended, including the second-round multi-target-competitor-key regression), `tests/test_rename_ambiguity_properties.py` (new — primitive-level property tests for `added_side_ambiguity_resolver`, per `abicheck/compare/AGENTS.md`'s convention for a new matching primitive, including the second-round regression at the primitive level too).
- Changelog fragment.

## Bug-fix test contract


This PR bundles two independent bug-class fixes; each is answered separately below.

**Fix 1 — raw pre-strip closure markers left unrenumbered on load**
- Bug class: a snapshot loaded from disk skips a normalization step (`strip_anonymous_type_location`) that the dump path applies at extraction time, so `renumber_anonymous_closure_identities`'s marker regex (which requires the already-stripped spelling) silently no-ops on a raw `(lambda at ...)` marker.
- Publicly observable failure: comparing a pre-normalization baseline (`scan --against`, `compare`) against a freshly-dumped snapshot of the *identical, unedited* closure-parameterized declaration reports a spurious `type_removed`/`func_removed` plus `type_added`/`func_added` pair purely from checkout-root/line drift, not a real ABI change.
- Regression test fails on base: yes — `TestRawPreStripBaselinesAreNormalizedOnLoad` in `tests/test_raw_pre_strip_snapshot_normalization.py` (all methods) fails on `main` (confirmed locally by reverting the fix and re-running).
- Negative control: `test_rewrite_is_idempotent_on_an_already_stripped_snapshot` confirms a snapshot already in stripped or ordinal form is unaffected (no spurious rewrite).
- Public-surface test: `test_raw_pre_strip_baseline_agrees_with_a_fresh_dump_across_line_and_root_drift` and the `compare()`-based end-to-end assertions go through `snapshot_from_dict` + `compare()`, the real load/compare pipeline, not just the internal helper.
- Real-dependency test: `test_loading_a_raw_pre_strip_snapshot_from_a_real_json_file_on_disk` writes the fixture as real JSON text to a file on disk and loads it through `load_snapshot()` (`snapshot_io.read_snapshot_text` -&gt; `json.loads` -&gt; `snapshot_from_dict`), not a hand-built Python dict handed directly to the internal function — closing the ADR-059 §12 gap (a test against only the in-memory shortcut can pass identically before and after the bug).
- Axes covered: differing checkout root, differing line/col (pure drift), multiple lambdas in one header (ordinal ordering), already-normalized snapshots (idempotence), the real file/JSON loading boundary.
- General invariant: `test_property_no_phantom_findings_for_any_line_or_root_drift` is a Hypothesis property test over randomized lines/roots/headers (50 examples) asserting no `TYPE_REMOVED`/`TYPE_ADDED` finding is ever produced for a raw-marker baseline vs. a fresh dump of the same declaration — not just the one originally-reported line/path pair.

**Fix 2 — namespace-move batch added-side ambiguity gate**
- Bug class: an ambiguity-resolution primitive applies global-support corroboration on one side of a symmetric relation (`removed_id_to_added_symbols`) but not its mirror (`added_id_to_removed_symbols`), so a real, well-supported pairing can be vetoed by an isolated, uncorroborated coincidence purely because the veto happens to originate from the untreated side. A follow-up round of the same bug class: dismissibility was scoped too coarsely twice — first per competitor alone (any resolved key anywhere), then per `(competitor, added_id)` pair without checking whether the competitor's *own* candidacy under that exact key was itself unambiguous.
- Publicly observable failure: `SYMBOL_RENAMED_BATCH` under-reports its own supporting-pairs list, or — when the collateral loss drops a group below 2 pairs — a real namespace-move batch is not reported as a batch at all, reverting to noisy unpaired `func_removed`/`func_added` findings; conversely, an under-scoped dismissibility check fabricates a batch member (and can let one removed symbol resolve to two different added targets at once).
- Regression test fails on base: yes — `test_a_real_batch_below_threshold_is_recovered` and `test_a_real_batch_below_threshold_is_recovered_through_compare` in `tests/test_namespace_move_cross_position_ambiguity.py` fail on `main` (confirmed locally); `test_a_competitor_with_two_targets_under_the_same_key_still_vetoes` (added after the second Codex review round) reproduces the narrower fabricated-batch counterexample and is confirmed to fail against the pre-this-fix version of `_competitor_is_dismissible` (reverted locally and re-run).
- Negative control: `test_a_genuine_added_side_tie_still_rejects` confirms that when the competing identity IS itself independently corroborated, the ambiguity is genuine and both sides still reject; `test_a_repeated_segment_collision_on_the_added_side_still_rejects` confirms the added-side mirror of the repeated-segment collision guard still rejects unconditionally; `test_a_competitor_resolved_elsewhere_does_not_dismiss_an_unrelated_unresolved_claim` (first review round) confirms a competitor resolved on an unrelated target no longer vouches for its own still-unresolved rivalry on the target in question.
- Public-surface test: `test_a_real_batch_below_threshold_is_recovered_through_compare` exercises the real `compare()` entry point.
- Axes covered: dismissible isolated coincidence (recovered), genuinely corroborated competitor (still rejects), repeated-key-text collision on the added side (still rejects), a competitor resolved on an unrelated target (still rejects), a competitor whose own candidacy under the resolved key is itself multi-target (still rejects) — plus the full pre-existing 110-test suite across both rename test files confirmed unaffected, and primitive-level property/example tests in `tests/test_rename_ambiguity_properties.py` (permutation independence, single-claimant fast path, unresolved-competitor-always-vetoes, resolved-uncorroborated-competitor-is-dismissible, multi-target-competitor-key-still-vetoes) exercising the resolver directly, decoupled from the caller.
- General invariant: the fix is structural (a missing corroboration branch mirrored from the existing one, scoped per `(competitor, added_id, resolved_key)` triple with the competitor's own raw candidacy under that key required to be single-target), verified against real-world-shaped scenarios (recovery, genuine tie, repeated-key collision, unrelated-target resolution, multi-target-key resolution) plus the standalone property suite, not just the one reported "7 of 15" case.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — not needed, no user-facing surface (flag/schema/report field) changed; `docs/contribute/known-gaps.md` updated to document a related, deliberately-deferred limitation
- [x] `ruff check` / `ruff format --check` pass on all changed files
- [x] `mypy` passes clean on all changed files
- [x] `scripts/check_architecture.py` reports 0 findings (verified against the real PR base revision)
- [x] No new `mypy` or `ruff` errors introduced
- [x] Full local unit suite passes; the 2 pre-existing failures are confirmed environment-specific and present on `main` too
