### PR TITLE
fix(storage): an unrecognized ast_producer evidences no header backend

### DIFF
--- a/abicheck/storage/fact_backfill.py
+++ b/abicheck/storage/fact_backfill.py
@@ -123,6 +123,12 @@ def _owner_pairs(
 #: provenance is *recorded* (see :func:`evidenced_producers`).
 _HEADER_AST_BACKENDS: frozenset[str] = frozenset({"castxml", "clang"})
 
+#: Every ``ast_producer`` spelling this build understands. ``serialization``'s
+#: own reliability computations record that the field has always held exactly
+#: these three, verified against every write site -- so a *fourth* string is
+#: not a producer this build can reason about (see :func:`evidenced_producers`).
+_KNOWN_AST_PRODUCERS: frozenset[str] = _HEADER_AST_BACKENDS | {"hybrid"}
+
 
 def evidenced_producers(
     *,
@@ -145,8 +151,20 @@ def evidenced_producers(
     - ``castxml``/``clang`` only when header provenance is **recorded**
       (an inferred ``from_headers`` is a guess a legacy DWARF-only dump
       satisfies too); a recorded ``ast_producer`` narrows to that one
-      backend, ``"hybrid"`` (or an unrecorded producer on a confirmed
-      header snapshot) admits both.
+      backend, and ``"hybrid"`` admits both.
+
+      An **absent** ``ast_producer`` also admits both, but an
+      *unrecognized* one admits neither (Codex review, PR #995): those are
+      different states, not one. ``None`` means the document format did not
+      carry the field yet, and its recorded ``from_headers`` still says a
+      header-AST backend ran -- only which one is unknown, and each field's
+      own ``*_facts_reliable`` computation in ``serialization.py`` is what
+      answers that conservatively. A fourth *spelling* means the document
+      names a producer this build cannot identify (``ast_producer`` has held
+      exactly ``castxml``/``clang``/``hybrid`` at every write site), so this
+      build cannot say what it produces, and the falsy ``""`` is the same
+      malformed case. Crediting both there let a header-only fact stay
+      ``PRESENT`` on a document naming neither backend.
     - ``elf``/``pe``/``macho`` from the document's own ``platform``.
 
     **No debug-info producer is ever credited from a debug block.** The
@@ -207,7 +225,7 @@ def evidenced_producers(
     if header_provenance_confirmed:
         if ast_producer in _HEADER_AST_BACKENDS:
             evidenced.add(ast_producer)
-        else:
+        elif ast_producer is None or ast_producer == "hybrid":
             evidenced |= _HEADER_AST_BACKENDS
     if platform in {"elf", "pe", "macho"}:
         evidenced.add(platform)

--- a/changelog.d/1787020700_claude_evidenced-producers.md
+++ b/changelog.d/1787020700_claude_evidenced-producers.md
@@ -46,3 +46,11 @@
   truncated or hand-authored document could therefore reach exactly the
   confirmed claim this mechanism exists to prevent. The skip now tests for a
   usable fact, the same falsy check the decoder applies.
+
+- An unrecognized `ast_producer` spelling no longer credits both header-AST
+  backends. That branch covered three different states at once — `"hybrid"`,
+  a document predating the field, and a producer this build has never heard
+  of — and treated all three as "both backends ran", so a header-only fact
+  stayed `PRESENT` on a document naming neither. `castxml`/`clang`/`hybrid`
+  and an absent value are honoured as before; anything else (a typo, a
+  future producer, an empty string) evidences no header backend.

--- a/tests/test_last_case_a_facts.py
+++ b/tests/test_last_case_a_facts.py
@@ -939,3 +939,70 @@ class TestEvidencedProducerInvariantAcrossEveryCaseAFact:
             assert getattr(obj, f"{field}_fact").status is FactStatus.PRESENT, (
                 f"{owner}.{field}: a persisted PRESENT fact was discarded"
             )
+
+    #: (ast_producer, whether a header-AST backend is evidenced by it).
+    #: `ast_producer` has held exactly castxml/clang/hybrid at every write
+    #: site, so anything else is a document this build cannot interpret.
+    _AST_PRODUCERS: tuple[tuple[object, bool], ...] = (
+        ("castxml", True),
+        ("clang", True),
+        ("hybrid", True),
+        (None, True),  # the field predates this document's schema
+        ("gcc-xml", False),  # a producer this build does not know
+        ("CASTXML", False),  # right backend, wrong spelling
+        ("castxml ", False),  # ... and with stray whitespace
+        ("", False),  # malformed/empty
+        ("dwarf", False),  # a real producer name, but not an AST one
+    )
+
+    @pytest.mark.parametrize(
+        "producer,evidences_header",
+        _AST_PRODUCERS,
+        ids=[repr(p) for p, _e in _AST_PRODUCERS],
+    )
+    def test_only_a_recognized_ast_producer_evidences_a_header_backend(
+        self, producer: object, evidences_header: bool
+    ) -> None:
+        """An unrecognized `ast_producer` credits neither backend.
+
+        The `else` branch here covered three different states at once —
+        "hybrid", "the format didn't record it yet", and "the document names
+        something this build has never heard of" — and credited both
+        backends for all three. The third is not a header-AST backend at
+        all, so a header-only fact stayed `PRESENT` on a document naming
+        neither (Codex review, PR #995).
+
+        `None` deliberately still credits both: the document format did not
+        carry the field, and its *recorded* `from_headers` still says a
+        header backend ran. Stated over every rule, with the known spellings
+        as controls so a fix that simply rejected everything fails.
+        """
+        statuses: dict[tuple[str, str], FactStatus] = {}
+        for owner, field, collection, resting, _non_resting in self._FIELDS:
+            shape = {"from_headers": True}
+            if producer is not None:
+                shape["ast_producer"] = producer
+            d = self._document(owner, collection, resting, shape)
+            obj = self._loaded(
+                snapshot_from_dict(json.loads(json.dumps(d))), owner, collection
+            )
+            statuses[owner, field] = getattr(obj, f"{field}_fact").status
+
+        if evidences_header:
+            # Not "every rule stays PRESENT": `Variable.access` names only
+            # castxml and `Param.is_va_list` only clang, so a recognized
+            # producer legitimately fails to evidence some of them, and each
+            # rule's own reliability flag can downgrade independently. The
+            # control is that a recognized producer still credits *something*
+            # — without it, a fix that rejected every producer would satisfy
+            # the negative half below.
+            assert FactStatus.PRESENT in statuses.values(), (
+                f"ast_producer {producer!r} is a recognized header-AST "
+                f"producer but evidenced no rule at all"
+            )
+        else:
+            assert set(statuses.values()) == {FactStatus.NOT_COLLECTED}, (
+                f"ast_producer {producer!r} evidences no backend, but "
+                f"{[k for k, v in statuses.items() if v is not FactStatus.NOT_COLLECTED]}"
+                f" resolved PRESENT"
+            )


### PR DESCRIPTION
## Summary

Follow-up to #995, which merged at `6b80afc` — one commit short, the same way #993 did. This is that commit, rebased onto current `main`: the fix for the tenth Codex review round on #995, which was answered and its thread resolved there but did not make it into the merge.

## Motivation

The bug is live on `main` today:

```python
>>> from abicheck.storage.fact_backfill import evidenced_producers
>>> evidenced_producers(header_provenance_confirmed=True, ast_producer="gcc-xml", platform="elf")
frozenset({'castxml', 'clang', 'elf'})   # names neither backend
>>> evidenced_producers(header_provenance_confirmed=True, ast_producer="CASTXML", platform="elf")
frozenset({'castxml', 'clang', 'elf'})   # right backend, wrong spelling
>>> evidenced_producers(header_provenance_confirmed=True, ast_producer="", platform="elf")
frozenset({'castxml', 'clang', 'elf'})   # malformed
```

`evidenced_producers`' `else` branch collapsed three genuinely different states into one:

| `ast_producer` | what it means | credited |
|---|---|---|
| `"hybrid"` | both backends genuinely ran | both ✅ |
| absent (`None`) | the document format predates the field | both ✅ |
| anything else | the document names a producer this build cannot identify | both ❌ |

So a header-only fact stayed `PRESENT` on a legacy or hand-authored document naming neither backend — the same confirmed-claim-without-evidence defect #995 exists to close, reached through the provenance argument rather than the debug block.

## Changes

Only `"hybrid"` and an absent value admit both backends now; any other spelling admits neither. `ast_producer` has held exactly `castxml`/`clang`/`hybrid` at every write site — `serialization.py`'s own `*_facts_reliable` computations record and rely on that — so a fourth string is not a producer this build can reason about.

**`None` deliberately still credits both**, and the docstring says why these are not the same state rather than leaving it to be rediscovered. `None` means the *format* did not carry the field, while the document's *recorded* `from_headers` still says a header-AST backend ran: we know one did, only not which — and for that question each field's own `*_facts_reliable` computation already answers conservatively, which is existing reviewed behaviour this change should not quietly alter. An unrecognized spelling is uninterpretable rather than merely ambiguous, so it fails closed.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `evidence.silent_degradation_to_clean_verdict` (`tests/regressions/manifest.py`) — the inverse-direction sibling this PR family has been closing throughout: absent or uninterpretable evidence rendered as a *confirmed* fact status instead of a policy-visible "not collected".
- Publicly observable failure: `snapshot_from_dict()` on a legacy document with `from_headers: true` and an `ast_producer` this build does not recognize returns `PRESENT` for header-only case-(a) facts — `compare` then treats "no identifiable producer ran" as a confirmed observation, with no `NOT_COLLECTED` for policy to see.
- Regression test fails on base: yes — `tests/test_last_case_a_facts.py::TestEvidencedProducerInvariantAcrossEveryCaseAFact::test_only_a_recognized_ast_producer_evidences_a_header_backend` fails against `main` at `fbcfb7e` on its five unrecognized-producer rows.
- Negative control: yes, and it is load-bearing rather than decorative — the same test asserts the *other* direction for `castxml`, `clang`, `hybrid` and `None`: a recognized producer must still evidence something. Without it, a "fix" that rejected every producer would satisfy the negative half completely. Verified against both mutations: restoring the old `else` fails the five unrecognized rows; deleting the recognized-producer branch fails `'hybrid'` and `None`.
- Public-surface test: yes — every case drives `abicheck.serialization.snapshot_from_dict` over a whole raw legacy document, not `evidenced_producers` directly, so the assertion is on what a snapshot reader hands the rest of the pipeline.
- Real-dependency test: not applicable — this change touches no third-party or format boundary; it is a resolution rule over a field the caller already supplies. The surrounding suite's existing real-`AbiSnapshot` round-trip coverage (`test_no_debug_block_is_producer_evidence`) is unchanged.
- Axes covered: producer spelling (exact match, wrong case, trailing whitespace, an unknown tool name, a real-but-non-AST producer name, empty string, absent), provenance (recorded vs inferred `from_headers`), and every rule in the backfill table — all 15, not the subset this fix's own field family covers, via `_FIELDS`.
- General invariant: after a legacy load, a header-AST backend is evidenced only by a producer spelling this build recognizes; every other spelling evidences none, and a recognized one still evidences at least one rule. Stated over the whole rule table crossed with the producer vocabulary rather than the one reported spelling, and `test_the_enumeration_covers_every_applied_rule` keeps that crossing exhaustive mechanically — a rule added without a row fails rather than being silently skipped.

## Checklist

- [x] Tests added / updated — see the contract section above
- [x] Changelog fragment added
- [x] `ruff check`, `ruff format --check`, `mypy abicheck/`, `check_ai_readiness.py`, `check_architecture.py` all clean
- [x] Targeted suites green on this rebased base (5,213 tests across the fact/serialization/storage/provenance modules)

### Known blocker, not this PR's

`mutmut (detector core)` never reaches a mutant: `mutmut run`'s stats phase aborts on `tests/test_agent_evals.py::test_manifest_base_commit_exists_in_history`, because `agent-evals/tasks/add-change-kind-small/manifest.yaml` pins `83972cb8`, a pre-squash commit from #604 reachable from no ref. Diagnosis and a proposed one-line patch are in [a comment on #995](https://github.com/abicheck/abicheck/pull/995#issuecomment-5504278784). It fails identically on `main`; the unit lanes hide it because their shallow checkouts trip the test's own skip guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkKfPAz71P35Udh2W3ciFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkKfPAz71P35Udh2W3ciFR)_