### PR TITLE
feat: ADR-063 Phase 6 slice 1 — canonical SemanticIR, persistence, hybrid merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,14 @@ Core pipeline (in order of data flow):
    `from abicheck.elf_metadata import ElfMetadata` still resolves. **A new
    fact's field goes in `model/`, next to the format it belongs to — not in
    the parser.**
+   `model/semantic_ir.py` is ADR-063 Phase 6's canonical, backend-independent
+   IR (`SemanticIR.occurrences`, keyed by `OccurrenceId` so an ODR-duplicate
+   pair is never collapsed; `CanonicalEntity` holds only the non-identity
+   payload). Persisted as `AbiSnapshot.semantic_ir` (schema v38,
+   `storage/semantic_ir_codec.py`) and reconciled across the two header-AST
+   backends by `extract/semantic_ir_merge.py` — but **no backend produces one
+   yet**: the parser narrowing and `extract/semantic_normalizer.py` are the
+   remainder of that phase.
 1. **Parsing** — extract metadata from binaries
    - `elf_metadata.py`, `pe_metadata.py`, `macho_metadata.py` — platform-specific
    - `dwarf_metadata.py`, `dwarf_advanced.py`, `dwarf_unified.py` — DWARF debug info

--- a/abicheck/dumper_hybrid.py
+++ b/abicheck/dumper_hybrid.py
@@ -120,6 +120,7 @@ from .dumper_castxml import (
     is_synthetic_ctor_key,
     is_synthetic_dtor_key,
 )
