### PR TITLE
fix: match relative paths against the allowlist with forward slashes

### DIFF
--- a/tests/test_fact_bridged_replace_guard.py
+++ b/tests/test_fact_bridged_replace_guard.py
@@ -179,7 +179,12 @@ def _named_violations() -> list[tuple[str, int, str, list[str]]]:
             )
             if not unsynced:
                 continue
-            rel = str(path.relative_to(_PKG.parent))
+            # .as_posix(), not str(): the allowlist keys are hardcoded
+            # forward-slash paths, and str() on Windows yields backslash
+            # separators -- that mismatch made every allowlist entry read
+            # as stale (and every real call site as unreviewed) on the
+            # windows-latest CI lane regardless of which PR ran it.
+            rel = path.relative_to(_PKG.parent).as_posix()
             func = _enclosing_function(tree, node)
             unreviewed = [
                 name
@@ -203,7 +208,13 @@ def _starred_calls() -> list[tuple[str, int, str]]:
             if not _is_replace_call(node):
                 continue
             if any(kw.arg is None for kw in node.keywords):
-                rel = str(path.relative_to(_PKG.parent))
+                # .as_posix(), not str(): the allowlist keys are hardcoded
+                # forward-slash paths, and str() on Windows yields backslash
+                # separators -- that mismatch made every allowlist entry
+                # read as stale (and every real call site as unreviewed)
+                # on the windows-latest CI lane regardless of which PR
+                # ran it.
+                rel = path.relative_to(_PKG.parent).as_posix()
                 found.append((rel, node.lineno, _enclosing_function(tree, node)))
     return found
 
@@ -240,7 +251,12 @@ class TestNoUnsyncedReplace:
         live: set[tuple[str, str, str]] = set()
         for path in _module_paths():
             tree = ast.parse(path.read_text(encoding="utf-8"))
-            rel = str(path.relative_to(_PKG.parent))
+            # .as_posix(), not str(): the allowlist keys are hardcoded
+            # forward-slash paths, and str() on Windows yields backslash
+            # separators -- that mismatch made every allowlist entry read
+            # as stale (and every real call site as unreviewed) on the
+            # windows-latest CI lane regardless of which PR ran it.
+            rel = path.relative_to(_PKG.parent).as_posix()
             for node in ast.walk(tree):
                 if not _is_replace_call(node):
                     continue


### PR DESCRIPTION
## Summary

`unit-tests (windows-latest, 3.13, false)` fails unconditionally on `main` (confirmed at the current tip, run 33583371497 / job 100102240768) because `tests/test_fact_bridged_replace_guard.py` compares OS-native relative paths against a hardcoded forward-slash allowlist.

## Motivation

Discovered while driving PR #1001 to green: the Windows unit-tests job failed there too, and turned out to already be red on `main` — unrelated to that PR's own changes.

## Changes

- `_named_violations()`, `_starred_calls()`, and `test_the_named_allowlist_has_no_stale_entries()` all computed each scanned module's relative path via `str(path.relative_to(_PKG.parent))`. On Windows, `str()` renders a `PureWindowsPath` with backslash separators, while `_NAMED_CALL_ALLOWLIST`/`_STARRED_CALL_ALLOWLIST` are hardcoded with forward slashes. Every real call site therefore failed to match its own allowlist entry on `windows-latest` CI — every entry read as stale, and every real call site read as unreviewed — unconditionally failing all four `TestNoUnsyncedReplace` tests on that platform, for every PR, regardless of which files it touches.
- Switched to `.as_posix()` at all three call sites.

## Bug-fix test contract

- Bug class: an OS-native `str(Path.relative_to(...))` compared against a hardcoded-POSIX-separator constant/allowlist — silently mismatches on Windows only.
- Publicly observable failure: `unit-tests (windows-latest, 3.13, false)` fails on every PR, unconditionally, with `test_the_allowlist_has_no_stale_entries`/`test_every_starred_replace_is_reviewed`/etc. all reporting every real call site as stale/unreviewed.
- Regression test fails on base: yes — `tests/test_fact_bridged_replace_guard.py`'s existing suite (unchanged in this PR) already encodes the invariant; it was failing only on the Windows platform this sandbox can't run directly, confirmed instead via the live CI job on `main`'s current tip named above.
- Negative control: the same suite already passes on Linux/macOS before and after this change (`.as_posix()` and `str()` agree on POSIX), so this fix only changes behavior on the platform it was broken on.
- Public-surface test: n/a — this is a repo-internal AI-readiness-adjacent test guard, not a user-facing surface.
- Axes covered: all three call sites computing this relative path are fixed identically.
- General invariant: any path comparison against a hardcoded string constant in this repo's tests must normalize to `.as_posix()` first, not rely on `str()`'s platform-dependent separator.

## Checklist

- [x] Tests added / updated for new behaviour (existing suite now exercises the fixed path on every platform; verified locally on Linux)
- [x] Changelog fragment — not needed, this PR touches only `tests/`, not `abicheck/**/*.py`
- [ ] Docs updated if user-visible behaviour changed — n/a
- [x] `pre-commit run --all-files` passes locally (ruff check/format, mypy unaffected — pre-existing unrelated `tests/` mypy findings confirmed unchanged before/after)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MHS7gkcXid1WeHh1w34rig)_