### PR TITLE
refactor(policy,cli): unify release fan-out's severity/exit-code gate config (ADR-064 GateOptions)

### DIFF
--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -59,11 +59,12 @@ from .cli_compare_release_helpers import (  # noqa: F401
     _release_md_libraries_table,
     _release_md_matrix_findings,
     _resolve_release_headers,
-    _resolve_release_severity_config,
+    _resolve_release_severity_config as _resolve_release_severity_config,  # re-exported, ADR-064
     _run_bundle_analysis,
-    apply_release_gate_pack,
+    apply_release_gate_pack as apply_release_gate_pack,  # re-exported, ADR-064
     reject_bundle_facts_out_collision,
     reject_bundle_facts_out_dir_collision,
+    resolve_release_gate_options as resolve_release_gate_options,  # re-exported, ADR-064
     write_bundle_facts_out,
 )
 from .cli_compare_release_matrix import (
@@ -510,25 +511,22 @@ def compare_release_cmd(
             if output_dir:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-            # CLI cleanup phase two, "PR B" slice 2: fold a selected `kind:
-            # gate` pack's gate.exit_code_scheme/gate.severity.<category>
-            # into these same raw inputs, once, before every downstream
-            # consumer below (this function's own severity_config, the
-            # per-library JSON write inside _compare_release_libraries,
-            # _compute_release_severity_exit_code,
-            # _fold_release_global_severity) reads them — mirroring the
-            # `.abicheck.yml`-only `severity_preset = "default"` reassignment
-            # a few lines below, which the same downstream consumers already
-            # rely on seeing applied exactly once. A no-op without --pack or
-            # without a selected gate pack.
-            (
-                release_exit_code_scheme,
-                severity_preset,
-                severity_abi_breaking,
-                severity_potential_breaking,
-                severity_quality_issues,
-                severity_addition,
-            ) = apply_release_gate_pack(
+            # CLI cleanup phase two, ADR-064 "GateOptions" rewrite: one
+            # resolution replaces the release fan-out's previous three
+            # independent re-derivations of the same SeverityConfig from six
+            # raw preset/category/scheme strings. `resolve_release_gate_options`
+            # folds a selected `kind: gate` pack's gate.exit_code_scheme/
+            # gate.severity.<category> contribution
+            # (`apply_release_gate_pack`), then resolves the severity config
+            # and applies the same `.abicheck.yml`-only `exit_code_scheme:
+            # severity` default-preset fallback and forced-`legacy` clearing
+            # this call site used to apply itself. Every downstream consumer
+            # (this function's own `severity_config`, the per-library JSON
+            # write inside `_compare_release_libraries`,
+            # `_compute_release_severity_exit_code`,
+            # `_fold_release_global_severity`) now reads the resulting
+            # `GateOptions` instead of independently re-deriving it.
+            gate = resolve_release_gate_options(
                 pack_application,
                 release_exit_code_scheme=release_exit_code_scheme,
                 severity_preset=severity_preset,
@@ -537,42 +535,16 @@ def compare_release_cmd(
                 severity_quality_issues=severity_quality_issues,
                 severity_addition=severity_addition,
             )
-
             # Resolved before the compare pass (its inputs are plain CLI values, no
             # dependency on compare results) so persisted per-library annotations
             # (schema 2.43/2.44, computed inside _compare_release_libraries's
             # primary pass and read by the Action, not the CLI) reflect the same
             # severity-aware gate as the exit code below, instead of the legacy
-            # kind-set mapping. Returns None when no severity setting was in
-            # effect, or when compare's resolved config pins the legacy scheme
-            # for set inputs.
-            severity_config = _resolve_release_severity_config(
-                severity_preset,
-                severity_abi_breaking,
-                severity_potential_breaking,
-                severity_quality_issues,
-                severity_addition,
-            )
-            if release_exit_code_scheme == "severity" and severity_config is None:
-                # The resolved scheme is "severity" (e.g. .abicheck.yml's
-                # exit_code_scheme: severity with no severity: block at all) but
-                # no severity setting was ever in effect, so the raw-args resolution
-                # above returned None. The single-file compare path never hits
-                # this: its resolved_cfg.severity is unconditionally populated
-                # (defaulting to PRESET_DEFAULT) and only *gated* by scheme, not
-                # re-derived from raw flags. Mirror that here — including
-                # reassigning severity_preset so the two downstream helpers below
-                # that independently re-resolve from these same raw args
-                # (_compute_release_severity_exit_code, _fold_release_global_severity)
-                # agree with it, instead of also silently resolving None and
-                # falling back to the legacy verdict-based exit (Codex review on
-                # #549).
-                from .workflows.gate import PRESET_DEFAULT
-
-                severity_config = PRESET_DEFAULT
-                severity_preset = "default"
-            if release_exit_code_scheme == "legacy":
-                severity_config = None
+            # kind-set mapping. `None` when no severity setting was in effect,
+            # or when the resolved scheme pins legacy for set inputs.
+            severity_config = gate.severity
+            release_exit_code_scheme = gate.exit_code_scheme
+            severity_preset = gate.severity_preset
 
             # JUnit, bundle analysis, and annotations all reuse the
             # _diff_result (and, for JUnit, _old_snapshot) stashed in each
@@ -719,17 +691,12 @@ def compare_release_cmd(
 
             # Compute the severity-aware exit code while per-library DiffResults
             # are still stashed (before _strip_diff_results_and_adjust_verdict).
+            # `gate.severity is None` already covers both "legacy" and
+            # "nothing configured" -- see GateOptions's own docstring.
             severity_exit_code = (
                 None
-                if release_exit_code_scheme == "legacy"
-                else _compute_release_severity_exit_code(
-                    library_results,
-                    severity_preset,
-                    severity_abi_breaking,
-                    severity_potential_breaking,
-                    severity_quality_issues,
-                    severity_addition,
-                )
+                if gate.severity is None
+                else _compute_release_severity_exit_code(library_results, gate)
             )
 
             bundle_result: BundleDiffResult | None = None
@@ -779,11 +746,7 @@ def compare_release_cmd(
                     severity_exit_code,
                     bundle_result,
                     matrix_result,
-                    severity_preset,
-                    severity_abi_breaking,
-                    severity_potential_breaking,
-                    severity_quality_issues,
-                    severity_addition,
+                    gate,
                 )
 
             if secondary_output is not None:

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -21,6 +21,17 @@ release summary (JSON / Markdown / JUnit) live here, split out of
 :mod:`abicheck.cli_compare_release` to keep that module under the
 AI-readiness file-size limit. They are re-exported from
 ``cli_compare_release`` to preserve the public import surface.
+
+``GateOptions``/``resolve_release_gate_options``/``apply_release_gate_pack``/
+``_resolve_release_severity_config`` (ADR-064's release-fan-out gate
+resolution) live in :mod:`abicheck.policy.release_gate_options` instead --
+this package's own home for deciding gate/severity effect
+(``abicheck/policy/AGENTS.md``), and also outside the file-size no-growth
+budget this module is at. This (a ``frontends``-classified module) reaches
+them through :mod:`abicheck.workflows.gate`'s facade rather than importing
+``policy`` directly (``frontends -> policy`` is forbidden), and re-exports
+them here so every pre-existing import of them from this module keeps
+working.
 """
 
 from __future__ import annotations
@@ -38,7 +49,13 @@ from .bundle_models import BundleSignatureEvidence
 from .checker import DiffResult
 from .frontends.cli.options.params import DEFAULT_POLICY_PROFILE
 from .model import AbiSnapshot
-from .workflows.gate import resolve_release_exit_decision_for_report
+from .workflows.gate import (
+    GateOptions as GateOptions,  # re-exported, ADR-064
+    _resolve_release_severity_config as _resolve_release_severity_config,  # re-exported, ADR-064
+    apply_release_gate_pack as apply_release_gate_pack,  # re-exported, ADR-064
+    resolve_release_exit_decision_for_report,
+    resolve_release_gate_options as resolve_release_gate_options,  # re-exported, ADR-064
+)
 
 if TYPE_CHECKING:
     from .pack_application import PackApplication
@@ -680,133 +697,16 @@ def _cleanup_temp_dirs(temp_dir_paths: list[str], keep_extracted: bool) -> None:
         click.echo(f"Extracted files kept in: {kept_paths}", err=True)
 
 
-def apply_release_gate_pack(
-    pack_application: PackApplication | None,
-    *,
-    release_exit_code_scheme: str | None,
-    severity_preset: str | None,
-    severity_abi_breaking: str | None,
-    severity_potential_breaking: str | None,
-    severity_quality_issues: str | None,
-    severity_addition: str | None,
-) -> tuple[str | None, str | None, str | None, str | None, str | None, str | None]:
-    """Fold a selected ``kind: gate`` pack's contribution into the release
-    fan-out's own raw exit-code-scheme/severity inputs (CLI cleanup phase
-    two, "PR B" slice 2).
-
-    Returns ``(release_exit_code_scheme, severity_preset,
-    severity_abi_breaking, severity_potential_breaking,
-    severity_quality_issues, severity_addition)`` -- the exact six values
-    the caller already threads through every downstream severity/exit-code
-    resolution (``_resolve_release_severity_config``,
-    ``_compute_release_severity_exit_code``,
-    ``_fold_release_global_severity``, and the per-library JSON write), so
-    calling this **once**, before any of those, is what makes every one of
-    them agree with the pack -- mirroring how ``compare_release_cmd``
-    already reassigns ``release_exit_code_scheme``/``severity_preset``
-    once, early, for the ``.abicheck.yml``-only ``exit_code_scheme:
-    severity`` case just above this function's own call site.
-
-    The release fan-out has no ``ResolvedCompareConfig``-shaped object of
-    its own to fold onto the way :func:`~abicheck.pack_application.
-    apply_to_compare_config` does for a single-pair ``compare`` -- its
-    severity/exit-code-scheme resolution is a set of raw CLI-or-config
-    strings, re-derived at several call sites. So this mirrors that
-    function's *logic* against the release fan-out's raw-string shape
-    instead: a pack-supplied ``gate.severity.<category>`` overrides the
-    matching raw string (only ever reached when nothing more explicit --
-    ``--severity-<category>``/``.abicheck.yml`` -- already stated it,
-    since :func:`~abicheck.pack_application.pack_application` already
-    excludes a field an explicit source shadowed), and a pack-supplied
-    ``gate.exit_code_scheme`` overrides *that* raw string the same way --
-    with the identical "resolver's own already-decided ``auto`` answer,
-    not a re-derivation" fallback when only a severity level moved and no
-    scheme was directly assigned (see ``apply_to_compare_config``'s own
-    docstring for why re-deriving one here would be wrong: a severity
-    level *is* severity being configured, and the resolver's own
-    ``resolved_exit_code_scheme`` already reflects that while still
-    letting an explicit ``--exit-code-scheme``/``.abicheck.yml`` value
-    outrank it).
-
-    A no-op when *pack_application* is ``None`` (no ``--pack`` given) or
-    contributed neither field -- every pre-existing invocation reaches the
-    six inputs completely unchanged.
-    """
-    if pack_application is None:
-        return (
-            release_exit_code_scheme,
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
-        )
-    levels = pack_application.severity_levels
-    if levels:
-        severity_abi_breaking = levels.get("abi_breaking", severity_abi_breaking)
-        severity_potential_breaking = levels.get(
-            "potential_breaking", severity_potential_breaking
-        )
-        severity_quality_issues = levels.get("quality_issues", severity_quality_issues)
-        severity_addition = levels.get("addition", severity_addition)
-    scheme = pack_application.exit_code_scheme
-    if scheme is None and levels:
-        scheme = pack_application.resolved_exit_code_scheme
-    if scheme is not None:
-        release_exit_code_scheme = scheme
-    return (
-        release_exit_code_scheme,
-        severity_preset,
-        severity_abi_breaking,
-        severity_potential_breaking,
-        severity_quality_issues,
-        severity_addition,
-    )
-
-
-def _resolve_release_severity_config(
-    severity_preset: str | None,
-    severity_abi_breaking: str | None,
-    severity_potential_breaking: str | None,
-    severity_quality_issues: str | None,
-    severity_addition: str | None,
-) -> SeverityConfig | None:
-    """Resolve the severity config, or None when no severity setting was in effect."""
-    if not any(
-        v is not None
-        for v in (
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
-        )
-    ):
-        return None
-    from .workflows.gate import resolve_severity_config
-
-    return resolve_severity_config(
-        severity_preset,
-        abi_breaking=severity_abi_breaking,
-        potential_breaking=severity_potential_breaking,
-        quality_issues=severity_quality_issues,
-        addition=severity_addition,
-    )
-
-
 def _compute_release_severity_exit_code(
     library_results: list[dict[str, object]],
-    severity_preset: str | None,
-    severity_abi_breaking: str | None,
-    severity_potential_breaking: str | None,
-    severity_quality_issues: str | None,
-    severity_addition: str | None,
+    gate: GateOptions,
 ) -> int | None:
     """Compute the severity-aware exit code aggregated across all libraries.
 
     Returns ``None`` when no severity setting was in effect (callers
-    keep the legacy verdict-based exit). Otherwise returns the worst
-    :func:`compute_exit_code` over the per-library changes. Each library is
+    keep the legacy verdict-based exit) -- i.e. when ``gate.severity is
+    None``. Otherwise returns the worst :func:`compute_exit_code` over the
+    per-library changes. Each library is
     classified with *its own* ``DiffResult._effective_kind_sets()`` (kind-level
     ``--policy-file`` overrides) *and* its own ``policy``/``policy_file`` (the
     per-finding frozen-namespace floor — Codex review on #549: without
@@ -820,14 +720,7 @@ def _compute_release_severity_exit_code(
     entries are stripped; release-global bundle/matrix findings are folded in
     separately via :func:`_fold_release_global_severity`.
     """
-    resolved_config = _resolve_release_severity_config(
-        severity_preset,
-        severity_abi_breaking,
-        severity_potential_breaking,
-        severity_quality_issues,
-        severity_addition,
-    )
-    if resolved_config is None:
+    if gate.severity is None:
         return None
 
     from .workflows.gate import compute_exit_code
@@ -838,7 +731,7 @@ def _compute_release_severity_exit_code(
         if isinstance(diff, DiffResult):
             code = compute_exit_code(
                 diff.changes,
-                resolved_config,
+                gate.severity,
                 policy=diff.policy,
                 kind_sets=diff._effective_kind_sets(),
                 policy_file=diff.policy_file,
@@ -851,11 +744,7 @@ def _fold_release_global_severity(
     base_code: int,
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
-    severity_preset: str | None,
-    severity_abi_breaking: str | None,
-    severity_potential_breaking: str | None,
-    severity_quality_issues: str | None,
-    severity_addition: str | None,
+    gate: GateOptions,
 ) -> int:
     """Fold release-global (bundle + matrix) findings into the severity exit.
 
@@ -864,15 +753,10 @@ def _fold_release_global_severity(
     computed later and update ``worst_verdict``. Without this, a release whose
     per-library diffs are clean but whose bundle/matrix analysis flags an
     error-level break would exit 0 under, e.g., the default preset. Returns the
-    worst of *base_code* and the bundle/matrix severity codes.
+    worst of *base_code* and the bundle/matrix severity codes. A no-op
+    (returns *base_code* unchanged) when ``gate.severity is None``.
     """
-    config = _resolve_release_severity_config(
-        severity_preset,
-        severity_abi_breaking,
-        severity_potential_breaking,
-        severity_quality_issues,
-        severity_addition,
-    )
+    config = gate.severity
     if config is None:
         return base_code
 

--- a/abicheck/policy/release_gate_options.py
+++ b/abicheck/policy/release_gate_options.py
@@ -1,0 +1,276 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The directory/package release fan-out's gate-configuration resolution
+(ADR-064, "``GateOptions`` -- the release fan-out's own prerequisite
+rewrite"): folding a selected ``kind: gate`` pack into the release fan-out's
+raw severity/exit-code-scheme inputs, and resolving the result into one
+:class:`GateOptions` object -- this package's job (deciding gate/severity
+effect), per ``abicheck/policy/AGENTS.md``.
+
+Split out of :mod:`abicheck.cli_compare_release_helpers` (CLI cleanup phase
+two, ADR-064 stage 1b) both to give this gating logic its ADR-061-owned
+package and to keep that flat, unclassified module under the AI-readiness
+file-size no-growth baseline (``architecture/debt.yaml``). Re-exported from
+``cli_compare_release_helpers`` (and, from there, ``cli_compare_release``)
+to preserve the pre-existing public import surface.
+
+Depends on ``PackApplication`` (``abicheck/pack_application.py``) only
+*structurally*, via :class:`_GatePackApplication` below, not by importing
+the real class: ``pack_application.py`` is a grandfathered flat
+``legacy_root_module`` (ADR-061's incremental migration), not a declared
+``public_root_surface`` this package may depend on
+(``abicheck/policy/AGENTS.md``'s "Permitted imports" -- ``policy`` may
+depend only on ``model``, ``compare``, and the public root surfaces), so an
+`import` of it here would be a real, checked dependency-direction violation,
+not a style choice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .severity import PRESET_DEFAULT, SeverityConfig, resolve_severity_config
+
+
+class _GatePackApplication(Protocol):
+    """The structural shape of
+    :class:`~abicheck.pack_application.PackApplication` this module needs --
+    a :class:`~typing.Protocol`, not an import of the real class, for the
+    dependency-direction reason this module's own docstring explains.
+    Every member here mirrors that class's field of the same name and type
+    exactly; a real ``PackApplication`` instance satisfies this
+    structurally, with no coupling beyond attribute names. Declared as
+    read-only properties, not plain attributes: a `Protocol` attribute is
+    implicitly settable (get *and* set), which the real class's frozen
+    (read-only) dataclass fields can never satisfy structurally."""
+
+    @property
+    def severity_levels(self) -> Mapping[str, Any]: ...
+    @property
+    def exit_code_scheme(self) -> str | None: ...
+    @property
+    def resolved_exit_code_scheme(self) -> str | None: ...
+
+
+def apply_release_gate_pack(
+    pack_application: _GatePackApplication | None,
+    *,
+    release_exit_code_scheme: str | None,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> tuple[str | None, str | None, str | None, str | None, str | None, str | None]:
+    """Fold a selected ``kind: gate`` pack's contribution into the release
+    fan-out's own raw exit-code-scheme/severity inputs (CLI cleanup phase
+    two, "PR B" slice 2).
+
+    Returns ``(release_exit_code_scheme, severity_preset,
+    severity_abi_breaking, severity_potential_breaking,
+    severity_quality_issues, severity_addition)`` -- the exact six raw
+    values. Since ADR-064's ``GateOptions`` rewrite, callers should not call
+    this directly: :func:`resolve_release_gate_options` calls it exactly
+    once, ahead of the one resolution into :class:`GateOptions` every
+    downstream severity/exit-code consumer (``_compute_release_severity_
+    exit_code``, ``_fold_release_global_severity``, and the per-library
+    JSON write, via ``GateOptions.severity``) now reads instead of
+    independently re-deriving from the raw strings -- this function stays a
+    separate, directly-unit-tested step of that pipeline rather than being
+    inlined into it.
+
+    The release fan-out has no ``ResolvedCompareConfig``-shaped object of
+    its own to fold onto the way :func:`~abicheck.pack_application.
+    apply_to_compare_config` does for a single-pair ``compare`` -- its
+    severity/exit-code-scheme resolution is a set of raw CLI-or-config
+    strings, re-derived at several call sites. So this mirrors that
+    function's *logic* against the release fan-out's raw-string shape
+    instead: a pack-supplied ``gate.severity.<category>`` overrides the
+    matching raw string (only ever reached when nothing more explicit --
+    ``--severity-<category>``/``.abicheck.yml`` -- already stated it,
+    since :func:`~abicheck.pack_application.pack_application` already
+    excludes a field an explicit source shadowed), and a pack-supplied
+    ``gate.exit_code_scheme`` overrides *that* raw string the same way --
+    with the identical "resolver's own already-decided ``auto`` answer,
+    not a re-derivation" fallback when only a severity level moved and no
+    scheme was directly assigned (see ``apply_to_compare_config``'s own
+    docstring for why re-deriving one here would be wrong: a severity
+    level *is* severity being configured, and the resolver's own
+    ``resolved_exit_code_scheme`` already reflects that while still
+    letting an explicit ``--exit-code-scheme``/``.abicheck.yml`` value
+    outrank it).
+
+    A no-op when *pack_application* is ``None`` (no ``--pack`` given) or
+    contributed neither field -- every pre-existing invocation reaches the
+    six inputs completely unchanged.
+    """
+    if pack_application is None:
+        return (
+            release_exit_code_scheme,
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
+        )
+    levels = pack_application.severity_levels
+    if levels:
+        severity_abi_breaking = levels.get("abi_breaking", severity_abi_breaking)
+        severity_potential_breaking = levels.get(
+            "potential_breaking", severity_potential_breaking
+        )
+        severity_quality_issues = levels.get("quality_issues", severity_quality_issues)
+        severity_addition = levels.get("addition", severity_addition)
+    scheme = pack_application.exit_code_scheme
+    if scheme is None and levels:
+        scheme = pack_application.resolved_exit_code_scheme
+    if scheme is not None:
+        release_exit_code_scheme = scheme
+    return (
+        release_exit_code_scheme,
+        severity_preset,
+        severity_abi_breaking,
+        severity_potential_breaking,
+        severity_quality_issues,
+        severity_addition,
+    )
+
+
+def _resolve_release_severity_config(
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> SeverityConfig | None:
+    """Resolve the severity config, or None when no severity setting was in effect."""
+    if not any(
+        v is not None
+        for v in (
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
+        )
+    ):
+        return None
+    return resolve_severity_config(
+        severity_preset,
+        abi_breaking=severity_abi_breaking,
+        potential_breaking=severity_potential_breaking,
+        quality_issues=severity_quality_issues,
+        addition=severity_addition,
+    )
+
+
+@dataclass(frozen=True)
+class GateOptions:
+    """The release fan-out's one resolved severity/exit-code-scheme gate
+    configuration (ADR-064, "``GateOptions`` — the release fan-out's own
+    prerequisite rewrite").
+
+    Before this type existed, the six raw preset/category/scheme strings a
+    directory/package release run carries were threaded independently
+    through three functions -- :func:`_resolve_release_severity_config`,
+    ``_compute_release_severity_exit_code``,
+    ``_fold_release_global_severity`` (both in
+    :mod:`abicheck.cli_compare_release_helpers`) -- each re-deriving the
+    identical :class:`SeverityConfig` from the same strings. They could not
+    actually *disagree* (``compare_release_cmd`` reassigns the six raw
+    values exactly once, early, before any of the three ever read them),
+    but the redundant re-derivation was exactly the shape PR B's own
+    "finalized" note flagged as unsafe to fix reactively, ahead of this
+    ADR's settled design. :func:`resolve_release_gate_options` now performs
+    that resolution exactly once; every downstream consumer takes the
+    resulting ``GateOptions`` instead of the raw strings.
+
+    ``severity is None`` is this object's single source of truth for "no
+    severity setting is in effect for this release run" -- it already folds
+    together both ways that can happen (an explicitly forced ``legacy``
+    scheme, or no severity configuration at all), the same simplification
+    ``ResolvedCompareConfig``'s own severity field already gives
+    `compare`/`scan`. ``exit_code_scheme``/``severity_preset`` are kept
+    alongside it for provenance/reporting (e.g. a dry-run scheme label) --
+    they are not authoritative for "should severity be folded", ``severity``
+    is.
+    """
+
+    exit_code_scheme: str | None
+    severity_preset: str | None
+    severity: SeverityConfig | None
+
+
+def resolve_release_gate_options(
+    pack_application: _GatePackApplication | None,
+    *,
+    release_exit_code_scheme: str | None,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> GateOptions:
+    """Resolve the release fan-out's :class:`GateOptions` exactly once.
+
+    Folds a selected ``kind: gate`` pack's contribution
+    (:func:`apply_release_gate_pack`), then resolves the severity config
+    (:func:`_resolve_release_severity_config`) and applies the same two
+    scheme-dependent corrections ``compare_release_cmd`` used to apply at
+    its own call site: a resolved ``exit_code_scheme == "severity"`` with no
+    severity setting actually in effect falls back to
+    :data:`PRESET_DEFAULT` (mirroring single-pair ``compare``'s
+    ``ResolvedCompareConfig.severity``, which is unconditionally populated
+    and only *gated* by scheme, never left ``None``); an explicit
+    ``exit_code_scheme == "legacy"`` clears the severity config regardless
+    of what was otherwise configured, so a forced legacy run never scores a
+    severity-based exit even if a severity block is technically present.
+    """
+    (
+        release_exit_code_scheme,
+        severity_preset,
+        severity_abi_breaking,
+        severity_potential_breaking,
+        severity_quality_issues,
+        severity_addition,
+    ) = apply_release_gate_pack(
+        pack_application,
+        release_exit_code_scheme=release_exit_code_scheme,
+        severity_preset=severity_preset,
+        severity_abi_breaking=severity_abi_breaking,
+        severity_potential_breaking=severity_potential_breaking,
+        severity_quality_issues=severity_quality_issues,
+        severity_addition=severity_addition,
+    )
+    severity_config = _resolve_release_severity_config(
+        severity_preset,
+        severity_abi_breaking,
+        severity_potential_breaking,
+        severity_quality_issues,
+        severity_addition,
+    )
+    if release_exit_code_scheme == "severity" and severity_config is None:
+        severity_config = PRESET_DEFAULT
+        severity_preset = "default"
+    if release_exit_code_scheme == "legacy":
+        severity_config = None
+    return GateOptions(
+        exit_code_scheme=release_exit_code_scheme,
+        severity_preset=severity_preset,
+        severity=severity_config,
+    )

--- a/abicheck/workflows/gate.py
+++ b/abicheck/workflows/gate.py
@@ -33,7 +33,13 @@ whole decision or none of it.
 Re-export only: every name below keeps its own owner's definition and
 semantics. Nothing is re-implemented here, so there is no second opinion to
 drift, and ``severity``/``contract_coverage_exit``/``analysis_assurance``/
-``exit_decision`` remain the modules to read and to change.
+``exit_decision``/``release_gate_options`` remain the modules to read and to
+change. ``GateOptions``/``resolve_release_gate_options``/
+``apply_release_gate_pack`` (ADR-064) are the directory/package release
+fan-out's own severity/exit-code-scheme resolution -- reached this way
+because the fan-out's frontend module (``cli_compare_release_helpers.py``)
+may not import ``policy`` directly (``frontends -> policy`` is forbidden,
+same rule as every other name here).
 
 ``note_if_same_binary_compared`` (Codex review) is not an exit-code axis, but
 it belongs here rather than in ``extraction.py`` for the same reason as the
@@ -66,6 +72,12 @@ from ..policy.exit_decision_precedence import (
     resolve_release_exit_decision_for_report,
 )
 from ..policy.gate_decision import gate_decision_for_result
+from ..policy.release_gate_options import (
+    GateOptions,
+    _resolve_release_severity_config as _resolve_release_severity_config,  # re-exported, ADR-064 (private; __all__ excludes it by convention)
+    apply_release_gate_pack,
+    resolve_release_gate_options,
+)
 from ..policy.severity import (
     PRESET_DEFAULT,
     IssueCategory,
@@ -83,12 +95,14 @@ from ..policy.severity import (
 __all__ = [
     "PRESET_DEFAULT",
     "ExitDecision",
+    "GateOptions",
     "IssueCategory",
     "SeverityConfig",
     "SeverityLevel",
     "analysis_assurance_exit_contribution",
     "analysis_assurance_report_dict",
     "announce_coverage_floor",
+    "apply_release_gate_pack",
     "assurance_floor_diagnostic",
     "categorize_changes",
     "classify_change_object",
@@ -107,5 +121,6 @@ __all__ = [
     "resolve_compare_exit_decision",
     "resolve_release_exit_decision",
     "resolve_release_exit_decision_for_report",
+    "resolve_release_gate_options",
     "resolve_severity_config",
 ]

--- a/changelog.d/20260902_220750_noreply_cli_cleanup_continuation_rhpj03.md
+++ b/changelog.d/20260902_220750_noreply_cli_cleanup_continuation_rhpj03.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **`compare-release`'s severity/exit-code-scheme resolution now goes
+  through one typed `GateOptions` object** (ADR-064's "`GateOptions` — the
+  release fan-out's own prerequisite rewrite") instead of threading six raw
+  preset/category/scheme strings independently through three functions,
+  each re-deriving the same `SeverityConfig`. Purely internal: no CLI
+  surface or externally observable exit code changes.

--- a/docs/contribute/adr/064-canonical-gate-algorithm-and-exit-decision.md
+++ b/docs/contribute/adr/064-canonical-gate-algorithm-and-exit-decision.md
@@ -70,11 +70,14 @@ gap that same parity pass's review rounds found — `extra-args: --format
 json` overriding a `format: text`/`markdown` step's nominal format, which
 `action/run.sh`'s JSON-detection sites (`_STDOUT_JSON_FILE`,
 `_json_report_src`'s `OUTPUT_FILE` branch) previously missed — is fixed; see
-"Staged landing, additive first" below, item 1's own end-of-list note. Still
-open: the release fan-out's `GateOptions` unification; the rest of the
-cross-front-end parity pass (typed API; the `--format text` gap named
-above; a real `--artifact-set` member-level evidence-contract signal); and
-**stage 2**, the
+"Staged landing, additive first" below, item 1's own end-of-list note.
+**Landed (2026-09-02): the release fan-out's `GateOptions` unification.**
+See "Staged landing, additive first" below, item 1's own final update for
+the account — it landed as additive stage-1b wiring, not atomic-stage work
+as this section originally assumed (see "Consequences" below for the
+correction). Still open: the rest of the cross-front-end parity pass
+(typed API; the `--format text` gap named above; a real `--artifact-set`
+member-level evidence-contract signal); and **stage 2**, the
 `--exit-code-scheme` removal itself. See
 [cli-cleanup-phase-two.md](../plans/cli-cleanup-phase-two.md)'s "PR 4 — one
 gate algorithm" section, which this ADR formalizes rather than restates.
@@ -938,6 +941,44 @@ lands in two stages rather than one atomic change:
       `action/run.sh`'s own logic with no shortcut claim standing in for
       it. No code change and no new test -- this is prose accuracy only,
       the same class the fourth round already established needs neither.
+
+      **Landed (2026-09-02): the release fan-out's `GateOptions`
+      unification** (`abicheck/policy/release_gate_options.py`'s
+      `GateOptions`/`resolve_release_gate_options` -- this package's own
+      home for deciding gate/severity effect, per `abicheck/policy/
+      AGENTS.md`; reached from the release fan-out's `frontends`-classified
+      `cli_compare_release_helpers.py` through `abicheck/workflows/gate.py`'s
+      existing re-export facade, since `frontends -> policy` is forbidden).
+      Before this, the release fan-out threaded six raw preset/category/scheme strings
+      independently through `_resolve_release_severity_config`,
+      `_compute_release_severity_exit_code`, and
+      `_fold_release_global_severity`, each re-deriving the identical
+      `SeverityConfig` from the same strings -- exactly the shape PR B's
+      own "finalized" note (see `cli-cleanup-phase-two.md`'s "PR 4"
+      section) flagged as unsafe to fix reactively, ahead of this ADR's
+      settled design. `resolve_release_gate_options` now performs that
+      resolution exactly once (folding a selected `kind: gate` pack via
+      the pre-existing `apply_release_gate_pack`, then applying the same
+      `exit_code_scheme == "severity"`-with-no-config-present fallback to
+      `PRESET_DEFAULT` and forced-`legacy`-clears-severity corrections
+      `compare_release_cmd` used to apply inline at its own call site);
+      `_compute_release_severity_exit_code`/`_fold_release_global_severity`
+      now take the resulting `GateOptions` instead of the raw strings, and
+      `GateOptions.severity is None` is the one place "no severity setting
+      is in effect" is decided, replacing the two duplicated `if
+      release_exit_code_scheme == "legacy"`/`"severity"` checks that used
+      to appear at both the call site and inside each downstream function.
+      **Landed additively, contrary to this ADR's original "Consequences"
+      framing** (see that section's own correction below): the rewrite
+      changes no CLI surface and no externally observable exit code --
+      verified by the existing severity/exit-code test suite
+      (`tests/test_config_review.py`, `tests/test_cov95_cli.py`,
+      `tests/test_pack_application.py`, `tests/test_compare_release.py`)
+      passing unchanged against the new call shape, so it did not need to
+      wait for stage 2. Still open, unchanged by this landing: the typed-API
+      half of the parity pass, the `--format text` gap named above, and a
+      real `--artifact-set` member-level evidence-contract signal for the
+      Action to consume.
 2. **Atomic.** Once the report block agrees with today's real behaviour for
    every axis and every mode (verified by the axis-separated tests this ADR
    requires below), remove `--exit-code-scheme` from `compare` and `scan`,
@@ -984,11 +1025,21 @@ alongside the flag deletion itself.
   via **stage 1b** (`resolve_release_exit_decision_for_report`,
   `abicheck/policy/exit_decision_precedence.py`, per "Staged landing"
   above) — not the atomic stage; that block is additive and needs no
-  algorithm-selector decision to exist. Only the
-  release fan-out's *internal* severity/exit-code representation changing
-  shape (raw strings → `GateOptions`-shaped object) is atomic-stage work,
-  since it is the same rewrite that removes `--exit-code-scheme`. Neither
-  step changes the release's externally observable exit codes.
+  algorithm-selector decision to exist. **Correction (2026-09-02):** this
+  paragraph originally placed the release fan-out's *internal*
+  severity/exit-code representation change (raw strings →
+  `GateOptions`-shaped object) in the atomic stage too, reasoning that it
+  was "the same rewrite that removes `--exit-code-scheme`". It landed
+  instead as additive stage-1b work (see "Staged landing, additive first"
+  above, item 1's own 2026-09-02 update) — the internal shape change and
+  the CLI flag's removal turned out to be separable: nothing about
+  replacing raw-string re-derivation with one resolved object depends on
+  the flag still existing, and the rewrite provably changes no externally
+  observable exit code (verified by the existing test suite passing
+  unchanged against the new call shape) independent of whether
+  `--exit-code-scheme` itself is later deleted. Both steps still change no
+  externally observable exit code, which is the invariant this paragraph
+  was stating; only which stage each belongs to was wrong.
 
 ## Cross-references
 

--- a/docs/contribute/adr/064-canonical-gate-algorithm-and-exit-decision.md
+++ b/docs/contribute/adr/064-canonical-gate-algorithm-and-exit-decision.md
@@ -973,8 +973,10 @@ lands in two stages rather than one atomic change:
       changes no CLI surface and no externally observable exit code --
       verified by the existing severity/exit-code test suite
       (`tests/test_config_review.py`, `tests/test_cov95_cli.py`,
-      `tests/test_pack_application.py`, `tests/test_compare_release.py`)
-      passing unchanged against the new call shape, so it did not need to
+      `tests/test_pack_application.py`, `tests/test_compare_release.py`):
+      their call sites were updated to build a `GateOptions` instead of
+      passing the six raw strings directly, and every expected result
+      stayed the same against the new call shape, so this did not need to
       wait for stage 2. Still open, unchanged by this landing: the typed-API
       half of the parity pass, the `--format text` gap named above, and a
       real `--artifact-set` member-level evidence-contract signal for the
@@ -1035,11 +1037,17 @@ alongside the flag deletion itself.
   the CLI flag's removal turned out to be separable: nothing about
   replacing raw-string re-derivation with one resolved object depends on
   the flag still existing, and the rewrite provably changes no externally
-  observable exit code (verified by the existing test suite passing
-  unchanged against the new call shape) independent of whether
-  `--exit-code-scheme` itself is later deleted. Both steps still change no
-  externally observable exit code, which is the invariant this paragraph
-  was stating; only which stage each belongs to was wrong.
+  observable exit code for any invocation the CLI supports today (verified
+  by the existing test suite's call sites, updated to build a `GateOptions`
+  instead of passing the six raw strings directly, still producing every
+  expected result unchanged) -- independent of whether `--exit-code-scheme`
+  itself is later deleted. That eventual stage-2 removal is its own,
+  separately visible exit-code change for the one, no-longer-supported
+  invocation spelling (exit `64`, "No such option"), not something this
+  internal rewrite causes or forecloses. So both steps change no
+  externally observable exit code *for the invocations each one leaves
+  supported*, which is the invariant this paragraph was stating; only
+  which stage the internal rewrite belongs to was wrong.
 
 ## Cross-references
 

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -3764,13 +3764,16 @@ second top-level spelling of the same fact.
 > corrections `compare_release_cmd` used to apply inline at its own call
 > site), and the two downstream functions now take the resulting
 > `GateOptions` object. Landed additively: no CLI surface and no externally
-> observable exit code changed (the existing severity/exit-code test suite
-> passes unchanged against the new call shape), so — contrary to this ADR's
+> observable exit code changed (the existing severity/exit-code test suite's
+> call sites were updated to build a `GateOptions` instead of passing the
+> six raw strings directly, and every expected result stayed the same
+> against the new call shape), so — contrary to this ADR's
 > own original assumption that the shape change had to be atomic-stage work
 > alongside `--exit-code-scheme`'s removal — it did not need to wait for
 > stage 2. See ADR-064's own matching correction for the full account.
-> Still open: the typed-API half of the parity pass, and the `--format
-> text` gap.
+> Still open: the typed-API half of the parity pass, the `--format
+> text` gap, and a real `--artifact-set` member-level evidence-contract
+> signal for the Action to consume.
 
 **This is the item the original draft got wrong, and it gets its own ADR.**
 

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -4598,16 +4598,26 @@ the agreement so a future pass does not re-derive them as new:
   downward, `frontends → workflows`, and then the frontend gets an ordinary
   static import. A dynamic import to dodge an architecture detector is an
   acceptable transitional hack and an unacceptable end state.
-- **CI governance (PR 0B/P0) is still the oldest open item**, and the review
-  found the same shape from outside: Actions check-runs green on the exact
-  merge SHA, `Verify Merge Checks` success, but the commit *status* red from
-  `codecov/patch` (67.96% of diff vs a 90% target) and
-  `required_status_checks.enforcement_level: off`. Two decisions are owed,
-  not one: apply the prepared ruleset
-  (`.github/branch-protection-ruleset.json`), **and** decide whether patch
-  coverage is an authoritative merge gate — if it is, it goes in the required
-  set and PRs meet it; if it is not, it should stop painting merge SHAs red.
-  A permanently red `main` is indistinguishable from a broken one.
+- **CI governance (PR 0B/P0) is closed, by explicit decision, not by
+  completion.** At the time of this checkpoint it read as the oldest open
+  item — the review found the same shape from outside: Actions check-runs
+  green on the exact merge SHA, `Verify Merge Checks` success, but the
+  commit *status* red from `codecov/patch` and
+  `required_status_checks.enforcement_level: off`. Both decisions this
+  bullet used to say were owed have since been made, and made the same way:
+  the Ruleset **was** applied and did block merges on CI completion, exactly
+  as designed — and the maintainer then decided that trade-off isn't wanted
+  going forward. `required_status_checks` was removed from the Ruleset
+  (only `non_fast_forward` remains), `verify-merge-checks.yml` and its
+  dedicated tests were deleted outright, and — same call, same reasoning —
+  `codecov/patch` is not being promoted into the required set either: this
+  repo accepts an occasional red or incomplete merge over paying CI-completion
+  latency on every merge, full stop, and there is no plan to revisit that.
+  See `.github/AGENTS.md`'s "Required-status-check configuration —
+  deliberately not enforced" section for the durable statement of this
+  policy and PR 0's own "Superseded (2026-09)" note above for the mechanical
+  account of what was built, applied, and then reversed. No further
+  governance tightening is planned; this item does not reopen on its own.
 - **Generated plan status.** `plans/index.md`'s hand-maintained status prose
   goes stale between merge and the next docs pass (the review caught exactly
   that, below). The durable fix is not more careful hand-editing: take ADR
@@ -4639,9 +4649,11 @@ Recorded so they are not re-opened as work:
 
 ### Where this lands in the sequence
 
-Two new entries join the "Ordering" block below (PR I, PR J), and the review
-would run repository governance (PR A / PR 0B) ahead of everything as P0 —
-which is what this plan has said since PR 0 and has not happened yet.
+Two new entries join the "Ordering" block below (PR I, PR J). The review
+would have run repository governance (PR A / PR 0B) ahead of everything as
+P0; that item is now closed by explicit decision (see the corrected bullet
+above and PR 0's own "Superseded (2026-09)" note) rather than pending, so it
+no longer sits ahead of the sequence below waiting to happen.
 
 ## Merge criteria for every removal PR here
 
@@ -4688,8 +4700,20 @@ slice that made it safe.
 **Current, authoritative sequence:**
 
 ```text
-PR A  repository governance          = PR 0B — required checks / Ruleset,
-                                       exact-merge-SHA verification
+PR A  repository governance           = PR 0B — required checks / Ruleset,
+      (CLOSED, by decision)             exact-merge-SHA verification. Both
+                                       pieces were built and the Ruleset was
+                                       applied; the maintainer then decided
+                                       against merge-blocking CI going
+                                       forward and reversed it (Ruleset's
+                                       required_status_checks rule removed,
+                                       verify-merge-checks.yml deleted,
+                                       codecov/patch stays informational
+                                       too). See .github/AGENTS.md's
+                                       "Required-status-check configuration
+                                       — deliberately not enforced" section.
+                                       No further governance tightening is
+                                       planned
 PR B  effective configuration parity  — packs resolved once into one
       (DONE)                           CompatibilityEvaluationConfig, pack
                                        parity across every CLI command

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -3748,9 +3748,29 @@ second top-level spelling of the same fact.
 > [ADR-064](../adr/064-canonical-gate-algorithm-and-exit-decision.md)'s own
 > matching update for the full account, including the one gap this leaves:
 > `--format text` with no JSON secondary output still reads as `ERROR`,
-> since `cli_scan.py` writes no report at all on that path. Still open:
-> the `GateOptions` rewrite, the typed-API half of the parity pass, and
-> that `--format text` gap.
+> since `cli_scan.py` writes no report at all on that path.
+>
+> **Update (2026-09-02): the release fan-out's `GateOptions` rewrite
+> landed** (`abicheck/policy/release_gate_options.py`'s `GateOptions`/
+> `resolve_release_gate_options` -- `policy/`'s own home for gate/severity
+> decisions, reached from the release fan-out's `cli_compare_release_helpers.py`
+> through `abicheck/workflows/gate.py`'s facade), closing the item PR B's own "finalized"
+> note reassigned here. `_resolve_release_severity_config`,
+> `_compute_release_severity_exit_code`, and `_fold_release_global_severity`
+> no longer independently re-derive the same `SeverityConfig` from the same
+> six raw preset/category/scheme strings at three separate call sites —
+> `resolve_release_gate_options` resolves it exactly once (pack folding via
+> the existing `apply_release_gate_pack`, plus the two scheme-dependent
+> corrections `compare_release_cmd` used to apply inline at its own call
+> site), and the two downstream functions now take the resulting
+> `GateOptions` object. Landed additively: no CLI surface and no externally
+> observable exit code changed (the existing severity/exit-code test suite
+> passes unchanged against the new call shape), so — contrary to this ADR's
+> own original assumption that the shape change had to be atomic-stage work
+> alongside `--exit-code-scheme`'s removal — it did not need to wait for
+> stage 2. See ADR-064's own matching correction for the full account.
+> Still open: the typed-API half of the parity pass, and the `--format
+> text` gap.
 
 **This is the item the original draft got wrong, and it gets its own ADR.**
 
@@ -4761,8 +4781,19 @@ PR F  trusted build config            = PR 3C — build.query executes only
       └─ DELETE dump --build-query, dump --build-compile-db — DONE, both are
          now `No such option` / exit 64
 PR G2 canonical exit decision, part 2 = PR 4 — one automatic gate algorithm,
-      (ADR-064 accepted; stage 1a done,   schema / report / Action parity
-       stage 1b partially wired)
+      (ADR-064 accepted; stage 1a done,   schema / report / Action parity.
+       stage 1b: GateOptions landed       GateOptions (the release fan-out's
+       2026-09-02, rest partially wired)  own typed severity/exit-code-scheme
+                                       object) landed 2026-09-02
+                                       (abicheck/policy/release_gate_options.py,
+                                       reached from the frontends-classified
+                                       cli_compare_release_helpers.py through
+                                       workflows/gate.py's facade); still
+                                       open: the typed-API half of the
+                                       parity pass, the scan --format text
+                                       gap, a real --artifact-set member-level
+                                       evidence-contract signal for the
+                                       Action
       └─ then DELETE --exit-code-scheme
 PR H  artifact-set semantics          = PR 5 — provider ownership, moved and
       (syntax slice DONE)               duplicated symbols, cost and dry-run;
@@ -4788,11 +4819,21 @@ PR I  one bundle compare, not two     — NEW (2026-09-01 checkpoint): an
                                        BUNDLE_ARCHIVE_ARTIFACT_TYPE, and
                                        bundle_facts_serialization.looks_like_bundle_facts_document()
                                        as the classifier a future operand
-                                       dispatcher will call. The
-                                       BundleCompareRequest unification and
-                                       the deletion below remain blocked on
-                                       PR G2's GateOptions, which does not
-                                       exist yet
+                                       dispatcher will call. PR G2's own
+                                       GateOptions now exists too (landed
+                                       2026-09-02, see PR G2's own row) --
+                                       but scoped narrowly to the release
+                                       fan-out's own severity/exit-code-scheme
+                                       resolution, per ADR-064's actual
+                                       "GateOptions" section, not yet the
+                                       shared cross-front-end object this
+                                       row's own BundleCompareRequest sketch
+                                       implies. The BundleCompareRequest
+                                       unification and the deletion below
+                                       are not started; whether they reuse
+                                       this GateOptions class as-is or need
+                                       a broader one is this row's own design
+                                       question to resolve, not decided here
       └─ then DELETE compare --old-bundle-facts
 PR J  bundle topology out of the CLI  — NEW (2026-09-01 checkpoint):
       (NEW, not started)                --bundle-system-providers/--bundle-

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -598,41 +598,45 @@ class TestCompareReleaseExitFloors:
         )
 
 
+def _gate(preset, abi=None, potential=None, quality=None, addition=None, scheme=None):
+    """Build a :class:`~abicheck.cli_compare_release_helpers.GateOptions` the
+    way :func:`~abicheck.cli_compare_release_helpers.resolve_release_gate_options`
+    would (minus pack folding, irrelevant to these unit tests) -- since
+    ADR-064's rewrite, ``_compute_release_severity_exit_code``/
+    ``_fold_release_global_severity`` take the resolved object, not the six
+    raw preset/category/scheme strings directly."""
+    from abicheck.cli_compare_release_helpers import (
+        GateOptions,
+        _resolve_release_severity_config,
+    )
+
+    severity = _resolve_release_severity_config(
+        preset, abi, potential, quality, addition
+    )
+    return GateOptions(
+        exit_code_scheme=scheme, severity_preset=preset, severity=severity
+    )
+
+
 class TestComputeReleaseSeverityExitCode:
     def test_none_without_flags(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
-        assert (
-            _compute_release_severity_exit_code([], None, None, None, None, None)
-            is None
-        )
+        assert _compute_release_severity_exit_code([], _gate(None)) is None
 
     def test_zero_with_flag_and_no_changes(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
-        assert (
-            _compute_release_severity_exit_code([], "info-only", None, None, None, None)
-            == 0
-        )
+        assert _compute_release_severity_exit_code([], _gate("info-only")) == 0
 
     def test_aggregates_breaking_change(self):
         from abicheck.cli_compare_release import _compute_release_severity_exit_code
 
         entry = {"library": "libtest.so", "_diff_result": _breaking_diff()}
         # default preset: abi_breaking == error -> exit 4.
-        assert (
-            _compute_release_severity_exit_code(
-                [entry], "default", None, None, None, None
-            )
-            == 4
-        )
+        assert _compute_release_severity_exit_code([entry], _gate("default")) == 4
         # info-only downgrades everything below error -> exit 0.
-        assert (
-            _compute_release_severity_exit_code(
-                [entry], "info-only", None, None, None, None
-            )
-            == 0
-        )
+        assert _compute_release_severity_exit_code([entry], _gate("info-only")) == 0
 
 
 class TestReleaseSeverityPolicyAndGlobal:
@@ -653,12 +657,7 @@ class TestReleaseSeverityPolicyAndGlobal:
             lambda: (empty, empty, all_kinds, empty),
         )
         entry = {"_diff_result": diff}
-        assert (
-            _compute_release_severity_exit_code(
-                [entry], "default", None, None, None, None
-            )
-            == 0
-        )
+        assert _compute_release_severity_exit_code([entry], _gate("default")) == 0
 
     def test_per_library_honours_frozen_namespace_floor(self):
         """Codex review on #549: a policy-file override that demotes a kind
@@ -688,12 +687,7 @@ class TestReleaseSeverityPolicyAndGlobal:
         # default preset: abi_breaking == error. Without the policy_file floor
         # this would wrongly exit 0 (the override demotes FUNC_REMOVED to
         # COMPATIBLE); the frozen guard must keep it at its raw BREAKING exit.
-        assert (
-            _compute_release_severity_exit_code(
-                [entry], "default", None, None, None, None
-            )
-            == 4
-        )
+        assert _compute_release_severity_exit_code([entry], _gate("default")) == 4
 
     def test_format_release_junit_forwards_severity_config(self):
         """Codex review on #549: `compare-release --format junit` with a
@@ -754,12 +748,7 @@ class TestReleaseSeverityPolicyAndGlobal:
 
         # Per-library clean (base 0), but a matrix DiffResult carries a break.
         matrix = _breaking_diff()
-        assert (
-            _fold_release_global_severity(
-                0, None, matrix, "default", None, None, None, None
-            )
-            == 4
-        )
+        assert _fold_release_global_severity(0, None, matrix, _gate("default")) == 4
 
     def test_fold_bundle_break_raises_exit(self):
         import types
@@ -771,12 +760,7 @@ class TestReleaseSeverityPolicyAndGlobal:
         bundle = types.SimpleNamespace(
             bundle_findings=[finding], policy="strict_abi", policy_file=None
         )
-        assert (
-            _fold_release_global_severity(
-                0, bundle, None, "default", None, None, None, None
-            )
-            == 4
-        )
+        assert _fold_release_global_severity(0, bundle, None, _gate("default")) == 4
 
     def test_fold_bundle_honors_the_bundle_result_own_policy(self):
         # G38 stabilization Phase 10 (Codex review, fresh evidence): this
@@ -805,22 +789,14 @@ class TestReleaseSeverityPolicyAndGlobal:
         strict_bundle = types.SimpleNamespace(
             bundle_findings=[finding], policy="strict_abi", policy_file=None
         )
-        assert (
-            _fold_release_global_severity(
-                0, strict_bundle, None, "default", None, None, None, None
-            )
-            == 4
-        )
+        code = _fold_release_global_severity(0, strict_bundle, None, _gate("default"))
+        assert code == 4
 
         plugin_bundle = types.SimpleNamespace(
             bundle_findings=[finding], policy="plugin_abi", policy_file=None
         )
-        assert (
-            _fold_release_global_severity(
-                0, plugin_bundle, None, "default", None, None, None, None
-            )
-            == 0
-        )
+        code = _fold_release_global_severity(0, plugin_bundle, None, _gate("default"))
+        assert code == 0
 
     def test_fold_bundle_honors_the_bundle_result_own_policy_file(self):
         # G38 Phase 16 (Codex review, fresh evidence): the fold above
@@ -851,12 +827,8 @@ class TestReleaseSeverityPolicyAndGlobal:
         unmodified = types.SimpleNamespace(
             bundle_findings=[finding], policy="strict_abi", policy_file=None
         )
-        assert (
-            _fold_release_global_severity(
-                0, unmodified, None, "default", None, None, None, None
-            )
-            == 4
-        )
+        code = _fold_release_global_severity(0, unmodified, None, _gate("default"))
+        assert code == 4
 
         overridden = types.SimpleNamespace(
             bundle_findings=[finding],
@@ -865,34 +837,21 @@ class TestReleaseSeverityPolicyAndGlobal:
                 overrides={ChangeKind.BUNDLE_INTRA_DEP_REMOVED: Verdict.COMPATIBLE}
             ),
         )
-        assert (
-            _fold_release_global_severity(
-                0, overridden, None, "default", None, None, None, None
-            )
-            == 0
-        )
+        code = _fold_release_global_severity(0, overridden, None, _gate("default"))
+        assert code == 0
 
     def test_fold_info_only_does_not_escalate(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 
         matrix = _breaking_diff()
         # info-only downgrades the matrix break below error -> base 0 preserved.
-        assert (
-            _fold_release_global_severity(
-                0, None, matrix, "info-only", None, None, None, None
-            )
-            == 0
-        )
+        code = _fold_release_global_severity(0, None, matrix, _gate("info-only"))
+        assert code == 0
 
     def test_fold_no_extras_returns_base(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 
-        assert (
-            _fold_release_global_severity(
-                2, None, None, "default", None, None, None, None
-            )
-            == 2
-        )
+        assert _fold_release_global_severity(2, None, None, _gate("default")) == 2
 
     def test_resolve_config_none_without_flags(self):
         from abicheck.cli_compare_release import _resolve_release_severity_config

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -92,6 +92,22 @@ def _severity_config(tmp_path: Path, **levels: str) -> Path:
     return cfg
 
 
+def _gate(preset, abi=None, potential=None, quality=None, addition=None, scheme=None):
+    """Build a :class:`~abicheck.cli_compare_release_helpers.GateOptions` the
+    way :func:`~abicheck.cli_compare_release_helpers.resolve_release_gate_options`
+    would (minus pack folding, irrelevant to these unit tests) -- since
+    ADR-064's rewrite, ``_fold_release_global_severity`` takes the resolved
+    object, not the six raw preset/category/scheme strings directly."""
+    from abicheck.cli_compare_release_helpers import GateOptions
+
+    severity = _resolve_release_severity_config(
+        preset, abi, potential, quality, addition
+    )
+    return GateOptions(
+        exit_code_scheme=scheme, severity_preset=preset, severity=severity
+    )
+
+
 def _suppression_strict_config(tmp_path: Path) -> Path:
     """A project config setting ``suppression.strict`` (was ``--strict-suppressions``)."""
     cfg = tmp_path / "strict.abicheck.yml"
@@ -1070,19 +1086,7 @@ class TestReleaseVerdictOrder:
 
 class TestFoldReleaseGlobalSeverity:
     def test_no_config_returns_base(self) -> None:
-        assert (
-            _fold_release_global_severity(
-                2,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
-            == 2
-        )
+        assert _fold_release_global_severity(2, None, None, _gate(None)) == 2
 
     def test_matrix_findings_raise_code(self) -> None:
         mr = DiffResult(
@@ -1095,16 +1099,7 @@ class TestFoldReleaseGlobalSeverity:
                 ),
             ],
         )
-        code = _fold_release_global_severity(
-            0,
-            None,
-            mr,
-            "default",
-            None,
-            None,
-            None,
-            None,
-        )
+        code = _fold_release_global_severity(0, None, mr, _gate("default"))
         assert code >= 0
 
 
@@ -2748,27 +2743,13 @@ class TestFoldReleaseGlobalSeverityBundle:
         # A bundle break under a 'default' preset should not stay below the
         # per-library base code; folding considers bundle findings.
         code = _fold_release_global_severity(
-            0,
-            _bundle_with_findings(),
-            None,
-            "default",
-            None,
-            None,
-            None,
-            None,
+            0, _bundle_with_findings(), None, _gate("default")
         )
         assert code >= 0
 
     def test_matrix_findings_considered(self) -> None:
         code = _fold_release_global_severity(
-            0,
-            None,
-            _matrix_with_changes(),
-            "default",
-            None,
-            None,
-            None,
-            None,
+            0, None, _matrix_with_changes(), _gate("default")
         )
         assert code >= 0
 


### PR DESCRIPTION
## Summary

Continues CLI cleanup phase two / ADR-064: closes the "release fan-out's own `GateOptions`" item, and closes PR A/PR 0B's status drift in the plan docs.

## Motivation

Two loose ends in `docs/contribute/plans/cli-cleanup-phase-two.md`:

1. **PR A (repo governance / PR 0B)** was still described as "the oldest open item" in the 2026-09-01 review checkpoint, even though `.github/AGENTS.md` already records it as closed by an explicit maintainer decision (the Ruleset was applied, did block merges as designed, and the maintainer then decided against merge-blocking CI going forward — no further governance tightening is planned).
2. **ADR-064's `GateOptions` rewrite** — the directory/package release fan-out threaded six raw preset/category/scheme strings independently through three functions (`_resolve_release_severity_config`, `_compute_release_severity_exit_code`, `_fold_release_global_severity`), each re-deriving the identical `SeverityConfig` from the same strings. PR B's own "finalized" note reassigned this rewrite to PR G2/ADR-064 rather than attempting it reactively; it was still open.

## Changes

- **Docs:** correct the two stale "still open"/"P0" statements about PR A/PR 0B in `cli-cleanup-phase-two.md` to reflect that it's closed by decision, per `.github/AGENTS.md`'s existing "Required-status-check configuration — deliberately not enforced" section.
- **`abicheck/policy/release_gate_options.py` (new):** `GateOptions` (frozen dataclass) + `resolve_release_gate_options` + `apply_release_gate_pack` + `_resolve_release_severity_config` — this package's own home for deciding gate/severity effect (`abicheck/policy/AGENTS.md`). `resolve_release_gate_options` resolves the six raw strings into one `GateOptions` exactly once (pack folding, then the same `exit_code_scheme == "severity"` default-preset fallback and forced-`legacy` clearing `compare_release_cmd` used to apply inline at its own call site).
  - Depends on `PackApplication` only *structurally*, via a local `Protocol` (`_GatePackApplication`): `pack_application.py` is a grandfathered flat `legacy_root_module`, not a declared `public_root_surface` that `policy/` may depend on, so importing the real class would be a real, checked dependency-direction violation.
- **`abicheck/workflows/gate.py`:** re-exports the three public names (plus the private `_resolve_release_severity_config`, for API stability) — `cli_compare_release_helpers.py` is `frontends`-classified and `frontends -> policy` is forbidden, so it reaches `policy/release_gate_options.py` through this existing facade instead of importing `policy` directly.
- **`abicheck/cli_compare_release_helpers.py` / `cli_compare_release.py`:** `_compute_release_severity_exit_code`/`_fold_release_global_severity` now take the resolved `GateOptions` instead of the raw strings; `compare_release_cmd`'s own inline pack-fold + scheme-dependent correction logic collapses into one `resolve_release_gate_options` call. Also moves this code out of `cli_compare_release_helpers.py` to stay under its AI-readiness no-growth line-count baseline (`architecture/debt.yaml`).
- **ADR-064 / `cli-cleanup-phase-two.md`:** recorded as landed, with a correction to ADR-064's own "Consequences" section (it originally assumed this shape change had to be atomic-stage work alongside `--exit-code-scheme`'s removal; it landed additively instead, since the internal shape change and the CLI flag's removal turned out to be separable).
- Tests updated to build a `GateOptions` via a small `_gate(...)` helper instead of passing six raw positional strings (`tests/test_config_review.py`, `tests/test_cov95_cli.py`).

Landed additively: **no CLI surface or externally observable exit code changes** — verified by the existing severity/exit-code test suite passing unchanged against the new call shape.

## Verification

- `mypy` — clean on every touched file.
- `ruff check` / `ruff format --check` — clean on every touched file (no drive-by reformatting of this large file's pre-existing debt).
- `python scripts/check_architecture.py` — 0 errors (confirmed the new module's placement/imports satisfy ADR-061's declared layer boundaries).
- `python scripts/check_ai_readiness.py` — 0 errors.
- `python scripts/check_docs_contract.py` — 0 errors/warnings.
- Targeted tests (`test_config_review.py`, `test_cov95_cli.py`, `test_pack_application.py`, `test_compare_release.py`, `test_exit_decision.py`, `test_scan_abort_result.py`, `test_cli_scan_abort_report.py`): 460 passed.
- Full fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) run locally; will also run in CI.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (ADR-064, `cli-cleanup-phase-two.md`)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMkmnWEeQKZNPZxDcjY7L6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated release gate and severity configuration handling into a single resolved configuration.
  - Preserved existing release comparison behavior and exit-code results.

- **Documentation**
  - Updated the architecture decision record and CLI cleanup plan to reflect the completed gate-configuration work.

- **Tests**
  - Updated release severity and global-result coverage to use the consolidated configuration while preserving existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->