+from .extract.semantic_ir_merge import merge_semantic_ir
 from .fact_provenance import (
     backfill_fact,
     enum_fact_key,
@@ -854,8 +855,19 @@ def merge_snapshots(castxml_snap: AbiSnapshot, clang_snap: AbiSnapshot) -> AbiSn
         provenance[var_fact_key(v.mangled, "visibility")] = "clang"
     merged_variables.extend(clang_only_variables)
 
+    # ADR-063 Phase 6: the semantic IR needs the same base-plus-backfill
+    # reconciliation every legacy field above already gets. Carrying
+    # castxml's through unchanged, while `functions`/`types` include
+    # clang-only and clang-backfilled data, would leave one freshly built
+    # snapshot's two representations disagreeing (extract/semantic_ir_merge.py).
+    merged_ir, ir_conflicts = merge_semantic_ir(
+        castxml_snap.semantic_ir, clang_snap.semantic_ir
+    )
+
     merged = replace(
         castxml_snap,
+        semantic_ir=merged_ir,
+        semantic_ir_conflicts={**castxml_snap.semantic_ir_conflicts, **ir_conflicts},
         functions=merged_functions,
         variables=merged_variables,
         types=merged_types,

--- a/abicheck/extract/AGENTS.md
+++ b/abicheck/extract/AGENTS.md
@@ -30,7 +30,7 @@ inside this directory.
 | Change | Module |
 |---|---|
 | Header-AST parser backend (castxml or clang), split by parsed entity or parser-state responsibility per ADR-061 D9 | `headers/castxml/`, `headers/clang/` |
-| Reconciling two backends' `SemanticIR` into one (the `--ast-frontend hybrid` merge, ADR-063 Phase 6) | `semantic_ir_merge.py` |
+| Reconciling two backends' `SemanticIR` (the hybrid merge, ADR-063 Phase 6) | `semantic_ir_merge.py` |
 | ELF/PE/Mach-O binary parsing | `binary/` (not yet created — still `elf_metadata.py`, `pe_metadata.py`, `macho_metadata.py`) |
 | DWARF/PDB debug-info parsing | `debug/` (not yet created) |
 | compile-commands/CMake/Bazel/Make build evidence | `build/` (not yet created) |
@@ -144,8 +144,7 @@ an explicit keyword-only parameter rather than importing it back through
 - **Don't reach back into a flat legacy module's private helpers.** A new
   module here imports the *public* surface of an unmigrated sibling (or, if
   none exists, that is itself a sign the shared piece needs its own leaf
-  module both sides can depend on — see ADR-061's own account of
-  `itanium_scope_components` for the pattern to avoid).
+  module both sides can depend on — see ADR-061 on `itanium_scope_components`).
 - **A migrated module must never import back through its old flat facade**
   (`abicheck.dumper`, `abicheck.service`, `abicheck.cli`) — that reintroduces
   exactly the reverse coupling this package exists to remove.

--- a/abicheck/extract/AGENTS.md
+++ b/abicheck/extract/AGENTS.md
@@ -30,6 +30,7 @@ inside this directory.
 | Change | Module |
 |---|---|
 | Header-AST parser backend (castxml or clang), split by parsed entity or parser-state responsibility per ADR-061 D9 | `headers/castxml/`, `headers/clang/` |
+| Reconciling two backends' `SemanticIR` into one (the `--ast-frontend hybrid` merge, ADR-063 Phase 6) | `semantic_ir_merge.py` |
 | ELF/PE/Mach-O binary parsing | `binary/` (not yet created — still `elf_metadata.py`, `pe_metadata.py`, `macho_metadata.py`) |
 | DWARF/PDB debug-info parsing | `debug/` (not yet created) |
 | compile-commands/CMake/Bazel/Make build evidence | `build/` (not yet created) |

--- a/abicheck/extract/semantic_ir_merge.py
+++ b/abicheck/extract/semantic_ir_merge.py
@@ -201,14 +201,28 @@ def merge_semantic_ir(
             continue
         pairs = _pair_group(base_ids, overlay_ids)
         if pairs is None:
-            # No unique matching: union both sides verbatim, base first, so
-            # an occurrence both sides key identically keeps the base's
-            # entity (the same precedence every matched pair uses).
+            # No unique matching: union both sides, base first. An occurrence
+            # both sides key *identically* is not a guessed pairing at all --
+            # one `OccurrenceId` names one occurrence, by that type's own
+            # definition -- so it is merged here under the ordinary
+            # base-plus-backfill rule rather than dropped. "Union verbatim"
+            # has no meaning for a key collision: `setdefault` would silently
+            # discard the overlay's entity, losing exactly the facts (and
+            # conflict records) this function exists to preserve, which is a
+            # strictly worse outcome than either merging or keeping both --
+            # and keeping both is not representable (Codex review). What
+            # stays fail-closed is what the ambiguity is actually about:
+            # no occurrence is paired with a *differently* keyed one.
             for occ in base_ids:
                 merged[occ] = base.occurrences[occ]
             for occ in overlay_ids:
-                merged.setdefault(occ, overlay.occurrences[occ])
                 consumed_overlay.add(occ)
+                if occ in merged:
+                    merged[occ] = _merge_entity(
+                        merged[occ], overlay.occurrences[occ], occ, conflicts
+                    )
+                else:
+                    merged[occ] = overlay.occurrences[occ]
             continue
         for base_occ, overlay_occ in pairs:
             base_entity = base.occurrences[base_occ]

--- a/abicheck/extract/semantic_ir_merge.py
+++ b/abicheck/extract/semantic_ir_merge.py
@@ -212,7 +212,10 @@ def merge_semantic_ir(
             # strictly worse outcome than either merging or keeping both --
             # and keeping both is not representable (Codex review). What
             # stays fail-closed is what the ambiguity is actually about:
-            # no occurrence is paired with a *differently* keyed one.
+            # a pairing is refused only when both sides supply a
+            # disambiguator and they disagree, never merely because two
+            # keys differ (castxml supplies none, so the ordinary match
+            # pairs an empty key against a non-empty one).
             for occ in base_ids:
                 merged[occ] = base.occurrences[occ]
             for occ in overlay_ids:

--- a/abicheck/extract/semantic_ir_merge.py
+++ b/abicheck/extract/semantic_ir_merge.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reconcile two backends' :class:`~abicheck.model.semantic_ir.SemanticIR`
+into one (ADR-063 Phase 6, the ``--ast-frontend hybrid`` path).
+
+``dumper_hybrid.merge_snapshots()`` reconciles two *already-assembled*
+snapshots: castxml is the base, clang backfills only the facts castxml did
+not resolve, and ``fact_provenance`` records which backend won per legacy
+fact. Once each sub-snapshot also carries its own ``semantic_ir``, that
+field needs the identical treatment — a merged snapshot whose legacy
+``functions``/``types`` include clang-only entities while its ``semantic_ir``
+still holds only castxml's would be two representations of one freshly
+built snapshot disagreeing with each other, which is the one outcome
+ADR-063's governing invariant forbids.
+
+The matching rule (plan, "Phase 6") is deliberately fail-closed at every
+cardinality it cannot resolve uniquely:
+
+1. **Match on the bare ``EntityId``**, not the full ``OccurrenceId``. Both
+   backends parse the same headers, so the ordinary case is two
+   structurally identical ``EntityId``s. A disambiguator is a *per-backend*
+   TU-context signal (clang derives a USR; castxml has no USR concept at
+   all), so an empty disambiguator on either side is "no additional signal
+   from that backend", never a disagreement.
+2. **Cardinality is checked before any pairwise comparison.** One
+   ``EntityId`` may legitimately name several occurrences on one side (the
+   ODR-duplicate/incomplete-declaration case ``SemanticIR.occurrences``
+   exists to preserve), so the group is matched as a whole:
+
+   * every non-empty disambiguator value present on **both** sides must
+     name exactly one occurrence per side, and those pair 1:1;
+   * the leftovers (which need not be empty-disambiguator occurrences — a
+     one-sided non-empty disambiguator is still "no signal from the other
+     backend") pair only when exactly one remains per side, and only unless
+     *both* are non-empty and unequal — the one real, two-sided
+     disagreement this rule refuses;
+   * a leftover with no counterpart at all (one side exhausted) is unioned
+     verbatim, which is not an ambiguity.
+
+   Any group this leaves without a unique complete matching — a non-empty
+   disambiguator value claimed twice on one side, more than one leftover
+   per side, or a genuinely disagreeing leftover pair — is left **entirely
+   unmerged**: every occurrence from both sides is unioned in verbatim,
+   rather than guessing at a pairing.
+3. **The base wins every matched pair.** Clang backfills only facts
+   castxml carries as non-``PRESENT``; a fact both resolved, disagreeing,
+   keeps castxml's value and records the discarded one in
+   ``AbiSnapshot.semantic_ir_conflicts`` (occurrence-keyed — see
+   :func:`~abicheck.model.semantic_ir.semantic_ir_conflict_key` for why
+   ``fact_provenance``'s declaration-only key is the wrong shape here).
+4. **An overlay-only ``EntityId`` is unioned verbatim**, exactly mirroring
+   how a genuinely clang-only function/type is appended rather than dropped
+   by the legacy-field merge.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import replace
+from typing import Any
+
+from ..model.fact import Fact
+from ..model.identity import EntityId
+from ..model.occurrence import OccurrenceId
+from ..model.semantic_ir import CanonicalEntity, SemanticIR, semantic_ir_conflict_key
+
+__all__ = ["MERGED_PRODUCER", "merge_semantic_ir"]
+
+#: ``CanonicalEntity.producer`` for a matched pair that actually took at
+#: least one fact from the overlay. A pair the overlay contributed nothing
+#: to keeps the base entity untouched, producer included — claiming
+#: ``"hybrid"`` there would overstate what the second backend supplied.
+MERGED_PRODUCER = "hybrid"
+
+
+def _by_entity_id(
+    ir: SemanticIR,
+) -> dict[EntityId, list[OccurrenceId]]:
+    grouped: dict[EntityId, list[OccurrenceId]] = defaultdict(list)
+    for occ_id in ir.occurrences:
+        grouped[occ_id.entity_id].append(occ_id)
+    return grouped
+
+
+def _pair_group(
+    base_ids: list[OccurrenceId], overlay_ids: list[OccurrenceId]
+) -> list[tuple[OccurrenceId, OccurrenceId | None]] | None:
+    """The unique complete matching between one ``EntityId``'s occurrences on
+    each side, or ``None`` when no unique matching exists.
+
+    Returns ``(base_occurrence, overlay_occurrence_or_None)`` pairs covering
+    every base occurrence; overlay occurrences left unmatched are the
+    caller's to union in verbatim (this function does not decide that, since
+    it reports only how the base side was matched).
+    """
+    base_by_tag: dict[str, list[OccurrenceId]] = defaultdict(list)
+    overlay_by_tag: dict[str, list[OccurrenceId]] = defaultdict(list)
+    for occ in base_ids:
+        if occ.disambiguator:
+            base_by_tag[occ.disambiguator].append(occ)
+    for occ in overlay_ids:
+        if occ.disambiguator:
+            overlay_by_tag[occ.disambiguator].append(occ)
+
+    pairs: list[tuple[OccurrenceId, OccurrenceId | None]] = []
+    matched_base: set[OccurrenceId] = set()
+    matched_overlay: set[OccurrenceId] = set()
+    for tag in sorted(base_by_tag.keys() & overlay_by_tag.keys()):
+        if len(base_by_tag[tag]) != 1 or len(overlay_by_tag[tag]) != 1:
+            # One side spells the same TU-context signal on two
+            # occurrences: a genuine ambiguity this rule cannot resolve.
+            return None
+        base_occ, overlay_occ = base_by_tag[tag][0], overlay_by_tag[tag][0]
+        pairs.append((base_occ, overlay_occ))
+        matched_base.add(base_occ)
+        matched_overlay.add(overlay_occ)
+
+    base_left = [occ for occ in base_ids if occ not in matched_base]
+    overlay_left = [occ for occ in overlay_ids if occ not in matched_overlay]
+    if len(base_left) > 1 or len(overlay_left) > 1:
+        return None
+    if base_left and overlay_left:
+        left_base, left_overlay = base_left[0], overlay_left[0]
+        if (
+            left_base.disambiguator
+            and left_overlay.disambiguator
+            and left_base.disambiguator != left_overlay.disambiguator
+        ):
+            # Both backends derived a TU-context signal and they disagree —
+            # the one case this rule genuinely refuses.
+            return None
+        pairs.append((left_base, left_overlay))
+    elif base_left:
+        pairs.append((base_left[0], None))
+    return pairs
+
+
+def _merge_entity(
+    base: CanonicalEntity,
+    overlay: CanonicalEntity,
+    base_occ: OccurrenceId,
+    conflicts: dict[str, str],
+) -> CanonicalEntity:
+    """*base* with every non-``PRESENT`` fact backfilled from *overlay*,
+    recording each two-sided disagreement into *conflicts*."""
+    updates: dict[str, Any] = {}
+    overlay_facts = dict(overlay.fact_items())
+    for name, base_fact in base.fact_items():
+        overlay_fact: Fact[Any] | None = overlay_facts.get(name)
+        if overlay_fact is None or not overlay_fact.is_present:
+            continue
+        if not base_fact.is_present:
+            updates[name] = overlay_fact
+        elif base_fact.value != overlay_fact.value:
+            conflicts[semantic_ir_conflict_key(base_occ, name)] = repr(
+                overlay_fact.value
+            )
+    if not updates:
+        return base
+    return replace(base, producer=MERGED_PRODUCER, **updates)
+
+
+def merge_semantic_ir(
+    base: SemanticIR | None, overlay: SemanticIR | None
+) -> tuple[SemanticIR | None, dict[str, str]]:
+    """Reconcile *overlay* onto *base*, returning the merged IR and the
+    occurrence-keyed conflict records it produced.
+
+    ``None`` on either side means that backend produced no IR at all: the
+    other side is returned unchanged (and ``None``/``{}`` when neither did),
+    never a half-merged IR claiming evidence nobody supplied.
+    """
+    if base is None or not base.occurrences:
+        return (base if overlay is None else overlay), {}
+    if overlay is None or not overlay.occurrences:
+        return base, {}
+
+    conflicts: dict[str, str] = {}
+    merged: dict[OccurrenceId, CanonicalEntity] = {}
+    overlay_groups = _by_entity_id(overlay)
+    consumed_overlay: set[OccurrenceId] = set()
+
+    for entity_id, base_ids in _by_entity_id(base).items():
+        overlay_ids = overlay_groups.get(entity_id, [])
+        if not overlay_ids:
+            for occ in base_ids:
+                merged[occ] = base.occurrences[occ]
+            continue
+        pairs = _pair_group(base_ids, overlay_ids)
+        if pairs is None:
+            # No unique matching: union both sides verbatim, base first, so
+            # an occurrence both sides key identically keeps the base's
+            # entity (the same precedence every matched pair uses).
+            for occ in base_ids:
+                merged[occ] = base.occurrences[occ]
+            for occ in overlay_ids:
+                merged.setdefault(occ, overlay.occurrences[occ])
+                consumed_overlay.add(occ)
+            continue
+        for base_occ, overlay_occ in pairs:
+            base_entity = base.occurrences[base_occ]
+            if overlay_occ is None:
+                merged[base_occ] = base_entity
+                continue
+            consumed_overlay.add(overlay_occ)
+            merged[base_occ] = _merge_entity(
+                base_entity, overlay.occurrences[overlay_occ], base_occ, conflicts
+            )
+
+    for occ, entity in overlay.occurrences.items():
+        if occ not in consumed_overlay:
+            merged.setdefault(occ, entity)
+    return SemanticIR(occurrences=merged), conflicts

--- a/abicheck/model/AGENTS.md
+++ b/abicheck/model/AGENTS.md
@@ -78,6 +78,7 @@ types, so `from abicheck.elf_metadata import ElfMetadata` still resolves.
 | A decl/type node-id normalization rule | `graph_identity.py` |
 | A `EntityResolver`/canonical-identity resolution rule | `entity_resolver.py`, `entity_identity.py` |
 | An already-built L5 graph node/edge public/internal/consumer-compiled classification predicate | `source_graph_query.py` |
+| A canonical, backend-independent IR field or canonicalization rule (ADR-063 Phase 6) | `semantic_ir.py` |
 
 `__init__.py` is the supported import surface and stays a re-export list
 with `__all__` — no logic, no new names that are not owned by a submodule.

--- a/abicheck/model/semantic_ir.py
+++ b/abicheck/model/semantic_ir.py
@@ -52,7 +52,6 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, fields
 from typing import Any
 
-from .availability import FactStatus
 from .fact import Fact
 from .identity import EntityId, _packed
 from .occurrence import OccurrenceId, canonical_key
@@ -129,7 +128,15 @@ class CanonicalEntity:
 
     def __post_init__(self) -> None:
         cv = self.cv_qualification
-        if cv.status is FactStatus.PRESENT and cv.value is not None:
+        # `is_present`, not `status is PRESENT`: `PARTIAL` is usable evidence
+        # everywhere else in this IR (`Fact.is_present`,
+        # `resolved_fact_count`, the hybrid merge's backfill), so checking
+        # only `PRESENT` would accept a non-canonical ("volatile", "const")
+        # from a partial fact while rejecting the identical present one --
+        # two spellings of one qualification, which is what canonicalization
+        # exists to prevent, and a false hybrid conflict when two backends
+        # land on different ones (Codex review).
+        if cv.is_present and cv.value is not None:
             canonical = canonical_cv_qualification(cv.value)
             if tuple(cv.value) != canonical:
                 raise ValueError(
@@ -153,7 +160,8 @@ class CanonicalEntity:
         )
 
     def resolved_fact_count(self) -> int:
-        """How many of this entity's facts are ``PRESENT`` — the ranking
+        """How many of this entity's facts carry usable evidence
+        (``PRESENT``/``PARTIAL``, i.e. ``Fact.is_present``) — the ranking
         :meth:`SemanticIR.canonical_entities` reduces on."""
         return sum(1 for _, fact in self.fact_items() if fact.is_present)
 

--- a/abicheck/model/semantic_ir.py
+++ b/abicheck/model/semantic_ir.py
@@ -127,6 +127,23 @@ class CanonicalEntity:
     producer: str = ""
 
     def __post_init__(self) -> None:
+        # A usable fact must actually carry its declared value. These fields
+        # are `Fact[str]`/`Fact[tuple[str, ...]]`, and their own docstrings
+        # name the confirmed-absence spelling for each: `Fact.present(())`
+        # for a non-template declaration, an empty tuple for no
+        # CV-qualification. `Fact.present(None)` is legitimate in the general
+        # `Fact` vocabulary (for a field whose `T` includes `None`) but not
+        # for these three, and admitting it here would let
+        # `resolved_fact_count` — and through it `canonical_entities()`'s
+        # reduction and the hybrid merge's backfill — treat a value the
+        # entity does not carry as usable evidence (Codex review).
+        for name, fact in self.fact_items():
+            if fact.is_present and fact.value is None:
+                raise ValueError(
+                    f"{name} is {fact.status.value} but carries no value; "
+                    "confirmed absence is spelled with this field's own "
+                    "empty value (\"\" or ()), never None"
+                )
         cv = self.cv_qualification
         # `is_present`, not `status is PRESENT`: `PARTIAL` is usable evidence
         # everywhere else in this IR (`Fact.is_present`,

--- a/abicheck/model/semantic_ir.py
+++ b/abicheck/model/semantic_ir.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``SemanticIR``/``CanonicalEntity`` — the one canonical IR between the
+extraction backends and the checker (ADR-063 Phase 6).
+
+This module is Phase 6's *first* step, deliberately: the plan
+(``docs/contribute/plans/one-semantic-pipeline.md``, "Phase 6") requires the
+IR itself to be defined and tested before any backend parser is narrowed to
+feed it, so the per-backend migrations converge on one shape rather than
+each backend's own reading of "canonical" behind a shared name.
+
+**Keyed by ``OccurrenceId``, not collapsed to one entry per ``EntityId``.**
+A complete definition and an incomplete/ODR-duplicate declaration can
+legitimately share one :class:`~abicheck.model.identity.EntityId` while
+carrying different availability, origin, or producer facts;
+a one-entry-per-identity map would overwrite or merge that evidence away
+before comparison ever saw it. :meth:`SemanticIR.canonical_entities` is the
+explicit, separate reduction for a consumer that genuinely wants one view
+per identity — never the only shape this IR offers, and never the shape the
+legacy ``AbiSnapshot.functions``/``types``/... projection is built from.
+
+**``CanonicalEntity`` carries no identity of its own.** No ``ScopePath``, no
+``EntityId``, no ``OccurrenceId`` field: identity lives exclusively in the
+mapping's key, so a normalizer or deserializer bug cannot produce a mapping
+whose key names one scope and whose value reports another (ADR-063's
+governing invariant — one concept, one representation). A caller that needs
+an entity's scope reads it off the key it was retrieved with
+(``occurrence_id.entity_id.scope``); a function handing a
+:class:`CanonicalEntity` to a caller without that key in scope returns the
+*pair*, never a value carrying a second copy of what the key already states.
+
+Leaf module: depends only on ``model.fact``/``model.availability``/
+``model.identity``/``model.occurrence``, per ADR-063 D10.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+from .availability import FactStatus
+from .fact import Fact
+from .identity import EntityId, _packed
+from .occurrence import OccurrenceId, canonical_key
+
+__all__ = [
+    "CV_QUALIFIER_ORDER",
+    "CanonicalEntity",
+    "SemanticIR",
+    "canonical_cv_qualification",
+    "semantic_ir_conflict_key",
+]
+
+#: The canonical order CV-qualifiers are rendered in, so two backends
+#: spelling the same qualification in different orders (``const volatile``
+#: vs. ``volatile const``) produce one value, not two. Ordering — rather
+#: than a set — keeps the field a plain, JSON-round-trippable tuple while
+#: still being canonical.
+CV_QUALIFIER_ORDER = ("const", "volatile", "restrict")
+
+
+def canonical_cv_qualification(spellings: Iterable[str]) -> tuple[str, ...]:
+    """Canonicalize CV-qualifier *spellings* into :data:`CV_QUALIFIER_ORDER`
+    order, deduplicated, ignoring surrounding whitespace and empty entries.
+
+    Raises ``ValueError`` for a qualifier this vocabulary does not name — a
+    silently-dropped unknown qualifier would be exactly the "two backends,
+    two readings of canonical" outcome this IR exists to prevent.
+    """
+    seen: set[str] = set()
+    for raw in spellings:
+        spelling = raw.strip()
+        if not spelling:
+            continue
+        if spelling not in CV_QUALIFIER_ORDER:
+            raise ValueError(
+                f"unknown CV-qualifier {spelling!r} "
+                f"(known: {', '.join(CV_QUALIFIER_ORDER)})"
+            )
+        seen.add(spelling)
+    return tuple(q for q in CV_QUALIFIER_ORDER if q in seen)
+
+
+@dataclass(frozen=True)
+class CanonicalEntity:
+    """One occurrence's canonicalized, backend-independent payload.
+
+    Every semantic field is a :class:`~abicheck.model.fact.Fact`, so a
+    backend that structurally cannot produce one states
+    ``Fact.unsupported()`` rather than a default a reader would mistake for
+    a confirmed value (ADR-063 Phase 0). ``producer`` is *not* a fact: it
+    names which backend produced this payload (``"castxml"``/``"clang"``/
+    ``"dwarf"``/``"pdb"``/``"btf"``/``"ctf"``, or ``"hybrid"`` for an
+    occurrence the hybrid merge backfilled across two backends), and is
+    empty for a hand-constructed entity with no backend behind it.
+    """
+
+    #: The canonical spelling of the declaration's own type (a record's
+    #: canonical qualified name, a function's canonical signature spelling,
+    #: a typedef's canonical underlying type), after anonymous-marker,
+    #: closure-identity and namespace-join canonicalization.
+    canonical_spelling: Fact[str]
+    #: The canonical, ordered template-argument spellings, empty for a
+    #: non-template declaration (``Fact.present(())``, which is a *confirmed*
+    #: absence — distinct from ``Fact.not_collected()``).
+    template_arguments: Fact[tuple[str, ...]] = field(
+        default_factory=lambda: Fact.not_collected()
+    )
+    #: CV-qualification in :data:`CV_QUALIFIER_ORDER` order — see
+    #: :func:`canonical_cv_qualification`.
+    cv_qualification: Fact[tuple[str, ...]] = field(
+        default_factory=lambda: Fact.not_collected()
+    )
+    producer: str = ""
+
+    def __post_init__(self) -> None:
+        cv = self.cv_qualification
+        if cv.status is FactStatus.PRESENT and cv.value is not None:
+            canonical = canonical_cv_qualification(cv.value)
+            if tuple(cv.value) != canonical:
+                raise ValueError(
+                    f"cv_qualification {tuple(cv.value)!r} is not canonical; "
+                    f"expected {canonical!r} (see canonical_cv_qualification)"
+                )
+
+    def fact_items(self) -> tuple[tuple[str, Fact[Any]], ...]:
+        """This entity's ``Fact``-typed fields as ``(name, fact)`` pairs, in
+        declaration order.
+
+        Every consumer that has to walk "each semantic fact" — the hybrid
+        merge's backfill, the wire codec, a completeness check — walks this
+        instead of restating the field list, so adding a field to this class
+        cannot leave one of them silently ignoring it.
+        """
+        return tuple(
+            (f.name, value)
+            for f in fields(self)
+            if isinstance(value := getattr(self, f.name), Fact)
+        )
+
+    def resolved_fact_count(self) -> int:
+        """How many of this entity's facts are ``PRESENT`` — the ranking
+        :meth:`SemanticIR.canonical_entities` reduces on."""
+        return sum(1 for _, fact in self.fact_items() if fact.is_present)
+
+
+@dataclass(frozen=True)
+class SemanticIR:
+    """Every canonicalized occurrence one extraction produced, keyed by
+    :class:`~abicheck.model.occurrence.OccurrenceId`.
+
+    ``frozen`` guards the binding, not the mapping: ``occurrences`` is
+    typed as a read-only :class:`~collections.abc.Mapping` so a consumer
+    cannot mutate it through this type, matching how every other model-layer
+    collection in this codebase is handed out.
+    """
+
+    occurrences: Mapping[OccurrenceId, CanonicalEntity] = field(default_factory=dict)
+
+    def occurrences_for(self, entity_id: EntityId) -> tuple[OccurrenceId, ...]:
+        """Every occurrence key naming *entity_id*, in this IR's own order.
+
+        More than one is the ordinary ODR-duplicate/incomplete-declaration
+        case this IR exists to preserve, not an anomaly.
+        """
+        return tuple(occ for occ in self.occurrences if occ.entity_id == entity_id)
+
+    def canonical_entities(self) -> dict[EntityId, CanonicalEntity]:
+        """One entity per :class:`EntityId` — an explicit *reduction*, for a
+        consumer that genuinely wants a single canonical view.
+
+        The winner is the occurrence with the most ``PRESENT`` facts; ties
+        break on :func:`~abicheck.model.occurrence.canonical_key` order, so
+        the result never depends on insertion order (two IRs holding the
+        same occurrences reduce identically regardless of how each was
+        built).
+
+        **Never the projection the legacy ``AbiSnapshot.functions``/
+        ``types``/... fields are built from** — those keep one entry per
+        occurrence, exactly as today's assembly already produces; routing
+        them through this method would collapse an ODR-duplicate pair to
+        one entry and lose the evidence ``occurrences`` exists to keep.
+        """
+        best: dict[EntityId, tuple[int, str, CanonicalEntity]] = {}
+        for occ_id, entity in self.occurrences.items():
+            rank = (-entity.resolved_fact_count(), canonical_key(occ_id))
+            current = best.get(occ_id.entity_id)
+            if current is None or rank < (current[0], current[1]):
+                best[occ_id.entity_id] = (rank[0], rank[1], entity)
+        return {entity_id: chosen for entity_id, (_, _, chosen) in best.items()}
+
+
+def semantic_ir_conflict_key(occurrence_id: OccurrenceId, fact_name: str) -> str:
+    """The ``AbiSnapshot.semantic_ir_conflicts`` key for *fact_name* on
+    *occurrence_id*.
+
+    Keyed on the *occurrence*, not the declaration, unlike
+    ``fact_provenance``'s own ``func_fact_key``/``type_fact_key`` family:
+    those name a declaration, which is correct for every legacy field the
+    hybrid merge reconciles (none of which can have more than one matched
+    pair per identity), but this IR's own matching explicitly allows two
+    matched pairs to share one ``EntityId`` — two conflicts on the same fact
+    name would then collide on one declaration-keyed string and the second
+    would silently discard the first.
+    """
+    return _packed(canonical_key(occurrence_id), fact_name)

--- a/abicheck/model/snapshot.py
+++ b/abicheck/model/snapshot.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
         PythonApiSurface,
         PythonExtMetadata,
     )
+    from .semantic_ir import SemanticIR
     from .sycl_facts import SyclMetadata
 
 _model_log = _logging.getLogger(__name__)
@@ -672,6 +673,19 @@ class AbiSnapshot:
     ast_resolved_standard_fact: Fact[str | None] | None = field(
         default=None, kw_only=True
     )
+
+    # ADR-063 Phase 6 (schema v38) — the canonical, backend-independent IR
+    # these declarations were canonicalized into, keyed by ``OccurrenceId``
+    # (``model/semantic_ir.py`` owns the full rationale).
+    # Additive: the legacy ``functions``/``types``/... fields stay populated
+    # as before, one entry per occurrence (never a ``canonical_entities()``
+    # reduction). ``None`` predating it / for an un-narrowed backend.
+    semantic_ir: SemanticIR | None = field(default=None, kw_only=True)
+    # Every fact BOTH header-AST backends resolved, disagreeing, on a hybrid
+    # merge — keyed by ``semantic_ir_conflict_key``, absent key == none. Not
+    # ``fact_provenance``: that keeps only the winner's name, per declaration
+    # (``extract/semantic_ir_merge.py``: why neither half of that suffices).
+    semantic_ir_conflicts: dict[str, str] = field(default_factory=dict, kw_only=True)
 
     # Runtime-only provenance qualifier (not serialized — popped in
     # snapshot_to_dict). True when ``from_headers`` was *inferred* for a legacy

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -73,6 +73,7 @@ from .storage.fact_codec import (
     decode_variable_facts,
     encode_fact_fields,
 )
+from .storage.semantic_ir_codec import decode_semantic_ir, encode_semantic_ir
 from .storage.snapshot_load_normalization import (
     backfill_missing_elf_binding,
     build_mode_from_dict,
@@ -341,7 +342,7 @@ from .storage.surface_graph_codec import decode_surface_graph, encode_surface_gr
 # doesn't hit any producer-specific threshold above stays silent, since every
 # CI baseline is *always* some number of versions behind and warning
 # regardless of relevance would just be noise.
-SCHEMA_VERSION: int = 37  # v37: ElfMetadata.dynamic_flags_fact/has_init_fact/has_fini_fact, PeMetadata.delay_imports_fact, MachoMetadata.rpaths_fact persisted (snapshot_platform_blocks.py/storage/fact_codec.py); v36: AbiSnapshot.ast_resolved_standard_fact persisted (storage/fact_codec.py); v35: Function.contract_attributes_fact/is_explicit_fact/is_hidden_friend_fact/source_header_fact/is_variadic_fact/exception_spec_fact/is_override_fact/hidden_friend_owner_fact/elf_binding_fact/is_compiler_generated_fact persisted (storage/fact_codec.py); v34: Variable.source_header_fact/alignment_bits_fact/elf_binding_fact persisted (storage/fact_codec.py); v33: EnumType.qualified_name_fact/source_header_fact persisted (storage/fact_codec.py); v32: RecordType.is_abstract_fact/data_size_bits_fact/is_standard_layout_fact/is_trivially_copyable_fact/qualified_name_fact/source_header_fact persisted (storage/fact_codec.py); v31: typedef/constant entity_id sidecars persisted (storage/entity_id_codec.py); v30: RecordType.is_final_fact persisted (storage/fact_codec.py); v29: AbiSnapshot.surface_graph persisted (storage/surface_graph_codec.py); v28: entity_id carrier persisted (storage/entity_id_codec.py).
+SCHEMA_VERSION: int = 38  # v38: AbiSnapshot.semantic_ir + semantic_ir_conflicts persisted (storage/semantic_ir_codec.py); v37: ElfMetadata.dynamic_flags_fact/has_init_fact/has_fini_fact, PeMetadata.delay_imports_fact, MachoMetadata.rpaths_fact persisted (snapshot_platform_blocks.py/storage/fact_codec.py); v36: AbiSnapshot.ast_resolved_standard_fact persisted (storage/fact_codec.py); v35: Function.contract_attributes_fact/is_explicit_fact/is_hidden_friend_fact/source_header_fact/is_variadic_fact/exception_spec_fact/is_override_fact/hidden_friend_owner_fact/elf_binding_fact/is_compiler_generated_fact persisted (storage/fact_codec.py); v34: Variable.source_header_fact/alignment_bits_fact/elf_binding_fact persisted (storage/fact_codec.py); v33: EnumType.qualified_name_fact/source_header_fact persisted (storage/fact_codec.py); v32: RecordType.is_abstract_fact/data_size_bits_fact/is_standard_layout_fact/is_trivially_copyable_fact/qualified_name_fact/source_header_fact persisted (storage/fact_codec.py); v31: typedef/constant entity_id sidecars persisted (storage/entity_id_codec.py); v30: RecordType.is_final_fact persisted (storage/fact_codec.py); v29: AbiSnapshot.surface_graph persisted (storage/surface_graph_codec.py); v28: entity_id carrier persisted (storage/entity_id_codec.py).
 
 # Schema version at which CastXML field CV facts became reliable (see v9 above).
 _MIN_SCHEMA_VERSION_FOR_CV_FACTS = 9
@@ -409,13 +410,20 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     # them for the call and restore after, so this stays pure from the caller.
     caches = (snap._func_by_mangled, snap._var_by_mangled, snap._type_by_name)
     graph = snap.surface_graph
+    # ADR-063 Phase 6 (v38): asdict() recurses into a dict's KEYS, so an
+    # OccurrenceId-keyed mapping raises (unhashable dict key) inside asdict()
+    # itself -- encode_semantic_ir() below owns this field's encoding, from
+    # the still-typed object, exactly as surface_graph's codec does.
+    semantic_ir = snap.semantic_ir
     try:
         snap._func_by_mangled = snap._var_by_mangled = snap._type_by_name = None
         snap.surface_graph = None
+        snap.semantic_ir = None
         d = asdict(snap)
     finally:
         snap._func_by_mangled, snap._var_by_mangled, snap._type_by_name = caches
         snap.surface_graph = graph
+        snap.semantic_ir = semantic_ir
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)
@@ -458,6 +466,7 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     else:
         converted.pop("build_source", None)
     encode_surface_graph(converted, snap)  # storage/surface_graph_codec.py
+    encode_semantic_ir(converted, snap)  # storage/semantic_ir_codec.py (v38)
 
     # Embed schema version for forward-compatibility.
     # Placed at top level so loaders can inspect it without parsing the full snapshot.
@@ -1178,6 +1187,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         contract=contract,
     )
     decode_surface_graph(d, snap)  # storage/surface_graph_codec.py (v29)
+    decode_semantic_ir(d, snap)  # storage/semantic_ir_codec.py (v38)
 
     # G14: derive the CPython extension surface for snapshots that predate the
     # key (or a `dump` path that didn't attach it), so a saved abi3 baseline is

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -61,6 +61,7 @@ from .guards import (
     identity_text,
     mapping as _require_mapping,
     provenance_text,
+    required_field,
     row_sequence,
 )
 
@@ -231,8 +232,15 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
         return
     document = _mapping(d["semantic_ir"], "semantic_ir")
     occurrences: dict[OccurrenceId, CanonicalEntity] = {}
+    # `required_field`, not a default: this codec always writes the key (an
+    # IR that observed nothing is `{"occurrences": []}`), so a present
+    # `semantic_ir` without it is a truncated document. Substituting `()`
+    # would turn "the occurrence evidence is missing" into the *claim* that
+    # a backend ran and established there are none -- the "absence is not
+    # evidence" reading this package exists to refuse (Codex review).
     for entry_raw in row_sequence(
-        _present_or(document, "occurrences", ()), "semantic_ir occurrences"
+        required_field(document, "occurrences", "semantic_ir"),
+        "semantic_ir occurrences",
     ):
         entry = _mapping(entry_raw, "semantic_ir occurrence entry")
         occurrence = _mapping(entry.get("occurrence"), "semantic_ir occurrence")

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -209,11 +209,25 @@ def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
     if not snap.semantic_ir_conflicts:
         d.pop("semantic_ir_conflicts", None)
     else:
+        # Validated on the way OUT as strictly as on the way in, and for a
+        # reason specific to writing: a non-string key survives in memory
+        # but `json.dumps` renders it as a string, so `{1: "first", "1":
+        # "second"}` writes one JSON object with two `"1"` keys and the load
+        # keeps whichever came last -- a conflict record discarded by the
+        # writer, before any reader could refuse it (CodeRabbit review).
         # Sorted for the same reason the occurrence list is: `json.dumps`
         # preserves a mapping's insertion order, so two runs that recorded
         # the same conflicts in a different order would otherwise write
         # different documents for identical state.
-        d["semantic_ir_conflicts"] = dict(sorted(snap.semantic_ir_conflicts.items()))
+        d["semantic_ir_conflicts"] = {
+            identity_text(key, "semantic_ir_conflicts key"): identity_text(
+                value, "semantic_ir_conflicts value"
+            )
+            for key, value in sorted(
+                _mapping(snap.semantic_ir_conflicts, "semantic_ir_conflicts").items(),
+                key=lambda item: identity_text(item[0], "semantic_ir_conflicts key"),
+            )
+        }
     ir = snap.semantic_ir
     if ir is None:
         d.pop("semantic_ir", None)

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -53,10 +53,10 @@ from typing import TYPE_CHECKING, Any
 
 from ..model.availability import FactStatus
 from ..model.fact import Fact
-from ..model.occurrence import OccurrenceId
+from ..model.occurrence import OccurrenceId, canonical_key
 from ..model.semantic_ir import CanonicalEntity, SemanticIR
 from .entity_ids import domain_entity_id_from_dto, domain_entity_id_to_dto
-from .guards import mapping as _require_mapping
+from .guards import identity_text, mapping as _require_mapping, provenance_text
 
 if TYPE_CHECKING:
     from ..model.snapshot import AbiSnapshot
@@ -99,6 +99,14 @@ def _fact_from_dict(raw: Any, *, as_tuple: bool) -> Fact[Any]:
     )
 
 
+def _disambiguator(raw: Any) -> str:
+    """An occurrence's disambiguator: absent/``null`` is the ordinary empty
+    case, anything else must genuinely be a string."""
+    if raw is None or raw == "":
+        return ""
+    return identity_text(raw, "semantic_ir occurrence disambiguator")
+
+
 def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
     document: dict[str, Any] = {
         name: _fact_to_dict(fact) for name, fact in entity.fact_items()
@@ -115,7 +123,13 @@ def _entity_from_dict(raw: Any) -> CanonicalEntity:
         for name, value in data.items()
         if name != "producer"
     }
-    return CanonicalEntity(producer=str(data.get("producer", "")), **facts)
+    producer = data.get("producer", "")
+    return CanonicalEntity(
+        producer=provenance_text(producer, "semantic_ir entity producer")
+        if producer != ""
+        else "",
+        **facts,
+    )
 
 
 def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
@@ -140,7 +154,14 @@ def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
                 },
                 "entity": _entity_to_dict(entity),
             }
-            for occ_id, entity in ir.occurrences.items()
+            # Sorted, never the mapping's incidental insertion order: two
+            # equal ``SemanticIR`` values built in opposite orders must
+            # serialize identically, or a content hash over the document
+            # reports a difference the stored state does not have
+            # (``storage/AGENTS.md`` invariant 4).
+            for occ_id, entity in sorted(
+                ir.occurrences.items(), key=lambda item: canonical_key(item[0])
+            )
         ]
     }
 
@@ -160,7 +181,9 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
     conflicts = d.get("semantic_ir_conflicts")
     if conflicts:
         snap.semantic_ir_conflicts = {
-            str(key): str(value)
+            identity_text(key, "semantic_ir_conflicts key"): identity_text(
+                value, "semantic_ir_conflicts value"
+            )
             for key, value in _mapping(conflicts, "semantic_ir_conflicts").items()
         }
     raw = d.get("semantic_ir")
@@ -175,7 +198,11 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
             entity_id=domain_entity_id_from_dto(
                 _mapping(occurrence.get("entity_id"), "semantic_ir entity_id")
             ),
-            disambiguator=str(occurrence.get("disambiguator") or ""),
+            # identity_text, never str(): a JSON ``1`` and ``"1"`` would
+            # otherwise become one ``OccurrenceId``, and the assignment
+            # below would silently drop one of the two occurrences
+            # (``storage/AGENTS.md`` invariant 6).
+            disambiguator=_disambiguator(occurrence.get("disambiguator")),
         )
         occurrences[occ_id] = _entity_from_dict(entry.get("entity"))
     snap.semantic_ir = SemanticIR(occurrences=occurrences)

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -149,27 +149,15 @@ def _fact_from_dict(raw: Any, *, as_tuple: bool, field_name: str) -> Fact[Any]:
         # ``"diagnostics": "parse error"`` would decode to eleven
         # single-character diagnostics and be written back that way, and a
         # non-string member would be coerced into a manufactured one.
-        # `_present_or` rather than `... or ()`: a FALSEY malformed value
-        # (`False`, `0`, `{}`) would otherwise skip the guard entirely and
-        # be rewritten as "no diagnostics" -- the same silent-discard this
-        # guard exists to refuse, reached by a different route.
-        diagnostics=diagnostics_from(_present_or(data, "diagnostics", ())),
+        # Required, not defaulted: this writer emits the key for every fact
+        # (an empty list when there are none), so a missing one is a
+        # truncated document -- and defaulting it erases a FAILED fact's
+        # only explanation of why the producer could not establish the
+        # value, which is the whole reason diagnostics are persisted.
+        diagnostics=diagnostics_from(
+            required_field(data, "diagnostics", "semantic_ir fact")
+        ),
     )
-
-
-def _present_or(document: Mapping[str, Any], key: str, default: Any) -> Any:
-    """*document*'s value for *key*, or *default* when the key is genuinely
-    absent.
-
-    Absence and a falsey-but-present value are different documents and this
-    codec must not conflate them: `document.get(key) or default` hands a
-    malformed `False`/`0`/`{}`/`[]` straight past whichever guard was meant
-    to inspect it, turning "this field is corrupt" into "this field says
-    nothing" with no error anywhere. Every guarded read below goes through
-    here, so the distinction cannot be forgotten at one site the way it was
-    at three (Codex review).
-    """
-    return document[key] if key in document else default
 
 
 def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -94,14 +94,45 @@ def _fact_to_dict(fact: Fact[Any]) -> dict[str, Any]:
     }
 
 
-def _fact_from_dict(raw: Any, *, as_tuple: bool) -> Fact[Any]:
+def _fact_value(raw: Any, field_name: str, *, as_tuple: bool) -> Any:
+    """One semantic fact's value, checked against the shape its field
+    declares rather than admitted as whatever the document holds.
+
+    ``None`` is legitimate for every status (a confirmed-absent
+    ``Fact.present(None)``, and the value-less statuses). Anything else must
+    match the field's declared type: a `str` spelling, or a list of `str`
+    for a tuple-valued field. Without this, `"cv_qualification": {"value":
+    ""}` entered the IR as a present-but-scalar qualification and
+    `canonical_cv_qualification` read it as the *empty* one -- malformed
+    persisted state reaching reduction and hybrid merging as if a backend
+    had established it (Codex review).
+    """
+    if raw is None:
+        return None
+    if not as_tuple:
+        return identity_text(raw, f"semantic_ir {field_name} value")
+    entries = row_sequence(raw, f"semantic_ir {field_name} value")
+    return tuple(
+        identity_text(entry, f"semantic_ir {field_name} value[{index}]")
+        for index, entry in enumerate(entries)
+    )
+
+
+def _fact_from_dict(raw: Any, *, as_tuple: bool, field_name: str) -> Fact[Any]:
     data = _mapping(raw, "semantic_ir fact")
-    value = data.get("value")
-    if as_tuple and isinstance(value, list):
-        value = tuple(value)
     return Fact(
-        status=FactStatus(data["status"]),
-        value=value,
+        # required_field, not `data[...]`/`data.get(...)`: a truncated fact
+        # keeping `"status": "present"` while losing `value` would otherwise
+        # construct `Fact(PRESENT, None)`, which `resolved_fact_count` reads
+        # as usable evidence for a spelling the document no longer carries;
+        # and a bare subscript raises `KeyError`, which is neither of the two
+        # exceptions this package documents as "the document is malformed".
+        status=FactStatus(required_field(data, "status", "semantic_ir fact")),
+        value=_fact_value(
+            required_field(data, "value", "semantic_ir fact"),
+            field_name,
+            as_tuple=as_tuple,
+        ),
         # diagnostics_from, never bare tuple(): a string is a Sequence, so
         # ``"diagnostics": "parse error"`` would decode to eleven
         # single-character diagnostics and be written back that way, and a
@@ -149,7 +180,9 @@ def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
 def _entity_from_dict(raw: Any) -> CanonicalEntity:
     data = _mapping(raw, "semantic_ir entity")
     facts = {
-        name: _fact_from_dict(value, as_tuple=name in _TUPLE_VALUED_FACTS)
+        name: _fact_from_dict(
+            value, as_tuple=name in _TUPLE_VALUED_FACTS, field_name=name
+        )
         for name, value in data.items()
         if name != "producer"
     }

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -160,14 +160,6 @@ def _present_or(document: Mapping[str, Any], key: str, default: Any) -> Any:
     return document[key] if key in document else default
 
 
-def _disambiguator(raw: Any) -> str:
-    """An occurrence's disambiguator: absent/``null`` is the ordinary empty
-    case, anything else must genuinely be a string."""
-    if raw is None or raw == "":
-        return ""
-    return identity_text(raw, "semantic_ir occurrence disambiguator")
-
-
 def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
     document: dict[str, Any] = {
         name: _fact_to_dict(fact) for name, fact in entity.fact_items()
@@ -281,11 +273,21 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
             entity_id=domain_entity_id_from_dto(
                 _mapping(occurrence.get("entity_id"), "semantic_ir entity_id")
             ),
-            # identity_text, never str(): a JSON ``1`` and ``"1"`` would
-            # otherwise become one ``OccurrenceId``, and the assignment
-            # below would silently drop one of the two occurrences
-            # (``storage/AGENTS.md`` invariant 6).
-            disambiguator=_disambiguator(occurrence.get("disambiguator")),
+            # Required and never coerced. This writer always emits the
+            # field (an undisambiguated occurrence is `""`), so `null` or a
+            # missing key is a truncated document, and accepting either as
+            # `""` would rewrite it as a *genuinely* undisambiguated
+            # occurrence -- changing what the hybrid merge's matching does
+            # with it. `identity_text` then refuses a coerced value: a JSON
+            # `1` and `"1"` would otherwise become one `OccurrenceId` and
+            # the assignment below would drop one of the two occurrences
+            # (`storage/AGENTS.md` invariant 6).
+            disambiguator=identity_text(
+                required_field(
+                    occurrence, "disambiguator", "semantic_ir occurrence"
+                ),
+                "semantic_ir occurrence disambiguator",
+            ),
         )
         if occ_id in occurrences:
             # The list encoding can spell a duplicate that the mapping cannot

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encode/decode ``AbiSnapshot.semantic_ir`` for the wire (ADR-063 Phase 6,
+schema v38).
+
+**Why ``dataclasses.asdict()`` cannot do this, and why it is a hard blocker
+rather than a formatting preference.** ``SemanticIR.occurrences`` is keyed by
+an ``OccurrenceId`` *dataclass*, and ``asdict()`` recurses into a dict's keys
+exactly as it does into its values — so the key becomes a nested dict, and a
+dict is unhashable: ``asdict()`` itself raises while building the converted
+mapping, for every snapshot carrying a populated ``semantic_ir``, long before
+``json.dump()`` runs. ``serialization.snapshot_to_dict`` therefore clears the
+field for the ``asdict()`` call (the same special-casing ``surface_graph``
+already needs) and hands the original, still-typed object here.
+
+**Encoded as a list of entries, not a dict.** Flattening ``OccurrenceId``
+into a string key is the same lossy move ADR-063 Phase 2 already rejected for
+``EntityId``'s own ``ScopePath``, for the identical structural reason: an
+``OccurrenceId`` carries an ``EntityId`` carrying a ``ScopePath``, so a
+rendered key cannot be reversed. Each entry is
+``{"occurrence": {...}, "entity": {...}}``, with the occurrence's own
+``EntityId`` going through :mod:`abicheck.storage.entity_ids`' existing
+``domain_entity_id_to_dto``/``domain_entity_id_from_dto`` bridge rather than a
+second, parallel encoding of the same structure.
+
+**Owned by ``storage``, not ``model``.** The plan's own text put these two
+functions in ``serialization.py`` for one specific reason — a ``model``-
+resident ``to_dict()`` would need ``model -> storage``, reversing ADR-061's
+fixed direction. This module satisfies that constraint the way this package's
+two sibling codecs (``entity_id_codec.py``, ``surface_graph_codec.py``)
+already do: ``storage`` may depend on ``model``, so the conversion lives here
+and ``serialization.py`` calls it, keeping that module (already at its
+``architecture/debt.yaml`` no-growth baseline) to the call-site plumbing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from ..model.availability import FactStatus
+from ..model.fact import Fact
+from ..model.occurrence import OccurrenceId
+from ..model.semantic_ir import CanonicalEntity, SemanticIR
+from .entity_ids import domain_entity_id_from_dto, domain_entity_id_to_dto
+from .guards import mapping as _require_mapping
+
+if TYPE_CHECKING:
+    from ..model.snapshot import AbiSnapshot
+
+__all__ = ["decode_semantic_ir", "encode_semantic_ir"]
+
+#: The ``CanonicalEntity`` fields carrying a tuple-valued ``Fact``. JSON has
+#: no tuple, so these come back as lists and are re-tupled on load — without
+#: this, a saved-then-loaded IR would compare unequal to the one that was
+#: written, for no semantic reason.
+_TUPLE_VALUED_FACTS = ("template_arguments", "cv_qualification")
+
+
+def _mapping(raw: Any, field_name: str) -> Mapping[str, Any]:
+    """*raw*, checked to be a mapping first — :func:`storage.guards.mapping`
+    validates without returning, and every read below needs both."""
+    _require_mapping(raw, field_name)
+    assert isinstance(raw, Mapping)  # narrowed by the guard above, for mypy
+    return raw
+
+
+def _fact_to_dict(fact: Fact[Any]) -> dict[str, Any]:
+    value = fact.value
+    return {
+        "status": fact.status.value,
+        "value": list(value) if isinstance(value, tuple) else value,
+        "diagnostics": list(fact.diagnostics),
+    }
+
+
+def _fact_from_dict(raw: Any, *, as_tuple: bool) -> Fact[Any]:
+    data = _mapping(raw, "semantic_ir fact")
+    value = data.get("value")
+    if as_tuple and isinstance(value, list):
+        value = tuple(value)
+    return Fact(
+        status=FactStatus(data["status"]),
+        value=value,
+        diagnostics=tuple(data.get("diagnostics") or ()),
+    )
+
+
+def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        name: _fact_to_dict(fact) for name, fact in entity.fact_items()
+    }
+    if entity.producer:
+        document["producer"] = entity.producer
+    return document
+
+
+def _entity_from_dict(raw: Any) -> CanonicalEntity:
+    data = _mapping(raw, "semantic_ir entity")
+    facts = {
+        name: _fact_from_dict(value, as_tuple=name in _TUPLE_VALUED_FACTS)
+        for name, value in data.items()
+        if name != "producer"
+    }
+    return CanonicalEntity(producer=str(data.get("producer", "")), **facts)
+
+
+def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
+    """In-place: write ``snap.semantic_ir``'s list-of-entries encoding into
+    ``d["semantic_ir"]``, or drop the key when the snapshot carries none.
+
+    Dropping (rather than writing ``null``) matches every other sparse,
+    only-present-when-meaningful field this package's wire format already
+    uses, so a snapshot from a backend not yet narrowed onto the normalizer
+    serializes exactly as it did before this field existed.
+    """
+    ir = snap.semantic_ir
+    if ir is None:
+        d.pop("semantic_ir", None)
+        return
+    d["semantic_ir"] = {
+        "occurrences": [
+            {
+                "occurrence": {
+                    "entity_id": domain_entity_id_to_dto(occ_id.entity_id),
+                    "disambiguator": occ_id.disambiguator,
+                },
+                "entity": _entity_to_dict(entity),
+            }
+            for occ_id, entity in ir.occurrences.items()
+        ]
+    }
+
+
+def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
+    """In-place: rebuild ``snap.semantic_ir`` and ``snap.semantic_ir_conflicts``
+    from *d*, leaving the IR ``None`` for a document that carries no
+    ``semantic_ir`` key (every snapshot written before schema v38, and every
+    one written since by a backend with no IR to record).
+
+    The conflict map is decoded independently of the IR: a merged snapshot
+    can legitimately record conflicts while a *reader* of that document has
+    no IR key to attach them to only if the writer dropped one, so tying the
+    two together would silently discard evidence in the one case the pairing
+    is not guaranteed.
+    """
+    conflicts = d.get("semantic_ir_conflicts")
+    if conflicts:
+        snap.semantic_ir_conflicts = {
+            str(key): str(value)
+            for key, value in _mapping(conflicts, "semantic_ir_conflicts").items()
+        }
+    raw = d.get("semantic_ir")
+    if not raw:
+        return
+    document = _mapping(raw, "semantic_ir")
+    occurrences: dict[OccurrenceId, CanonicalEntity] = {}
+    for entry_raw in document.get("occurrences") or ():
+        entry = _mapping(entry_raw, "semantic_ir occurrence entry")
+        occurrence = _mapping(entry.get("occurrence"), "semantic_ir occurrence")
+        occ_id = OccurrenceId(
+            entity_id=domain_entity_id_from_dto(
+                _mapping(occurrence.get("entity_id"), "semantic_ir entity_id")
+            ),
+            disambiguator=str(occurrence.get("disambiguator") or ""),
+        )
+        occurrences[occ_id] = _entity_from_dict(entry.get("entity"))
+    snap.semantic_ir = SemanticIR(occurrences=occurrences)

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -56,7 +56,12 @@ from ..model.fact import Fact
 from ..model.occurrence import OccurrenceId, canonical_key
 from ..model.semantic_ir import CanonicalEntity, SemanticIR
 from .entity_ids import domain_entity_id_from_dto, domain_entity_id_to_dto
-from .guards import identity_text, mapping as _require_mapping, provenance_text
+from .guards import (
+    diagnostics_from,
+    identity_text,
+    mapping as _require_mapping,
+    provenance_text,
+)
 
 if TYPE_CHECKING:
     from ..model.snapshot import AbiSnapshot
@@ -95,7 +100,11 @@ def _fact_from_dict(raw: Any, *, as_tuple: bool) -> Fact[Any]:
     return Fact(
         status=FactStatus(data["status"]),
         value=value,
-        diagnostics=tuple(data.get("diagnostics") or ()),
+        # diagnostics_from, never bare tuple(): a string is a Sequence, so
+        # ``"diagnostics": "parse error"`` would decode to eleven
+        # single-character diagnostics and be written back that way, and a
+        # non-string member would be coerced into a manufactured one.
+        diagnostics=diagnostics_from(data.get("diagnostics") or ()),
     )
 
 
@@ -211,5 +220,16 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
             # (``storage/AGENTS.md`` invariant 6).
             disambiguator=_disambiguator(occurrence.get("disambiguator")),
         )
+        if occ_id in occurrences:
+            # The list encoding can spell a duplicate that the mapping cannot
+            # hold; assigning over it would report a successful load having
+            # discarded an occurrence, which is the one thing this package
+            # never does (``storage/AGENTS.md``: never resolve identity by
+            # discarding an occurrence).
+            raise ValueError(
+                f"semantic_ir names the same occurrence twice "
+                f"({canonical_key(occ_id)!r}); one of the two entities would "
+                "be discarded on load"
+            )
         occurrences[occ_id] = _entity_from_dict(entry.get("entity"))
     snap.semantic_ir = SemanticIR(occurrences=occurrences)

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -61,6 +61,7 @@ from .guards import (
     identity_text,
     mapping as _require_mapping,
     provenance_text,
+    row_sequence,
 )
 
 if TYPE_CHECKING:
@@ -104,8 +105,27 @@ def _fact_from_dict(raw: Any, *, as_tuple: bool) -> Fact[Any]:
         # ``"diagnostics": "parse error"`` would decode to eleven
         # single-character diagnostics and be written back that way, and a
         # non-string member would be coerced into a manufactured one.
-        diagnostics=diagnostics_from(data.get("diagnostics") or ()),
+        # `_present_or` rather than `... or ()`: a FALSEY malformed value
+        # (`False`, `0`, `{}`) would otherwise skip the guard entirely and
+        # be rewritten as "no diagnostics" -- the same silent-discard this
+        # guard exists to refuse, reached by a different route.
+        diagnostics=diagnostics_from(_present_or(data, "diagnostics", ())),
     )
+
+
+def _present_or(document: Mapping[str, Any], key: str, default: Any) -> Any:
+    """*document*'s value for *key*, or *default* when the key is genuinely
+    absent.
+
+    Absence and a falsey-but-present value are different documents and this
+    codec must not conflate them: `document.get(key) or default` hands a
+    malformed `False`/`0`/`{}`/`[]` straight past whichever guard was meant
+    to inspect it, turning "this field is corrupt" into "this field says
+    nothing" with no error anywhere. Every guarded read below goes through
+    here, so the distinction cannot be forgotten at one site the way it was
+    at three (Codex review).
+    """
+    return document[key] if key in document else default
 
 
 def _disambiguator(raw: Any) -> str:
@@ -194,20 +214,26 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
     two together would silently discard evidence in the one case the pairing
     is not guaranteed.
     """
-    conflicts = d.get("semantic_ir_conflicts")
-    if conflicts:
+    if "semantic_ir_conflicts" in d:
         snap.semantic_ir_conflicts = {
             identity_text(key, "semantic_ir_conflicts key"): identity_text(
                 value, "semantic_ir_conflicts value"
             )
-            for key, value in _mapping(conflicts, "semantic_ir_conflicts").items()
+            for key, value in _mapping(
+                d["semantic_ir_conflicts"], "semantic_ir_conflicts"
+            ).items()
         }
-    raw = d.get("semantic_ir")
-    if not raw:
+    if "semantic_ir" not in d:
+        # Key absent: this snapshot predates v38, or its backend produced no
+        # IR. A key that is PRESENT but malformed (`[]`, `""`, `0`) is a
+        # different document and is rejected below rather than read as
+        # "no backend produced one".
         return
-    document = _mapping(raw, "semantic_ir")
+    document = _mapping(d["semantic_ir"], "semantic_ir")
     occurrences: dict[OccurrenceId, CanonicalEntity] = {}
-    for entry_raw in document.get("occurrences") or ():
+    for entry_raw in row_sequence(
+        _present_or(document, "occurrences", ()), "semantic_ir occurrences"
+    ):
         entry = _mapping(entry_raw, "semantic_ir occurrence entry")
         occurrence = _mapping(entry.get("occurrence"), "semantic_ir occurrence")
         occ_id = OccurrenceId(

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -141,6 +141,13 @@ def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
     uses, so a snapshot from a backend not yet narrowed onto the normalizer
     serializes exactly as it did before this field existed.
     """
+    # Same sparse convention for the conflict map: written only when a merge
+    # actually recorded one, so a snapshot with nothing to say carries no key
+    # rather than an empty object. Without this, every v38 document would
+    # differ from the v37 one it would otherwise have been -- for a field
+    # only the hybrid path can ever populate.
+    if not snap.semantic_ir_conflicts:
+        d.pop("semantic_ir_conflicts", None)
     ir = snap.semantic_ir
     if ir is None:
         d.pop("semantic_ir", None)

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -77,9 +77,7 @@ __all__ = ["decode_semantic_ir", "encode_semantic_ir"]
 #: one is truncated: letting the dataclass default fill it in would turn
 #: missing persisted evidence into a valid `NOT_COLLECTED` availability claim.
 _FACT_FIELDS = tuple(
-    f.name
-    for f in fields(CanonicalEntity)
-    if f.name not in ("producer",)
+    f.name for f in fields(CanonicalEntity) if f.name not in ("producer",)
 )
 
 #: The ``CanonicalEntity`` fields carrying a tuple-valued ``Fact``. JSON has
@@ -98,6 +96,7 @@ def _mapping(raw: Any, field_name: str) -> Mapping[str, Any]:
 
 
 def _fact_to_dict(fact: Fact[Any]) -> dict[str, Any]:
+    """One ``Fact``'s wire form: status value, JSON-native value, diagnostics."""
     value = fact.value
     return {
         "status": fact.status.value,
@@ -161,6 +160,9 @@ def _fact_from_dict(raw: Any, *, as_tuple: bool, field_name: str) -> Fact[Any]:
 
 
 def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
+    """One ``CanonicalEntity``'s wire form: every ``Fact`` field, plus
+    ``producer`` when the entity names one (sparse, like every other
+    only-present-when-meaningful key in this format)."""
     document: dict[str, Any] = {
         name: _fact_to_dict(fact) for name, fact in entity.fact_items()
     }
@@ -170,6 +172,8 @@ def _entity_to_dict(entity: CanonicalEntity) -> dict[str, Any]:
 
 
 def _entity_from_dict(raw: Any) -> CanonicalEntity:
+    """Rebuild a ``CanonicalEntity``, requiring every fact field the writer
+    emits — see :data:`_FACT_FIELDS`."""
     data = _mapping(raw, "semantic_ir entity")
     facts = {
         name: _fact_from_dict(
@@ -204,6 +208,12 @@ def encode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
     # only the hybrid path can ever populate.
     if not snap.semantic_ir_conflicts:
         d.pop("semantic_ir_conflicts", None)
+    else:
+        # Sorted for the same reason the occurrence list is: `json.dumps`
+        # preserves a mapping's insertion order, so two runs that recorded
+        # the same conflicts in a different order would otherwise write
+        # different documents for identical state.
+        d["semantic_ir_conflicts"] = dict(sorted(snap.semantic_ir_conflicts.items()))
     ir = snap.semantic_ir
     if ir is None:
         d.pop("semantic_ir", None)
@@ -284,9 +294,7 @@ def decode_semantic_ir(d: dict[str, Any], snap: AbiSnapshot) -> None:
             # the assignment below would drop one of the two occurrences
             # (`storage/AGENTS.md` invariant 6).
             disambiguator=identity_text(
-                required_field(
-                    occurrence, "disambiguator", "semantic_ir occurrence"
-                ),
+                required_field(occurrence, "disambiguator", "semantic_ir occurrence"),
                 "semantic_ir occurrence disambiguator",
             ),
         )

--- a/abicheck/storage/semantic_ir_codec.py
+++ b/abicheck/storage/semantic_ir_codec.py
@@ -49,6 +49,7 @@ and ``serialization.py`` calls it, keeping that module (already at its
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import fields
 from typing import TYPE_CHECKING, Any
 
 from ..model.availability import FactStatus
@@ -69,6 +70,17 @@ if TYPE_CHECKING:
     from ..model.snapshot import AbiSnapshot
 
 __all__ = ["decode_semantic_ir", "encode_semantic_ir"]
+
+#: Every ``Fact``-typed field on ``CanonicalEntity``, derived from the
+#: dataclass itself so a new field cannot be added to the model and silently
+#: left unrequired here. The writer emits all of them, so a document short of
+#: one is truncated: letting the dataclass default fill it in would turn
+#: missing persisted evidence into a valid `NOT_COLLECTED` availability claim.
+_FACT_FIELDS = tuple(
+    f.name
+    for f in fields(CanonicalEntity)
+    if f.name not in ("producer",)
+)
 
 #: The ``CanonicalEntity`` fields carrying a tuple-valued ``Fact``. JSON has
 #: no tuple, so these come back as lists and are re-tupled on load — without
@@ -173,10 +185,11 @@ def _entity_from_dict(raw: Any) -> CanonicalEntity:
     data = _mapping(raw, "semantic_ir entity")
     facts = {
         name: _fact_from_dict(
-            value, as_tuple=name in _TUPLE_VALUED_FACTS, field_name=name
+            required_field(data, name, "semantic_ir entity"),
+            as_tuple=name in _TUPLE_VALUED_FACTS,
+            field_name=name,
         )
-        for name, value in data.items()
-        if name != "producer"
+        for name in _FACT_FIELDS
     }
     producer = data.get("producer", "")
     return CanonicalEntity(

--- a/architecture/debt.yaml
+++ b/architecture/debt.yaml
@@ -763,12 +763,12 @@
     },
     {
       "path": "abicheck/dumper_hybrid.py",
-      "baseline_lines": 1005,
+      "baseline_lines": 1018,
       "target": "see ADR-061 ownership map",
       "rule": "no_growth",
       "category": "legacy_oversized_module",
       "owner": "abicheck maintainers",
-      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice. Raised by 10 for ADR-063 Phase 2's closing slice: the merged snapshot must union the typedef_entity_ids/constant_entity_ids sidecars in the same direction it already unions typedefs_qualified, or the sidecars desync from the dicts they annotate. Raised by a further 16 in the same slice's follow-up (Codex review): constants itself is NOT merged the same way typedefs_qualified is, so constant_entity_ids needed an explicit filter to the keys castxml_snap.constants actually retains, or a clang-only constant would leave a phantom sidecar key with no matching entry.",
+      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice. Raised by 10 for ADR-063 Phase 2's closing slice: the merged snapshot must union the typedef_entity_ids/constant_entity_ids sidecars in the same direction it already unions typedefs_qualified, or the sidecars desync from the dicts they annotate. Raised by a further 16 in the same slice's follow-up (Codex review): constants itself is NOT merged the same way typedefs_qualified is, so constant_entity_ids needed an explicit filter to the keys castxml_snap.constants actually retains, or a clang-only constant would leave a phantom sidecar key with no matching entry. Raised by a further 13 for ADR-063 Phase 6's first slice: merge_snapshots() must reconcile the two sub-snapshots' semantic_ir the same way it already reconciles every legacy field, or the merged snapshot's two representations disagree on every clang-only/clang-backfilled declaration. The matching/backfill algorithm itself lives in the new extract/semantic_ir_merge.py, so only the call-site plumbing lands here.",
       "review_by": "2026-11-30"
     },
     {

--- a/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
+++ b/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
@@ -14,8 +14,10 @@
   list of entries rather than a string-keyed map so the typed `ScopePath`
   inside each key round-trips losslessly. The field is additive and
   currently `None` on every snapshot a real `dump` produces — no backend is
-  narrowed onto the shared normalizer yet, so no detector, verdict, exit
-  code or existing snapshot document changes.
+  narrowed onto the shared normalizer yet, so no detector, verdict or exit
+  code changes, and such a snapshot's document differs from the one this
+  release's predecessor wrote only in its `schema_version` stamp (both new
+  keys are written only when there is something to record).
 - **`--ast-frontend hybrid` reconciles `semantic_ir` across both backends**
   the same way `merge_snapshots()` already reconciles every legacy field:
   castxml is the base, clang backfills only the facts castxml left

--- a/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
+++ b/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
@@ -26,5 +26,8 @@
   one in the new `AbiSnapshot.semantic_ir_conflicts` — keyed per
   *occurrence*, since `fact_provenance`'s declaration-only key cannot
   separate two matched occurrence pairs sharing one `EntityId`. Matching is
-  fail-closed: a group with no unique complete matching is left entirely
-  unmerged rather than paired by guess.
+  fail-closed: two occurrences pair only when at most one side supplies a
+  disambiguator, and a group with no unique complete matching keeps every
+  occurrence from both sides rather than being paired by guess — except an
+  occurrence the two sides key *identically*, which is one occurrence by
+  definition and still merges.

--- a/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
+++ b/changelog.d/1787100000_claude_adr063-phase6-semantic-ir.md
@@ -1,0 +1,28 @@
+### Added
+
+- **Snapshots can now carry a canonical `SemanticIR`** (ADR-063 Phase 6's
+  first slice): `abicheck/model/semantic_ir.py` defines the one
+  backend-independent shape every extraction backend will canonicalize into
+  — `SemanticIR.occurrences`, keyed by `OccurrenceId` so a complete
+  definition and an ODR-duplicate/incomplete declaration sharing one
+  `EntityId` both survive, with `canonical_entities()` as the explicit,
+  deterministic reduction for a consumer that genuinely wants one view per
+  identity. `CanonicalEntity` carries only the non-identity payload
+  (canonical spelling, template arguments, CV-qualification, each wrapped in
+  `Fact[...]`), never a second copy of the identity its key already states.
+  `AbiSnapshot.semantic_ir` persists through schema **v38**, encoded as a
+  list of entries rather than a string-keyed map so the typed `ScopePath`
+  inside each key round-trips losslessly. The field is additive and
+  currently `None` on every snapshot a real `dump` produces — no backend is
+  narrowed onto the shared normalizer yet, so no detector, verdict, exit
+  code or existing snapshot document changes.
+- **`--ast-frontend hybrid` reconciles `semantic_ir` across both backends**
+  the same way `merge_snapshots()` already reconciles every legacy field:
+  castxml is the base, clang backfills only the facts castxml left
+  unresolved, a clang-only entity is unioned in, and a fact both backends
+  resolved to different values keeps castxml's while recording the discarded
+  one in the new `AbiSnapshot.semantic_ir_conflicts` — keyed per
+  *occurrence*, since `fact_provenance`'s declaration-only key cannot
+  separate two matched occurrence pairs sharing one `EntityId`. Matching is
+  fail-closed: a group with no unique complete matching is left entirely
+  unmerged rather than paired by guess.

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -531,8 +531,11 @@
   disagreement keeping castxml's value and recording the discarded one
   per *occurrence* (`fact_provenance`'s declaration-only key cannot
   separate two matched pairs sharing one `EntityId`), and a fail-closed
-  matcher that leaves a group with no unique complete matching entirely
-  unmerged. Each of the plan's four review-falsified matching rules is
+  matcher that never pairs an occurrence with a differently-keyed one — a
+  group with no unique complete matching keeps every occurrence from both
+  sides, while an occurrence the two sides key *identically* still merges,
+  since one `OccurrenceId` names one occurrence and discarding the
+  overlay's copy would lose the evidence this step exists to preserve. Each of the plan's four review-falsified matching rules is
   pinned as a property test (`tests/test_semantic_ir_merge.py`); one of
   them — two occurrences on one side sharing a non-empty disambiguator —
   turns out to be structurally unreachable from a real `SemanticIR` (that

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -531,9 +531,12 @@
   disagreement keeping castxml's value and recording the discarded one
   per *occurrence* (`fact_provenance`'s declaration-only key cannot
   separate two matched pairs sharing one `EntityId`), and a fail-closed
-  matcher that never pairs an occurrence with a differently-keyed one — a
+  matcher whose one refusal is a *two-sided* disagreement: two occurrences
+  pair when at most one side supplies a disambiguator (castxml routinely
+  supplies none, so this is the ordinary case, and the two keys then
+  legitimately differ), and never when both supply one and they differ. A
   group with no unique complete matching keeps every occurrence from both
-  sides, while an occurrence the two sides key *identically* still merges,
+  sides; an occurrence the two sides key *identically* still merges there,
   since one `OccurrenceId` names one occurrence and discarding the
   overlay's copy would lose the evidence this step exists to preserve. Each of the plan's four review-falsified matching rules is
   pinned as a property test (`tests/test_semantic_ir_merge.py`); one of

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -504,7 +504,53 @@
   reported fact" population D7's own amendment scopes as a future,
   separately-justified extension beyond the availability-bearing subset
   this phase (and D7's initial realization) actually covers.
-- **Phases 6–10** are still unimplemented design text.
+- **Phase 6** (one canonical `SemanticIR` between the backends and the
+  checker) has landed its **first slice — the IR itself, its persistence,
+  and the hybrid merge's reconciliation of it — and no parser narrowing.**
+  That ordering is the plan's own: `SemanticIR` is defined and tested
+  before any backend is narrowed onto it, so the per-backend migrations
+  converge on one shape rather than on each backend's own reading of
+  "canonical" behind a shared name. `abicheck/model/semantic_ir.py` (new)
+  defines `SemanticIR.occurrences: Mapping[OccurrenceId, CanonicalEntity]`
+  — keyed by occurrence, never collapsed per `EntityId`, so an
+  ODR-duplicate/incomplete-declaration pair keeps both sides' availability
+  — plus `canonical_entities()` as the explicit, order-independent
+  reduction (most-resolved occurrence wins, ties broken on
+  `canonical_key`), and `CanonicalEntity`, which carries only the
+  non-identity payload (`Fact`-wrapped canonical spelling, template
+  arguments, CV-qualification, and a `producer` tag), never a second copy
+  of the identity its key already states. `AbiSnapshot.semantic_ir` and
+  `AbiSnapshot.semantic_ir_conflicts` persist through
+  `storage/semantic_ir_codec.py` (`SCHEMA_VERSION` 37→38) as a **list of
+  entries** rather than a string-keyed map, for the two reasons the plan
+  names: `dataclasses.asdict()` raises outright on a dataclass dict key,
+  and a rendered string key cannot carry back the typed `ScopePath` inside
+  an `OccurrenceId`. `dumper_hybrid.merge_snapshots()` gains the fifth
+  reconciliation step (`extract/semantic_ir_merge.py`): base-plus-backfill
+  with castxml as the base, a clang-only entity unioned in, a two-sided
+  disagreement keeping castxml's value and recording the discarded one
+  per *occurrence* (`fact_provenance`'s declaration-only key cannot
+  separate two matched pairs sharing one `EntityId`), and a fail-closed
+  matcher that leaves a group with no unique complete matching entirely
+  unmerged. Each of the plan's four review-falsified matching rules is
+  pinned as a property test (`tests/test_semantic_ir_merge.py`); one of
+  them — two occurrences on one side sharing a non-empty disambiguator —
+  turns out to be structurally unreachable from a real `SemanticIR` (that
+  pair *is* one `OccurrenceId`, hence one dict key), so the guard is
+  tested at the matcher's own list-taking entry point and the reachability
+  limit is stated rather than left implied by a test that only appears to
+  cover it. **Deliberately not in this slice, and therefore not yet
+  observable to any user:** no backend produces an IR yet
+  (`dumper_castxml.py`/`dumper_clang.py`/`dwarf_snapshot.py`/
+  `pdb_metadata.py`/`btf_metadata.py`/`ctf_metadata.py` are unchanged),
+  `extract/semantic_normalizer.py` does not exist, and none of the five
+  assembly call sites projects through it — so `semantic_ir` is `None` on
+  every snapshot a real `dump` produces, every v38 document is
+  byte-identical to the v37 one it would have been, and the snapshot cache
+  version is deliberately *not* bumped (no dumping-pipeline output
+  changed). The parser narrowing, the normalizer, and the per-call-site
+  parity tests are the remainder of this phase.
+- **Phases 7–10** are still unimplemented design text.
 
 See the [implementation plan](../plans/one-semantic-pipeline.md) for the
 full phase-by-phase state, including every slice's own "Landed"/"What this

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -549,7 +549,9 @@
   `extract/semantic_normalizer.py` does not exist, and none of the five
   assembly call sites projects through it — so `semantic_ir` is `None` on
   every snapshot a real `dump` produces, every v38 document is
-  byte-identical to the v37 one it would have been, and the snapshot cache
+  identical to the v37 one it would have been apart from the version stamp
+  itself (the `semantic_ir_conflicts` map is written only when a hybrid merge
+  recorded one, never as an empty object), and the snapshot cache
   version is deliberately *not* bumped (no dumping-pipeline output
   changed). The parser narrowing, the normalizer, and the per-call-site
   parity tests are the remainder of this phase.

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -12509,7 +12509,10 @@ its own stated reasoning:
    one occurrence by that type's own definition, so an exact key match is
    not a guessed pairing: it merges under the ordinary base-plus-backfill
    rule. What stays fail-closed is what the ambiguity is actually about —
-   no occurrence is ever paired with a *differently* keyed one.
+   two occurrences pair only when at most one side supplies a
+   disambiguator, never when both supply one and they disagree. (Differing
+   *keys* are not themselves the refusal: castxml supplies no disambiguator
+   at all, so the ordinary match pairs an empty key with a non-empty one.)
 3. **The "two occurrences on one side sharing a non-empty disambiguator"
    ambiguity is unreachable from a real `SemanticIR`**, because that pair
    *is* one `OccurrenceId` and therefore one dict key. The guard stays (the

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -12524,7 +12524,9 @@ produces an IR (`dumper_castxml.py`/`dumper_clang.py`/`dwarf_snapshot.py`/
 untouched), `extract/semantic_normalizer.py` does not exist, and none of
 the five assembly call sites projects through it — so `semantic_ir` is
 `None` on every snapshot a real `dump` produces, a v38 document is
-byte-identical to the v37 one it would have been, and the snapshot cache
+identical to the v37 one it would have been apart from the version stamp
+itself -- both new keys are sparse, written only when there is something to
+say -- and the snapshot cache
 version is deliberately not bumped. The per-call-site end-to-end parity
 tests this section requires belong with that work, since there is no
 normalizer-mediated assembly path to prove behavior-preserving yet; the

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -12490,7 +12490,7 @@ chokepoints; `abicheck/extract/semantic_ir_merge.py` wired into
 (`test_model_semantic_ir.py`, `test_semantic_ir_merge.py`,
 `test_semantic_ir_serialization.py`, `test_dumper_hybrid_semantic_ir.py`).
 
-Two deliberate deviations from this section's letter, both in service of
+Three deliberate deviations from this section's letter, each in service of
 its own stated reasoning:
 
 1. **`encode_semantic_ir`/`decode_semantic_ir` live in `storage/`, not in
@@ -12501,7 +12501,16 @@ its own stated reasoning:
    (`entity_id_codec.py`, `surface_graph_codec.py`), and keeps
    `serialization.py` — already at its `architecture/debt.yaml` no-growth
    baseline — to the call-site plumbing.
-2. **The "two occurrences on one side sharing a non-empty disambiguator"
+2. **An ambiguous group is not "unioned verbatim" for an occurrence both
+   sides key identically** — that phrasing has no meaning for a key
+   collision, and taking it literally means `setdefault` silently discarding
+   the overlay's entity, losing exactly the facts and conflict records this
+   step exists to preserve (Codex review, PR #991). One `OccurrenceId` names
+   one occurrence by that type's own definition, so an exact key match is
+   not a guessed pairing: it merges under the ordinary base-plus-backfill
+   rule. What stays fail-closed is what the ambiguity is actually about —
+   no occurrence is ever paired with a *differently* keyed one.
+3. **The "two occurrences on one side sharing a non-empty disambiguator"
    ambiguity is unreachable from a real `SemanticIR`**, because that pair
    *is* one `OccurrenceId` and therefore one dict key. The guard stays (the
    matcher takes plain lists, and the invariant belongs to the caller's key

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -12474,6 +12474,65 @@ three phases.
 
 ### Phase 6 — canonical `SemanticIR` between backends and the checker
 
+**LANDED (first slice): the IR, its persistence, and the hybrid merge's
+reconciliation of it — no parser narrowing.** Exactly the ordering this
+phase's own Design section requires ("this model file, and a
+primitive-level test suite pinning its shape directly ... land as their own
+first step in this phase, before any of the following narrowing work"), so
+the per-backend migrations have one concrete target to converge on.
+Landed: `abicheck/model/semantic_ir.py` (`SemanticIR`/`CanonicalEntity`/
+`canonical_cv_qualification`/`semantic_ir_conflict_key`);
+`AbiSnapshot.semantic_ir`/`semantic_ir_conflicts`;
+`abicheck/storage/semantic_ir_codec.py` (schema v38, the list-of-entries
+encoding this section specifies) called from `serialization.py`'s two
+chokepoints; `abicheck/extract/semantic_ir_merge.py` wired into
+`dumper_hybrid.merge_snapshots()`; and four test modules
+(`test_model_semantic_ir.py`, `test_semantic_ir_merge.py`,
+`test_semantic_ir_serialization.py`, `test_dumper_hybrid_semantic_ir.py`).
+
+Two deliberate deviations from this section's letter, both in service of
+its own stated reasoning:
+
+1. **`encode_semantic_ir`/`decode_semantic_ir` live in `storage/`, not in
+   `serialization.py` itself.** The reason this section moved them off the
+   domain types was the `model -> storage` edge ADR-061 forbids; a
+   `storage`-resident codec has no such problem (`storage -> model` is the
+   allowed direction), matches this package's two sibling codecs
+   (`entity_id_codec.py`, `surface_graph_codec.py`), and keeps
+   `serialization.py` — already at its `architecture/debt.yaml` no-growth
+   baseline — to the call-site plumbing.
+2. **The "two occurrences on one side sharing a non-empty disambiguator"
+   ambiguity is unreachable from a real `SemanticIR`**, because that pair
+   *is* one `OccurrenceId` and therefore one dict key. The guard stays (the
+   matcher takes plain lists, and the invariant belongs to the caller's key
+   type), is tested at that entry point directly, and the limit is recorded
+   rather than papered over with a test that only looks like it covers the
+   case.
+
+**Not landed, and therefore this phase is not complete:** no backend
+produces an IR (`dumper_castxml.py`/`dumper_clang.py`/`dwarf_snapshot.py`/
+`pdb_metadata.py`/`btf_metadata.py`/`ctf_metadata.py`/`pdb_model.py` are
+untouched), `extract/semantic_normalizer.py` does not exist, and none of
+the five assembly call sites projects through it — so `semantic_ir` is
+`None` on every snapshot a real `dump` produces, a v38 document is
+byte-identical to the v37 one it would have been, and the snapshot cache
+version is deliberately not bumped. The per-call-site end-to-end parity
+tests this section requires belong with that work, since there is no
+normalizer-mediated assembly path to prove behavior-preserving yet; the
+`--ast-frontend hybrid` half of that requirement is covered now, at the
+merge function itself. One further obligation is named here so the
+narrowing work does not rediscover it: `qualified_name_segments.
+_LAMBDA_IDENTITY_FIELDS` renumbers lambda/closure ordinals across the
+snapshot fields that carry them, and an `EntityId` inside a `SemanticIR`
+key can hold exactly such an ordinal (`Anonymous`/`LocalToFunction`), so
+the first slice that actually populates the IR must decide whether
+`semantic_ir` joins that walk — the same "a sidecar's keys must be
+renumbered exactly when its partner's are" rule the `typedef_entity_ids`
+sidecar already follows. It is not an open question *today* only because
+the map is always empty. The checklist row below ("each backend parser's own
+copy of anonymous-marker/closure-identity/namespace-join logic") is
+correspondingly still open.
+
 **Goal.** Type-spelling, scope, template-argument, anonymous/lambda, and
 CV-qualification canonicalization happens once, not once per backend.
 

--- a/docs/reference/snapshot-format.md
+++ b/docs/reference/snapshot-format.md
@@ -156,7 +156,8 @@ key as a string would lose the typed `ScopePath` inside it exactly as v28's
 own `entity_id` encoding would have. Absent (the key is dropped, not
 written as `null`) for a snapshot whose extraction produced no IR, which is
 every snapshot written by a backend not yet narrowed onto the shared
-normalizer — so a v38 document is byte-identical to a v37 one for those.
+normalizer. `semantic_ir_conflicts` is sparse the same way, so for such a
+snapshot a v38 document differs from the v37 one only in the version stamp.
 ### Forward / backward compatibility
 
 abicheck loads a snapshot best-effort and never migrates it in place. The rule

--- a/docs/reference/snapshot-format.md
+++ b/docs/reference/snapshot-format.md
@@ -31,13 +31,13 @@ compatibility rules, and its top-level structure.
 ## Schema version
 
 Every snapshot carries a top-level **`schema_version`** field — a single
-**integer** (not `MAJOR.MINOR`). The current value is **`37`** (see
+**integer** (not `MAJOR.MINOR`). The current value is **`38`** (see
 `abicheck/serialization.py`'s `SCHEMA_VERSION` for the authoritative,
 up-to-date value and the full per-version history comment).
 
 ```json
 {
-  "schema_version": 37,
+  "schema_version": 38,
   "library": "libfoo.so.1",
   "version": "1.2.3"
 }
@@ -147,7 +147,16 @@ backend-driven since each block is parsed by exactly one backend;
 `frozenset` rather than left as the bare JSON list
 (`snapshot_platform_blocks.elf_from_dict`), the identical reconstruction
 `Variable.elf_binding_fact`/`Function.elf_binding_fact` already need for
-their own non-JSON-native value type.
+their own non-JSON-native value type, and (v38) `AbiSnapshot.semantic_ir`
+— ADR-063 Phase 6's canonical, backend-independent IR, plus its
+`semantic_ir_conflicts` sibling. Encoded by `storage/semantic_ir_codec.py`
+as a **list of `{"occurrence": …, "entity": …}` entries**, not a JSON
+object: the IR is keyed by an `OccurrenceId` dataclass, and rendering that
+key as a string would lose the typed `ScopePath` inside it exactly as v28's
+own `entity_id` encoding would have. Absent (the key is dropped, not
+written as `null`) for a snapshot whose extraction produced no IR, which is
+every snapshot written by a backend not yet narrowed onto the shared
+normalizer — so a v38 document is byte-identical to a v37 one for those.
 ### Forward / backward compatibility
 
 abicheck loads a snapshot best-effort and never migrates it in place. The rule
@@ -157,7 +166,7 @@ is determined entirely by comparing the file's `schema_version` against the
 | File `schema_version` | Behavior on load |
 |-----------------------|------------------|
 | **Missing** | Treated as `1` (the pre-versioning format) and loaded normally. |
-| **Older or equal** to this build (`<= 37`) | Loaded cleanly. Fields introduced by newer versions are absent and fall back to their defaults (`None`, empty, or a tri-state `None` that suppresses the detectors depending on that evidence). No warning. |
+| **Older or equal** to this build (`<= 38`) | Loaded cleanly. Fields introduced by newer versions are absent and fall back to their defaults (`None`, empty, or a tri-state `None` that suppresses the detectors depending on that evidence). No warning. |
 | **Newer** than this build, **and** `< 14` | Loaded **best-effort** with a `UserWarning` ("Data may be incomplete or misinterpreted. Upgrade abicheck…"). The load is **not** aborted — unrecognised keys are ignored and recognised keys are read. |
 | **Newer** than this build, **and** `>= 14` | **Hard-rejected** — `IncompatibleSnapshotSchemaError` — instead of warn-and-continue. |
 
@@ -222,7 +231,7 @@ serializer (`abicheck/serialization.py`) from the `AbiSnapshot` model
 
 | Key | Type | Meaning |
 |-----|------|---------|
-| `schema_version` | int | Snapshot format version (currently `37`). |
+| `schema_version` | int | Snapshot format version (currently `38`). |
 | `library` | string | Library identity, e.g. `libfoo.so.1`. |
 | `version` | string | Library version string, e.g. `1.2.3`. |
 | `source_path` | string \| null | Original path the snapshot was taken from. |
@@ -356,7 +365,7 @@ files:
 | | Snapshot (`dump`) | Comparison report (`compare --format json`) |
 |-|-------------------|---------------------------------------------|
 | **Version field** | `schema_version` | `report_schema_version` |
-| **Type** | integer (currently `37`) | string `MAJOR.MINOR` (e.g. `1.0`) |
+| **Type** | integer (currently `38`) | string `MAJOR.MINOR` (e.g. `1.0`) |
 | **Describes** | one library's ABI surface | the diff between two snapshots |
 
 A snapshot has no `report_schema_version`, and a report has no

--- a/examples/case143_audit_accidental_export/snapshot.abi.json
+++ b/examples/case143_audit_accidental_export/snapshot.abi.json
@@ -298,7 +298,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case144_audit_private_header_leak/snapshot.abi.json
+++ b/examples/case144_audit_private_header_leak/snapshot.abi.json
@@ -202,7 +202,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case145_audit_unversioned_export/snapshot.abi.json
+++ b/examples/case145_audit_unversioned_export/snapshot.abi.json
@@ -140,7 +140,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case146_audit_rtti_for_internal/snapshot.abi.json
+++ b/examples/case146_audit_rtti_for_internal/snapshot.abi.json
@@ -224,7 +224,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case147_scan_depth_ladder/snapshot.abi.json
+++ b/examples/case147_scan_depth_ladder/snapshot.abi.json
@@ -298,7 +298,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case148_xcheck_header_build_mismatch/snapshot.abi.json
+++ b/examples/case148_xcheck_header_build_mismatch/snapshot.abi.json
@@ -99,7 +99,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case149_xcheck_odr_variant/snapshot.abi.json
+++ b/examples/case149_xcheck_odr_variant/snapshot.abi.json
@@ -111,7 +111,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case150_xcheck_export_public_pair/snapshot.abi.json
+++ b/examples/case150_xcheck_export_public_pair/snapshot.abi.json
@@ -287,7 +287,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case151_xcheck_provider_matrix/snapshot.abi.json
+++ b/examples/case151_xcheck_provider_matrix/snapshot.abi.json
@@ -283,7 +283,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case151_xcheck_provider_matrix/thin.abi.json
+++ b/examples/case151_xcheck_provider_matrix/thin.abi.json
@@ -202,7 +202,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/examples/case181_xcheck_public_to_internal_dependency/snapshot.abi.json
+++ b/examples/case181_xcheck_public_to_internal_dependency/snapshot.abi.json
@@ -188,7 +188,7 @@
   "platform": null,
   "python_api": null,
   "python_ext": null,
-  "schema_version": 37,
+  "schema_version": 38,
   "scope_fallback": null,
   "source_mtime": null,
   "source_mtime_epoch": false,

--- a/tests/test_baseline_pinning.py
+++ b/tests/test_baseline_pinning.py
@@ -29,7 +29,7 @@ def _sample_snap(**kwargs) -> AbiSnapshot:
 
 class TestSchemaV4:
     def test_schema_version_is_current(self):
-        assert SCHEMA_VERSION == 37
+        assert SCHEMA_VERSION == 38
 
     def test_provenance_fields_roundtrip(self):
         snap = _sample_snap(

--- a/tests/test_dumper_hybrid_semantic_ir.py
+++ b/tests/test_dumper_hybrid_semantic_ir.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``merge_snapshots()``'s ``semantic_ir`` reconciliation (ADR-063 Phase 6).
+
+The merge *algorithm* is tested at primitive level in
+``test_semantic_ir_merge.py``; this file covers the wiring, i.e. that the
+hybrid path actually reconciles the field rather than carrying the castxml
+sub-snapshot's IR through unchanged beside legacy fields that did get
+reconciled. Its own file rather than a class inside ``test_dumper_hybrid.py``,
+which is already at its ``architecture/debt.yaml`` no-growth baseline.
+"""
+
+from __future__ import annotations
+
+from abicheck.dumper_hybrid import merge_snapshots
+from abicheck.model import AbiSnapshot, Function
+from abicheck.model.fact import Fact
+from abicheck.model.identity import entity_id_for_type
+from abicheck.model.occurrence import OccurrenceId
+from abicheck.model.semantic_ir import (
+    CanonicalEntity,
+    SemanticIR,
+    semantic_ir_conflict_key,
+)
+
+FOO = entity_id_for_type((), "Foo")
+BAR = entity_id_for_type((), "Bar")
+
+
+def _snap(ir: SemanticIR | None, producer: str, **kwargs: object) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version="1.0",
+        from_headers=True,
+        ast_producer=producer,
+        semantic_ir=ir,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _entity(
+    spelling: str, *, template: tuple[str, ...] | None = None
+) -> CanonicalEntity:
+    return CanonicalEntity(
+        canonical_spelling=Fact.present(spelling),
+        template_arguments=(
+            Fact.present(template) if template is not None else Fact.not_collected()
+        ),
+    )
+
+
+class TestMergeSnapshotsReconcilesSemanticIr:
+    def test_clang_only_entity_reaches_the_merged_ir(self) -> None:
+        """The exact drift this step exists to close: a clang-only entity is
+        already unioned into the merged ``functions``/``types``, so leaving it
+        out of ``semantic_ir`` would make one snapshot's two representations
+        disagree."""
+        castxml_occ = OccurrenceId(FOO)
+        clang_occ = OccurrenceId(BAR)
+        merged = merge_snapshots(
+            _snap(SemanticIR({castxml_occ: _entity("Foo")}), "castxml"),
+            _snap(SemanticIR({clang_occ: _entity("Bar")}), "clang"),
+        )
+        assert merged.semantic_ir is not None
+        assert set(merged.semantic_ir.occurrences) == {castxml_occ, clang_occ}
+
+    def test_clang_backfills_an_unresolved_castxml_fact(self) -> None:
+        occ = OccurrenceId(FOO)
+        merged = merge_snapshots(
+            _snap(SemanticIR({occ: _entity("Foo")}), "castxml"),
+            _snap(SemanticIR({occ: _entity("Foo", template=("int",))}), "clang"),
+        )
+        assert merged.semantic_ir is not None
+        assert merged.semantic_ir.occurrences[occ].template_arguments.value == ("int",)
+
+    def test_a_two_sided_disagreement_is_recorded_not_dropped(self) -> None:
+        occ = OccurrenceId(FOO)
+        merged = merge_snapshots(
+            _snap(SemanticIR({occ: _entity("castxml::Foo")}), "castxml"),
+            _snap(SemanticIR({occ: _entity("clang::Foo")}), "clang"),
+        )
+        assert merged.semantic_ir is not None
+        assert merged.semantic_ir.occurrences[occ].canonical_spelling.value == (
+            "castxml::Foo"
+        )
+        assert merged.semantic_ir_conflicts == {
+            semantic_ir_conflict_key(occ, "canonical_spelling"): repr("clang::Foo")
+        }
+
+    def test_no_ir_on_either_side_leaves_the_field_none(self) -> None:
+        merged = merge_snapshots(_snap(None, "castxml"), _snap(None, "clang"))
+        assert merged.semantic_ir is None
+        assert merged.semantic_ir_conflicts == {}
+
+    def test_one_sided_ir_survives(self) -> None:
+        occ = OccurrenceId(FOO)
+        merged = merge_snapshots(
+            _snap(None, "castxml"), _snap(SemanticIR({occ: _entity("Foo")}), "clang")
+        )
+        assert merged.semantic_ir is not None
+        assert set(merged.semantic_ir.occurrences) == {occ}
+
+    def test_pre_existing_conflicts_are_preserved(self) -> None:
+        """A castxml leg that is itself a merge result (a nested hybrid dump)
+        carries conflicts of its own; this merge adds to them rather than
+        replacing the map."""
+        occ = OccurrenceId(FOO)
+        merged = merge_snapshots(
+            _snap(
+                SemanticIR({occ: _entity("Foo")}),
+                "castxml",
+                semantic_ir_conflicts={"earlier": "'value'"},
+            ),
+            _snap(SemanticIR({occ: _entity("Foo", template=("int",))}), "clang"),
+        )
+        assert merged.semantic_ir_conflicts == {"earlier": "'value'"}
+
+    def test_a_one_sided_fallback_returns_castxml_untouched(self) -> None:
+        """The existing early return (one side never got header evidence) is
+        not weakened: the castxml snapshot, IR included, comes back as-is."""
+        castxml = _snap(SemanticIR({OccurrenceId(FOO): _entity("Foo")}), "castxml")
+        clang = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            from_headers=False,
+            ast_producer="clang",
+            semantic_ir=SemanticIR({OccurrenceId(BAR): _entity("Bar")}),
+        )
+        assert merge_snapshots(castxml, clang) is castxml
+
+
+class TestLegacyFieldsAreUnaffected:
+    def test_merging_snapshots_without_an_ir_is_unchanged(self) -> None:
+        """Parity: every snapshot produced today carries no ``semantic_ir``
+        (no backend is narrowed onto the normalizer yet), so the hybrid
+        merge's existing output must be bit-identical."""
+        func = Function(name="f", mangled="_Z1fv", return_type="void", params=[])
+        merged = merge_snapshots(
+            _snap(None, "castxml", functions=[func]),
+            _snap(None, "clang", functions=[func]),
+        )
+        assert [f.mangled for f in merged.functions] == ["_Z1fv"]
+        assert merged.semantic_ir is None

--- a/tests/test_model_semantic_ir.py
+++ b/tests/test_model_semantic_ir.py
@@ -193,6 +193,37 @@ class TestCanonicalCvQualification:
                 cv_qualification=Fact.present(("volatile", "const")),
             )
 
+    @pytest.mark.parametrize("constructor", [Fact.present, Fact.partial])
+    def test_every_usable_status_is_canonicalized(self, constructor: object) -> None:
+        """`PARTIAL` is usable evidence everywhere else in this IR, so a
+        status-specific check would accept a non-canonical spelling from one
+        constructor and reject the identical value from the other — two
+        spellings of one qualification, which is what canonicalization exists
+        to prevent."""
+        with pytest.raises(ValueError, match="not canonical"):
+            CanonicalEntity(
+                canonical_spelling=Fact.present("Foo"),
+                cv_qualification=constructor(("volatile", "const")),  # type: ignore[operator]
+            )
+        # ...and the canonical spelling is accepted from both, so the check
+        # is not simply rejecting the status.
+        entity = CanonicalEntity(
+            canonical_spelling=Fact.present("Foo"),
+            cv_qualification=constructor(("const", "volatile")),  # type: ignore[operator]
+        )
+        assert entity.cv_qualification.is_present
+
+    @pytest.mark.parametrize(
+        "fact",
+        [Fact.not_collected(), Fact.unsupported(), Fact.failed("no"), Fact.present(None)],
+    )
+    def test_a_fact_with_no_usable_value_is_not_checked(self, fact: object) -> None:
+        entity = CanonicalEntity(
+            canonical_spelling=Fact.present("Foo"),
+            cv_qualification=fact,  # type: ignore[arg-type]
+        )
+        assert entity.cv_qualification == fact
+
     def test_confirmed_absence_is_present_and_empty(self) -> None:
         entity = CanonicalEntity(
             canonical_spelling=Fact.present("Foo"),

--- a/tests/test_model_semantic_ir.py
+++ b/tests/test_model_semantic_ir.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``SemanticIR``/``CanonicalEntity`` primitives (ADR-063 Phase 6).
+
+Primitive-level, per AGENTS.md's "Primitive-level property tests" rule: the
+IR is a new, reusable shape several backends and one merge algorithm will
+key on, so its contract is stated here as invariants over generated input,
+independent of any one backend's domain logic — not only through whichever
+caller happens to exist first.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from hypothesis import given, strategies as st
+
+from abicheck.model.fact import Fact
+from abicheck.model.identity import Namespace, entity_id_for_type
+from abicheck.model.occurrence import OccurrenceId, canonical_key
+from abicheck.model.semantic_ir import (
+    CV_QUALIFIER_ORDER,
+    CanonicalEntity,
+    SemanticIR,
+    canonical_cv_qualification,
+    semantic_ir_conflict_key,
+)
+
+_names = st.text(
+    min_size=1, max_size=10, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
+)
+_tags = st.text(
+    min_size=1, max_size=8, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
+)
+
+
+def _entity(spelling: str = "ns::Foo", **kwargs: object) -> CanonicalEntity:
+    return CanonicalEntity(canonical_spelling=Fact.present(spelling), **kwargs)  # type: ignore[arg-type]
+
+
+class TestIdentityLivesOnlyInTheKey:
+    """The Governing-Invariant rule this type was redesigned around: a
+    ``CanonicalEntity`` carries no second, independently-settable copy of the
+    identity its mapping key already states, so no mapping can exist whose
+    key names one scope and whose value reports another."""
+
+    def test_no_identity_field_on_the_value(self) -> None:
+        field_names = {f.name for f in dataclasses.fields(CanonicalEntity)}
+        assert not field_names & {
+            "scope",
+            "scope_path",
+            "entity_id",
+            "occurrence_id",
+            "qualified_name",
+            "leaf_name",
+        }
+
+    def test_scope_is_read_off_the_key(self) -> None:
+        eid = entity_id_for_type((Namespace("ns"),), "Foo")
+        ir = SemanticIR(occurrences={OccurrenceId(eid): _entity()})
+        (occ_id,) = ir.occurrences
+        assert occ_id.entity_id.scope == (Namespace("ns"),)
+
+
+class TestOccurrencesAreNotCollapsed:
+    """One ``EntityId`` may legitimately name several occurrences — an
+    ODR-duplicate pair, or an incomplete declaration beside its complete
+    definition — carrying different availability. The mapping keeps both."""
+
+    def test_two_occurrences_one_entity_id_keep_their_own_facts(self) -> None:
+        eid = entity_id_for_type((), "Foo")
+        complete = OccurrenceId(eid, disambiguator="tu-a")
+        incomplete = OccurrenceId(eid, disambiguator="tu-b")
+        ir = SemanticIR(
+            occurrences={
+                complete: _entity(template_arguments=Fact.present(("int",))),
+                incomplete: _entity(template_arguments=Fact.not_collected()),
+            }
+        )
+        assert len(ir.occurrences) == 2
+        assert set(ir.occurrences_for(eid)) == {complete, incomplete}
+        assert ir.occurrences[complete].template_arguments.is_present
+        assert not ir.occurrences[incomplete].template_arguments.is_present
+
+    @given(tag_a=_tags, tag_b=_tags)
+    def test_distinct_disambiguators_never_share_a_key(
+        self, tag_a: str, tag_b: str
+    ) -> None:
+        eid = entity_id_for_type((), "Foo")
+        occurrences = {
+            OccurrenceId(eid, disambiguator=tag_a): _entity(),
+            OccurrenceId(eid, disambiguator=tag_b): _entity("other"),
+        }
+        assert len(occurrences) == (1 if tag_a == tag_b else 2)
+
+
+class TestCanonicalEntitiesReduction:
+    """``canonical_entities()`` is the *explicit* reduction — one entity per
+    identity, deterministic, never the shape the legacy snapshot fields are
+    projected from."""
+
+    def test_most_resolved_occurrence_wins(self) -> None:
+        eid = entity_id_for_type((), "Foo")
+        sparse = OccurrenceId(eid, disambiguator="a")
+        rich = OccurrenceId(eid, disambiguator="b")
+        ir = SemanticIR(
+            occurrences={
+                sparse: _entity(),
+                rich: _entity(
+                    template_arguments=Fact.present(("int",)),
+                    cv_qualification=Fact.present(("const",)),
+                ),
+            }
+        )
+        reduced = ir.canonical_entities()
+        assert set(reduced) == {eid}
+        assert reduced[eid] is ir.occurrences[rich]
+
+    @given(tags=st.lists(_tags, min_size=2, max_size=5, unique=True))
+    def test_reduction_does_not_depend_on_insertion_order(
+        self, tags: list[str]
+    ) -> None:
+        eid = entity_id_for_type((), "Foo")
+        # Every occurrence carries the same number of resolved facts, so the
+        # tie-break — and only the tie-break — decides: an order-dependent
+        # implementation would answer differently for a reversed dict.
+        entries = [
+            (OccurrenceId(eid, disambiguator=tag), _entity(f"spelling::{tag}"))
+            for tag in tags
+        ]
+        forward = SemanticIR(occurrences=dict(entries)).canonical_entities()
+        backward = SemanticIR(occurrences=dict(reversed(entries))).canonical_entities()
+        assert forward == backward
+
+    @given(tags=st.lists(_tags, min_size=1, max_size=5, unique=True))
+    def test_tie_break_is_canonical_key_order(self, tags: list[str]) -> None:
+        eid = entity_id_for_type((), "Foo")
+        entries = {
+            OccurrenceId(eid, disambiguator=tag): _entity(f"spelling::{tag}")
+            for tag in tags
+        }
+        expected_key = min(canonical_key(occ) for occ in entries)
+        winner = next(
+            entity
+            for occ, entity in entries.items()
+            if canonical_key(occ) == expected_key
+        )
+        assert SemanticIR(occurrences=entries).canonical_entities()[eid] == winner
+
+
+class TestCanonicalCvQualification:
+    @given(
+        qualifiers=st.lists(st.sampled_from(CV_QUALIFIER_ORDER), max_size=6),
+    )
+    def test_order_and_duplicate_independent(self, qualifiers: list[str]) -> None:
+        canonical = canonical_cv_qualification(qualifiers)
+        assert canonical == canonical_cv_qualification(reversed(qualifiers))
+        assert canonical == canonical_cv_qualification(qualifiers + qualifiers)
+        assert canonical == canonical_cv_qualification(canonical)  # idempotent
+        assert list(canonical) == [q for q in CV_QUALIFIER_ORDER if q in qualifiers]
+
+    def test_blank_entries_are_ignored(self) -> None:
+        # A backend that emits "" / " const " for an unqualified or padded
+        # spelling must not produce a different canonical value than one that
+        # emits nothing at all.
+        assert canonical_cv_qualification(["", "  ", " const "]) == ("const",)
+        assert canonical_cv_qualification([""]) == ()
+
+    def test_unknown_qualifier_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="unknown CV-qualifier"):
+            canonical_cv_qualification(["constexpr"])
+
+    def test_entity_refuses_a_non_canonical_value(self) -> None:
+        # Two backends spelling one qualification in two orders must not be
+        # able to construct two different entities for the same fact.
+        with pytest.raises(ValueError, match="not canonical"):
+            CanonicalEntity(
+                canonical_spelling=Fact.present("Foo"),
+                cv_qualification=Fact.present(("volatile", "const")),
+            )
+
+    def test_confirmed_absence_is_present_and_empty(self) -> None:
+        entity = CanonicalEntity(
+            canonical_spelling=Fact.present("Foo"),
+            cv_qualification=Fact.present(()),
+        )
+        assert entity.cv_qualification.is_present
+        assert entity.cv_qualification.value == ()
+
+
+class TestFactItems:
+    def test_covers_every_fact_typed_field(self) -> None:
+        entity = _entity()
+        names = [name for name, _ in entity.fact_items()]
+        assert names == [
+            f.name
+            for f in dataclasses.fields(CanonicalEntity)
+            if isinstance(getattr(entity, f.name), Fact)
+        ]
+        assert "producer" not in names
+
+    @given(resolved=st.integers(min_value=0, max_value=3))
+    def test_resolved_fact_count_matches_present_facts(self, resolved: int) -> None:
+        facts = [Fact.present("x"), Fact.present(("a",)), Fact.present(("const",))]
+        blanks = [Fact.not_collected(), Fact.unsupported(), Fact.failed("no")]
+        chosen = facts[:resolved] + blanks[resolved:]
+        entity = CanonicalEntity(
+            canonical_spelling=chosen[0],
+            template_arguments=chosen[1],
+            cv_qualification=chosen[2],
+        )
+        assert entity.resolved_fact_count() == resolved
+
+
+class TestConflictKey:
+    """Occurrence-keyed, not declaration-keyed: two matched pairs sharing one
+    ``EntityId`` must not collide on one key (the defect a ``fact_provenance``
+    -shaped key would reintroduce)."""
+
+    @given(tag_a=_tags, tag_b=_tags, fact=_names)
+    def test_distinct_occurrences_get_distinct_keys(
+        self, tag_a: str, tag_b: str, fact: str
+    ) -> None:
+        eid = entity_id_for_type((), "Foo")
+        key_a = semantic_ir_conflict_key(OccurrenceId(eid, tag_a), fact)
+        key_b = semantic_ir_conflict_key(OccurrenceId(eid, tag_b), fact)
+        assert (key_a == key_b) == (tag_a == tag_b)
+
+    @given(fact_a=_names, fact_b=_names)
+    def test_distinct_facts_get_distinct_keys(self, fact_a: str, fact_b: str) -> None:
+        occ = OccurrenceId(entity_id_for_type((), "Foo"), "tu-a")
+        keys_equal = semantic_ir_conflict_key(occ, fact_a) == semantic_ir_conflict_key(
+            occ, fact_b
+        )
+        assert keys_equal == (fact_a == fact_b)

--- a/tests/test_model_semantic_ir.py
+++ b/tests/test_model_semantic_ir.py
@@ -214,8 +214,7 @@ class TestCanonicalCvQualification:
         assert entity.cv_qualification.is_present
 
     @pytest.mark.parametrize(
-        "fact",
-        [Fact.not_collected(), Fact.unsupported(), Fact.failed("no"), Fact.present(None)],
+        "fact", [Fact.not_collected(), Fact.unsupported(), Fact.failed("no")]
     )
     def test_a_fact_with_no_usable_value_is_not_checked(self, fact: object) -> None:
         entity = CanonicalEntity(
@@ -223,6 +222,33 @@ class TestCanonicalCvQualification:
             cv_qualification=fact,  # type: ignore[arg-type]
         )
         assert entity.cv_qualification == fact
+
+    @pytest.mark.parametrize("name", ["canonical_spelling", "cv_qualification"])
+    @pytest.mark.parametrize("constructor", [Fact.present, Fact.partial])
+    def test_a_usable_fact_must_carry_its_value(
+        self, name: str, constructor: object
+    ) -> None:
+        """`Fact.present(None)` is legitimate in the general `Fact`
+        vocabulary, for a field whose `T` includes `None` — but these fields
+        are `Fact[str]`/`Fact[tuple[str, ...]]`, and their own docstrings name
+        the confirmed-absence spelling as this field's *empty* value. Admitting
+        `None` would let `resolved_fact_count` (and through it the reduction
+        and the hybrid backfill) treat a value the entity does not carry as
+        usable evidence."""
+        kwargs = {
+            "canonical_spelling": Fact.present("Foo"),
+            name: constructor(None),  # type: ignore[operator]
+        }
+        with pytest.raises(ValueError, match="carries no value"):
+            CanonicalEntity(**kwargs)  # type: ignore[arg-type]
+
+    def test_the_declared_empty_value_is_how_absence_is_spelled(self) -> None:
+        entity = CanonicalEntity(
+            canonical_spelling=Fact.present(""),
+            template_arguments=Fact.present(()),
+            cv_qualification=Fact.present(()),
+        )
+        assert entity.resolved_fact_count() == 3
 
     def test_confirmed_absence_is_present_and_empty(self) -> None:
         entity = CanonicalEntity(

--- a/tests/test_semantic_ir_merge.py
+++ b/tests/test_semantic_ir_merge.py
@@ -1,0 +1,349 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``merge_semantic_ir`` — the hybrid backend's ``SemanticIR``
+reconciliation (ADR-063 Phase 6).
+
+Primitive-level property tests, per AGENTS.md: this is a reusable
+merge/matching primitive, and the plan's own design text records four
+independently-falsified drafts of its matching rule (an "either side
+non-empty" disagreement test that never merged the ordinary case; a
+one-occurrence-per-side assumption the IR's own shape contradicts; an
+"exactly one surviving pair" ambiguity test that rejected a real bijection;
+a leftover rule that assumed every leftover was empty). Each of those
+counterexamples is pinned below as an invariant over generated input, not as
+a single fixed example.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from abicheck.extract.semantic_ir_merge import (
+    MERGED_PRODUCER,
+    _pair_group,
+    merge_semantic_ir,
+)
+from abicheck.model.fact import Fact
+from abicheck.model.identity import entity_id_for_type
+from abicheck.model.occurrence import OccurrenceId
+from abicheck.model.semantic_ir import (
+    CanonicalEntity,
+    SemanticIR,
+    semantic_ir_conflict_key,
+)
+
+_tags = st.text(
+    min_size=1, max_size=8, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
+)
+
+FOO = entity_id_for_type((), "Foo")
+BAR = entity_id_for_type((), "Bar")
+
+
+def _entity(
+    spelling: str | None = "Foo",
+    *,
+    template: tuple[str, ...] | None = None,
+    producer: str = "castxml",
+) -> CanonicalEntity:
+    return CanonicalEntity(
+        canonical_spelling=(
+            Fact.present(spelling) if spelling is not None else Fact.not_collected()
+        ),
+        template_arguments=(
+            Fact.present(template) if template is not None else Fact.not_collected()
+        ),
+        producer=producer,
+    )
+
+
+def _ir(*entries: tuple[OccurrenceId, CanonicalEntity]) -> SemanticIR:
+    return SemanticIR(occurrences=dict(entries))
+
+
+class TestOrdinaryOneSidedDisambiguator:
+    """The case the plan's first matching rule got wrong: castxml has no USR
+    concept, so its side of an ordinary match is routinely empty while
+    clang's is not. That is "no signal from that backend", never a
+    disagreement — reading it as one would leave the *common* hybrid case
+    permanently unmerged."""
+
+    @given(tag=_tags)
+    def test_empty_against_non_empty_still_merges(self, tag: str) -> None:
+        base_occ = OccurrenceId(FOO)
+        overlay_occ = OccurrenceId(FOO, disambiguator=tag)
+        merged, conflicts = merge_semantic_ir(
+            _ir((base_occ, _entity())),
+            _ir((overlay_occ, _entity(template=("int",), producer="clang"))),
+        )
+        assert merged is not None
+        assert list(merged.occurrences) == [base_occ]
+        entity = merged.occurrences[base_occ]
+        assert entity.template_arguments.value == ("int",)
+        assert entity.producer == MERGED_PRODUCER
+        assert conflicts == {}
+
+    @given(tag_a=_tags, tag_b=_tags)
+    def test_two_sided_disagreement_is_the_only_refusal(
+        self, tag_a: str, tag_b: str
+    ) -> None:
+        base_occ = OccurrenceId(FOO, disambiguator=tag_a)
+        overlay_occ = OccurrenceId(FOO, disambiguator=tag_b)
+        merged, _ = merge_semantic_ir(
+            _ir((base_occ, _entity())),
+            _ir((overlay_occ, _entity(template=("int",), producer="clang"))),
+        )
+        assert merged is not None
+        if tag_a == tag_b:
+            assert merged.occurrences[base_occ].template_arguments.value == ("int",)
+        else:
+            # Both backends derived a TU-context signal and they differ: no
+            # pairing is guessed at, both occurrences survive verbatim.
+            assert set(merged.occurrences) == {base_occ, overlay_occ}
+            assert not merged.occurrences[base_occ].template_arguments.is_present
+
+
+class TestBasePrecedenceAndConflicts:
+    def test_present_base_fact_is_never_overwritten(self) -> None:
+        occ = OccurrenceId(FOO)
+        merged, conflicts = merge_semantic_ir(
+            _ir((occ, _entity("castxml::Foo"))),
+            _ir((occ, _entity("clang::Foo", producer="clang"))),
+        )
+        assert merged is not None
+        assert merged.occurrences[occ].canonical_spelling.value == "castxml::Foo"
+        assert conflicts == {
+            semantic_ir_conflict_key(occ, "canonical_spelling"): repr("clang::Foo")
+        }
+
+    def test_agreement_records_no_conflict(self) -> None:
+        occ = OccurrenceId(FOO)
+        merged, conflicts = merge_semantic_ir(
+            _ir((occ, _entity("Foo"))),
+            _ir((occ, _entity("Foo", producer="clang"))),
+        )
+        assert merged is not None
+        assert conflicts == {}
+        # Nothing was contributed, so the base entity — producer included —
+        # is carried through untouched rather than relabelled "hybrid".
+        assert merged.occurrences[occ].producer == "castxml"
+
+    def test_two_pairs_sharing_one_entity_id_keep_both_conflicts(self) -> None:
+        """The defect a ``fact_provenance``-shaped, declaration-only key
+        would reintroduce: the second pair's conflict silently overwriting
+        the first's."""
+        first = OccurrenceId(FOO, disambiguator="usr1")
+        second = OccurrenceId(FOO, disambiguator="usr2")
+        merged, conflicts = merge_semantic_ir(
+            _ir((first, _entity("base::One")), (second, _entity("base::Two"))),
+            _ir(
+                (first, _entity("clang::One", producer="clang")),
+                (second, _entity("clang::Two", producer="clang")),
+            ),
+        )
+        assert merged is not None
+        assert conflicts == {
+            semantic_ir_conflict_key(first, "canonical_spelling"): repr("clang::One"),
+            semantic_ir_conflict_key(second, "canonical_spelling"): repr("clang::Two"),
+        }
+
+
+class TestMultiOccurrenceMatching:
+    def test_bijection_over_a_group_merges_every_pair(self) -> None:
+        """Two occurrences per side whose non-empty disambiguators are a
+        bijection have exactly one correct pairing — an "exactly one
+        surviving pair" ambiguity test rejects it wrongly."""
+        one = OccurrenceId(FOO, disambiguator="usr1")
+        two = OccurrenceId(FOO, disambiguator="usr2")
+        merged, _ = merge_semantic_ir(
+            _ir((one, _entity()), (two, _entity())),
+            _ir(
+                (one, _entity(template=("int",), producer="clang")),
+                (two, _entity(template=("char",), producer="clang")),
+            ),
+        )
+        assert merged is not None
+        assert merged.occurrences[one].template_arguments.value == ("int",)
+        assert merged.occurrences[two].template_arguments.value == ("char",)
+
+    def test_one_sided_leftover_pairs_with_an_empty_leftover(self) -> None:
+        """castxml ``{empty, usr1}`` against clang ``{usr1, usr2}``: ``usr1``
+        pairs in the first pass, and the leftovers (``empty`` and ``usr2``)
+        are exactly as safe to pair as an empty-vs-empty pair is."""
+        base_empty = OccurrenceId(FOO)
+        base_usr1 = OccurrenceId(FOO, disambiguator="usr1")
+        overlay_usr1 = OccurrenceId(FOO, disambiguator="usr1")
+        overlay_usr2 = OccurrenceId(FOO, disambiguator="usr2")
+        merged, _ = merge_semantic_ir(
+            _ir((base_empty, _entity()), (base_usr1, _entity())),
+            _ir(
+                (overlay_usr1, _entity(template=("int",), producer="clang")),
+                (overlay_usr2, _entity(template=("char",), producer="clang")),
+            ),
+        )
+        assert merged is not None
+        assert set(merged.occurrences) == {base_empty, base_usr1}
+        assert merged.occurrences[base_usr1].template_arguments.value == ("int",)
+        assert merged.occurrences[base_empty].template_arguments.value == ("char",)
+
+    def test_repeated_disambiguator_on_one_side_is_refused(self) -> None:
+        """A non-empty disambiguator naming two occurrences on one side is a
+        genuine ambiguity for that value, and the matcher refuses it.
+
+        Deliberately exercised through ``_pair_group`` directly: it cannot
+        reach ``merge_semantic_ir`` from a real ``SemanticIR``, because two
+        occurrences of one ``EntityId`` sharing one disambiguator *are* one
+        ``OccurrenceId`` and therefore one dict key. The guard stays — this
+        function takes plain lists, and the invariant that makes it
+        unreachable belongs to the caller's key type, not to the matcher —
+        but the reachability limit is stated here rather than left implied
+        by a test that only looks like it covers the case.
+        """
+        repeated = [
+            OccurrenceId(FOO, disambiguator="usr1"),
+            OccurrenceId(FOO, disambiguator="usr1"),
+        ]
+        assert _pair_group(repeated, [OccurrenceId(FOO, disambiguator="usr1")]) is None
+
+    def test_a_shared_entity_id_cannot_repeat_a_disambiguator_in_one_ir(self) -> None:
+        ir = _ir(
+            (OccurrenceId(FOO, disambiguator="usr1"), _entity("first")),
+            (OccurrenceId(FOO, disambiguator="usr1"), _entity("second")),
+        )
+        assert len(ir.occurrences) == 1
+
+    def test_a_base_leftover_with_no_counterpart_survives_unmerged(self) -> None:
+        """base ``{empty, usr1}`` against overlay ``{usr1}``: ``usr1`` pairs,
+        and the base occurrence the overlay never matched is neither dropped
+        nor backfilled from an unrelated occurrence."""
+        base_empty = OccurrenceId(FOO)
+        base_usr1 = OccurrenceId(FOO, disambiguator="usr1")
+        merged, _ = merge_semantic_ir(
+            _ir((base_empty, _entity()), (base_usr1, _entity())),
+            _ir((base_usr1, _entity(template=("int",), producer="clang"))),
+        )
+        assert merged is not None
+        assert set(merged.occurrences) == {base_empty, base_usr1}
+        assert merged.occurrences[base_usr1].template_arguments.value == ("int",)
+        assert not merged.occurrences[base_empty].template_arguments.is_present
+
+    def test_more_than_one_leftover_per_side_is_unmerged(self) -> None:
+        base_ids = [OccurrenceId(FOO), OccurrenceId(FOO, disambiguator="usr1")]
+        overlay_ids = [
+            OccurrenceId(FOO, disambiguator="usr2"),
+            OccurrenceId(FOO, disambiguator="usr3"),
+        ]
+        merged, conflicts = merge_semantic_ir(
+            _ir(*((occ, _entity()) for occ in base_ids)),
+            _ir(
+                *(
+                    (occ, _entity(template=("int",), producer="clang"))
+                    for occ in overlay_ids
+                )
+            ),
+        )
+        assert merged is not None
+        assert set(merged.occurrences) == set(base_ids) | set(overlay_ids)
+        for occ in base_ids:
+            assert not merged.occurrences[occ].template_arguments.is_present
+        assert conflicts == {}
+
+
+class TestUnionRules:
+    def test_overlay_only_entity_is_unioned_verbatim(self) -> None:
+        base_occ = OccurrenceId(FOO)
+        overlay_occ = OccurrenceId(BAR)
+        merged, _ = merge_semantic_ir(
+            _ir((base_occ, _entity())),
+            _ir((overlay_occ, _entity("Bar", producer="clang"))),
+        )
+        assert merged is not None
+        assert merged.occurrences[overlay_occ].producer == "clang"
+
+    def test_base_only_entity_survives(self) -> None:
+        base_occ = OccurrenceId(FOO)
+        merged, _ = merge_semantic_ir(
+            _ir((base_occ, _entity())), _ir((OccurrenceId(BAR), _entity("Bar")))
+        )
+        assert merged is not None
+        assert base_occ in merged.occurrences
+
+    def test_missing_side_returns_the_other_unchanged(self) -> None:
+        ir = _ir((OccurrenceId(FOO), _entity()))
+        assert merge_semantic_ir(ir, None) == (ir, {})
+        assert merge_semantic_ir(None, ir) == (ir, {})
+        assert merge_semantic_ir(None, None) == (None, {})
+        assert merge_semantic_ir(SemanticIR(), ir) == (ir, {})
+
+
+class TestMergeProperties:
+    @given(
+        tags=st.lists(_tags, min_size=1, max_size=4, unique=True),
+        reverse_base=st.booleans(),
+        reverse_overlay=st.booleans(),
+    )
+    def test_result_never_depends_on_input_order(
+        self, tags: list[str], reverse_base: bool, reverse_overlay: bool
+    ) -> None:
+        base_entries = [(OccurrenceId(FOO, disambiguator=t), _entity()) for t in tags]
+        overlay_entries = [
+            (
+                OccurrenceId(FOO, disambiguator=t),
+                _entity(template=(t,), producer="clang"),
+            )
+            for t in tags
+        ]
+        reference, reference_conflicts = merge_semantic_ir(
+            _ir(*base_entries), _ir(*overlay_entries)
+        )
+        shuffled, shuffled_conflicts = merge_semantic_ir(
+            _ir(*(reversed(base_entries) if reverse_base else base_entries)),
+            _ir(*(reversed(overlay_entries) if reverse_overlay else overlay_entries)),
+        )
+        assert reference is not None and shuffled is not None
+        assert dict(reference.occurrences) == dict(shuffled.occurrences)
+        assert reference_conflicts == shuffled_conflicts
+
+    @given(tags=st.lists(_tags, min_size=1, max_size=4, unique=True))
+    def test_no_occurrence_is_ever_dropped(self, tags: list[str]) -> None:
+        """Whatever the matching decides, every base occurrence survives, and
+        every overlay occurrence either merged into one of them or survives on
+        its own — a merge may fail closed, never lose evidence."""
+        base = _ir(*((OccurrenceId(FOO, disambiguator=t), _entity()) for t in tags))
+        overlay = _ir(
+            *(
+                (OccurrenceId(BAR, disambiguator=t), _entity("Bar", producer="clang"))
+                for t in tags
+            )
+        )
+        merged, _ = merge_semantic_ir(base, overlay)
+        assert merged is not None
+        assert set(base.occurrences) | set(overlay.occurrences) <= set(
+            merged.occurrences
+        )
+
+    @given(tags=st.lists(_tags, min_size=1, max_size=4, unique=True))
+    def test_merging_an_ir_with_itself_changes_nothing(self, tags: list[str]) -> None:
+        ir = _ir(
+            *(
+                (OccurrenceId(FOO, disambiguator=t), _entity(template=(t,)))
+                for t in tags
+            )
+        )
+        merged, conflicts = merge_semantic_ir(ir, ir)
+        assert merged is not None
+        assert dict(merged.occurrences) == dict(ir.occurrences)
+        assert conflicts == {}

--- a/tests/test_semantic_ir_merge.py
+++ b/tests/test_semantic_ir_merge.py
@@ -262,6 +262,111 @@ class TestMultiOccurrenceMatching:
         assert conflicts == {}
 
 
+class TestAmbiguousGroupsStillKeepEvidence:
+    """A group with no unique matching is not paired by guess — but an
+    occurrence both sides key *identically* is not a guess at all, and
+    dropping the overlay's copy of it (the only thing a verbatim union can do
+    with a key collision) loses exactly the facts and conflict records this
+    function exists to preserve."""
+
+    def test_an_exact_key_match_inside_an_ambiguous_group_still_backfills(
+        self,
+    ) -> None:
+        shared = OccurrenceId(FOO, disambiguator="usr1")
+        base_extra = OccurrenceId(FOO, disambiguator="usr2")
+        base_empty = OccurrenceId(FOO)
+        overlay_extra_a = OccurrenceId(FOO, disambiguator="usr3")
+        overlay_extra_b = OccurrenceId(FOO, disambiguator="usr4")
+        # usr1 pairs in the first pass; two unmatched leftovers remain on each
+        # side, so the group as a whole has no unique matching.
+        merged, conflicts = merge_semantic_ir(
+            _ir(
+                (shared, _entity("base::Shared")),
+                (base_extra, _entity()),
+                (base_empty, _entity()),
+            ),
+            _ir(
+                (
+                    shared,
+                    _entity("clang::Shared", template=("int",), producer="clang"),
+                ),
+                (overlay_extra_a, _entity("Other", producer="clang")),
+                (overlay_extra_b, _entity("Other", producer="clang")),
+            ),
+        )
+        assert merged is not None
+        # Every occurrence from both sides survives...
+        assert set(merged.occurrences) == {
+            shared,
+            base_extra,
+            base_empty,
+            overlay_extra_a,
+            overlay_extra_b,
+        }
+        # ...and the identically-keyed pair kept base precedence, took the
+        # overlay's unresolved-fact backfill, and recorded the disagreement,
+        # rather than the overlay entity being silently discarded.
+        assert merged.occurrences[shared].canonical_spelling.value == "base::Shared"
+        assert merged.occurrences[shared].template_arguments.value == ("int",)
+        assert conflicts == {
+            semantic_ir_conflict_key(shared, "canonical_spelling"): repr(
+                "clang::Shared"
+            )
+        }
+
+    @given(tags=st.lists(_tags, min_size=3, max_size=5, unique=True))
+    def test_no_overlay_fact_is_ever_silently_dropped(self, tags: list[str]) -> None:
+        """Generalized: for any group shape, every overlay occurrence's facts
+        end up somewhere — merged into the base entity it paired with, or
+        carried on its own entry. What may legitimately not survive is the
+        overlay's *key* (base precedence renames a matched pair to the base
+        occurrence's key); what may never not survive is its evidence.
+
+        Each overlay entity carries a distinct template-argument value, so
+        "its facts are present" is checkable without asking the
+        implementation which pairing it chose.
+        """
+        base_entries = [
+            (OccurrenceId(FOO, disambiguator=t), _entity(f"base::{t}")) for t in tags
+        ]
+        overlay_entries = [
+            (
+                OccurrenceId(FOO, disambiguator=t),
+                _entity(f"clang::{t}", template=(f"arg-{t}",), producer="clang"),
+            )
+            for t in tags[:-1]
+        ] + [
+            (
+                OccurrenceId(FOO),
+                _entity("clang::extra", template=("arg-extra",), producer="clang"),
+            )
+        ]
+        merged, _ = merge_semantic_ir(_ir(*base_entries), _ir(*overlay_entries))
+        assert merged is not None
+        surviving = {
+            entity.template_arguments.value for entity in merged.occurrences.values()
+        }
+        for _, overlay_entity in overlay_entries:
+            assert overlay_entity.template_arguments.value in surviving
+
+    @given(tags=st.lists(_tags, min_size=1, max_size=4, unique=True))
+    def test_every_base_occurrence_keeps_its_key(self, tags: list[str]) -> None:
+        """The other half: base precedence means a base occurrence's key is
+        never replaced by an overlay one."""
+        base_entries = [
+            (OccurrenceId(FOO, disambiguator=t), _entity(f"base::{t}")) for t in tags
+        ]
+        merged, _ = merge_semantic_ir(
+            _ir(*base_entries),
+            _ir(
+                (OccurrenceId(FOO), _entity("clang::x", producer="clang")),
+                (OccurrenceId(BAR), _entity("clang::y", producer="clang")),
+            ),
+        )
+        assert merged is not None
+        assert {occ for occ, _ in base_entries} <= set(merged.occurrences)
+
+
 class TestUnionRules:
     def test_overlay_only_entity_is_unioned_verbatim(self) -> None:
         base_occ = OccurrenceId(FOO)

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -336,6 +336,73 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(TypeError, match="semantic_ir_conflicts"):
             snapshot_from_dict(document)
 
+    def _document_with_fact(self, fact_name: str, patch: dict) -> dict:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.present("Foo"),
+                    template_arguments=Fact.present(("int",)),
+                    cv_qualification=Fact.present(("const",)),
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        document["semantic_ir"]["occurrences"][0]["entity"][fact_name].update(patch)
+        return document
+
+    @pytest.mark.parametrize("fact_name", ["canonical_spelling", "cv_qualification"])
+    def test_a_truncated_fact_missing_its_value_is_rejected(
+        self, fact_name: str
+    ) -> None:
+        """`{"status": "present"}` with no `value` would construct
+        `Fact(PRESENT, None)` — usable evidence, by `resolved_fact_count`, for
+        a spelling the document no longer carries."""
+        document = self._document_with_fact(fact_name, {})
+        del document["semantic_ir"]["occurrences"][0]["entity"][fact_name]["value"]
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
+
+    def test_a_fact_missing_its_status_is_rejected(self) -> None:
+        document = self._document_with_fact("canonical_spelling", {})
+        del document["semantic_ir"]["occurrences"][0]["entity"]["canonical_spelling"][
+            "status"
+        ]
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize("bad", ["", "const", 1, {"a": "b"}, ["const", 2], [None]])
+    def test_a_malformed_tuple_fact_value_is_rejected(self, bad: object) -> None:
+        """A scalar where a list belongs is the defect that mattered:
+        `cv_qualification.value = ""` passed straight through
+        `canonical_cv_qualification` as the *empty* qualification."""
+        document = self._document_with_fact("cv_qualification", {"value": bad})
+        with pytest.raises(TypeError):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize("bad", [1, ["Foo"], {"a": "b"}, True])
+    def test_a_malformed_scalar_fact_value_is_rejected(self, bad: object) -> None:
+        document = self._document_with_fact("canonical_spelling", {"value": bad})
+        with pytest.raises(TypeError):
+            snapshot_from_dict(document)
+
+    def test_a_null_value_stays_legitimate_for_every_status(self) -> None:
+        """`Fact.present(None)` is a confirmed absence, and the value-less
+        statuses carry `None` too — the validation must not refuse those."""
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.present(None),  # type: ignore[arg-type]
+                    template_arguments=Fact.not_collected(),
+                    cv_qualification=Fact.unsupported("no evidence"),
+                )
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
     def test_a_non_string_conflict_entry_is_rejected(self) -> None:
         document = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts={"k": "v"}))
         document["semantic_ir_conflicts"] = {"k": 3}

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -443,6 +443,25 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(ValueError, match="carries no value"):
             snapshot_from_dict(document)
 
+    def test_a_fact_missing_its_diagnostics_is_rejected(self) -> None:
+        """Defaulting the key erases a FAILED fact's only explanation of why
+        the producer could not establish the value — the reason diagnostics
+        are persisted at all."""
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.failed("castxml exited 1")
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        del document["semantic_ir"]["occurrences"][0]["entity"]["canonical_spelling"][
+            "diagnostics"
+        ]
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
+
     @pytest.mark.parametrize(
         "missing", ["canonical_spelling", "template_arguments", "cv_qualification"]
     )

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -229,7 +229,12 @@ class TestMalformedDocumentsAreRefused:
 
 class TestAbsence:
     def test_a_snapshot_without_an_ir_writes_no_key(self) -> None:
-        assert "semantic_ir" not in snapshot_to_dict(_snapshot(None))
+        document = snapshot_to_dict(_snapshot(None))
+        assert "semantic_ir" not in document
+        # Nor an empty conflict map: a snapshot no hybrid merge touched must
+        # serialize exactly as it did before this field existed, or every
+        # document written by every backend grows a key that says nothing.
+        assert "semantic_ir_conflicts" not in document
 
     def test_a_document_without_the_key_loads_as_none(self) -> None:
         document = snapshot_to_dict(_snapshot(None))

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -206,6 +206,36 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(TypeError):
             snapshot_from_dict(document)
 
+    def test_a_missing_disambiguator_is_rejected(self) -> None:
+        """The writer always emits this identity field (an undisambiguated
+        occurrence is `""`), so a missing one is a truncated document —
+        reading it as `""` would rewrite it as genuinely undisambiguated and
+        change what the hybrid merge's matching does with it."""
+        document = self._document_with_disambiguators("a", "b")
+        del document["semantic_ir"]["occurrences"][0]["occurrence"]["disambiguator"]
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
+
+    def test_a_null_disambiguator_is_rejected(self) -> None:
+        document = self._document_with_disambiguators(None, "b")
+        with pytest.raises(TypeError, match="disambiguator"):
+            snapshot_from_dict(document)
+
+    def test_an_empty_disambiguator_stays_legitimate(self) -> None:
+        # The value the writer emits for every ordinary occurrence: it must
+        # not be caught by the rejections above.
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.present("Foo")
+                )
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
     def test_a_non_string_producer_is_rejected(self) -> None:
         eid = entity_id_for_type((), "Foo")
         ir = SemanticIR(

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -149,6 +149,23 @@ class TestDeterministicEncoding:
             backward, sort_keys=True
         )
 
+    @pytest.mark.parametrize("bad", [{1: "v"}, {"k": 2}, {None: "v"}, {"k": None}])
+    def test_a_malformed_conflict_map_is_refused_on_write(self, bad: dict) -> None:
+        """The writer validates as strictly as the reader, for a reason
+        specific to writing: a non-string key survives in memory but
+        `json.dumps` renders it as a string, so `{1: "first", "1": "second"}`
+        would write one object with two `"1"` keys and the load would keep
+        whichever came last — a record discarded by the writer, before any
+        reader could refuse it."""
+        with pytest.raises(TypeError, match="semantic_ir_conflicts"):
+            snapshot_to_dict(_snapshot(None, semantic_ir_conflicts=bad))
+
+    def test_a_json_key_collision_cannot_be_written(self) -> None:
+        with pytest.raises(TypeError):
+            snapshot_to_dict(
+                _snapshot(None, semantic_ir_conflicts={1: "first", "1": "second"})
+            )
+
     @given(keys=st.lists(_tags, min_size=2, max_size=5, unique=True))
     def test_conflict_map_order_does_not_change_the_document(
         self, keys: list[str]

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -220,6 +220,61 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(TypeError, match="producer"):
             snapshot_from_dict(document)
 
+    def test_a_duplicate_occurrence_entry_is_rejected(self) -> None:
+        """The list encoding can spell a duplicate the mapping cannot hold —
+        a load that silently kept the last one would report success having
+        discarded occurrence evidence."""
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid, disambiguator="tu-a"): CanonicalEntity(
+                    canonical_spelling=Fact.present("first")
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        entries = document["semantic_ir"]["occurrences"]
+        duplicate = json.loads(json.dumps(entries[0]))
+        duplicate["entity"]["canonical_spelling"]["value"] = "second"
+        entries.append(duplicate)
+        with pytest.raises(ValueError, match="same occurrence twice"):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize(
+        "bad", ["parse error", [1], [None], ["ok", 2], {"a": "b"}]
+    )
+    def test_malformed_fact_diagnostics_are_rejected(self, bad: object) -> None:
+        """A bare `tuple()` would split a string into one diagnostic per
+        character and coerce a non-string member into a manufactured one —
+        both written back as if a producer had reported them."""
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.failed("real diagnostic")
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        entity = document["semantic_ir"]["occurrences"][0]["entity"]
+        entity["canonical_spelling"]["diagnostics"] = bad
+        with pytest.raises(TypeError):
+            snapshot_from_dict(document)
+
+    def test_well_formed_diagnostics_survive(self) -> None:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.failed("castxml exited 1"),
+                    template_arguments=Fact.unsupported("no template evidence"),
+                )
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
     def test_a_non_string_conflict_entry_is_rejected(self) -> None:
         document = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts={"k": "v"}))
         document["semantic_ir_conflicts"] = {"k": 3}

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``AbiSnapshot.semantic_ir`` persistence (ADR-063 Phase 6, schema v38).
+
+Goes through the real ``snapshot_to_dict``/``snapshot_from_dict``
+chokepoints and through ``json.dumps`` — not the codec's own internals —
+per AGENTS.md's third-party-boundary rule: the two defects this encoding
+exists to avoid (``dataclasses.asdict()`` raising on a dataclass dict key,
+and a string-flattened key losing the typed ``ScopePath`` inside it) are
+both invisible to a test that calls the codec directly with an
+already-flat fixture.
+"""
+
+from __future__ import annotations
+
+import json
+
+from hypothesis import given, strategies as st
+
+from abicheck.model.fact import Fact
+from abicheck.model.identity import Namespace, Record, entity_id_for_type
+from abicheck.model.occurrence import OccurrenceId
+from abicheck.model.semantic_ir import CanonicalEntity, SemanticIR
+from abicheck.model.snapshot import AbiSnapshot
+from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+
+_tags = st.text(
+    min_size=1, max_size=8, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
+)
+
+
+def _snapshot(ir: SemanticIR | None, **kwargs: object) -> AbiSnapshot:
+    return AbiSnapshot(library="libfoo.so.1", version="1.0.0", semantic_ir=ir, **kwargs)  # type: ignore[arg-type]
+
+
+def _round_trip(snap: AbiSnapshot) -> AbiSnapshot:
+    # json.dumps/loads, not just the dict: a tuple that survives the dict
+    # round trip but comes back as a list from JSON would otherwise pass.
+    return snapshot_from_dict(json.loads(json.dumps(snapshot_to_dict(snap))))
+
+
+class TestRoundTrip:
+    def test_odr_duplicate_pair_survives_with_both_occurrences(self) -> None:
+        """Two occurrences sharing one ``EntityId`` — the shape a string-keyed
+        or ``canonical_entities()``-reduced encoding would collapse."""
+        eid = entity_id_for_type((Namespace("ns"), Record("Outer")), "Inner")
+        complete = OccurrenceId(eid, disambiguator="tu-a")
+        incomplete = OccurrenceId(eid, disambiguator="tu-b")
+        ir = SemanticIR(
+            occurrences={
+                complete: CanonicalEntity(
+                    canonical_spelling=Fact.present("ns::Outer::Inner"),
+                    template_arguments=Fact.present(("int", "char")),
+                    cv_qualification=Fact.present(("const", "volatile")),
+                    producer="castxml",
+                ),
+                incomplete: CanonicalEntity(
+                    canonical_spelling=Fact.present("ns::Outer::Inner"),
+                    template_arguments=Fact.not_collected(),
+                    cv_qualification=Fact.unsupported("no cv evidence"),
+                    producer="clang",
+                ),
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
+    def test_typed_scope_segments_survive(self) -> None:
+        """A rendered-string key could not tell these two apart: identical
+        leaf names, identical rendering, different typed scope."""
+        nested_in_record = entity_id_for_type((Record("Outer"),), "Inner")
+        nested_in_namespace = entity_id_for_type((Namespace("Outer"),), "Inner")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(nested_in_record): CanonicalEntity(
+                    canonical_spelling=Fact.present("Outer::Inner"),
+                ),
+                OccurrenceId(nested_in_namespace): CanonicalEntity(
+                    canonical_spelling=Fact.present("Outer::Inner"),
+                ),
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert len(reloaded.semantic_ir.occurrences) == 2
+        scopes = {occ.entity_id.scope for occ in reloaded.semantic_ir.occurrences}
+        assert scopes == {(Record("Outer"),), (Namespace("Outer"),)}
+
+    @given(tags=st.lists(_tags, min_size=1, max_size=4, unique=True))
+    def test_every_occurrence_round_trips(self, tags: list[str]) -> None:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid, disambiguator=tag): CanonicalEntity(
+                    canonical_spelling=Fact.present(f"Foo<{tag}>"),
+                    template_arguments=Fact.present((tag,)),
+                )
+                for tag in tags
+            }
+        )
+        reloaded = _round_trip(_snapshot(ir))
+        assert reloaded.semantic_ir is not None
+        assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
+    def test_conflicts_round_trip(self) -> None:
+        snap = _snapshot(None, semantic_ir_conflicts={"key": "'clang::Foo'"})
+        assert _round_trip(snap).semantic_ir_conflicts == {"key": "'clang::Foo'"}
+
+
+class TestAbsence:
+    def test_a_snapshot_without_an_ir_writes_no_key(self) -> None:
+        assert "semantic_ir" not in snapshot_to_dict(_snapshot(None))
+
+    def test_a_document_without_the_key_loads_as_none(self) -> None:
+        document = snapshot_to_dict(_snapshot(None))
+        document.pop("semantic_ir", None)
+        assert snapshot_from_dict(document).semantic_ir is None
+
+    def test_empty_ir_round_trips_as_empty_not_none(self) -> None:
+        document = snapshot_to_dict(_snapshot(SemanticIR()))
+        assert document["semantic_ir"] == {"occurrences": []}
+        # An IR that observed nothing is not the same as no IR at all — the
+        # first says a narrowed backend ran and found nothing, the second
+        # that no backend produced one — so the two must not both decode to
+        # ``None``.
+        reloaded = snapshot_from_dict(document)
+        assert reloaded.semantic_ir == SemanticIR(occurrences={})

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -28,11 +28,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from hypothesis import given, strategies as st
 
 from abicheck.model.fact import Fact
 from abicheck.model.identity import Namespace, Record, entity_id_for_type
-from abicheck.model.occurrence import OccurrenceId
+from abicheck.model.occurrence import OccurrenceId, canonical_key
 from abicheck.model.semantic_ir import CanonicalEntity, SemanticIR
 from abicheck.model.snapshot import AbiSnapshot
 from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
@@ -119,6 +120,111 @@ class TestRoundTrip:
     def test_conflicts_round_trip(self) -> None:
         snap = _snapshot(None, semantic_ir_conflicts={"key": "'clang::Foo'"})
         assert _round_trip(snap).semantic_ir_conflicts == {"key": "'clang::Foo'"}
+
+
+class TestDeterministicEncoding:
+    """`storage/AGENTS.md` invariant 4: a semantic digest must never depend on
+    incidental order. Two equal `SemanticIR` values built in opposite
+    insertion orders describe identical state, so they must encode to an
+    identical document — otherwise a content hash over the snapshot reports a
+    difference that does not exist."""
+
+    @given(tags=st.lists(_tags, min_size=2, max_size=5, unique=True))
+    def test_insertion_order_does_not_change_the_document(
+        self, tags: list[str]
+    ) -> None:
+        eid = entity_id_for_type((), "Foo")
+        entries = [
+            (
+                OccurrenceId(eid, disambiguator=tag),
+                CanonicalEntity(canonical_spelling=Fact.present(f"Foo<{tag}>")),
+            )
+            for tag in tags
+        ]
+        forward = snapshot_to_dict(_snapshot(SemanticIR(occurrences=dict(entries))))
+        backward = snapshot_to_dict(
+            _snapshot(SemanticIR(occurrences=dict(reversed(entries))))
+        )
+        assert json.dumps(forward, sort_keys=True) == json.dumps(
+            backward, sort_keys=True
+        )
+
+    def test_entries_are_sorted_by_canonical_key(self) -> None:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid, disambiguator=tag): CanonicalEntity(
+                    canonical_spelling=Fact.present("Foo")
+                )
+                for tag in ("zzz", "aaa", "mmm")
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        written = [
+            entry["occurrence"]["disambiguator"]
+            for entry in document["semantic_ir"]["occurrences"]
+        ]
+        assert written == sorted(
+            written,
+            key=lambda tag: canonical_key(OccurrenceId(eid, disambiguator=tag)),
+        )
+
+
+class TestMalformedDocumentsAreRefused:
+    """`storage/AGENTS.md` invariant 6: never coerce a value a decision reads.
+    A coerced disambiguator would make a JSON `1` and `"1"` one `OccurrenceId`
+    and silently drop one of the two occurrences on load."""
+
+    def _document_with_disambiguators(self, first: object, second: object) -> dict:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid, disambiguator="1"): CanonicalEntity(
+                    canonical_spelling=Fact.present("first")
+                ),
+                OccurrenceId(eid, disambiguator="2"): CanonicalEntity(
+                    canonical_spelling=Fact.present("second")
+                ),
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        entries = document["semantic_ir"]["occurrences"]
+        entries[0]["occurrence"]["disambiguator"] = first
+        entries[1]["occurrence"]["disambiguator"] = second
+        return document
+
+    @pytest.mark.parametrize("bad", [1, 1.0, True, ["1"], {"v": "1"}])
+    def test_a_non_string_disambiguator_is_rejected(self, bad: object) -> None:
+        document = self._document_with_disambiguators(bad, "2")
+        with pytest.raises(TypeError, match="disambiguator"):
+            snapshot_from_dict(document)
+
+    def test_coercion_would_have_lost_an_occurrence(self) -> None:
+        # The failure the rejection above prevents, stated directly: a
+        # coercing decoder maps JSON 1 and "1" onto one key.
+        document = self._document_with_disambiguators(1, "1")
+        with pytest.raises(TypeError):
+            snapshot_from_dict(document)
+
+    def test_a_non_string_producer_is_rejected(self) -> None:
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.present("Foo"), producer="castxml"
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        document["semantic_ir"]["occurrences"][0]["entity"]["producer"] = 7
+        with pytest.raises(TypeError, match="producer"):
+            snapshot_from_dict(document)
+
+    def test_a_non_string_conflict_entry_is_rejected(self) -> None:
+        document = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts={"k": "v"}))
+        document["semantic_ir_conflicts"] = {"k": 3}
+        with pytest.raises(TypeError, match="semantic_ir_conflicts"):
+            snapshot_from_dict(document)
 
 
 class TestAbsence:

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -275,6 +275,58 @@ class TestMalformedDocumentsAreRefused:
         assert reloaded.semantic_ir is not None
         assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
 
+    @pytest.mark.parametrize("bad", [False, 0, {}, "", []])
+    def test_a_falsey_malformed_diagnostics_value_is_rejected(
+        self, bad: object
+    ) -> None:
+        """The class the earlier `or ()` fix left open: a *falsey* malformed
+        value skipped the guard entirely and was rewritten as "no
+        diagnostics". Absence and a present-but-corrupt value are different
+        documents."""
+        eid = entity_id_for_type((), "Foo")
+        ir = SemanticIR(
+            occurrences={
+                OccurrenceId(eid): CanonicalEntity(
+                    canonical_spelling=Fact.failed("real diagnostic")
+                )
+            }
+        )
+        document = snapshot_to_dict(_snapshot(ir))
+        entity = document["semantic_ir"]["occurrences"][0]["entity"]
+        entity["canonical_spelling"]["diagnostics"] = bad
+        if bad == []:
+            # The one falsey value that is genuinely well-formed: an empty
+            # list is a real, empty diagnostics collection.
+            assert snapshot_from_dict(document).semantic_ir is not None
+        else:
+            with pytest.raises(TypeError):
+                snapshot_from_dict(document)
+
+    @pytest.mark.parametrize("bad", [[], "", 0, False, ["occurrences"]])
+    def test_a_falsey_malformed_semantic_ir_container_is_rejected(
+        self, bad: object
+    ) -> None:
+        """Same class, one level up: a present-but-malformed `semantic_ir`
+        must not decode as "no backend produced one"."""
+        document = snapshot_to_dict(_snapshot(None))
+        document["semantic_ir"] = bad
+        with pytest.raises(TypeError, match="semantic_ir"):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize("bad", [{}, "", 0, False, "occurrences"])
+    def test_a_malformed_occurrences_list_is_rejected(self, bad: object) -> None:
+        document = snapshot_to_dict(_snapshot(SemanticIR()))
+        document["semantic_ir"]["occurrences"] = bad
+        with pytest.raises(TypeError):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize("bad", [[], "", 0, False])
+    def test_a_falsey_malformed_conflict_map_is_rejected(self, bad: object) -> None:
+        document = snapshot_to_dict(_snapshot(None))
+        document["semantic_ir_conflicts"] = bad
+        with pytest.raises(TypeError, match="semantic_ir_conflicts"):
+            snapshot_from_dict(document)
+
     def test_a_non_string_conflict_entry_is_rejected(self) -> None:
         document = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts={"k": "v"}))
         document["semantic_ir_conflicts"] = {"k": 3}

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -416,14 +416,16 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(TypeError):
             snapshot_from_dict(document)
 
-    def test_a_null_value_stays_legitimate_for_every_status(self) -> None:
-        """`Fact.present(None)` is a confirmed absence, and the value-less
-        statuses carry `None` too — the validation must not refuse those."""
+    def test_a_null_value_stays_legitimate_for_a_value_less_status(self) -> None:
+        """`not_collected`/`unsupported`/`failed` carry `None` by
+        construction, so the value validation must not refuse them — only a
+        *usable* status with no value is malformed (see
+        `CanonicalEntity.__post_init__`)."""
         eid = entity_id_for_type((), "Foo")
         ir = SemanticIR(
             occurrences={
                 OccurrenceId(eid): CanonicalEntity(
-                    canonical_spelling=Fact.present(None),  # type: ignore[arg-type]
+                    canonical_spelling=Fact.present(""),
                     template_arguments=Fact.not_collected(),
                     cv_qualification=Fact.unsupported("no evidence"),
                 )
@@ -432,6 +434,27 @@ class TestMalformedDocumentsAreRefused:
         reloaded = _round_trip(_snapshot(ir))
         assert reloaded.semantic_ir is not None
         assert dict(reloaded.semantic_ir.occurrences) == dict(ir.occurrences)
+
+    def test_a_present_fact_with_a_null_value_is_rejected(self) -> None:
+        """The document form of the model rule above: a persisted
+        `{"status": "present", "value": null}` must not load as usable
+        evidence for a value the document does not carry."""
+        document = self._document_with_fact("canonical_spelling", {"value": None})
+        with pytest.raises(ValueError, match="carries no value"):
+            snapshot_from_dict(document)
+
+    @pytest.mark.parametrize(
+        "missing", ["canonical_spelling", "template_arguments", "cv_qualification"]
+    )
+    def test_an_entity_missing_a_fact_field_is_rejected(self, missing: str) -> None:
+        """The writer emits every fact field, so a document short of one is
+        truncated — letting `CanonicalEntity`'s dataclass default fill it in
+        would turn missing persisted evidence into a `NOT_COLLECTED`
+        availability *claim*."""
+        document = self._document_with_fact("canonical_spelling", {})
+        del document["semantic_ir"]["occurrences"][0]["entity"][missing]
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
 
     def test_a_non_string_conflict_entry_is_rejected(self) -> None:
         document = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts={"k": "v"}))

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -149,6 +149,23 @@ class TestDeterministicEncoding:
             backward, sort_keys=True
         )
 
+    @given(keys=st.lists(_tags, min_size=2, max_size=5, unique=True))
+    def test_conflict_map_order_does_not_change_the_document(
+        self, keys: list[str]
+    ) -> None:
+        """`json.dumps` preserves a mapping's insertion order, so the
+        conflict map needs the same canonical ordering the occurrence list
+        has — two runs recording the same conflicts in a different order
+        describe identical state."""
+        conflicts = {key: f"discarded::{key}" for key in keys}
+        forward = snapshot_to_dict(_snapshot(None, semantic_ir_conflicts=conflicts))
+        backward = snapshot_to_dict(
+            _snapshot(
+                None, semantic_ir_conflicts=dict(reversed(list(conflicts.items())))
+            )
+        )
+        assert json.dumps(forward) == json.dumps(backward)
+
     def test_entries_are_sorted_by_canonical_key(self) -> None:
         eid = entity_id_for_type((), "Foo")
         ir = SemanticIR(
@@ -270,9 +287,7 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(ValueError, match="same occurrence twice"):
             snapshot_from_dict(document)
 
-    @pytest.mark.parametrize(
-        "bad", ["parse error", [1], [None], ["ok", 2], {"a": "b"}]
-    )
+    @pytest.mark.parametrize("bad", ["parse error", [1], [None], ["ok", 2], {"a": "b"}])
     def test_malformed_fact_diagnostics_are_rejected(self, bad: object) -> None:
         """A bare `tuple()` would split a string into one diagnostic per
         character and coerce a non-string member into a manufactured one —

--- a/tests/test_semantic_ir_serialization.py
+++ b/tests/test_semantic_ir_serialization.py
@@ -320,6 +320,15 @@ class TestMalformedDocumentsAreRefused:
         with pytest.raises(TypeError):
             snapshot_from_dict(document)
 
+    def test_a_missing_occurrences_collection_is_rejected(self) -> None:
+        """`{"semantic_ir": {}}` is a truncated document, not the claim that
+        a backend ran and found nothing — this codec always writes the key,
+        and an IR that observed nothing is `{"occurrences": []}`."""
+        document = snapshot_to_dict(_snapshot(SemanticIR()))
+        document["semantic_ir"] = {}
+        with pytest.raises(ValueError, match="missing required field"):
+            snapshot_from_dict(document)
+
     @pytest.mark.parametrize("bad", [[], "", 0, False])
     def test_a_falsey_malformed_conflict_map_is_rejected(self, bad: object) -> None:
         document = snapshot_to_dict(_snapshot(None))

--- a/tests/unit/storage/adr062_scope.py
+++ b/tests/unit/storage/adr062_scope.py
@@ -43,8 +43,9 @@ import pathlib
 #: ADR-063's own snapshot encode/decode/legacy-backfill helpers (Phase 0's
 #: Fact[T] pair `fact_codec`/`enum_codec`, Phase 2's `entity_id_codec`,
 #: which keeps the parse-time `EntityId` carrier out of the wire format, and
-#: Phase 3's `surface_graph_codec`, the identical shape for
-#: `AbiSnapshot.surface_graph`) — a third, independent body of work in this
+#: Phase 3's `surface_graph_codec` and Phase 6's `semantic_ir_codec`, the
+#: identical shape for `AbiSnapshot.surface_graph`/`semantic_ir`) — a third,
+#: independent body of work in this
 #: package, unrelated to either ADR-062's Phase 0 primitives or G40's
 #: container. `snapshot_load_normalization` is a fourth, equally unrelated
 #: body of work: `serialization.snapshot_from_dict`'s on-load legacy-format
@@ -62,6 +63,7 @@ NON_ADR062_MODULES = frozenset(
         "enum_codec",
         "entity_id_codec",
         "surface_graph_codec",
+        "semantic_ir_codec",
         "snapshot_load_normalization",
     }
 )


### PR DESCRIPTION
## Summary

ADR-063 Phase 6's first slice: the canonical `SemanticIR` itself, its persistence (schema v38), and the `--ast-frontend hybrid` merge's reconciliation of it — no parser narrowing.

## Motivation

Phase 6's own Design section requires the IR to be defined and tested **before** any backend parser is narrowed to feed it, so that the per-backend migrations converge on one shape rather than each backend's own reading of "canonical" behind a shared name. This slice is exactly that step, plus the two pieces of plumbing that cannot be deferred without leaving a half-built representation: persistence (a field that exists only in memory reads as data loss on reload, per `model/AGENTS.md`) and the hybrid merge (a merged snapshot whose legacy `functions`/`types` include clang-only data while its `semantic_ir` holds only castxml's is exactly the two-representations-disagreeing outcome the governing invariant forbids).

## Changes

- **`abicheck/model/semantic_ir.py` (new)** — `SemanticIR.occurrences: Mapping[OccurrenceId, CanonicalEntity]`, keyed by occurrence and never collapsed per `EntityId`, so an ODR-duplicate/incomplete-declaration pair keeps both sides' availability. `canonical_entities()` is the explicit, order-independent reduction (most-resolved occurrence wins; ties break on `canonical_key`), never the projection the legacy snapshot fields come from. `CanonicalEntity` carries only the non-identity payload — `Fact`-wrapped canonical spelling, template arguments, CV-qualification, plus a `producer` tag — and no `ScopePath`/`EntityId` field, so no mapping can exist whose key names one scope and whose value reports another. Its `__post_init__` owns the per-field value contract: canonical CV ordering, and a usable fact carrying the value its field declares.
- **`AbiSnapshot.semantic_ir` / `semantic_ir_conflicts`**, persisted at **schema v38** through the new **`abicheck/storage/semantic_ir_codec.py`**. Encoded as a *list of entries*, not a JSON object: `dataclasses.asdict()` raises outright on a dataclass dict key, and a string-rendered key cannot carry back the typed `ScopePath` inside an `OccurrenceId` (the same lossy flattening Phase 2 already rejected for `EntityId`). Entries are emitted in canonical-key order, so two equal IRs cannot serialize differently. The codec lives in `storage` — which may depend on `model`, satisfying the dependency-direction reason the plan gave for moving these functions off the domain types — keeping `serialization.py` at its `architecture/debt.yaml` no-growth baseline, and matching its two sibling codecs.
- **`abicheck/extract/semantic_ir_merge.py` (new)**, wired into `dumper_hybrid.merge_snapshots()` as the fifth reconciliation step: castxml is the base, clang backfills only facts castxml left unresolved, a clang-only entity is unioned in verbatim, and a fact both backends resolved to different values keeps castxml's while recording the discarded one in `semantic_ir_conflicts` — keyed per *occurrence*, since `fact_provenance`'s declaration-only key cannot separate two matched pairs sharing one `EntityId`. A pairing is refused only when *both* sides supply a disambiguator and they disagree (castxml supplies none, so the ordinary match pairs an empty key against a non-empty one); a group with no unique complete matching keeps every occurrence from both sides.
- Docs: ADR-063's status bullet, the plan's Phase 6 section (what landed, three deliberate deviations, and what is explicitly still open), `docs/reference/snapshot-format.md` (v38), `AGENTS.md` + the `model`/`extract` package tables, and a changelog fragment.

**Deliberately not in this slice** (stated in the ADR and plan, not left implied): no backend produces an IR, `extract/semantic_normalizer.py` does not exist, and no assembly call site projects through it — so `semantic_ir` is `None` on every snapshot a real `dump` produces, such a snapshot's document differs from the v37 one it would have been *only in its `schema_version` stamp* (both new keys are written only when there is something to record), and the snapshot cache version is deliberately not bumped (no dumping-pipeline output changed).

## Testing

- `tests/test_model_semantic_ir.py`, `tests/test_semantic_ir_merge.py` — primitive-level property tests (AGENTS.md's "Primitive-level property tests" rule). Each of the plan's four review-falsified matching rules is pinned as an invariant over generated input: the one-sided-empty disambiguator that must still merge, the bijection over a multi-occurrence group, the mixed one-sided leftover, and the two-sided disagreement that is the only refusal — plus order-independence, no-evidence-ever-dropped, and self-merge idempotence.
- Two findings worth not rediscovering. The plan's "two occurrences sharing one non-empty disambiguator on one side" ambiguity is **structurally unreachable** from a real `SemanticIR` (that pair *is* one `OccurrenceId`, hence one dict key) — the guard stays, is tested at the matcher's own list-taking entry point, and the limit is stated rather than covered by a test that only appears to exercise it. And the "no evidence dropped" property falsified its own first phrasing: base precedence deliberately renames a merged pair to the base occurrence's key, so the overlay's *evidence* must survive, not its key.
- `tests/test_semantic_ir_serialization.py` — round trips through the real `snapshot_to_dict`/`snapshot_from_dict` chokepoints *and* `json.dumps`, with an ODR-duplicate fixture and a record-vs-namespace scope pair a string key could not distinguish; plus the malformed-document rejections (duplicate occurrences, coerced identity/provenance, truncated fields, malformed value shapes) with a positive round-trip beside each, so no rejection can be satisfied by refusing everything.
- `tests/test_dumper_hybrid_semantic_ir.py` — the merge wiring, including a parity case proving a snapshot with no IR merges exactly as before.
- New modules are at 100% line+branch coverage. `ruff check`, `mypy abicheck/` (0 errors), `scripts/check_ai_readiness.py` (0 errors), `scripts/check_architecture.py` (0 errors, run the way CI does with `ARCHITECTURE_BASE` set) and the golden lane are all clean. The full non-marker unit suite passes: 35,439 tests, with the only failures being two that reproduce identically at the merge base in a fresh worktree (`test_action_run_sh_baseline_set_fallback`, `test_verify_profiles::test_isolated_module_runner_…`) and are specific to the sandbox this ran in, not to this diff.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (ADR-063 status, Phase 6 plan section, `snapshot-format.md`, `AGENTS.md`)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SK84SKd5kJAzo8dsh1268k