### PR TITLE
docs(export_surface): fix stale ADR-063 Phase 3 traversal/xref claims

### DIFF
--- a/abicheck/export_surface.py
+++ b/abicheck/export_surface.py
@@ -30,9 +30,16 @@ second domain:
 - **closure** is the transitive walk over the *raw* record/enum/typedef graph
   from those roots' signatures, reusing
   :func:`~abicheck.policy.public_surface_closure._walk_type_closure` verbatim
-  (a real ``AbiSnapshot.surface_graph`` traversal, ADR-063 Phase 3 D5) so the
-  two domains cannot drift apart in how they follow fields, bases, and
-  typedef targets. Only the *seeds* differ, the difference ADR-049 D2 draws.
+  (ADR-063 Phase 3 D5's public-surface closure walk) so the two domains
+  cannot drift apart in how they follow fields, bases, and typedef targets.
+  **Not** a traversal of the persisted ``AbiSnapshot.surface_graph`` --
+  three review rounds found reading that graph unsafe (see
+  ``docs/contribute/known-gaps.md``'s ADR-063 Phase 3 entry), so the shared
+  walk resolves references via
+  :func:`~abicheck.compare.surface_graph.referenced_identifiers_by_node`, a
+  pure function of the snapshot's own current declarations, and never reads
+  ``snap.surface_graph``/``GraphNode.attrs``. Only the *seeds* differ, the
+  difference ADR-049 D2 draws.
 
 No header-origin filtering happens anywhere here: a private-header type
 reached from a real export *is* inside the export closure, and a
@@ -92,11 +99,11 @@ class ExportSurface:
     snapshot's full universe, used by a caller to tell "this entity exists and
     is provably not reachable from an export" apart from "this entity is not
     something this snapshot knows about at all" -- the same distinction
-    :class:`~abicheck.surface.PublicSurface` draws with its own ``all_*``
+    :class:`~abicheck.policy.public_surface.PublicSurface` draws with its own ``all_*``
     sets.
     """
 
-    #: Every symbol key (:func:`~abicheck.surface._symbol_keys`: demangled
+    #: Every symbol key (:func:`~abicheck.policy.public_surface._symbol_keys`: demangled
     #: name, mangled name, and the trailing ``::`` segment) of a declaration
     #: whose linker symbol appears in the observed export table.
     export_symbols: set[str] = field(default_factory=set)
@@ -310,7 +317,7 @@ def _linker_identity(name: str, mangled: str) -> str:
     The mangled name, or the plain name when the producer recorded no mangled
     one (a C symbol, or a backend that leaves the field empty; there is no
     other identity to match on). Deliberately **not**
-    :func:`~abicheck.surface._symbol_keys`, whose demangled-name and bare-tail
+    :func:`~abicheck.policy.public_surface._symbol_keys`, whose demangled-name and bare-tail
     aliases exist so a *finding* naming any encoding can be looked up: a
     binary exporting the C symbol ``foo`` while the headers also declare an
     unexported ``ns::foo`` would otherwise match on the bare tail ``"foo"``
@@ -422,7 +429,7 @@ def _seed_export_roots(
     the ``(table, spelling)`` pairs actually matched, and the roots' own
     linker identities.
 
-    Mirrors :func:`~abicheck.surface._seed_public_roots` field for field --
+    Mirrors :func:`~abicheck.policy.public_surface_closure._seed_public_roots` field for field --
     the return/parameter/variable types of every root, plus a method root's
     own enclosing class (a consumer holding an exported method can declare,
     allocate, and inherit that class, so its layout is inside the export
@@ -432,7 +439,7 @@ def _seed_export_roots(
     :data:`~abicheck.model.Visibility.PUBLIC`.
 
     A root's *lookup* keys are still the full
-    :func:`~abicheck.surface._symbol_keys` set, so a finding naming any
+    :func:`~abicheck.policy.public_surface._symbol_keys` set, so a finding naming any
     encoding of a genuine root resolves; only the rootness *decision* is
     narrowed to linker identity.
 
@@ -691,7 +698,7 @@ class _SpellingIndex(NamedTuple):
     #: namespace-suffix and stdlib-stripped form of it.
     nodes_by_spelling: dict[str, frozenset[str]]
     #: Lookup key -> the node identities
-    #: :func:`~abicheck.surface._walk_type_closure` actually reaches through
+    #: :func:`~abicheck.policy.public_surface_closure._walk_type_closure` actually reaches through
     #: it. Exactly the walk's own indexes: a record/enum by its name or bare
     #: ``::`` tail, a typedef by its exact key only.
     nodes_by_walk_key: dict[str, frozenset[str]]
@@ -902,7 +909,7 @@ def _edge_is_unresolved(
     Each ``_IDENT_RE`` token is judged on its own -- a template spelling
     like ``Wrapper<Payload>`` carries two independent edges, and either can
     be the missing one. This does not reuse
-    :func:`~abicheck.surface._type_identifiers`, which flattens a token and
+    :func:`~abicheck.policy.public_surface._type_identifiers`, which flattens a token and
     its bare tail into one set: a qualified token whose bare tail happens to
     be unknown would then look like a second, missing edge.
 
@@ -920,7 +927,7 @@ def _edge_is_unresolved(
     what it will not do is invent a scope the snapshot never recorded.
 
     **Naming a known node is necessary but not sufficient.** The token must
-    also be one :func:`~abicheck.surface._walk_type_closure` could actually
+    also be one :func:`~abicheck.policy.public_surface_closure._walk_type_closure` could actually
     look up, which is a strictly narrower set: the walk resolves a record or
     enum through its own name or bare ``::`` tail, but a *typedef* only
     through its exact key, with no spelling tolerance at all. Registered
@@ -1009,7 +1016,7 @@ def _followed_typedef_aliases(
     """Typedef keys named by *type_str* whose target is worth scanning too.
 
     A token is resolved to the alias key the closure *actually traversed*,
-    via :func:`~abicheck.surface._type_identifiers` -- the same function the
+    via :func:`~abicheck.policy.public_surface._type_identifiers` -- the same function the
     walk queues from -- rather than matched against ``snap.typedefs``
     literally (Codex review, confirmed empirically). The direct-clang
     backend stores a typedef under its bare ``node["name"]`` (the
@@ -1184,7 +1191,8 @@ def compute_export_surface(snap: AbiSnapshot) -> ExportSurface:
 
     # A `PublicSurface` is used purely as the scratch structure
     # `_index_surface_types`/`_walk_type_closure` already know how to fill --
-    # reusing surface.py's own indexing and closure walk verbatim, rather
+    # reusing policy/public_surface.py's own indexing and
+    # policy/public_surface_closure.py's closure walk verbatim, rather
     # than a second implementation of the same graph traversal that could
     # drift. Only its type-universe/closure outputs are read back; its
     # public_symbols/origin bookkeeping is header-domain state this domain
@@ -1204,8 +1212,9 @@ def compute_export_surface(snap: AbiSnapshot) -> ExportSurface:
     # minimal snapshot: `export_types` came back empty while
     # `exclusion_is_provable` was true). Adding each record's
     # `qualified_name` to this *local* index gives every such record an exact
-    # handle. Deliberately not done in `surface.py`'s shared indexing: that
-    # index is relied on by every other consumer of the closure walk, and
+    # handle. Deliberately not done in `policy/public_surface.py`'s shared
+    # indexing: that index is relied on by every other consumer of the
+    # closure walk, and
     # AGENTS.md already records its bare-tail lookup as needing its own
     # scoped design rather than a drive-by change. `ambiguous_type_names` is
     # computed above, from the un-augmented index, so these added keys cannot

--- a/changelog.d/1788130000_claude_adr-063-phase-3-export-surface-docs.md
+++ b/changelog.d/1788130000_claude_adr-063-phase-3-export-surface-docs.md
@@ -1,0 +1,13 @@
+### Documentation
+
+- **Fixed stale `export_surface.py` docstrings left over from ADR-063 Phase
+  3's public-surface migration.** Several module/class/function docstrings
+  still claimed the shared type-closure walk performs "a real
+  `AbiSnapshot.surface_graph` traversal" and pointed Sphinx cross-references
+  at `abicheck.surface.*` symbols that had already moved to
+  `abicheck.policy.public_surface`/`abicheck.policy.public_surface_closure`
+  (or were deleted from `surface.py` entirely). Both misstatements
+  contradicted ADR-063's own recorded final design — the closure walk
+  deliberately never reads `AbiSnapshot.surface_graph`/`GraphNode.attrs`,
+  per three review rounds documented in `docs/contribute/known-gaps.md` —
+  so the docstrings now describe what actually ships. No behavior change.


### PR DESCRIPTION
## Summary

You asked me to check that ADR-063 Phase 3's status is clearly marked as finalized and that there are no remaining places where it's left open/described inconsistently.

**Phase 3's own status record is already correct and complete on `main`.** `docs/contribute/adr/063-one-semantic-pipeline.md`'s Phase 3 entry, `docs/contribute/adr/index.md`'s ADR-063 row, and `docs/contribute/known-gaps.md`'s matching entries all consistently state the final, considered outcome: the graph infrastructure and the `surface.py`/`export_surface.py` closure-walk migration landed, but D5's own literal premise ("`compute_public_surface()` becomes a traversal *through the graph*") is **not** what shipped — three review rounds found that unsafe, so the shipped closure walk never reads `AbiSnapshot.surface_graph`/`GraphNode.attrs`, only a pure function of the snapshot's own declarations. That's stated explicitly as "a considered, reviewed departure... not an oversight," never as "phase complete." `scripts/adr_status_sync.py` passes with no contradictions.

**What I found and fixed:** `abicheck/export_surface.py`'s own docstrings had drifted from that final account:

- Its module docstring called the shared closure walk **"a real `AbiSnapshot.surface_graph` traversal"** — the literal opposite of what actually ships (the walk deliberately never touches that graph).
- Eight Sphinx cross-references (`:func:`~abicheck.surface._symbol_keys``, `_seed_public_roots`, `_walk_type_closure`, `_type_identifiers`, and the `PublicSurface` class ref) still pointed at `abicheck.surface`, but those symbols moved to `abicheck.policy.public_surface`/`abicheck.policy.public_surface_closure` during the migration (or were deleted from `surface.py` outright) — so a reader following them lands on nothing.
- Two inline comments similarly said "reusing `surface.py`'s own indexing" / "not done in `surface.py`'s shared indexing," which no longer exists there.

This is the one place I found where Phase 3's actual, final design wasn't accurately reflected — everywhere else (the ADR, the plan doc, `known-gaps.md`, `policy/public_surface_closure.py`'s own docstring) already states it correctly. Doc/comment-only change, no behavior change.

## Verification

- `mypy abicheck/export_surface.py` — clean
- `ruff check` / `ruff format --check` — clean
- `pytest tests/test_export_surface.py tests/test_policy_public_surface.py` — 111 passed
- `python scripts/check_ai_readiness.py` — 0 errors (unchanged warning set)
- `python scripts/adr_status_sync.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9ytLbq8foy9t6b5i5Vb9v)_