### PR TITLE
fix: enforce --depth as a ceiling, not only a floor, in compare

### DIFF
--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1089,8 +1089,6 @@ def _report_compare_result(
     show_impact: bool,
     demangle: bool, demangle_explicit: bool | None, follow_deps: bool,
     secondary_fmt: str | None, secondary_output: Path | None,
-    old_build_info: Path | None, new_build_info: Path | None,
-    old_sources: Path | None, new_sources: Path | None,
     require_complete_analysis: bool = False,
     depth: str | None = None,
     use_cases_manifest: Path | None = None,
@@ -1135,32 +1133,24 @@ def _report_compare_result(
     attach_evidence_metrics(result, evidence_metrics, extra_changes or [])
 
     # P0.4 (P1 review): recompute analysis_assurance now that the *real*
-    # evidence pack behind this comparison's findings is known.
-    # checker.compare() (inside compare_snapshots above) only ever saw each
-    # snapshot's own *embedded* BuildSourcePack -- an out-of-band
-    # --old/new-build-info / --old/new-sources pack directory is resolved
-    # separately via _resolve_side_pack and used to produce this run's real
-    # findings/coverage (prepare_embedded_build_source, before
-    # compare_snapshots was even called) without ever being attached back
-    # onto old/new. Without this, analysis_assurance would silently reflect
-    # whatever (possibly absent, possibly stale) payload the bare snapshots
-    # carry instead of the pack that actually backed this run -- defeating
-    # --require-complete-analysis's whole purpose. Re-resolving here is
-    # cheap (pure pack-directory metadata load, no diffing).
-    from .cli_buildsource_helpers import _resolve_side_pack
+    # evidence pack behind this comparison's findings is known. An
+    # out-of-band --old/new-build-info / --old/new-sources pack is now
+    # attached onto old.build_source/new.build_source, already capped to
+    # --depth, by run_compare's resolve-and-cap step above -- so reading it
+    # straight off old/new here (not re-resolving the raw paths, which would
+    # reload the uncapped pack and defeat the ceiling here) is correct at
+    # any --depth (Codex review, PR #1020, second round).
     from .cli_dump_helpers import evidence_depth_label
     from .workflows.gate import compute_analysis_assurance
 
-    old_pack = _resolve_side_pack(old_build_info, old_sources, old)
-    new_pack = _resolve_side_pack(new_build_info, new_sources, new)
+    old_pack = old.build_source
+    new_pack = new.build_source
     result.analysis_assurance = compute_analysis_assurance(
         result, old, new, old_pack=old_pack, new_pack=new_pack,
     )
     # ADR-061 Phase 2 item 5 (post-render mutation): resolved here, before
     # any report is rendered, and attached directly onto `result` -- mirrors
-    # `analysis_assurance` immediately above, which resolves the identical
-    # `old_pack`/`new_pack` for the identical reason (an out-of-band pack
-    # directory is never attached back onto the snapshot object itself).
+    # `analysis_assurance` immediately above.
     # `reporter.to_json`'s JSON builders read these two fields straight off
     # `result` now, instead of `_fold_evidence_depth_into_json` re-parsing
     # this function's own already-rendered JSON text afterwards to splice
@@ -1911,13 +1901,29 @@ def run_compare(
     if getattr(old, "from_headers", False) or getattr(new, "from_headers", False):
         extra_changes = fold_l0_hard_removals(old, new, lang, extra_changes)
 
+    # ADR-063 Phase 8 "--depth" ceiling (Codex review, PR #1020, second
+    # round): an out-of-band --old/new-sources/-build-info pack never lives
+    # on old/new until prepare_embedded_build_source diffs it, so
+    # project_pair_to_depth above can't cap it. Resolve + cap it ourselves,
+    # attach onto old/new, then pass None below so resolve_side_pack falls
+    # back to the now-capped embedded payload instead of the raw pack.
+    from .cli_buildsource_helpers import _resolve_side_pack
+    from .service_compare_pipeline import project_build_source_pack_to_depth
+
+    old.build_source = project_build_source_pack_to_depth(
+        _resolve_side_pack(old_build_info, old_sources, old), depth
+    )
+    new.build_source = project_build_source_pack_to_depth(
+        _resolve_side_pack(new_build_info, new_sources, new), depth
+    )
+
     # Build-info + source facts (ADR-028/033): the helper times inline diffing
     # for the D6/D9 metrics and returns coverage/metrics to attach post-compare.
     from .cli_buildsource import prepare_embedded_build_source
     extra_changes, layer_coverage_rows, evidence_metrics, _ev_changes = (
         prepare_embedded_build_source(
             old, new, collect_mode, extra_changes,
-            old_build_info, new_build_info, old_sources, new_sources,
+            None, None, None, None,
             policy_file=pf,
         )
     )
@@ -1976,8 +1982,6 @@ def run_compare(
         demangle=demangle, demangle_explicit=demangle_explicit,
         follow_deps=follow_deps,
         secondary_fmt=secondary_fmt, secondary_output=secondary_output,
-        old_build_info=old_build_info, new_build_info=new_build_info,
-        old_sources=old_sources, new_sources=new_sources,
         require_complete_analysis=require_complete_analysis,
         depth=depth,
         use_cases_manifest=use_cases_manifest,

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1850,6 +1850,18 @@ def run_compare(
         lang_explicit=lang_explicit,
     )
 
+    # ADR-063 Phase 8's "--depth floor vs ceiling" gap (Codex review, PR
+    # #1020): this native CLI path calls `compare_snapshots()` directly, not
+    # `classify_compare_pair`, so it needs the identical capped view applied
+    # here too -- before every subsequent reader of `old`/`new` below
+    # (`fold_l0_hard_removals`, the build-source diff, `compare_snapshots`
+    # itself). Imported from `service_compare_pipeline` (`workflows`), not
+    # `.policy.depth_projection` directly: ADR-061 forbids `frontends ->
+    # policy`, and this CLI module is `frontends`.
+    from .service_compare_pipeline import project_pair_to_depth
+
+    old, new = project_pair_to_depth(old, new, depth)
+
     suppression, pf = _load_suppression_and_policy(
         suppress, policy, policy_file_path,
         strict_suppressions=strict_suppressions,

--- a/abicheck/cli_compare_options.py
+++ b/abicheck/cli_compare_options.py
@@ -212,25 +212,21 @@ def _reject_depth_for_set_inputs(ctx: click.Context) -> str | None:
       explicit ``--depth binary`` assertion the fan-out can't provide, so it
       is accepted here and forwarded to every pair (mirrors a single-pair
       ``compare --depth binary``, which just clears header/build/source
-      evidence rather than requiring anything new). **Inherits, rather than
-      introduces, a pre-existing limitation** (Codex review, PR #1016, not
-      fixed here): this only clears *separately supplied* header/include
-      inputs. A directory/package member that is itself an already-dumped
-      JSON snapshot carrying richer embedded evidence (header facts, a
-      ``from_headers=True`` snapshot on disk) still loads that evidence
-      verbatim -- ``enforce_requested_depth``'s own docstring already
-      documents this exact "floor, not a ceiling" behavior for a single-pair
-      ``compare --depth binary`` against two such snapshots, which has never
-      projected requested depth down for a pre-built input either. This
-      decision only brings the fan-out to parity with that pre-existing,
-      already-accepted behavior; it does not extend it, and closing the
-      underlying gap (stripping higher-level facts from a snapshot operand
-      to actually enforce depth as a ceiling) is separate, repo-wide work,
-      not specific to directory/package operands. See
+      evidence rather than requiring anything new). This used to only clear
+      *separately supplied* header/include inputs, inheriting the
+      single-pair path's own "floor, not a ceiling" gap for a
+      directory/package member that is itself an already-dumped JSON
+      snapshot carrying richer embedded evidence — see
       ``docs/contribute/known-gaps.md``'s "``--depth`` is a floor for live
-      extraction, not a ceiling for a pre-built snapshot" entry for why the
-      two obvious-looking fixes (stripping the snapshot, or rejecting the
-      combination here) are each wrong.
+      extraction, not a ceiling for a pre-built snapshot" entry for the
+      full history. That gap is now closed for both shapes at once: each
+      pair here is forwarded through ``service.run_compare`` the same way a
+      plain single-pair ``compare`` is, so ``classify_compare_pair``'s
+      ``abicheck.policy.depth_projection.project_snapshot_to_depth``
+      projection (applied uniformly, not specific to directory/package
+      operands) already caps what each pair's classification sees down to
+      the requested rung, regardless of whether the richer evidence came
+      from a fresh extraction or a pre-built snapshot on disk.
     * ``headers`` is still rejected, but for a narrower, distinct reason than
       build/source: the fan-out *does* resolve per-pair header evidence
       (the same ``-H``/compile-context plumbing a plain directory `compare`

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -627,8 +627,42 @@ def compare_release_cmd(
 
             if bundle_facts_out is not None and not no_bundle_analysis:
                 # Resolved here, not in the leaf write_bundle_facts_out() (see its docstring).
+                #
+                # ADR-063 D1's second named exception: this used to call
+                # `cli_resolve._resolve_input()` directly -- the same Tier-2
+                # resolution `resolve_dump_request`/`execute_dump_request`
+                # wrap, but reached independently, with its own hand-rolled
+                # `depth=binary` header-clearing special-case (duplicating
+                # what `service_compare_evidence`'s shared evidence
+                # resolution already does for every matched pair) and no
+                # `AnalysisPlan` pre-flight check at all. Migrated onto the
+                # same `DumpRequest -> resolve_dump_request ->
+                # execute_dump_request` pipeline `dump`/`scan` already
+                # converge on: this stranded library is exactly one dump-
+                # shaped input, so building a real `DumpRequest` for it and
+                # running the shared pipeline both gets it the
+                # `AnalysisPlanner.resolve()` pre-flight check ADR-063 Phase 4
+                # already provides and drops the manual `is_binary_depth`
+                # special-case -- `DumpRequest.depth` feeds the identical
+                # evidence-resolution machinery a matched pair's own
+                # `CompareRequest` side does, so headers are cleared
+                # consistently by the one shared mechanism instead of a
+                # second, hand-copied rule that could drift from it.
+                #
+                # The "deliberately-degrading stranded-library fallback"
+                # ADR-063's own text names as the reason this isn't "the same
+                # shape of check" as an ordinary comparison is preserved
+                # exactly: a `PlanningError`/`ValidationError`/`SnapshotError`
+                # from either resolve or execute step still degrades to an
+                # ELF-only entry with a warning, not a hard failure -- the
+                # migration changes *how* the input resolves, not this
+                # function's own degrade-rather-than-abort contract.
                 def _resolve_stranded_library(old_path: Path) -> AbiSnapshot:
-                    from .cli_resolve import _resolve_input
+                    from .api_types import DumpRequest, InputSpec
+                    from .service_dump_pipeline import (
+                        execute_dump_request,
+                        resolve_dump_request,
+                    )
                     from .workflows import extraction
 
                     old_dbg = (
@@ -636,35 +670,22 @@ def compare_release_cmd(
                         if old_debug_dir
                         else None
                     )
-                    # `depth=binary` clears header inputs for every matched
-                    # pair (`_split_public_header_inputs_for_request`'s own
-                    # docstring); a stranded (removed-in-new) library must
-                    # get the same headerless resolution, else its BundleFacts
-                    # entry carries L2 header evidence a matched pair's
-                    # snapshot never would, silently reintroducing header/API
-                    # findings `--depth binary` was asked to exclude (Codex
-                    # review, P2).
-                    is_binary_depth = depth is not None and depth.lower() == "binary"
-                    stranded_h = [] if is_binary_depth else old_h
-                    stranded_inc = [] if is_binary_depth else old_inc
-                    # old_h doubles as the public-header set, matching the
-                    # normal compare path (else origin=UNKNOWN; Codex review).
-                    pub_headers, pub_dirs = extraction.split_public_header_inputs(
-                        stranded_h
-                    )
                     try:
-                        return _resolve_input(
-                            old_path,
-                            stranded_h,
-                            stranded_inc,
-                            old_version,
-                            lang,
-                            pdb_path=old_dbg,
-                            compile=compile_context,
-                            include_dependencies=include_dependencies,
-                            public_headers=pub_headers,
-                            public_header_dirs=pub_dirs,
+                        dump_request = DumpRequest(
+                            input=InputSpec.of(
+                                old_path,
+                                headers=old_h,
+                                includes=old_inc,
+                                version=old_version,
+                                pdb=old_dbg,
+                                compile=compile_context,
+                                include_dependencies=include_dependencies,
+                            ),
+                            lang=lang,
+                            depth=depth,
                         )
+                        resolved = resolve_dump_request(dump_request)
+                        return execute_dump_request(resolved).snapshot
                     except Exception as exc:
                         # Degrade rather than abort, but warn: lossy entry (Codex review).
                         click.echo(f"{old_path.name}: ELF-only ({exc})", err=True)

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -1107,6 +1107,12 @@ def _run_baseline_compare(
             f"Failed to load --baseline {baseline}: {exc}"
         ) from exc
 
+    # ADR-063 Phase 8 "--depth" ceiling (PR #1020): mirrors
+    # `cli_compare_helpers.run_compare`'s own capped view.
+    from .service_compare_pipeline import project_pair_to_depth
+
+    old_snap, new_snap = project_pair_to_depth(old_snap, new_snap, requested_depth)
+
     # Preserve hard L0 removals even when the richer header/source view cannot
     # prove public-header ownership for the removed entity.  A source/full scan
     # may parse both sides' headers through different consumer macro contexts;

--- a/abicheck/policy/AGENTS.md
+++ b/abicheck/policy/AGENTS.md
@@ -132,7 +132,12 @@ or a CLI flag directly is in the wrong layer.
   classify_compare_pair` applies it as a view over what gets classified,
   right after `workflows.artifact.execute.enforce_requested_depth`
   confirms the floor — the two functions are deliberately kept separate
-  (floor vs. ceiling), not merged into one.
+  (floor vs. ceiling), not merged into one. `project_build_source_pack_to_
+  depth()` is the sibling entry point for a `BuildSourcePack` resolved
+  *out-of-band* (an explicit `--old/new-sources`/`--old/new-build-info`
+  pack, not a snapshot's embedded payload) — `cli_compare_helpers.
+  run_compare` is the one caller, since that pack never lives on the
+  snapshot object `project_snapshot_to_depth` itself projects.
 
 ## Conventions
 

--- a/abicheck/policy/AGENTS.md
+++ b/abicheck/policy/AGENTS.md
@@ -119,6 +119,20 @@ or a CLI flag directly is in the wrong layer.
   compilation machinery, split out purely to keep `selectors.py` itself
   under the 800-line cap below (mechanical extraction, same pattern as
   `public_surface.py`/`public_surface_closure.py` above).
+- `depth_projection.py` — ADR-063 Phase 8 follow-up: the `--depth`
+  *ceiling* half `docs/contribute/known-gaps.md`'s "floor for live
+  extraction, not a ceiling for a pre-built snapshot" entry named but did
+  not attempt. `project_snapshot_to_depth()` is a pure gating decision
+  ("which facts may a comparison at this depth see"), mirrored from the
+  one prior validated reference implementation of the same idea —
+  `scripts/check_tier_accuracy.py`'s `project()` — generalized from that
+  script's synthetic corpus onto a real `AbiSnapshot` and its own public
+  `binary`/`headers`/`build`/`source` ladder (`evidence_depth.DEPTH_RANK`,
+  a `model`-layer leaf, not `compare`). `service_compare_pipeline.
+  classify_compare_pair` applies it as a view over what gets classified,
+  right after `workflows.artifact.execute.enforce_requested_depth`
+  confirms the floor — the two functions are deliberately kept separate
+  (floor vs. ceiling), not merged into one.
 
 ## Conventions
 

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cap an already-resolved snapshot's evidence to what an explicit ``--depth`` requested.
+
+``workflows.artifact.execute.enforce_requested_depth`` has long enforced
+``--depth`` as a **floor**: it fails a run when the resolved evidence falls
+short of what was requested. It never enforced a **ceiling** — an input that
+is an already-serialized JSON snapshot (or, equivalently, a freshly-resolved
+one whose extraction happened to reach further than asked) still carries
+every richer fact it embeds, so ``compare old.json new.json --depth binary``
+still emits real header-derived findings and can still publish ``BREAKING``
+even though only binary-level evidence was requested. That gap is long
+documented (``enforce_requested_depth``'s own docstring, and
+``docs/contribute/known-gaps.md``'s "``--depth`` is a floor for live
+extraction, not a ceiling for a pre-built snapshot" entry) — this module is
+the "real, separate design question" that entry named but did not attempt:
+"a comparison-time projection — resolve the snapshot as today, then filter
+what ``checker.compare()`` is allowed to see down to the requested rung,
+keeping the resolved ``AbiSnapshot`` itself untouched."
+
+:func:`project_snapshot_to_depth` is that filter. It is pure (returns a deep
+copy; never mutates its argument) and degrades exactly the fact families
+:mod:`abicheck.evidence_depth`'s own rank table already gates, mirrored from
+the one already-validated reference implementation of this exact idea —
+``scripts/check_tier_accuracy.py``'s ``project()``, which the per-tier
+accuracy gate runs against a real, if synthetic, labelled corpus. That
+function's ``Tier`` axis (L0-L3) is finer than the public ``EvidenceDepth``
+ladder (``binary``/``headers``/``build``/``source``, ``BINARY`` covering both
+L0 and L1: "no L2 AST", not "no debug info"); this module maps onto the
+coarser public ladder a caller actually requests through ``--depth``,
+keeping DWARF-derived layout/signatures at the ``binary`` rung the way a
+real DWARF-informed binary dump would.
+
+**Deliberately in scope** (the same fields the tier-accuracy gate's
+validated ``project()`` degrades, plus the ``BuildSourcePack``/
+``surface_graph`` L3-L5 split that synthetic corpus never populates):
+``functions``/``variables`` visibility+origin, ``types``/``enums`` origin,
+``constants``, ``python_api``, ``from_headers``, ``semantic_ir`` (an L2+
+header-AST fact, gated the same as ``from_headers``), ``build_mode``,
+``build_source`` (nulled below ``build``; degraded to its L3-only
+``build_evidence`` — ``source_abi``/``source_graph`` cleared — between
+``build`` and ``source``), and ``surface_graph`` (an L5 fact, nulled below
+``source``).
+
+**Deliberately out of scope, not silently assumed handled**: platform
+container facts (``elf``/``pe``/``macho``/``dwarf``/``dwarf_advanced``),
+``kabi``/``sycl``/``python_ext``/``numpy_capi``, ``typedefs`` (DWARF also
+carries typedef DIEs, so — like ``types``/``enums`` — these survive a
+``binary``-rung projection the same way the validated reference
+implementation keeps them below its own L0), ``dependency_info``,
+``contract``/``fact_provenance``/``ast_*``/entity-id maps, and
+``elf_only_mode`` (left exactly as resolved — forcing it ``True`` would
+misreport a projection of a real DWARF-informed snapshot as symbols-only,
+which the reference implementation itself only does at its fully-stripped
+L0, not at the L1-equivalent this module's ``binary`` rung maps to). A
+future extension of this module's scope is real, separately-justified work,
+not a residual of this docstring's own account.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+from ..evidence_depth import DEPTH_RANK
+from ..model import ScopeOrigin, Visibility
+
+if TYPE_CHECKING:
+    from ..model import AbiSnapshot
+
+__all__ = ["project_snapshot_to_depth"]
+
+
+def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
+    """Blank every L2+ (header-AST) fact on *snap*, in place.
+
+    Keeps DWARF-derived structural facts (layout, signatures, typedefs) —
+    those are an L0/L1 fact regardless of whether headers were also parsed —
+    and blanks only what a header AST alone contributes: scoping
+    (visibility/origin), macro/constexpr constant values, the Python-API
+    stub surface, and the header-AST-only ``SemanticIR``.
+    """
+    for f in snap.functions:
+        f.visibility = Visibility.ELF_ONLY
+        f.origin = ScopeOrigin.UNKNOWN
+    for v in snap.variables:
+        v.visibility = Visibility.ELF_ONLY
+        v.origin = ScopeOrigin.UNKNOWN
+    for t in snap.types:
+        t.origin = ScopeOrigin.UNKNOWN
+    for e in snap.enums:
+        e.origin = ScopeOrigin.UNKNOWN
+    snap.constants = {}
+    snap.from_headers = False
+    snap.python_api = None
+    snap.semantic_ir = None
+
+
+def project_snapshot_to_depth(snap: AbiSnapshot, depth: str | None) -> AbiSnapshot:
+    """Return a copy of *snap* capped to what an explicit ``--depth`` requested.
+
+    A no-op (returns *snap* itself, not a copy) when *depth* is ``None`` —
+    matching ``enforce_requested_depth``'s identical "no explicit depth, no
+    enforcement" contract — or when *depth* is not a recognized public rung
+    (``evidence_depth.DEPTH_RANK`` doesn't know it; validation elsewhere is
+    what rejects that case, this function simply declines to guess).
+
+    Callers should apply this only to the *view* a comparison classifies
+    from, after :func:`~abicheck.workflows.artifact.execute.
+    enforce_requested_depth` has already confirmed the resolved evidence
+    meets *depth* as a floor — this function only ever removes evidence, it
+    never restores what was never resolved. It never mutates its argument,
+    so a caller that also persists or reuses the original, un-projected
+    snapshot (a ``dump`` artifact meant for a later, deeper comparison) is
+    unaffected.
+    """
+    if depth is None:
+        return snap
+    depth = depth.lower()
+    if depth not in DEPTH_RANK:
+        return snap
+    rank = DEPTH_RANK[depth]
+    headers_rank = DEPTH_RANK["headers"]
+    build_rank = DEPTH_RANK["build"]
+    source_rank = DEPTH_RANK["source"]
+
+    out = copy.deepcopy(snap)
+    if rank < headers_rank:
+        _strip_header_and_above_evidence(out)
+    if rank < build_rank:
+        out.build_mode = None
+        out.build_source = None
+    elif rank < source_rank and out.build_source is not None:
+        # Between `build` and `source`: keep the L3 build_evidence payload,
+        # drop the L4 source-ABI replay and L5 source-graph payloads.
+        out.build_source.source_abi = None
+        out.build_source.source_graph = None
+    if rank < source_rank:
+        out.surface_graph = None
+    return out

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -56,28 +56,51 @@ still emit e.g. ``type_field_type_changed``).
 
 **Deliberately in scope** (the same fields the tier-accuracy gate's
 validated ``project()`` degrades, plus the ``BuildSourcePack`` L3-L5 split
-that synthetic corpus never populates): ``functions``/``variables``
-visibility+origin, ``types``/``enums``/``typedefs`` (fully stripped, not
-merely re-scoped, when no DWARF backs them — see above), ``constants``,
-``python_api``, ``from_headers``, ``semantic_ir`` and ``surface_graph``
-(both L2+ header-AST/header-graph facts, gated the same as
-``from_headers`` — ``_attach_header_graph``'s own docstring: "the
+that synthetic corpus never populates, plus three fields a second review
+round found this module itself needed to close — see below):
+``functions``/``variables`` visibility+origin (a ``Visibility.HIDDEN``
+— non-exported — declaration is dropped entirely, not promoted to
+``ELF_ONLY``: see :func:`_strip_header_and_above_evidence`'s own
+docstring), ``types``/``enums`` (kept only when DWARF specifically
+observed that declaration by name — :func:`_dwarf_confirmed_names`, real
+per-record evidence, not a whole-snapshot guess), ``typedefs`` (always
+cleared — this codebase's model has no per-name DWARF lookup for them at
+all), ``constants``, ``python_api``, ``from_headers``, ``semantic_ir`` and
+``surface_graph`` (both L2+ header-AST/header-graph facts, gated the same
+as ``from_headers`` — ``_attach_header_graph``'s own docstring: "the
 header-only (L2) semantic graph", not an L4/L5 fact despite a first
 version of this module gating it to ``source`` on that wrong assumption),
-``build_mode``, and ``build_source`` (nulled below ``build``; degraded to
-its L3-only ``build_evidence`` — ``source_abi``/``source_graph`` cleared —
-between ``build`` and ``source``).
+``contract`` (an ADR-050 ``ExtractionContract`` computed from the same
+header-scope/compile-context inputs this module discards — left alone, it
+can still make ``checker.compare()`` raise a scope/profile mismatch error
+from two sides' *original* header scopes even though a binary-only
+comparison was never going to look at either), ``build_mode``, and
+``build_source`` (nulled below ``build``; degraded to its L3-only
+``build_evidence`` — ``source_abi``/``source_graph`` cleared — between
+``build`` and ``source``). Callers that resolve build-info/source packs
+*out-of-band* (a real, pre-built pack directory, not embedded inline) must
+project or withhold those packs themselves before diffing them — this
+module only ever sees what already lives on the snapshot object it was
+handed; see ``cli_compare_helpers.run_compare``'s own comment on its
+``prepare_embedded_build_source`` call for the call-site half of that fix.
 
 **Deliberately out of scope, not silently assumed handled**: platform
 container facts (``elf``/``pe``/``macho``/``dwarf``/``dwarf_advanced``
 themselves are never cleared — only what they *justify keeping* in
 ``functions``/``types``/... changes), ``kabi``/``sycl``/``python_ext``/
-``numpy_capi``, ``dependency_info``, ``contract``/``fact_provenance``/
-``ast_*``/entity-id maps, and ``elf_only_mode`` (left exactly as resolved
-except where the no-DWARF L0 branch below sets it ``True`` itself, matching
-the reference implementation's identical choice at its own L0). A future
-extension of this module's scope is real, separately-justified work, not a
-residual of this docstring's own account.
+``numpy_capi``, ``dependency_info``, ``fact_provenance``/``ast_*``/
+entity-id maps, and ``elf_only_mode`` (left exactly as resolved except
+where the no-DWARF branch sets it ``True`` itself, matching the reference
+implementation's identical choice at its own L0). Function/variable
+*signatures* (return type, params, value) stay gated on whole-snapshot
+DWARF presence, not per-declaration — see
+:func:`_snapshot_has_native_debug_info`'s own docstring for exactly why:
+this codebase's model has no per-function DWARF-confirmation fact for a
+projection to read back, so getting this fully precise is real,
+separately-justified future work (it needs a new fact the dumper doesn't
+record yet), not a residual of this module's own scope. A future extension
+of this module's scope generally is the same: real, separately-justified
+work, not a residual of this docstring's own account.
 """
 
 from __future__ import annotations
@@ -89,9 +112,14 @@ from ..evidence_depth import DEPTH_RANK
 from ..model import ScopeOrigin, Visibility
 
 if TYPE_CHECKING:
+    from ..buildsource.pack import BuildSourcePack
     from ..model import AbiSnapshot
 
-__all__ = ["project_pair_to_depth", "project_snapshot_to_depth"]
+__all__ = [
+    "project_build_source_pack_to_depth",
+    "project_pair_to_depth",
+    "project_snapshot_to_depth",
+]
 
 
 def _snapshot_has_native_debug_info(snap: AbiSnapshot) -> bool:
@@ -105,37 +133,83 @@ def _snapshot_has_native_debug_info(snap: AbiSnapshot) -> bool:
     precedent exactly rather than inventing a wider, unvalidated heuristic —
     a real PDB-aware extension is separately-justified future work, not a
     residual of this function's own scope.
+
+    **Whole-snapshot, not per-declaration** — deliberately, and only for the
+    two fact families this codebase's model has no per-name DWARF lookup
+    for at all: function/variable signatures. ``types``/``enums`` *do* have
+    one (``DwarfMetadata.structs``/``.enums``, keyed by name) and are
+    filtered per-record instead — see :func:`_dwarf_confirmed_names`. For
+    functions/variables, this whole-snapshot gate matches the one
+    already-validated reference implementation of this idea,
+    ``scripts/check_tier_accuracy.py``'s ``project()``, exactly: its own L1
+    branch keeps every function's signature uniformly once *any* DWARF is
+    present, with no per-function check either — this codebase's dumper
+    merge process does not track "was this specific function's signature
+    confirmed by its own DWARF subprogram DIE, or only by headers" anywhere
+    a projection could read it back. A real per-function extension is
+    separately-justified future work (it would need a new fact the dumper
+    doesn't currently record), not a residual of this function's own scope
+    (Codex review, PR #1020, third round).
     """
     return snap.dwarf is not None and snap.dwarf.has_dwarf
+
+
+def _dwarf_confirmed_names(snap: AbiSnapshot) -> tuple[frozenset[str], frozenset[str]]:
+    """Struct and enum names DWARF specifically observed, respectively.
+
+    ``DwarfMetadata.structs``/``.enums`` are real per-name facts — unlike
+    the whole-snapshot ``has_dwarf`` flag, they answer "was *this*
+    declaration confirmed by DWARF" precisely, so an uninstantiated
+    header-only record sitting alongside unrelated real DWARF content is
+    correctly excluded rather than swept in by the coarser flag (Codex
+    review, PR #1020, third round — a first cut of this module used
+    ``_snapshot_has_native_debug_info`` for these two families too, which
+    over-retains exactly this case). Empty when *snap* has no ``dwarf`` at
+    all, which is what makes the no-DWARF-whatsoever case (this function's
+    old, coarser job) fall out of the same per-record filter for free.
+    """
+    dwarf = snap.dwarf
+    if dwarf is None:
+        return frozenset(), frozenset()
+    return frozenset(dwarf.structs), frozenset(dwarf.enums)
 
 
 def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     """Blank every L2+ (header-AST) fact on *snap*, in place.
 
-    When *snap* carries real DWARF debug info, this keeps DWARF-derived
-    structural facts (layout, signatures, typedefs) — those are an L1 fact
-    independent of whether headers were also parsed — and blanks only what a
-    header AST alone contributes: scoping (visibility/origin), macro/
-    constexpr constant values, the Python-API stub surface, and the
-    header-AST-only ``SemanticIR``.
-
-    When *snap* has no DWARF at all, every one of those structural facts
-    came *only* from the header AST — nothing else in the snapshot could
-    have produced them — so this additionally strips to L0: no types, no
-    enums, no typedefs, and functions/variables degrade to bare symbol
-    identity (no signature/type/value evidence), matching
-    ``scripts/check_tier_accuracy.py``'s own L0 branch exactly.
+    ``types``/``enums`` keep only the entries DWARF itself specifically
+    observed (:func:`_dwarf_confirmed_names`) — real per-record evidence,
+    not a whole-snapshot guess. ``typedefs`` are always cleared: this
+    codebase's model has no per-name DWARF lookup for them at all (no
+    ``DwarfMetadata.typedefs``), so there is no evidence-backed way to keep
+    any of them below `headers`. Function/variable *signatures*
+    (return type, params, value) stay gated on whole-snapshot DWARF
+    presence — see :func:`_snapshot_has_native_debug_info`'s own docstring
+    for exactly why that one stays coarser. A function/variable with
+    ``Visibility.HIDDEN`` (a real, non-exported header-only declaration,
+    never a fact a binary-only view could see at all) is dropped from the
+    snapshot entirely rather than promoted to ``ELF_ONLY`` — promoting it
+    would misrepresent an unexported symbol as binary-visible and could
+    manufacture a false ``*_removed_elf_only`` finding for a declaration no
+    real binary-only dump would ever have seen as a symbol in the first
+    place (Codex review, PR #1020, third round).
     """
+    snap.functions = [f for f in snap.functions if f.visibility != Visibility.HIDDEN]
+    snap.variables = [v for v in snap.variables if v.visibility != Visibility.HIDDEN]
     for f in snap.functions:
         f.visibility = Visibility.ELF_ONLY
         f.origin = ScopeOrigin.UNKNOWN
     for v in snap.variables:
         v.visibility = Visibility.ELF_ONLY
         v.origin = ScopeOrigin.UNKNOWN
+    confirmed_structs, confirmed_enums = _dwarf_confirmed_names(snap)
+    snap.types = [t for t in snap.types if t.name in confirmed_structs]
+    snap.enums = [e for e in snap.enums if e.name in confirmed_enums]
     for t in snap.types:
         t.origin = ScopeOrigin.UNKNOWN
     for e in snap.enums:
         e.origin = ScopeOrigin.UNKNOWN
+    snap.typedefs = {}
     snap.constants = {}
     snap.from_headers = False
     snap.python_api = None
@@ -144,11 +218,16 @@ def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     # graph" -- an L2 fact like the others above, not the L4/L5
     # `build_source.source_graph` this function leaves untouched.
     snap.surface_graph = None
+    # ADR-050 `ExtractionContract`: both fingerprints are computed from
+    # header-scope/compile-context inputs this function just discarded.
+    # Left alone, `checker.compare()`'s `check_contracts_comparable()` can
+    # still raise `ScopeMismatchError`/`ProfileMismatchError` from the two
+    # sides' *original* header scopes even though the comparison this
+    # snapshot now feeds is explicitly binary-only and was never going to
+    # look at either scope (Codex review, PR #1020, third round).
+    snap.contract = None
 
     if not _snapshot_has_native_debug_info(snap):
-        snap.types = []
-        snap.enums = []
-        snap.typedefs = {}
         for f in snap.functions:
             f.return_type = "?"
             f.params = []
@@ -157,6 +236,29 @@ def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
             v.is_const = False
             v.value = None
         snap.elf_only_mode = True
+
+
+def _project_build_source_pack(
+    pack: BuildSourcePack, rank: int, build_rank: int, source_rank: int
+) -> BuildSourcePack | None:
+    """Degrade one already-resolved ``BuildSourcePack`` to *rank*, in place.
+
+    Shared by :func:`project_snapshot_to_depth` (for a snapshot's embedded
+    ``build_source``) and :func:`project_build_source_pack_to_depth` (for a
+    pack resolved out-of-band from an explicit ``--build-info``/``--sources``
+    path) so the L3-L5 capping rule is stated once rather than duplicated
+    between the two callers. Below ``build``, the whole pack carries no
+    evidence an explicit ``--depth`` asked for and is dropped entirely;
+    between ``build`` and ``source``, the L3 ``build_evidence`` payload
+    survives but the L4 source-ABI replay and L5 source-graph payloads are
+    cleared; at or above ``source``, *pack* is returned unchanged.
+    """
+    if rank < build_rank:
+        return None
+    if rank < source_rank:
+        pack.source_abi = None
+        pack.source_graph = None
+    return pack
 
 
 def project_snapshot_to_depth(snap: AbiSnapshot, depth: str | None) -> AbiSnapshot:
@@ -192,13 +294,41 @@ def project_snapshot_to_depth(snap: AbiSnapshot, depth: str | None) -> AbiSnapsh
         _strip_header_and_above_evidence(out)
     if rank < build_rank:
         out.build_mode = None
-        out.build_source = None
-    elif rank < source_rank and out.build_source is not None:
-        # Between `build` and `source`: keep the L3 build_evidence payload,
-        # drop the L4 source-ABI replay and L5 source-graph payloads.
-        out.build_source.source_abi = None
-        out.build_source.source_graph = None
+    if out.build_source is not None:
+        out.build_source = _project_build_source_pack(
+            out.build_source, rank, build_rank, source_rank
+        )
     return out
+
+
+def project_build_source_pack_to_depth(
+    pack: BuildSourcePack | None, depth: str | None
+) -> BuildSourcePack | None:
+    """Return a copy of *pack* capped to what an explicit ``--depth`` requested.
+
+    The out-of-band counterpart to :func:`project_snapshot_to_depth`'s own
+    ``build_source`` handling, for a caller that resolves an explicit
+    ``--build-info``/``--sources`` pack *itself* rather than reading one
+    already embedded on a snapshot object. ``project_snapshot_to_depth`` only
+    ever sees what already lives on the snapshot it was handed, so a raw pack
+    path threaded straight through to ``prepare_embedded_build_source``
+    bypasses it entirely (Codex review, PR #1020, third round) — a caller
+    doing that must cap the pack itself with this function before attaching
+    or diffing it. A no-op (returns *pack* itself) when *pack* or *depth* is
+    ``None``, or *depth* is not a recognized public rung — matching
+    :func:`project_snapshot_to_depth`'s identical no-op contract.
+    """
+    if pack is None or depth is None:
+        return pack
+    depth = depth.lower()
+    if depth not in DEPTH_RANK:
+        return pack
+    rank = DEPTH_RANK[depth]
+    build_rank = DEPTH_RANK["build"]
+    source_rank = DEPTH_RANK["source"]
+    return _project_build_source_pack(
+        copy.deepcopy(pack), rank, build_rank, source_rank
+    )
 
 
 def project_pair_to_depth(

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -41,33 +41,43 @@ function's ``Tier`` axis (L0-L3) is finer than the public ``EvidenceDepth``
 ladder (``binary``/``headers``/``build``/``source``, ``BINARY`` covering both
 L0 and L1: "no L2 AST", not "no debug info"); this module maps onto the
 coarser public ladder a caller actually requests through ``--depth``,
-keeping DWARF-derived layout/signatures at the ``binary`` rung the way a
-real DWARF-informed binary dump would.
+picking L0 or L1 **per snapshot** (not fixed to L1) based on whether *that*
+snapshot actually carries DWARF debug info — see
+:func:`_snapshot_has_native_debug_info` — so a headers-only snapshot with no
+DWARF strips down to L0 (no structural facts survive at all) exactly the way
+the reference implementation's own L0 branch does, while a DWARF-informed
+one keeps layout/signatures at ``binary`` the way a real DWARF-informed
+binary dump would (Codex review, PR #1020: an earlier version of this
+module fixed every ``binary``-rung projection to the reference
+implementation's L1 branch unconditionally, so a purely header-derived
+snapshot with no DWARF at all still carried full ``types``/``enums``/
+function-signature data through a ``binary``-depth projection and could
+still emit e.g. ``type_field_type_changed``).
 
 **Deliberately in scope** (the same fields the tier-accuracy gate's
-validated ``project()`` degrades, plus the ``BuildSourcePack``/
-``surface_graph`` L3-L5 split that synthetic corpus never populates):
-``functions``/``variables`` visibility+origin, ``types``/``enums`` origin,
-``constants``, ``python_api``, ``from_headers``, ``semantic_ir`` (an L2+
-header-AST fact, gated the same as ``from_headers``), ``build_mode``,
-``build_source`` (nulled below ``build``; degraded to its L3-only
-``build_evidence`` — ``source_abi``/``source_graph`` cleared — between
-``build`` and ``source``), and ``surface_graph`` (an L5 fact, nulled below
-``source``).
+validated ``project()`` degrades, plus the ``BuildSourcePack`` L3-L5 split
+that synthetic corpus never populates): ``functions``/``variables``
+visibility+origin, ``types``/``enums``/``typedefs`` (fully stripped, not
+merely re-scoped, when no DWARF backs them — see above), ``constants``,
+``python_api``, ``from_headers``, ``semantic_ir`` and ``surface_graph``
+(both L2+ header-AST/header-graph facts, gated the same as
+``from_headers`` — ``_attach_header_graph``'s own docstring: "the
+header-only (L2) semantic graph", not an L4/L5 fact despite a first
+version of this module gating it to ``source`` on that wrong assumption),
+``build_mode``, and ``build_source`` (nulled below ``build``; degraded to
+its L3-only ``build_evidence`` — ``source_abi``/``source_graph`` cleared —
+between ``build`` and ``source``).
 
 **Deliberately out of scope, not silently assumed handled**: platform
-container facts (``elf``/``pe``/``macho``/``dwarf``/``dwarf_advanced``),
-``kabi``/``sycl``/``python_ext``/``numpy_capi``, ``typedefs`` (DWARF also
-carries typedef DIEs, so — like ``types``/``enums`` — these survive a
-``binary``-rung projection the same way the validated reference
-implementation keeps them below its own L0), ``dependency_info``,
-``contract``/``fact_provenance``/``ast_*``/entity-id maps, and
-``elf_only_mode`` (left exactly as resolved — forcing it ``True`` would
-misreport a projection of a real DWARF-informed snapshot as symbols-only,
-which the reference implementation itself only does at its fully-stripped
-L0, not at the L1-equivalent this module's ``binary`` rung maps to). A
-future extension of this module's scope is real, separately-justified work,
-not a residual of this docstring's own account.
+container facts (``elf``/``pe``/``macho``/``dwarf``/``dwarf_advanced``
+themselves are never cleared — only what they *justify keeping* in
+``functions``/``types``/... changes), ``kabi``/``sycl``/``python_ext``/
+``numpy_capi``, ``dependency_info``, ``contract``/``fact_provenance``/
+``ast_*``/entity-id maps, and ``elf_only_mode`` (left exactly as resolved
+except where the no-DWARF L0 branch below sets it ``True`` itself, matching
+the reference implementation's identical choice at its own L0). A future
+extension of this module's scope is real, separately-justified work, not a
+residual of this docstring's own account.
 """
 
 from __future__ import annotations
@@ -81,17 +91,40 @@ from ..model import ScopeOrigin, Visibility
 if TYPE_CHECKING:
     from ..model import AbiSnapshot
 
-__all__ = ["project_snapshot_to_depth"]
+__all__ = ["project_pair_to_depth", "project_snapshot_to_depth"]
+
+
+def _snapshot_has_native_debug_info(snap: AbiSnapshot) -> bool:
+    """Whether *snap* carries DWARF debug info independent of any header AST.
+
+    The same signal ``confidence.py``/``analysis_assurance.py`` already use
+    for "does this snapshot have debug info" (``dwarf is not None and
+    dwarf.has_dwarf``) — not restated, reused, so this module cannot silently
+    disagree with those about what counts. Deliberately does not also probe
+    PE/Mach-O-specific debug carriers (PDB, ...): matching that same existing
+    precedent exactly rather than inventing a wider, unvalidated heuristic —
+    a real PDB-aware extension is separately-justified future work, not a
+    residual of this function's own scope.
+    """
+    return snap.dwarf is not None and snap.dwarf.has_dwarf
 
 
 def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     """Blank every L2+ (header-AST) fact on *snap*, in place.
 
-    Keeps DWARF-derived structural facts (layout, signatures, typedefs) —
-    those are an L0/L1 fact regardless of whether headers were also parsed —
-    and blanks only what a header AST alone contributes: scoping
-    (visibility/origin), macro/constexpr constant values, the Python-API
-    stub surface, and the header-AST-only ``SemanticIR``.
+    When *snap* carries real DWARF debug info, this keeps DWARF-derived
+    structural facts (layout, signatures, typedefs) — those are an L1 fact
+    independent of whether headers were also parsed — and blanks only what a
+    header AST alone contributes: scoping (visibility/origin), macro/
+    constexpr constant values, the Python-API stub surface, and the
+    header-AST-only ``SemanticIR``.
+
+    When *snap* has no DWARF at all, every one of those structural facts
+    came *only* from the header AST — nothing else in the snapshot could
+    have produced them — so this additionally strips to L0: no types, no
+    enums, no typedefs, and functions/variables degrade to bare symbol
+    identity (no signature/type/value evidence), matching
+    ``scripts/check_tier_accuracy.py``'s own L0 branch exactly.
     """
     for f in snap.functions:
         f.visibility = Visibility.ELF_ONLY
@@ -107,6 +140,23 @@ def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     snap.from_headers = False
     snap.python_api = None
     snap.semantic_ir = None
+    # `_attach_header_graph`'s own docstring: "the header-only (L2) semantic
+    # graph" -- an L2 fact like the others above, not the L4/L5
+    # `build_source.source_graph` this function leaves untouched.
+    snap.surface_graph = None
+
+    if not _snapshot_has_native_debug_info(snap):
+        snap.types = []
+        snap.enums = []
+        snap.typedefs = {}
+        for f in snap.functions:
+            f.return_type = "?"
+            f.params = []
+        for v in snap.variables:
+            v.type = "?"
+            v.is_const = False
+            v.value = None
+        snap.elf_only_mode = True
 
 
 def project_snapshot_to_depth(snap: AbiSnapshot, depth: str | None) -> AbiSnapshot:
@@ -148,6 +198,16 @@ def project_snapshot_to_depth(snap: AbiSnapshot, depth: str | None) -> AbiSnapsh
         # drop the L4 source-ABI replay and L5 source-graph payloads.
         out.build_source.source_abi = None
         out.build_source.source_graph = None
-    if rank < source_rank:
-        out.surface_graph = None
     return out
+
+
+def project_pair_to_depth(
+    old: AbiSnapshot, new: AbiSnapshot, depth: str | None
+) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """:func:`project_snapshot_to_depth` applied to both sides of a comparison.
+
+    The one-line convenience every ``compare_snapshots()`` call site with two
+    resolved sides and an optional ``depth`` needs, so each keeps its own
+    call site to a single statement rather than two.
+    """
+    return project_snapshot_to_depth(old, depth), project_snapshot_to_depth(new, depth)

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -42,42 +42,51 @@ ladder (``binary``/``headers``/``build``/``source``, ``BINARY`` covering both
 L0 and L1: "no L2 AST", not "no debug info"); this module maps onto the
 coarser public ladder a caller actually requests through ``--depth``,
 picking L0 or L1 **per snapshot** (not fixed to L1) based on whether *that*
-snapshot actually carries DWARF debug info — see
-:func:`_snapshot_has_native_debug_info` — so a headers-only snapshot with no
-DWARF strips down to L0 (no structural facts survive at all) exactly the way
-the reference implementation's own L0 branch does, while a DWARF-informed
-one keeps layout/signatures at ``binary`` the way a real DWARF-informed
-binary dump would (Codex review, PR #1020: an earlier version of this
-module fixed every ``binary``-rung projection to the reference
-implementation's L1 branch unconditionally, so a purely header-derived
-snapshot with no DWARF at all still carried full ``types``/``enums``/
-function-signature data through a ``binary``-depth projection and could
-still emit e.g. ``type_field_type_changed``).
+snapshot's structural facts are genuinely DWARF/symbol-sourced — see
+:func:`_structural_facts_are_dwarf_confirmed` — so a headers-derived
+snapshot strips down to L0 (no structural facts survive at all) exactly the
+way the reference implementation's own L0 branch does, while a genuinely
+DWARF/symbols-only one keeps layout/signatures at ``binary`` the way a real
+DWARF-informed binary dump would (Codex review, PR #1020: an earlier
+version of this module fixed every ``binary``-rung projection to the
+reference implementation's L1 branch unconditionally, so a purely
+header-derived snapshot with no DWARF at all still carried full
+``types``/``enums``/function-signature data through a ``binary``-depth
+projection and could still emit e.g. ``type_field_type_changed``; a later
+version kept a *header-derived* ``RecordType`` wholesale whenever DWARF
+merely confirmed a struct by *name*, still letting an uncorroborated
+header-only field-type change through — see
+:func:`_structural_facts_are_dwarf_confirmed`'s own docstring for why
+``from_headers`` is now part of the gate, not just ``dwarf.has_dwarf``).
 
 **Deliberately in scope** (the same fields the tier-accuracy gate's
 validated ``project()`` degrades, plus the ``BuildSourcePack`` L3-L5 split
-that synthetic corpus never populates, plus three fields a second review
-round found this module itself needed to close — see below):
+that synthetic corpus never populates, plus several fields later review
+rounds found this module itself needed to close — see below):
 ``functions``/``variables`` visibility+origin (a ``Visibility.HIDDEN``
-— non-exported — declaration is dropped entirely, not promoted to
+— non-exported — declaration is dropped entirely, and a declaration with
+no confirmed export-table entry is dropped too, not promoted to
 ``ELF_ONLY``: see :func:`_strip_header_and_above_evidence`'s own
-docstring), ``types``/``enums`` (kept only when DWARF specifically
-observed that declaration by name — :func:`_dwarf_confirmed_names`, real
-per-record evidence, not a whole-snapshot guess), ``typedefs`` (always
-cleared — this codebase's model has no per-name DWARF lookup for them at
-all), ``constants``, ``python_api``, ``from_headers``, ``semantic_ir`` and
-``surface_graph`` (both L2+ header-AST/header-graph facts, gated the same
-as ``from_headers`` — ``_attach_header_graph``'s own docstring: "the
-header-only (L2) semantic graph", not an L4/L5 fact despite a first
-version of this module gating it to ``source`` on that wrong assumption),
-``contract`` (an ADR-050 ``ExtractionContract`` computed from the same
-header-scope/compile-context inputs this module discards — left alone, it
-can still make ``checker.compare()`` raise a scope/profile mismatch error
-from two sides' *original* header scopes even though a binary-only
-comparison was never going to look at either), ``build_mode``, and
-``build_source`` (nulled below ``build``; degraded to its L3-only
-``build_evidence`` — ``source_abi``/``source_graph`` cleared — between
-``build`` and ``source``). Callers that resolve build-info/source packs
+docstring), ``types``/``enums``/``typedefs`` (kept wholesale only when
+:func:`_structural_facts_are_dwarf_confirmed`, else fully cleared —
+genuine DWARF-visible struct/enum layout changes on a header-derived
+snapshot are still caught independently through the untouched
+``snap.dwarf`` fields, never through these), ``constants``, ``python_api``,
+``from_headers``, ``semantic_ir`` and ``surface_graph`` (both L2+
+header-AST/header-graph facts, gated the same as ``from_headers`` —
+``_attach_header_graph``'s own docstring: "the header-only (L2) semantic
+graph", not an L4/L5 fact despite a first version of this module gating it
+to ``source`` on that wrong assumption), ``contract`` (an ADR-050
+``ExtractionContract`` computed from the same header-scope/compile-context
+inputs this module discards — left alone, it can still make
+``checker.compare()`` raise a scope/profile mismatch error from two sides'
+*original* header scopes even though a binary-only comparison was never
+going to look at either), ``build_mode``, and ``build_source`` (nulled
+below ``build``; degraded to its L3-only ``build_evidence`` —
+``source_abi``/``source_graph`` cleared, and their own
+``BuildSourceManifest.coverage`` rows demoted to ``NOT_COLLECTED`` so a
+report can't still claim that evidence backed this run — between ``build``
+and ``source``). Callers that resolve build-info/source packs
 *out-of-band* (a real, pre-built pack directory, not embedded inline) must
 project or withhold those packs themselves before diffing them — this
 module only ever sees what already lives on the snapshot object it was
@@ -87,20 +96,14 @@ handed; see ``cli_compare_helpers.run_compare``'s own comment on its
 **Deliberately out of scope, not silently assumed handled**: platform
 container facts (``elf``/``pe``/``macho``/``dwarf``/``dwarf_advanced``
 themselves are never cleared — only what they *justify keeping* in
-``functions``/``types``/... changes), ``kabi``/``sycl``/``python_ext``/
-``numpy_capi``, ``dependency_info``, ``fact_provenance``/``ast_*``/
-entity-id maps, and ``elf_only_mode`` (left exactly as resolved except
-where the no-DWARF branch sets it ``True`` itself, matching the reference
-implementation's identical choice at its own L0). Function/variable
-*signatures* (return type, params, value) stay gated on whole-snapshot
-DWARF presence, not per-declaration — see
-:func:`_snapshot_has_native_debug_info`'s own docstring for exactly why:
-this codebase's model has no per-function DWARF-confirmation fact for a
-projection to read back, so getting this fully precise is real,
-separately-justified future work (it needs a new fact the dumper doesn't
-record yet), not a residual of this module's own scope. A future extension
-of this module's scope generally is the same: real, separately-justified
-work, not a residual of this docstring's own account.
+``functions``/``types``/... changes, and what :func:`_exported_symbol_names`
+reads back out of them), ``kabi``/``sycl``/``python_ext``/``numpy_capi``,
+``dependency_info``, ``fact_provenance``/``ast_*``/entity-id maps, and
+``elf_only_mode`` (left exactly as resolved except where the no-DWARF
+branch sets it ``True`` itself, matching the reference implementation's
+identical choice at its own L0). A future extension of this module's scope
+is real, separately-justified work, not a residual of this docstring's own
+account.
 """
 
 from __future__ import annotations
@@ -108,6 +111,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING
 
+from ..buildsource.model import CoverageStatus, DataLayer, LayerCoverage
 from ..evidence_depth import DEPTH_RANK
 from ..model import ScopeOrigin, Visibility
 
@@ -122,94 +126,150 @@ __all__ = [
 ]
 
 
-def _snapshot_has_native_debug_info(snap: AbiSnapshot) -> bool:
-    """Whether *snap* carries DWARF debug info independent of any header AST.
+def _structural_facts_are_dwarf_confirmed(snap: AbiSnapshot) -> bool:
+    """Whether *snap*'s ``types``/``enums``/``typedefs``/function-variable
+    signatures are genuinely DWARF/symbol-sourced, not header-parsed.
 
-    The same signal ``confidence.py``/``analysis_assurance.py`` already use
-    for "does this snapshot have debug info" (``dwarf is not None and
-    dwarf.has_dwarf``) — not restated, reused, so this module cannot silently
-    disagree with those about what counts. Deliberately does not also probe
-    PE/Mach-O-specific debug carriers (PDB, ...): matching that same existing
-    precedent exactly rather than inventing a wider, unvalidated heuristic —
-    a real PDB-aware extension is separately-justified future work, not a
-    residual of this function's own scope.
+    Requires both ``snap.dwarf.has_dwarf`` (the same signal
+    ``confidence.py``/``analysis_assurance.py`` already use for "does this
+    snapshot have debug info" — not restated, reused) **and**
+    ``not snap.from_headers``. ``AbiSnapshot.from_headers``'s own field
+    comment states the reason precisely: "DWARF-derived declarations
+    populate the SAME functions/types lists [as header-derived ones] but
+    must NOT be mistaken for header-level evidence." A header-derived
+    ``RecordType``'s numeric *layout* (size/offset) may be backfilled from
+    DWARF when the header backend can't compute it itself
+    (``dumper_layout_backfill.py``), but its field-level *type spelling*
+    stays whatever the header AST parsed — DWARF confirming a struct's
+    *name* says nothing about whether that struct's *fields* agree with the
+    header's own spelling (Codex review, PR #1020, fourth round — a third
+    cut of this module kept a header-derived ``RecordType`` wholesale
+    whenever DWARF merely confirmed the struct by name, which still let an
+    uncorroborated header-only field-type change through; a per-record
+    ``DwarfMetadata.structs``/``.enums`` name check was one level too
+    narrow, not a fix). The same reasoning applies to function/variable
+    signatures: this codebase's dumper merge process has no per-declaration
+    "was this signature confirmed by its own DWARF DIE, or only by
+    headers" fact either.
 
-    **Whole-snapshot, not per-declaration** — deliberately, and only for the
-    two fact families this codebase's model has no per-name DWARF lookup
-    for at all: function/variable signatures. ``types``/``enums`` *do* have
-    one (``DwarfMetadata.structs``/``.enums``, keyed by name) and are
-    filtered per-record instead — see :func:`_dwarf_confirmed_names`. For
-    functions/variables, this whole-snapshot gate matches the one
-    already-validated reference implementation of this idea,
-    ``scripts/check_tier_accuracy.py``'s ``project()``, exactly: its own L1
-    branch keeps every function's signature uniformly once *any* DWARF is
-    present, with no per-function check either — this codebase's dumper
-    merge process does not track "was this specific function's signature
-    confirmed by its own DWARF subprogram DIE, or only by headers" anywhere
-    a projection could read it back. A real per-function extension is
-    separately-justified future work (it would need a new fact the dumper
-    doesn't currently record), not a residual of this function's own scope
-    (Codex review, PR #1020, third round).
+    A genuinely DWARF/symbols-only dump (``from_headers`` is ``False``) has
+    no such ambiguity: ``dwarf_snapshot.py``'s own DWARF-only extraction
+    path populates ``types``/``enums``/``typedefs``/function-variable
+    signatures directly from DWARF DIEs, so every one of those fields is
+    real DWARF evidence there, safely kept wholesale. On a header-derived
+    snapshot, a real binary-visible struct/enum layout change is still
+    caught independently: ``diff_platform._diff_dwarf`` reads
+    ``snap.dwarf.structs``/``.enums`` directly, which this module never
+    clears, and degrades gracefully with no header model at all ("If the
+    header model is absent... fall back to comparing all DWARF types",
+    that function's own comment) — function/variable signature changes have
+    no such independent DWARF-native detector, a real, separately-justified
+    gap (it would need a new per-declaration confirmation fact the dumper
+    does not currently record), not a residual of this function's own
+    scope. Deliberately does not also probe PE/Mach-O-specific debug
+    carriers (PDB, ...) — matching the existing ``confidence.py``/
+    ``analysis_assurance.py`` precedent exactly rather than inventing a
+    wider, unvalidated heuristic; a real PDB-aware extension is
+    separately-justified future work too.
     """
-    return snap.dwarf is not None and snap.dwarf.has_dwarf
+    return snap.dwarf is not None and snap.dwarf.has_dwarf and not snap.from_headers
 
 
-def _dwarf_confirmed_names(snap: AbiSnapshot) -> tuple[frozenset[str], frozenset[str]]:
-    """Struct and enum names DWARF specifically observed, respectively.
+def _exported_symbol_names(snap: AbiSnapshot) -> frozenset[str] | None:
+    """*snap*'s raw platform export-table names, or ``None`` with no table at all.
 
-    ``DwarfMetadata.structs``/``.enums`` are real per-name facts — unlike
-    the whole-snapshot ``has_dwarf`` flag, they answer "was *this*
-    declaration confirmed by DWARF" precisely, so an uninstantiated
-    header-only record sitting alongside unrelated real DWARF content is
-    correctly excluded rather than swept in by the coarser flag (Codex
-    review, PR #1020, third round — a first cut of this module used
-    ``_snapshot_has_native_debug_info`` for these two families too, which
-    over-retains exactly this case). Empty when *snap* has no ``dwarf`` at
-    all, which is what makes the no-DWARF-whatsoever case (this function's
-    old, coarser job) fall out of the same per-record filter for free.
+    A small, local copy of the same "raw export table" read every other
+    consumer of this idea already keeps its own independent copy of
+    (``buildsource.crosscheck_base._exported_symbol_names``,
+    ``buildsource.snapshot_exports.exported_symbols_from_snapshot``,
+    ``post_manifest._exported_symbol_names``,
+    ``diff_unnamed_types._exported_symbol_names`` — see
+    ``buildsource/CLAUDE.md``'s own note that unifying these is a
+    deliberately separate slice, not folded in here): each has a slightly
+    different normalization/fallback need, and a ``policy``-layer caller
+    may import ``model``/``compare`` but not ``extract`` (ADR-061), where
+    most of those live. Matches ``crosscheck_base``'s own normalization
+    exactly (only default-versioned ELF exports; Mach-O's single leading
+    underscore stripped) since that is what must line up against
+    ``Function.mangled``/``Variable.mangled``'s own spelling.
+
+    ``None`` (never an empty ``frozenset``) when *snap* carries no platform
+    export table at all — a caller must treat "cannot confirm" differently
+    from "parsed and confirmed empty" (a real hidden-only library genuinely
+    exports nothing and that must still read as confirmed-empty, not as
+    "no evidence"), so :func:`_strip_header_and_above_evidence` skips this
+    check entirely rather than misreading an absent platform block as zero
+    exports.
     """
-    dwarf = snap.dwarf
-    if dwarf is None:
-        return frozenset(), frozenset()
-    return frozenset(dwarf.structs), frozenset(dwarf.enums)
+    elf = snap.elf
+    if elf is not None:
+        return frozenset(s.name for s in elf.symbols if s.name and s.is_default)
+    pe = snap.pe
+    if pe is not None:
+        return frozenset(e.name for e in pe.exports if e.name)
+    macho = snap.macho
+    if macho is not None:
+        return frozenset(
+            e.name[1:] if e.name.startswith("_") else e.name
+            for e in macho.exports
+            if e.name
+        )
+    return None
 
 
 def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     """Blank every L2+ (header-AST) fact on *snap*, in place.
 
-    ``types``/``enums`` keep only the entries DWARF itself specifically
-    observed (:func:`_dwarf_confirmed_names`) — real per-record evidence,
-    not a whole-snapshot guess. ``typedefs`` are always cleared: this
-    codebase's model has no per-name DWARF lookup for them at all (no
-    ``DwarfMetadata.typedefs``), so there is no evidence-backed way to keep
-    any of them below `headers`. Function/variable *signatures*
-    (return type, params, value) stay gated on whole-snapshot DWARF
-    presence — see :func:`_snapshot_has_native_debug_info`'s own docstring
-    for exactly why that one stays coarser. A function/variable with
-    ``Visibility.HIDDEN`` (a real, non-exported header-only declaration,
-    never a fact a binary-only view could see at all) is dropped from the
-    snapshot entirely rather than promoted to ``ELF_ONLY`` — promoting it
-    would misrepresent an unexported symbol as binary-visible and could
-    manufacture a false ``*_removed_elf_only`` finding for a declaration no
-    real binary-only dump would ever have seen as a symbol in the first
-    place (Codex review, PR #1020, third round).
+    ``types``/``enums``/``typedefs`` and function/variable *signatures*
+    (return type, params, value) survive wholesale only when
+    :func:`_structural_facts_are_dwarf_confirmed` — see that function's own
+    docstring for exactly why ``dwarf.has_dwarf`` alone is not enough.
+    Otherwise every one of those is fully cleared, not merely re-scoped.
+
+    A function/variable with ``Visibility.HIDDEN`` (a real, non-exported
+    header-only declaration, never a fact a binary-only view could see at
+    all) is dropped from the snapshot entirely rather than promoted to
+    ``ELF_ONLY`` (Codex review, PR #1020, third round). A surviving
+    function/variable is *additionally* required to appear in *snap*'s own
+    raw export table (:func:`_exported_symbol_names`, when one exists)
+    before promotion to ``ELF_ONLY`` — a header parser's own "declared
+    public, without contrary evidence" fallback (e.g. ``dumper_castxml.
+    _variable_visibility``'s un-emitted customization-point-object case)
+    can mark a declaration ``PUBLIC`` even though the compiler never
+    actually emitted a symbol for it, and promoting that declaration to
+    ``ELF_ONLY`` would manufacture a false ``*_removed_elf_only``/
+    ``*_removed`` finding for a symbol no real binary-only dump would ever
+    have seen (Codex review, PR #1020, fourth round). Skipped — no
+    filtering beyond the ``HIDDEN`` drop above — when *snap* carries no
+    platform export table at all, so a synthetic/incomplete snapshot with
+    no platform block populated keeps its prior, looser behavior rather
+    than being stripped to nothing.
     """
+    dwarf_sourced = _structural_facts_are_dwarf_confirmed(snap)
+
     snap.functions = [f for f in snap.functions if f.visibility != Visibility.HIDDEN]
     snap.variables = [v for v in snap.variables if v.visibility != Visibility.HIDDEN]
+    exported = _exported_symbol_names(snap)
+    if exported is not None:
+        snap.functions = [f for f in snap.functions if f.mangled in exported]
+        snap.variables = [v for v in snap.variables if v.mangled in exported]
     for f in snap.functions:
         f.visibility = Visibility.ELF_ONLY
         f.origin = ScopeOrigin.UNKNOWN
     for v in snap.variables:
         v.visibility = Visibility.ELF_ONLY
         v.origin = ScopeOrigin.UNKNOWN
-    confirmed_structs, confirmed_enums = _dwarf_confirmed_names(snap)
-    snap.types = [t for t in snap.types if t.name in confirmed_structs]
-    snap.enums = [e for e in snap.enums if e.name in confirmed_enums]
-    for t in snap.types:
-        t.origin = ScopeOrigin.UNKNOWN
-    for e in snap.enums:
-        e.origin = ScopeOrigin.UNKNOWN
-    snap.typedefs = {}
+
+    if dwarf_sourced:
+        for t in snap.types:
+            t.origin = ScopeOrigin.UNKNOWN
+        for e in snap.enums:
+            e.origin = ScopeOrigin.UNKNOWN
+    else:
+        snap.types = []
+        snap.enums = []
+        snap.typedefs = {}
+
     snap.constants = {}
     snap.from_headers = False
     snap.python_api = None
@@ -227,7 +287,7 @@ def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
     # look at either scope (Codex review, PR #1020, third round).
     snap.contract = None
 
-    if not _snapshot_has_native_debug_info(snap):
+    if not dwarf_sourced:
         for f in snap.functions:
             f.return_type = "?"
             f.params = []
@@ -236,6 +296,43 @@ def _strip_header_and_above_evidence(snap: AbiSnapshot) -> None:
             v.is_const = False
             v.value = None
         snap.elf_only_mode = True
+
+
+#: Layer values :func:`_project_build_source_pack` clears between ``build``
+#: and ``source`` — shared so the payload fields and their manifest coverage
+#: rows can never independently drift.
+_L4_L5_LAYER_VALUES = frozenset(
+    {DataLayer.L4_SOURCE_ABI.value, DataLayer.L5_SOURCE_GRAPH.value}
+)
+
+
+def _mark_layers_not_collected(
+    pack: BuildSourcePack, layer_values: frozenset[str]
+) -> None:
+    """Rewrite *pack*'s own ``manifest.coverage`` rows for *layer_values*, in place.
+
+    Clearing ``pack.source_abi``/``.source_graph`` alone leaves
+    ``pack.manifest.coverage``'s own ``LayerCoverage`` rows still claiming
+    ``PRESENT``/``PARTIAL`` for a layer this projection just removed —
+    ``evidence_report.optional_coverage()`` returns those rows directly, so
+    human output, JSON ``layer_coverage``, and the D9 evidence metrics could
+    still claim source-ABI/source-graph evidence backed this comparison even
+    though the depth ceiling excluded it from actually being diffed (Codex
+    review, PR #1020, fourth round). Demoting to ``NOT_COLLECTED`` (dropping
+    every other field — ``detail``/``confidence``/counts) matches the exact
+    "nothing collected" row shape every existing producer already
+    constructs for a layer it never ran (e.g. ``inline.py``'s own
+    ``else: LayerCoverage(layer=..., status=CoverageStatus.NOT_COLLECTED)``
+    branches), so a reader can't distinguish "genuinely never collected"
+    from "collected, then projected away below the requested depth" — which
+    is exactly the honest claim at this depth.
+    """
+    pack.manifest.coverage = [
+        LayerCoverage(layer=row.layer, status=CoverageStatus.NOT_COLLECTED)
+        if row.layer in layer_values
+        else row
+        for row in pack.manifest.coverage
+    ]
 
 
 def _project_build_source_pack(
@@ -248,16 +345,20 @@ def _project_build_source_pack(
     pack resolved out-of-band from an explicit ``--build-info``/``--sources``
     path) so the L3-L5 capping rule is stated once rather than duplicated
     between the two callers. Below ``build``, the whole pack carries no
-    evidence an explicit ``--depth`` asked for and is dropped entirely;
-    between ``build`` and ``source``, the L3 ``build_evidence`` payload
-    survives but the L4 source-ABI replay and L5 source-graph payloads are
-    cleared; at or above ``source``, *pack* is returned unchanged.
+    evidence an explicit ``--depth`` asked for and is dropped entirely — its
+    ``manifest.coverage`` goes with it, so no separate row-demotion is
+    needed there. Between ``build`` and ``source``, the L3 ``build_evidence``
+    payload survives but the L4 source-ABI replay and L5 source-graph
+    payloads are cleared, and their own coverage rows demoted alongside them
+    (:func:`_mark_layers_not_collected`); at or above ``source``, *pack* is
+    returned unchanged.
     """
     if rank < build_rank:
         return None
     if rank < source_rank:
         pack.source_abi = None
         pack.source_graph = None
+        _mark_layers_not_collected(pack, _L4_L5_LAYER_VALUES)
     return pack
 
 

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -67,7 +67,11 @@ from .compile_context import CompileContext
 from .confidence import note_if_same_binary_compared
 from .dependency_info import populate_pair_dependency_info
 from .errors import ValidationError
-from .policy.depth_projection import project_pair_to_depth, project_snapshot_to_depth
+from .policy.depth_projection import (
+    project_build_source_pack_to_depth,
+    project_pair_to_depth,
+    project_snapshot_to_depth,
+)
 from .workflows.artifact.execute import (
     enforce_requested_depth,
     resolve_side_snapshot,
@@ -82,6 +86,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ResolvedComparePair",
     "classify_compare_pair",
+    "project_build_source_pack_to_depth",
     "project_pair_to_depth",
     "project_snapshot_to_depth",
     "resolve_compare_request",

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -67,6 +67,7 @@ from .compile_context import CompileContext
 from .confidence import note_if_same_binary_compared
 from .dependency_info import populate_pair_dependency_info
 from .errors import ValidationError
+from .policy.depth_projection import project_pair_to_depth, project_snapshot_to_depth
 from .workflows.artifact.execute import (
     enforce_requested_depth,
     resolve_side_snapshot,
@@ -81,6 +82,8 @@ if TYPE_CHECKING:
 __all__ = [
     "ResolvedComparePair",
     "classify_compare_pair",
+    "project_pair_to_depth",
+    "project_snapshot_to_depth",
     "resolve_compare_request",
     "resolve_sides_sequentially",
     "run_compare",
@@ -426,19 +429,15 @@ def classify_compare_pair(
         attach_evidence_metrics,
         prepare_embedded_build_source,
     )
-    from .policy.depth_projection import project_snapshot_to_depth
 
     # ADR-063 Phase 8's "--depth floor vs ceiling" gap: `resolve_compare_
     # request`'s own `enforce_requested_depth` call already confirmed both
     # sides' *resolved* evidence meets `request.depth` as a floor -- this is
     # the ceiling half, filtering what this classification is allowed to see
     # down to that same rung. Deliberately a *view*, not a mutation of
-    # `pair.old`/`pair.new` themselves (see `project_snapshot_to_depth`'s own
-    # docstring) -- `pair` may still be read elsewhere for its unprojected
-    # snapshots. A no-op when `request.depth` is `None` (the overwhelming
-    # majority of calls), matching `enforce_requested_depth`'s identical gate.
-    old = project_snapshot_to_depth(pair.old, request.depth)
-    new = project_snapshot_to_depth(pair.new, request.depth)
+    # `pair.old`/`pair.new` (see `project_pair_to_depth`'s own docstring) --
+    # `pair` may still be read elsewhere for its unprojected snapshots.
+    old, new = project_pair_to_depth(pair.old, pair.new, request.depth)
     suppression, pf = service.load_suppression_and_policy(
         request.suppress, request.policy, request.policy_file_path
     )

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -426,8 +426,19 @@ def classify_compare_pair(
         attach_evidence_metrics,
         prepare_embedded_build_source,
     )
+    from .policy.depth_projection import project_snapshot_to_depth
 
-    old, new = pair.old, pair.new
+    # ADR-063 Phase 8's "--depth floor vs ceiling" gap: `resolve_compare_
+    # request`'s own `enforce_requested_depth` call already confirmed both
+    # sides' *resolved* evidence meets `request.depth` as a floor -- this is
+    # the ceiling half, filtering what this classification is allowed to see
+    # down to that same rung. Deliberately a *view*, not a mutation of
+    # `pair.old`/`pair.new` themselves (see `project_snapshot_to_depth`'s own
+    # docstring) -- `pair` may still be read elsewhere for its unprojected
+    # snapshots. A no-op when `request.depth` is `None` (the overwhelming
+    # majority of calls), matching `enforce_requested_depth`'s identical gate.
+    old = project_snapshot_to_depth(pair.old, request.depth)
+    new = project_snapshot_to_depth(pair.new, request.depth)
     suppression, pf = service.load_suppression_and_policy(
         request.suppress, request.policy, request.policy_file_path
     )

--- a/abicheck/workflows/artifact/execute.py
+++ b/abicheck/workflows/artifact/execute.py
@@ -768,13 +768,14 @@ def enforce_requested_depth(
     *sides* is ``(label, snapshot)`` pairs so the message names the side that
     fell short: ``compare`` passes both of its own, ``dump`` its single input.
 
-    Known, accepted limitation (Codex review, not fixed here): this is a
-    floor, not a ceiling. An input that is an already-serialized JSON snapshot
-    with richer embedded evidence than ``depth`` requested still carries all of
-    it — ``resolve_input``'s ``fmt == "json"`` branch returns
-    ``load_snapshot(path)`` verbatim, matching the CLI's own long-documented
-    default, which ``--depth`` has never projected down for a pre-built
-    snapshot either.
+    This function is the *floor* half only — it never strips evidence a
+    resolved snapshot carries beyond *depth*. The *ceiling* half is
+    :func:`abicheck.policy.depth_projection.project_snapshot_to_depth`,
+    applied by ``classify_compare_pair`` right after this function confirms
+    the floor — see that function's own docstring and
+    ``docs/contribute/known-gaps.md``'s "``--depth`` is a floor for live
+    extraction, not a ceiling for a pre-built snapshot" entry for the full
+    account, including why ``dump`` deliberately does not apply it.
     """
     if depth is None:
         return

--- a/architecture/debt.yaml
+++ b/architecture/debt.yaml
@@ -503,12 +503,12 @@
     },
     {
       "path": "abicheck/cli_scan_baseline.py",
-      "baseline_lines": 1343,
+      "baseline_lines": 1349,
       "target": "workflows-or-frontends",
       "rule": "no_growth",
       "category": "legacy_workflow_or_frontend_monolith",
       "owner": "abicheck maintainers",
-      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice.",
+      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice. Baseline raised 1343 -> 1349, ADR-063 Phase 8 follow-up (PR #1020, Codex review): `_run_baseline_compare` calls `compare_snapshots()` directly, the same as `cli_compare_helpers.run_compare` did before that review found neither call site applied the `--depth` ceiling projection (`project_pair_to_depth`, `abicheck/policy/depth_projection.py`) `classify_compare_pair` already had -- `scan --against --depth binary` leaked the identical header-derived findings the native `compare` CLI did. The added call is a single statement (`old_snap, new_snap = project_pair_to_depth(old_snap, new_snap, requested_depth)`) plus its import and a two-line attribution comment; no smaller diff closes the gap without leaving this call site silently unfixed while its sibling was.",
       "review_by": "2026-11-30"
     },
     {

--- a/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
+++ b/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
@@ -1,0 +1,23 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`--depth` now caps evidence for `compare`/`scan --against`, not only
+  floors it.** `enforce_requested_depth` has long failed a run when the
+  resolved evidence fell short of an explicit `--depth`, but never stripped
+  richer evidence a pre-built JSON snapshot (or a directory/package
+  operand) carried beyond what was requested — `compare old.json new.json
+  --depth binary` could still emit real header-derived findings and publish
+  `BREAKING`. `classify_compare_pair` now projects each side down to the
+  requested rung (`abicheck.policy.depth_projection.
+  project_snapshot_to_depth`) before classifying, so `--depth binary`
+  behaves the same whether the input was freshly extracted or loaded from
+  disk. `dump`'s own `--depth` is unaffected (it stays floor-only, so a
+  dumped artifact keeps whatever richer evidence extraction produced for a
+  later, deeper comparison).

--- a/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
+++ b/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
@@ -26,4 +26,11 @@ it should read in CHANGELOG.md. Delete the other sections.
   DWARF at all (fully stripped to bare symbol identity, matching a real
   headerless, debug-info-less dump). `dump`'s own `--depth` is unaffected
   (it stays floor-only, so a dumped artifact keeps whatever richer evidence
-  extraction produced for a later, deeper comparison).
+  extraction produced for a later, deeper comparison). An explicit
+  out-of-band `--old/new-sources`/`--old/new-build-info` pack is now capped
+  too — it previously bypassed the ceiling entirely — and the ceiling also
+  now clears a stale `ExtractionContract` (which could otherwise raise a
+  spurious scope-mismatch error), drops a non-exported (`HIDDEN`)
+  declaration outright instead of misreporting it as a binary-visible
+  removal, and filters `types`/`enums` by real per-record DWARF confirmation
+  rather than a coarser whole-snapshot flag.

--- a/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
+++ b/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
@@ -14,10 +14,16 @@ it should read in CHANGELOG.md. Delete the other sections.
   richer evidence a pre-built JSON snapshot (or a directory/package
   operand) carried beyond what was requested — `compare old.json new.json
   --depth binary` could still emit real header-derived findings and publish
-  `BREAKING`. `classify_compare_pair` now projects each side down to the
-  requested rung (`abicheck.policy.depth_projection.
-  project_snapshot_to_depth`) before classifying, so `--depth binary`
-  behaves the same whether the input was freshly extracted or loaded from
-  disk. `dump`'s own `--depth` is unaffected (it stays floor-only, so a
-  dumped artifact keeps whatever richer evidence extraction produced for a
-  later, deeper comparison).
+  `BREAKING`. Every `compare_snapshots()` call site that classifies a
+  resolved pair (the native `compare` CLI, the typed-API/directory-package
+  chokepoint, and `scan --against`'s baseline path) now projects each side
+  down to the requested rung (`abicheck.policy.depth_projection.
+  project_pair_to_depth`) first, so `--depth binary` behaves the same
+  whether the input was freshly extracted or loaded from disk. A
+  `binary`-depth projection now also correctly distinguishes a
+  DWARF-informed snapshot (structural facts kept, matching a real
+  DWARF-informed binary dump) from a purely header-derived one with no
+  DWARF at all (fully stripped to bare symbol identity, matching a real
+  headerless, debug-info-less dump). `dump`'s own `--depth` is unaffected
+  (it stays floor-only, so a dumped artifact keeps whatever richer evidence
+  extraction produced for a later, deeper comparison).

--- a/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
+++ b/changelog.d/20260902_220847_noreply_adr_063_phase_8_open_items_dfpn6j.md
@@ -20,17 +20,23 @@ it should read in CHANGELOG.md. Delete the other sections.
   down to the requested rung (`abicheck.policy.depth_projection.
   project_pair_to_depth`) first, so `--depth binary` behaves the same
   whether the input was freshly extracted or loaded from disk. A
-  `binary`-depth projection now also correctly distinguishes a
-  DWARF-informed snapshot (structural facts kept, matching a real
-  DWARF-informed binary dump) from a purely header-derived one with no
-  DWARF at all (fully stripped to bare symbol identity, matching a real
-  headerless, debug-info-less dump). `dump`'s own `--depth` is unaffected
-  (it stays floor-only, so a dumped artifact keeps whatever richer evidence
-  extraction produced for a later, deeper comparison). An explicit
-  out-of-band `--old/new-sources`/`--old/new-build-info` pack is now capped
-  too — it previously bypassed the ceiling entirely — and the ceiling also
-  now clears a stale `ExtractionContract` (which could otherwise raise a
-  spurious scope-mismatch error), drops a non-exported (`HIDDEN`)
-  declaration outright instead of misreporting it as a binary-visible
-  removal, and filters `types`/`enums` by real per-record DWARF confirmation
-  rather than a coarser whole-snapshot flag.
+  `binary`-depth projection now also correctly distinguishes a genuinely
+  DWARF/symbols-only snapshot (structural facts kept wholesale, matching a
+  real DWARF-informed binary dump with no headers) from a header-derived
+  one, DWARF-backed or not (structural facts fully stripped either way — a
+  header parser's own field-level spelling is never corroborated merely by
+  DWARF confirming a same-named struct/enum exists, only its real per-TU
+  DWARF layout is; a genuine DWARF-visible struct/enum change is still
+  caught independently, unaffected by any of this). `dump`'s own `--depth`
+  is unaffected (it stays floor-only, so a dumped artifact keeps whatever
+  richer evidence extraction produced for a later, deeper comparison). An
+  explicit out-of-band `--old/new-sources`/`--old/new-build-info` pack is
+  now capped too — it previously bypassed the ceiling entirely, and its own
+  `LayerCoverage` rows are demoted alongside a cleared L4/L5 payload so a
+  report can't still claim that evidence backed the run. The ceiling also
+  clears a stale `ExtractionContract` (which could otherwise raise a
+  spurious scope-mismatch error), and drops a declaration outright — never
+  misreporting it as a binary-visible removal — when it's non-exported
+  (`Visibility.HIDDEN`) or when the snapshot's own export table doesn't
+  confirm it (a header parser's "declared public, without contrary
+  evidence" fallback, e.g. an un-emitted customization-point object).

--- a/changelog.d/20260902_220901_noreply_adr_063_phase_8_open_items_dfpn6j.md
+++ b/changelog.d/20260902_220901_noreply_adr_063_phase_8_open_items_dfpn6j.md
@@ -1,0 +1,19 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`compare --bundle-facts-out`'s stranded-library resolver now clears
+  headers at `--depth binary` through the same shared evidence-resolution
+  machinery every matched pair uses**, instead of a hand-rolled
+  special-case that could drift from it. A stranded (removed-in-new)
+  library's `BundleFacts` entry is resolved through the same
+  `DumpRequest -> resolve_dump_request -> execute_dump_request` pipeline
+  `dump`/`scan` already converge on (ADR-063 D1), gaining the same
+  `AnalysisPlan` pre-flight check while keeping its existing
+  degrade-to-ELF-only fallback on failure.

--- a/docs/contribute/adr/062-project-snapshot-storage-v2.md
+++ b/docs/contribute/adr/062-project-snapshot-storage-v2.md
@@ -47,7 +47,17 @@ readable. The directory writer/reader
 path — but no `dump` CLI flag produces one today.
 Folding baseline sets/`BundleFacts` into sections, multi-artifact packages,
 variant capture, and the `.tar.zst` transport form (A1.4-A1.8) remain not
-implemented. All of Phase 2 is not implemented.
+implemented — note this is the **remainder of Phase 1**, not Phase 2 (Phase
+2 is the separate scale/performance work: lazy loading, streaming encode,
+cache migration, indexes). A full per-item design for A1.1's `.tar.zst`
+remainder and A1.4-A1.8 (Goal/Design/Files/Tests/Acceptance criteria each)
+now exists in `docs/contribute/plans/storage-format-v2.md`'s "Phases" →
+"Phase 1" section — design only, not implemented by that addition; the
+object model these items build on (`PackageManifest.artifact_refs`/
+`variant_refs`, `ArtifactRef.kind`/`.sections`) already supports every one
+of them without a schema change, which is why each item below is scoped as
+a producer/CLI-wiring gap rather than a storage-format gap. All of Phase 2
+is not implemented.
 **Decision maker:** abicheck maintainers
 **Supersedes (partially):** [ADR-015](015-snapshot-serialization.md)'s
 single-document logical model. [ADR-059](059-compressed-snapshot-storage.md)'s

--- a/docs/contribute/adr/063-one-semantic-pipeline.md
+++ b/docs/contribute/adr/063-one-semantic-pipeline.md
@@ -1071,27 +1071,45 @@ snapshot — not a gap this decision claims to close.
 
 **A second, narrower exception, found the same way (checked against real
 code, not assumed covered by "bundle/release fan-out" above): two branches
-inside `cli_compare_release.py` bypass the pipeline and are not migrated by
-this plan either.** `_collect_matrix_result()` (the `--probe-matrix-*`
-release-global build-configuration feature) calls `service.
-compare_snapshots()` directly over a pair of empty snapshots with
+inside `cli_compare_release.py` bypassed the pipeline.** `_collect_matrix_result()`
+(the `--probe-matrix-*` release-global build-configuration feature) calls
+`service.compare_snapshots()` directly over a pair of empty snapshots with
 `extra_changes` — the sanctioned Tier-2 chokepoint, not the disallowed
 Tier-1 `checker.compare()` core, so this does not itself trip the
 `cli-contract` gate — but it still never constructs a request or a plan,
-which is what this decision's own convergence is about. `_resolve_stranded_library()` (the
-`--bundle-facts-out` path's fallback for a library missing from the normal
-per-pair comparison) calls `cli_resolve._resolve_input()` directly — the
-same Tier-2 resolution `resolve_compare_request` itself calls, but reached
-independently, with its own bespoke fallback on top. The release fan-out's
-*main* per-pair path (`_run_compare_pair`) does route through `service.
-run_compare`, so "bundle/release fan-out" above is not uniformly
-unconverged — only these two narrower branches are. Migrating either is a
-real, separate design question (an `AnalysisPlan` pre-flight check for a
-probe-matrix build-config diff, or for a deliberately-degrading
-stranded-library fallback, is not the same shape of check this decision
-specifies for an ordinary comparison) and is named here, explicitly, as
-staying outside this decision's convergence rather than left to be
-discovered as a silent gap in an implementation phase's own accounting.
+which is what this decision's own convergence is about. This one remains
+unmigrated, and deliberately so: an `AnalysisPlan` pre-flight check has
+nothing to check here — there is no requested-vs-resolved evidence input to
+validate feasibility for, only two already-empty synthetic snapshots and an
+already-computed `extra_changes` list — so forcing this branch through
+`AnalysisPlanner.resolve()` would mean inventing a vacuous plan for a
+request shape the checker was never designed to answer, not closing a real
+gap.
+
+`_resolve_stranded_library()` (the `--bundle-facts-out` path's fallback for
+a library missing from the normal per-pair comparison) **is migrated**
+(ADR-063 Phase 8 follow-up): it used to call `cli_resolve._resolve_input()`
+directly — the same Tier-2 resolution `resolve_compare_request` itself
+calls, but reached independently, with its own hand-rolled `depth=binary`
+header-clearing special-case and no `AnalysisPlan` pre-flight check at all.
+Unlike the matrix branch above, this one genuinely is "the same shape of
+check" once looked at correctly: a stranded library is exactly one
+dump-shaped input (a path, headers, includes, version, language, an
+optional depth), so it now builds a real `DumpRequest` and runs it through
+`resolve_dump_request`/`execute_dump_request` — the identical pipeline
+`dump`/`scan` already converge on — gaining a real `AnalysisPlanner.
+resolve()` pre-flight check and dropping the hand-copied depth-clearing
+rule (the shared evidence-resolution machinery a matched pair's own
+`CompareRequest` side already uses does the identical clearing
+consistently). Its "deliberately-degrading stranded-library fallback"
+nature — the reason this was originally judged not-the-same-shape-of-check
+as an ordinary comparison — is preserved exactly, not designed away: a
+`PlanningError`/`ValidationError`/`SnapshotError` from either the resolve
+or execute step still degrades to an ELF-only entry with a warning rather
+than aborting the release. The release fan-out's *main* per-pair path
+(`_run_compare_pair`) already routed through `service.run_compare`, so
+"bundle/release fan-out" above is now unconverged in exactly one narrower
+branch (`_collect_matrix_result()`), not two.
 
 ### D2 — `Fact[T]`: one representation of "do we know this, and how"
 

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -6237,6 +6237,49 @@ looked like the obvious fix and wasn't.
   now picks L0 (fully stripped) vs. L1 (structural facts kept) per
   snapshot, not fixed to one or the other.
 
+  **A third review round (Codex, same PR) found four more real gaps, all
+  now closed:** (1) an explicit out-of-band `--old/new-sources`/
+  `--old/new-build-info` pack directory is resolved *separately* from the
+  snapshot object `project_pair_to_depth` projects — `cli_compare_helpers.
+  run_compare` passed the raw pack paths straight through to
+  `prepare_embedded_build_source`, which reloads and diffs them
+  unconditionally, so a pack-backed `compare --sources ... --depth binary`
+  still leaked full L3-L5 findings even after the first two rounds' fixes.
+  Closed with a new `project_build_source_pack_to_depth` (mirroring
+  `project_snapshot_to_depth`'s own `build_source` capping, factored into a
+  shared `_project_build_source_pack` helper both call) — `run_compare` now
+  resolves each side's pack itself, caps it, attaches the capped pack back
+  onto `old.build_source`/`new.build_source`, and passes `None` for the
+  four path arguments so `prepare_embedded_build_source`'s own
+  `resolve_side_pack` falls back to the now-capped embedded payload instead
+  of reloading the raw one; the same fix also corrected the *reporting*
+  side (`analysis_assurance`/`old_evidence_depth`/`new_evidence_depth`),
+  which previously re-resolved the uncapped pack from the raw paths a
+  second time for these fields even after the findings themselves were
+  capped. (2) `snap.contract` (an ADR-050 `ExtractionContract`) survived a
+  `binary`-depth projection, so `checker.compare()` could still raise a
+  scope/profile mismatch error from two sides' *original* header scopes
+  even though a binary-only comparison never looks at either — now cleared
+  alongside the other L2+ facts. (3) a `Visibility.HIDDEN` (non-exported)
+  function/variable was promoted to `ELF_ONLY` like every other function/
+  variable, manufacturing a false `*_removed_elf_only` finding for a
+  declaration no real binary-only dump would ever have seen as a symbol at
+  all — now dropped from the projected snapshot entirely instead. (4)
+  `types`/`enums` were kept or dropped by the whole-snapshot
+  `dwarf.has_dwarf` flag, the same coarse signal functions/variables still
+  use — but this codebase's model *does* carry real per-record DWARF
+  evidence for these two families (`DwarfMetadata.structs`/`.enums`, keyed
+  by name), so an uninstantiated header-only record sitting alongside
+  unrelated real DWARF content was incorrectly retained; a new
+  `_dwarf_confirmed_names` now filters `types`/`enums` per declaration name
+  instead of by the whole-snapshot flag. `typedefs` stay unconditionally
+  cleared below `headers` regardless — this codebase's model has no
+  per-name DWARF lookup for them at all — and function/variable
+  *signatures* deliberately keep the coarser whole-snapshot gate, since no
+  per-function DWARF-confirmation fact exists anywhere in the model for a
+  projection to read back (a real per-function extension is
+  separately-justified future work, not attempted here).
+
 ### The composite Action can't recover a compatibility verdict from an HTML primary report when its own JSON sidecar is suppressed
 
 A Codex review round on PR #1016 (R1: teaching `action/run.sh`'s verdict

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -6149,7 +6149,11 @@ looked like the obvious fix and wasn't.
 
 - **`--depth` is a floor for live extraction, not a ceiling for a pre-built
   snapshot — real, cross-cutting, and previously undocumented outside one
-  function's own docstring.** `enforce_requested_depth`
+  function's own docstring. Fixed (ADR-063 Phase 8 follow-up): the
+  comparison-time projection this entry's own "real fix" paragraph called
+  for is now `abicheck.policy.depth_projection.project_snapshot_to_depth`,
+  applied by `classify_compare_pair` right after `enforce_requested_depth`
+  confirms the floor.** `enforce_requested_depth`
   (`workflows/artifact/execute.py`) already fails a run when the *resolved*
   evidence falls short of an explicit `--depth`, and its own docstring has
   long carried this note: "this is a floor, not a ceiling. An input that is
@@ -6173,26 +6177,48 @@ looked like the obvious fix and wasn't.
   entry so the directory/package path states the same acknowledged
   limitation explicitly rather than silently inheriting an undocumented
   one.
-  **Not fixed here, and the two obvious-looking fixes are each wrong for a
-  reason worth recording so they aren't re-attempted as the "obvious"
-  patch:** stripping a resolved snapshot's higher-level facts down to the
-  requested depth *before* comparing would work for this one call site, but
-  would also discard evidence a caller legitimately wants to keep on a
-  snapshot that gets reused for a *later* comparison at a higher depth —
-  `--depth` is meant to gate what a comparison *uses*, not to mutate a
+  **The two obvious-looking fixes below were, and remain, correctly
+  rejected — the eventual fix is neither of them, kept here so both stay
+  un-reattempted:** stripping a resolved snapshot's higher-level facts down
+  to the requested depth *before* comparing would work for this one call
+  site, but would also discard evidence a caller legitimately wants to keep
+  on a snapshot that gets reused for a *later* comparison at a higher depth
+  — `--depth` is meant to gate what a comparison *uses*, not to mutate a
   snapshot's own persisted content. Rejecting `--depth binary` outright for
   any operand backed by a pre-built snapshot (matching the pre-#1016
   directory/package behavior) would reintroduce exactly the asymmetry D1
-  closed, since the single-pair path already accepts and silently
-  under-enforces the same combination. The real fix needs a
-  comparison-time projection — resolve the snapshot as today, then filter
-  what `checker.compare()` is allowed to see down to the requested rung,
-  keeping the resolved `AbiSnapshot` itself untouched — which is a real,
-  separate design question (which facts a given depth "sees" needs the
-  same explicit mapping `evidence_depth.py`'s own rank table already gives
-  requested-vs-resolved comparison, just applied the other direction), not
-  a one-line patch to either `resolve_input` or the two call sites that
-  triggered this entry.
+  closed, since the single-pair path already accepted and silently
+  under-enforced the same combination.
+
+  **The fix actually shipped is exactly the comparison-time projection this
+  entry called for**: resolve the snapshot as before, then filter what
+  `checker.compare()` is allowed to see down to the requested rung, keeping
+  the resolved `AbiSnapshot` itself untouched.
+  `abicheck.policy.depth_projection.project_snapshot_to_depth` is that
+  filter — pure (returns a deep copy), mapped onto the public
+  `binary`/`headers`/`build`/`source` ladder via the exact same rank table
+  (`evidence_depth.DEPTH_RANK`) this entry's own "applied the other
+  direction" phrase named, and validated against the one prior
+  already-trusted reference implementation of this idea:
+  `scripts/check_tier_accuracy.py`'s `project()`, which the per-tier
+  accuracy gate runs against a real (if synthetic) labelled corpus.
+  `classify_compare_pair` (`service_compare_pipeline.py`) applies it to a
+  local `old`/`new` view, gated on `request.depth is not None` — the same
+  "no explicit depth, no effect" contract `enforce_requested_depth` already
+  has — right after that function confirms the floor; `pair.old`/`pair.new`
+  themselves are never mutated, so a caller reading the unprojected
+  snapshot elsewhere is unaffected. `dump` deliberately does **not** apply
+  this at write time, for the exact reason given above (it would discard
+  evidence a later, deeper comparison might want) — `--depth` on `dump`
+  stays floor-only, unchanged. See `project_snapshot_to_depth`'s own
+  docstring for the precise field-by-field scope (deliberately mirrors what
+  the validated reference implementation degrades — visibility/origin
+  scoping, macro/constexpr constants, the Python-API stub surface, the
+  header-AST `SemanticIR`, `build_mode`, the `BuildSourcePack` L3/L4/L5
+  split, `surface_graph` — and just as deliberately leaves untouched what
+  that reference implementation never validated: platform container facts,
+  `kabi`/`sycl`/`python_ext`/`numpy_capi`, `typedefs`, dependency/contract/
+  provenance metadata).
 
 ### The composite Action can't recover a compatibility verdict from an HTML primary report when its own JSON sidecar is suppressed
 

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -6271,14 +6271,66 @@ looked like the obvious fix and wasn't.
   evidence for these two families (`DwarfMetadata.structs`/`.enums`, keyed
   by name), so an uninstantiated header-only record sitting alongside
   unrelated real DWARF content was incorrectly retained; a new
-  `_dwarf_confirmed_names` now filters `types`/`enums` per declaration name
-  instead of by the whole-snapshot flag. `typedefs` stay unconditionally
-  cleared below `headers` regardless — this codebase's model has no
-  per-name DWARF lookup for them at all — and function/variable
-  *signatures* deliberately keep the coarser whole-snapshot gate, since no
-  per-function DWARF-confirmation fact exists anywhere in the model for a
-  projection to read back (a real per-function extension is
-  separately-justified future work, not attempted here).
+  `_dwarf_confirmed_names` filtered `types`/`enums` per declaration name
+  instead of by the whole-snapshot flag. **Superseded by the fourth review
+  round below** — the per-record name check turned out to be one level too
+  narrow.
+
+  **A fourth review round (Codex, same PR) found three more real gaps, all
+  now closed:** (1) the third round's per-record `_dwarf_confirmed_names`
+  fix retained a *header-derived* `RecordType`/`EnumType` wholesale
+  whenever DWARF merely confirmed the same-named struct/enum *existed* —
+  DWARF confirming a struct's name says nothing about whether its *fields*
+  agree with the header's own spelling (DWARF only ever backfills numeric
+  *layout* onto a header-derived record — `dumper_layout_backfill.py`'s
+  own scope — never its field-level type text), so a header-only field-type
+  change could still leak through a `binary`-depth projection whenever an
+  unrelated real DWARF struct happened to share the changed struct's name.
+  Fixed by replacing the per-record name check with a whole-snapshot
+  `not snap.from_headers` requirement (`_structural_facts_are_dwarf_
+  confirmed`, replacing `_dwarf_confirmed_names`/`_snapshot_has_native_
+  debug_info`): `AbiSnapshot.from_headers`'s own field comment states the
+  real distinction precisely — "DWARF-derived declarations populate the
+  SAME functions/types lists [as header-derived ones] but must NOT be
+  mistaken for header-level evidence." Only a genuinely DWARF/symbols-only
+  dump (`from_headers` is `False`, where `dwarf_snapshot.py`'s own
+  DWARF-only extraction path populates `types`/`enums`/`typedefs`/
+  function-variable signatures directly from DWARF DIEs) may now keep
+  those fields wholesale; a header-derived snapshot always clears them at
+  `binary` depth, same as the no-DWARF-at-all case. A real DWARF-visible
+  struct/enum layout change on a header-derived snapshot is still caught
+  independently, through the untouched `snap.dwarf.structs`/`.enums`
+  fields via `diff_platform._diff_dwarf` (which this module never clears,
+  and degrades gracefully with no header model at all — "If the header
+  model is absent... fall back to comparing all DWARF types", that
+  function's own comment) — function/variable signature changes have no
+  equivalent independent DWARF-native detector, a real, separately-
+  justified gap (it would need a new per-declaration confirmation fact the
+  dumper does not currently record), not attempted here. (2) a function/
+  variable promoted from a header parser's own "declared public, without
+  contrary evidence" fallback (e.g. `dumper_castxml._variable_visibility`'s
+  un-emitted customization-point-object case) was promoted to `ELF_ONLY`
+  the same as a genuinely exported one, manufacturing a false
+  `*_removed`/`*_removed_elf_only` finding for a declaration no real
+  binary-only dump would ever have seen as a symbol at all. Fixed with a
+  new `_exported_symbol_names` (a small, local copy of the same "raw
+  export table" read this codebase's `crosscheck_base.py`/
+  `snapshot_exports.py`/`post_manifest.py`/`diff_unnamed_types.py` each
+  already keep their own independent copy of, since a `policy`-layer
+  caller may import `model`/`compare` but not `extract`, ADR-061, where
+  most of those live): a surviving function/variable must now also appear
+  in the snapshot's own raw ELF/PE/Mach-O export table before promotion to
+  `ELF_ONLY`; skipped (falls back to the prior, looser behavior) when no
+  platform table was parsed at all, so a synthetic/incomplete snapshot
+  isn't stripped to nothing. (3) nulling a `BuildSourcePack`'s
+  `source_abi`/`source_graph` between `build` and `source` left their own
+  `LayerCoverage` rows in `pack.manifest.coverage` still claiming
+  `PRESENT`/`PARTIAL` — `evidence_report.optional_coverage()` returns
+  those rows directly, so a report could still claim source-ABI/
+  source-graph evidence backed a comparison the depth ceiling actually
+  excluded it from. Fixed with `_mark_layers_not_collected`, demoting the
+  L4/L5 coverage rows to `NOT_COLLECTED` in the same place the payload
+  fields themselves are cleared.
 
 ### The composite Action can't recover a compatibility verdict from an HTML primary report when its own JSON sidecar is suppressed
 

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -6202,23 +6202,40 @@ looked like the obvious fix and wasn't.
   already-trusted reference implementation of this idea:
   `scripts/check_tier_accuracy.py`'s `project()`, which the per-tier
   accuracy gate runs against a real (if synthetic) labelled corpus.
-  `classify_compare_pair` (`service_compare_pipeline.py`) applies it to a
-  local `old`/`new` view, gated on `request.depth is not None` — the same
-  "no explicit depth, no effect" contract `enforce_requested_depth` already
-  has — right after that function confirms the floor; `pair.old`/`pair.new`
-  themselves are never mutated, so a caller reading the unprojected
-  snapshot elsewhere is unaffected. `dump` deliberately does **not** apply
-  this at write time, for the exact reason given above (it would discard
-  evidence a later, deeper comparison might want) — `--depth` on `dump`
-  stays floor-only, unchanged. See `project_snapshot_to_depth`'s own
-  docstring for the precise field-by-field scope (deliberately mirrors what
-  the validated reference implementation degrades — visibility/origin
-  scoping, macro/constexpr constants, the Python-API stub surface, the
-  header-AST `SemanticIR`, `build_mode`, the `BuildSourcePack` L3/L4/L5
-  split, `surface_graph` — and just as deliberately leaves untouched what
-  that reference implementation never validated: platform container facts,
-  `kabi`/`sycl`/`python_ext`/`numpy_capi`, `typedefs`, dependency/contract/
-  provenance metadata).
+  `classify_compare_pair` (`service_compare_pipeline.py`) applies it (via
+  `project_pair_to_depth`) to a local `old`/`new` view, gated on
+  `request.depth is not None` — the same "no explicit depth, no effect"
+  contract `enforce_requested_depth` already has — right after that
+  function confirms the floor; `pair.old`/`pair.new` themselves are never
+  mutated, so a caller reading the unprojected snapshot elsewhere is
+  unaffected. `dump` deliberately does **not** apply this at write time,
+  for the exact reason given above (it would discard evidence a later,
+  deeper comparison might want) — `--depth` on `dump` stays floor-only,
+  unchanged. See `project_snapshot_to_depth`'s own docstring for the
+  precise field-by-field scope (visibility/origin scoping, macro/constexpr
+  constants, the Python-API stub surface, the header-AST `SemanticIR`, the
+  header-only `surface_graph`, `build_mode`, the `BuildSourcePack`
+  L3/L4/L5 split; below `headers` with no DWARF backing (`dwarf.has_dwarf`
+  false), `types`/`enums`/`typedefs`/signatures are fully stripped too,
+  not merely re-scoped — matching a real DWARF-less binary-only dump
+  exactly, per `extract/export_symbol_identity.py`'s own production
+  behavior).
+
+  **A second review round (Codex, same PR) found two more real gaps in the
+  first cut of this fix, both now closed:** (1) the projection was wired
+  only into `classify_compare_pair` — the typed-API/release-fan-out
+  chokepoint — while the *native* `abicheck compare` CLI
+  (`cli_compare_helpers.run_compare`) and `scan --against`'s baseline path
+  (`cli_scan_baseline._run_baseline_compare`) each call
+  `compare_snapshots()` directly and never saw it; both now apply
+  `project_pair_to_depth` themselves, right after resolving their own
+  pair, mirroring `classify_compare_pair`'s placement. (2) the `binary`
+  rung's structural-fact handling was fixed at DWARF-informed (L1)
+  behavior unconditionally — a purely header-derived snapshot with no
+  DWARF at all still leaked full `types`/`enums`/function-signature data
+  through a `binary`-depth projection; `_snapshot_has_native_debug_info`
+  now picks L0 (fully stripped) vs. L1 (structural facts kept) per
+  snapshot, not fixed to one or the other.
 
 ### The composite Action can't recover a compatibility verdict from an HTML primary report when its own JSON sidecar is suppressed
 

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -11956,18 +11956,32 @@ doesn't itself trip the `cli-contract` gate — but it's still not through
 `service.run_compare`/`resolve_compare_request`, so it never constructs an
 `AnalysisPlan` either and has no pre-flight check for its own inputs.
 `_resolve_stranded_library()` (the `--bundle-facts-out` path's own
-fallback for a library missing from the normal per-pair comparison) calls
-`cli_resolve._resolve_input()` directly — the same Tier-2 resolution
-`resolve_compare_request` itself calls, but reached independently, bypassing
-the `AnalysisPlan`-producing wrapper around it, with its own bespoke ELF
-fallback (`except Exception: ... AbiSnapshot(...)`) on top. Neither is
-this phase's own Goal to migrate (an `AnalysisPlan` pre-flight check for a
-probe-matrix build-config diff or a deliberately-degrading stranded-library
-fallback is a real, separate design question, not a drive-by widening of
-this phase's Files list) — named here explicitly instead, as a residual
-this phase does **not** close: `cli_compare_release.py`'s release fan-out
-is converged for its main per-pair comparison path only; these two
-narrower branches remain outside the typed `AnalysisPlan` pipeline, a gap
+fallback for a library missing from the normal per-pair comparison) used
+to call `cli_resolve._resolve_input()` directly — the same Tier-2
+resolution `resolve_compare_request` itself calls, but reached
+independently, bypassing the `AnalysisPlan`-producing wrapper around it,
+with its own bespoke ELF fallback (`except Exception: ... AbiSnapshot(...)`)
+on top. Neither was this phase's own Goal to migrate (an `AnalysisPlan`
+pre-flight check for a probe-matrix build-config diff or a
+deliberately-degrading stranded-library fallback is a real, separate
+design question, not a drive-by widening of this phase's Files list) —
+named here explicitly instead, as a residual this phase does **not**
+close.
+
+**`_resolve_stranded_library()` was later migrated (ADR-063 Phase 8
+follow-up, not this phase), narrowing the residual to one branch.** Unlike
+the matrix branch, a stranded library genuinely is one dump-shaped input
+(a path, headers, includes, version, language, an optional depth) once
+looked at correctly, so it now builds a real `DumpRequest` and runs it
+through `resolve_dump_request`/`execute_dump_request` — gaining a real
+`AnalysisPlanner.resolve()` pre-flight check and dropping its hand-rolled
+`depth=binary` header-clearing special-case, while keeping its
+degrade-to-ELF-only-on-failure fallback exactly as before. `_collect_
+matrix_result()` remains unmigrated and is expected to stay that way: it
+has no requested-vs-resolved evidence input for an `AnalysisPlan` to check
+feasibility of at all (two already-empty synthetic snapshots, an
+already-computed `extra_changes` list), so `cli_compare_release.py`'s
+release fan-out is now converged everywhere except that one branch, a gap
 for a future, separately-scoped pass to close rather than a silent
 omission from this plan's own accounting. `bundle.py`'s `compare_bundle()`
 takes already-computed `per_library_results` as an input rather than

--- a/docs/contribute/plans/storage-format-v2.md
+++ b/docs/contribute/plans/storage-format-v2.md
@@ -172,27 +172,364 @@ nothing in the existing pipeline changes behavior.
 ### Phase 1
 
 1. `storage/package.py` — manifest, refs, and the object-store abstraction.
-   **Object model landed** (this change); the directory-backed store
-   implementing `ObjectStore` against real files is still open.
+   **Object model landed**, including multi-artifact/multi-variant shape
+   (`PackageManifest.artifact_refs`/`variant_refs` are already tuples, not
+   singletons — see A1.1's own design note below for what's actually
+   missing).
 2. `storage/import_v1.py` — the v1-v25 adapter (A1.2), including the
-   `*_facts_reliable` flags becoming `FactAvailability` records.
-3. Express a single-library dump as a one-artifact project (A1.3), behind
-   an opt-in writer flag.
-4. Fold baseline sets and `BundleFacts` into sections (A1.4/A1.5),
-   coordinating with G38 Phase 2 so only one persisted bundle shape exists.
-5. Variant capture and CLI wiring (A1.6/A1.7).
+   `*_facts_reliable` flags becoming `FactAvailability` records. **Landed.**
+3. Express a single-library dump as a one-artifact project (A1.3). **Landed**
+   — `project_snapshot_store.py`/`project_snapshot_legacy.py`; see
+   `docs/contribute/adr/063-one-semantic-pipeline.md`'s Phase 8 note for the
+   single-file-by-default CLI wiring this actually shipped as.
+4. **Open, designed below**: the `.tar.zst` transport form (the remainder of
+   A1.1), folding baseline sets and `BundleFacts` into sections plus
+   digest-deduplicated shared evidence (A1.4/A1.5), `bundle_variants:` CLI
+   wiring (A1.6), stored/live release-comparison reachability (A1.7), and
+   non-ELF artifact membership (A1.8).
 
 `AvailabilityLedger.declare` and `.override` rebuild, revalidate, and
 re-sort the whole mapping per call, so building a ledger of *n* overrides
 costs O(n² log n) (CodeRabbit review). That is deliberate for Phase 0,
 where nothing calls them in a loop and the validating, canonically-ordered
 reassignment is what makes the ledger's state impossible to corrupt in
-place. Step 3 above is where it starts to matter — the first producer that
-calls `override` per entity — so the container decision belongs with that
-producer, which knows the insertion pattern, rather than being guessed at
-now. Whatever replaces it must keep both properties the current shape buys:
-every stored key validated, and iteration order a function of content
-rather than of insertion.
+place. A1.5's digest-deduplicated shared-object writer below is where it
+starts to matter — the first producer that calls `override` per entity —
+so the container decision belongs with that producer, which knows the
+insertion pattern, rather than being guessed at now. Whatever replaces it
+must keep both properties the current shape buys: every stored key
+validated, and iteration order a function of content rather than of
+insertion.
+
+---
+
+#### A1.1 remainder — the `.tar.zst` transport form
+
+**Status: not implemented.** Everything else D6 specifies for the directory
+layout is real (`project_snapshot_store.DirectoryObjectStore` plus its
+manifest/ref writer and reader over ADR-059's physical envelope); only the
+single-file transport wrapper is missing, which is why a package today is
+"many small files… awkward to `scp`/commit/upload as a CI artifact" (this
+plan's own Problem statement, finding row derived from #6/#7) whenever it
+*is* used (the directory writer/reader remain real, typed-API primitives
+and a `compare`/`scan --against` input shape even though no `dump` CLI flag
+produces one — see ADR-063 Phase 8's landing note).
+
+**Goal.** A `ProjectSnapshotStore` directory tree round-trips through one
+deterministic archive file, so a multi-artifact package is exactly as easy
+to move around as today's single `.abi.json.zst` — one path to upload as a
+CI artifact, attach to a release, or hand to a teammate.
+
+**Design.** A thin archive/unarchive pair, not a new format: `pack(store_dir,
+out_path)` walks the D6 tree (`manifest.json`, `refs/**`, `objects/sha256/**`)
+in one canonical order — sorted by relative path, the same "iteration order
+a function of content, not insertion" discipline `storage/canonical.py`
+already establishes for in-document collections — and streams each file into
+a `tar` archive, `zstd`-compressed by ADR-059's existing `snapshot_io.py`
+compressor (same codec, same decompression-bomb limits; this is a container
+format change, not a new compression dependency). `unpack(archive_path,
+dest_dir)` is the exact inverse: it must reject a member path that would
+escape `dest_dir` (`../`, an absolute path, a symlink target outside the
+tree) the same way `snapshot_io.py`'s own decompression guard rejects a
+runaway decompressed size — an untrusted `.tar.zst` handed to `compare` is
+adversarial input, not merely malformed. Determinism is checked the same way
+A0.4 checks canonical JSON: two packs of the same logical content (built via
+different traversal orders, e.g. Python `dict` insertion order varying
+between constructing the manifest one way vs. another) must produce
+byte-identical archives — fixed `mtime`/uid/gid/mode on every tar member,
+sorted member order, no embedded timestamps in the outer zstd frame.
+
+**Files.** `abicheck/project_snapshot_transport.py` (new, sibling to
+`project_snapshot_store.py`/`project_snapshot_legacy.py`, for the same
+import-layering reason those live outside `storage/` — this is a CLI/
+filesystem-facing concern, not a leaf primitive): `pack_project_snapshot`/
+`unpack_project_snapshot`. `snapshot_io.py` gains no new public surface;
+this module calls its existing compressor/decompressor functions directly
+over the tar byte stream instead of a single JSON document's bytes.
+
+**Tests.** Round-trip identity (pack then unpack reproduces the exact
+directory tree, file-for-file, byte-for-byte); determinism (two packs of
+logically-identical content, built via different in-memory construction
+order, produce identical archive bytes); the path-traversal/symlink-escape
+adversarial cases, each asserted to raise rather than write outside
+`dest_dir`; a real multi-artifact package (see A1.4/A1.5 below) at a
+realistic size, per this repository's "toolchain/wire format changes need a
+round-trip test at production scale" convention.
+
+**Acceptance criteria.** A directory-backed package produced by
+`project_snapshot_store.py` packs and unpacks losslessly; `compare`/
+`scan --against`'s existing directory-package input path
+(`workflows.input_resolution.resolve_input`) accepts a `.tar.zst` archive
+interchangeably with an already-unpacked directory (unpacked to a temp
+directory internally, the same way a compressed single-file `.abi.json.zst`
+is transparently decompressed today).
+
+---
+
+#### A1.4/A1.5 — folding baseline sets/`BundleFacts` into sections, digest-deduplicated shared evidence
+
+**Status: not implemented.** This is the item this plan's "Relationship to
+G38" section flags as a coordination point: *whichever* of this plan's
+Phase 1 or G38's own Phase 2 lands first decides which document the other
+targets. Written here on the assumption G38 Phase 2 has not landed a second
+persisted bundle shape first — if it has, this section's target is
+`BundleFacts` document fields becoming a section, not a fresh design.
+
+**Goal.** A release directory (today: N per-library `.abi.json[.zst]`
+files, sometimes a `manifest.json`, sometimes a `BundleFacts` document
+embedding all N snapshots again) is representable as one
+`ProjectSnapshot` package: one `PackageManifest` naming N `ArtifactRef`s
+under a shared `VariantRef`, with cross-library evidence
+(`BuildSourcePack`, the project source graph, the instantiation manifest)
+stored **once** and referenced by digest from every artifact that needs it
+— closing finding #6 ("~57-59 MB graph repeated per artifact") directly,
+since today's per-snapshot embedding is exactly what A1.5 replaces.
+
+**Design.** Two distinct facts currently conflated in `BundleFacts`
+(`abicheck/bundle_facts.py`) get two distinct homes:
+
+- **Per-library ABI facts** (`BundleFacts.per_library_snapshots: dict[str,
+  AbiSnapshot]`) become what A1.3 already established: one `ArtifactRef` per
+  library, each with its own D8-sectioned `declarations`/`types`/`layout`/
+  `debug`/... objects. No design gap here — A1.3's per-artifact section
+  split already covers a single library; this item is applying it N times
+  under one manifest instead of once.
+- **Cross-library facts** (`BundleFacts.manifest: InstantiationManifest`,
+  `filesystem_aliases`, `library_filenames`, plus — once a package carries
+  build/source evidence at all — a shared `BuildSourcePack`/source graph)
+  become **project-level objects**: content-addressed, stored once under
+  `objects/sha256/...`, and referenced by every `ArtifactRef` that shares
+  them via one more `ObjectRef`-shaped field on `PackageManifest` itself
+  (not per-artifact `sections`, which is where A1.3's *per-artifact* D8
+  sections already live) — `PackageManifest.project_sections:
+  Mapping[str, ObjectRef]`, keyed the same way `ArtifactRef.sections` is
+  (`"instantiation_manifest"`, `"build_source_pack"`, `"source_graph"`,
+  `"filesystem_aliases"`). A library whose evidence happens to be
+  byte-identical to another's (the common case for a shared
+  `BuildSourcePack` across variants of the same project) collapses to one
+  stored object automatically, since `ObjectStore` addressing is by digest,
+  not by declared kind — no separate dedup pass is needed beyond writing
+  through the store's existing `put`/digest-return contract.
+
+  `filesystem_aliases`/`library_filenames` are per-artifact facts, not
+  cross-library ones, despite living on `BundleFacts` today (the dict key
+  is a library name) — those move onto `ArtifactRef.native_identity`
+  instead (already the designated `str -> str` fact map for
+  per-artifact content/build identity), not `project_sections`.
+
+  The instantiation manifest (`InstantiationManifest`, from
+  `bundle_manifest.py`) is genuinely project-level (it promises entries
+  across the whole bundle, not one library), so it is the first real
+  `project_sections` entry and the one this item's acceptance test targets.
+
+**A schema note this item must get right the first time, not retrofit
+later:** `ArtifactRef.sections`/the new `PackageManifest.project_sections`
+are both `Mapping[str, ObjectRef]` today (A1.1/A1.3's existing shape) —
+adding `project_sections` is additive to `PackageManifest` (a new optional
+field with an empty-mapping default, so every already-round-tripped
+one-artifact package stays valid) and needs no `PackageManifest.__post_init__`
+change beyond validating its own `ObjectRef` values the same way
+`ArtifactRef.sections` already does.
+
+**Files.** `abicheck/storage/package.py` (`PackageManifest.project_sections`
+field + validation, `to_dict`/`from_dict`); `abicheck/bundle_facts_store.py`
+(new — the writer that takes a real `BundleFacts` plus N `AbiSnapshot`s and
+produces a multi-artifact `PackageManifest` via the object store, and the
+reader that reconstructs a `BundleFacts`-shaped view from one for every
+existing `compare_bundle_from_facts` caller, so this is additive storage,
+not a `BundleFacts` API break); `abicheck/storage/legacy_sections.py` gains
+no new field allowlist entries (cross-library facts were never
+`AbiSnapshot` fields, so A1.2's per-`AbiSnapshot` split is untouched by this
+item).
+
+**Tests.** A real multi-library `BundleFacts` (oneDAL-shaped, per this
+plan's own Validation corpus) round-trips through
+`bundle_facts_store.py` and back to an equivalent `BundleFacts` at the
+semantic-digest level (mirrors A1.3's existing one-artifact round-trip
+test, generalized to N artifacts). A property test: two libraries sharing
+byte-identical `BuildSourcePack` content store exactly one
+`project_sections["build_source_pack"]` object, not two — the executable
+form of the "~57-59 MB graph repeated per artifact" finding actually
+closing. `compare_bundle_from_facts`'s existing test suite is re-run
+unmodified against the reconstructed-from-package `BundleFacts` view, per
+this item's "additive storage" acceptance bar below.
+
+**Acceptance criteria.** Every existing `compare_bundle_from_facts` test
+passes unmodified against a `BundleFacts` reconstructed from a
+`bundle_facts_store.py`-written package — this item changes *where the
+bytes live*, not `compare_bundle()`'s observable behavior. Peak decoded
+size for an N-library release with shared build/source evidence no longer
+scales with N × (per-library size + shared-evidence size); it scales with
+(sum of per-library sizes) + (shared-evidence size once).
+
+---
+
+#### A1.6 — `bundle_variants:` CLI wiring
+
+**Status: not implemented** (the config schema and pairing algorithm are —
+`bundle_variants_config.py`'s `parse_bundle_variants_config`/
+`pair_variants` are real and tested; nothing yet resolves a `.abicheck.yml`
+`bundle_variants:` block into an actual capture run).
+
+**Goal.** A project's `bundle_variants:` block (variant name →
+`target_triple`/`compiler_family`/`feature_toggles`/`required`) drives a
+real multi-variant capture, and both what was *declared* in config and what
+was *actually captured* end up on the package's own `VariantRef.declared`/
+`.captured` maps (already exactly this two-map shape, per that class's own
+docstring) — so a later comparison can tell a genuine variant-boundary
+change from an ordinary version bump.
+
+**Design.** `BundleVariantSpec`'s four fields map onto `VariantRef.declared`
+verbatim (`{"target_triple": ..., "compiler_family": ..., **feature_toggles}`)
+at config-parse time, before any capture runs — this is the `declared` half,
+knowable from `.abicheck.yml` alone. `.captured` is filled in per real
+capture run from whatever the toolchain/build actually reports (compiler
+version, resolved standard, resolved feature-toggle values where a build
+system can confirm them) — the same "two independent coordinate maps"
+split `VariantRef`'s own docstring already specifies, so this item is
+wiring a real producer for a schema that already exists, not designing a
+new one. A `required: true` variant that fails to capture is a hard error
+for the release-capture command (mirrors `AnalysisPlanner`'s "reject before
+extraction" discipline: knowing a required variant is unreachable belongs
+at plan time, not discovered as a silently-incomplete package after a long
+capture run); `required: false` degrades to a package missing that
+`VariantRef` entirely, not a placeholder with empty `captured`.
+
+**Files.** `abicheck/cli_project.py` (a new subcommand, per this
+repository's root-command admission bar in `AGENTS.md` — this is advanced,
+multi-target CI-integration surface that fits the existing `project` group,
+not a new root command) or an extension of whatever multi-library capture
+entry point A1.7 below settles on, since the two are naturally one CLI
+surface (capture N variants of M libraries into one package) rather than
+two independent flags. `abicheck/bundle_variants_capture.py` (new) —
+resolves a `.abicheck.yml` `bundle_variants:` block plus a real build
+description into one capture run per variant, writing each into the shared
+`bundle_facts_store.py` writer from A1.4/A1.5 above with the right
+`VariantRef`.
+
+**Tests.** A `bundle_variants:` block with two variants (one `required`,
+one not) against a fixture build; the `required` variant's simulated
+capture failure raises before any file is written (no partial package);
+`declared` vs. `captured` disagree on at least one field in the fixture
+(e.g. `.abicheck.yml` under-specifies a compiler version the real build
+reports), asserting both maps are kept, not merged/overwritten.
+
+**Acceptance criteria.** `pair_variants()` (already real) operates
+correctly over `VariantRef`s produced by a real capture run, not only over
+hand-constructed `BundleVariantSpec` fixtures — closing the "modelled but
+not captured" half of finding #7.
+
+---
+
+#### A1.7 — stored/live and stored/stored release comparison from the standard CLI
+
+**Status: not implemented.** `compare`/`scan --against` already accept a
+directory package as an operand (ADR-063 Phase 8's landing note); what's
+missing is a *release-level* command that compares two packages (or a
+package against a live directory of binaries) library-by-library and
+variant-by-variant, the multi-artifact counterpart to
+`cli_compare_release.py`'s existing directory-of-`.so`-files fan-out.
+
+**Goal.** `stored/live`, `live/stored`, and `stored/stored` release
+comparisons are reachable the same way `live/live` already is — not a
+second, parallel command family, per this plan's "Relationship to G38"
+principle of one container format and this repository's admission bar
+against a second vocabulary next to an established one.
+
+**Design.** `cli_compare_release.py`'s existing per-library fan-out
+(`_compare_release_libraries`, and — per this ADR-063 work's own D1
+migration above — `_resolve_stranded_library`) already resolves each
+library through the shared `CompareRequest`/`DumpRequest` pipelines; this
+item's job is giving that fan-out a *package* as one of its two top-level
+operands (today: two directories of loose files) — unpacking a
+`.tar.zst`/directory package into the same `old_map`/`new_map: dict[str,
+Path]` shape the fan-out already builds from a loose directory, keyed by
+`ArtifactRef.artifact_id`, so every downstream step (matching, per-pair
+comparison, bundle analysis, `--bundle-facts-out`) is unchanged code
+operating on resolved paths — a package is a *source* for that map, not a
+new code path through the fan-out. `--old-variant`/`--new-variant` select
+which `VariantRef` to compare when a package carries more than one
+(defaulting to the package's only variant when it carries exactly one, a
+usage error when it carries several and neither flag is given — the same
+"ambiguity is a hard usage error, not a silent first-match" discipline
+`SymbolIdentityIndex`'s `unique_alias_match` already establishes for a
+different kind of ambiguity elsewhere in this codebase).
+
+**Files.** `cli_compare_release.py` (accept a package path — file or
+directory — as either operand, detected via `project_snapshot_legacy.
+is_project_snapshot_package_dir`/a `.tar.zst` magic-byte sniff already
+established for the single-file path per ADR-059); `project_snapshot_
+legacy.py` or the new `bundle_facts_store.py` (A1.4/A1.5) for the
+package → `{artifact_id: resolved snapshot}` resolution a stored-side
+operand needs (a live-side operand keeps resolving through the existing
+binary-directory path unchanged).
+
+**Tests.** All three of `stored/live`, `live/stored`, `stored/stored`
+against a small real fixture package (2-3 libraries), each asserted to
+produce the identical `DiffResult` set a `live/live` run over the
+equivalent loose-file directories would — the "Stored-versus-live parity"
+row this plan's own Validation corpus section already commits to,
+finally exercised by a real test rather than only stated as a corpus
+requirement.
+
+**Acceptance criteria.** Closes finding #7's "no coherent multi-variant
+baseline from a normal workflow" for the comparison half (A1.6 above
+closes the capture half); no new root CLI command (`AGENTS.md`'s admission
+bar) — this is `compare`'s existing release fan-out gaining a new operand
+shape, not a new verb.
+
+---
+
+#### A1.8 — non-ELF artifact membership
+
+**Status: not implemented**, and deliberately the narrowest item here.
+`ArtifactRef.kind` already accepts any string (`"elf"`, `"pe"`, `"macho"`,
+`"python"`, `"header_only"`, ...) per its own docstring — the object model
+was built D6-complete from the start. What's missing is purely on the
+*producer* side: nothing today constructs an `ArtifactRef` for a PE/Mach-O/
+Python-visible/header-only member, because A1.3/A1.4's own capture paths
+have so far only ever fed them an ELF `AbiSnapshot`.
+
+**Goal.** A PE/Mach-O/Python-visible/header-only library is a first-class
+package member — representable, storable, and readable — even though
+bundle-level *resolution* (dependency-graph edges, ABI-affecting-type
+propagation) stays an ELF-only capability, per D6's own explicit split
+between "can this be a member" and "can this be resolved".
+
+**Design.** No new schema: `ArtifactRef(kind="pe", ...)` /
+`kind="header_only"` already round-trips through `to_dict`/`from_dict`
+today (confirmed by reading `ArtifactRef.__post_init__` — `kind` is
+validated as non-empty text, never restricted to a fixed enum). This item
+is therefore almost entirely a **producer + capability-declaration** change,
+not a storage change: `bundle_facts_store.py` (A1.4/A1.5) must accept a
+non-ELF `AbiSnapshot`/equivalent fact object without assuming
+`sections["binary"]` exists (a header-only member legitimately has no
+`"binary"` section at all, per `ArtifactRef.sections`'s own docstring), and
+whatever consumes `PackageManifest.artifact_refs` for bundle-level
+resolution (`bundle._compute_resolution_graph` and siblings) must treat a
+non-ELF `kind` as "a member with no resolution edges" rather than raising —
+the same "declared as an ELF-only capability rather than silently excluded"
+framing D6 already states, made mechanical: a resolution pass that silently
+drops a non-ELF member is the bug this item exists to close, one that
+silently *fails* on it (no diagnostic) or crashes is a regression this
+item must not introduce either.
+
+**Files.** `bundle_facts_store.py` (A1.4/A1.5) — accept any `ArtifactRef.kind`,
+not only `"elf"`; `abicheck/bundle.py`/`abicheck/bundle_soname.py` (wherever
+`_compute_resolution_graph` lives today) — an explicit non-ELF branch that
+records "no resolution edges, capability not applicable" rather than
+inferring absence from a missing ELF-shaped field.
+
+**Tests.** A package with one ELF member and one header-only member;
+bundle-level resolution runs over the ELF member unchanged and reports the
+header-only member's absence from the resolution graph as an explicit,
+named fact (not a silent gap a reader has to infer from the member simply
+not appearing).
+
+**Acceptance criteria.** Closes finding #7's "non-ELF artifacts... silently
+excluded" half specifically — a PE/Mach-O/Python/header-only library
+survives a round trip through the package format and appears in a package
+listing/report, even where no resolution graph can place it.
 
 ### Phase 2
 

--- a/tests/test_cli_compare_release_stranded_depth.py
+++ b/tests/test_cli_compare_release_stranded_depth.py
@@ -27,6 +27,14 @@ header/include set regardless of ``depth``. A ``--depth binary`` run's
 matched pair with a full L2 (header-evidence) snapshot for the stranded
 member, silently reintroducing header/API findings the run explicitly asked
 to exclude for a later stored-baseline comparison against that output.
+
+ADR-063 D1's second named exception migrated ``_resolve_stranded_library``
+off the direct ``cli_resolve._resolve_input()`` call onto the shared
+``DumpRequest -> resolve_dump_request -> execute_dump_request`` pipeline
+(dropping the hand-rolled ``is_binary_depth`` special-case this suite used to
+pin) -- these tests now capture ``resolve_dump_request``'s own
+``DumpRequest.input.headers``/``.includes`` instead of ``_resolve_input``'s
+raw arguments, but assert the identical depth-aware contract.
 """
 
 from __future__ import annotations
@@ -87,21 +95,31 @@ class TestBundleFactsOutStrandedLibraryHonoursDepthBinary:
     def _capture_stranded_resolve_input_args(
         self, monkeypatch: pytest.MonkeyPatch, stranded: Path
     ) -> dict[str, object]:
+        """Capture the *effective* (post depth-resolution) header set.
+
+        ``DumpRequest.input.headers`` itself always carries the caller's raw
+        input unchanged -- clearing at ``depth=binary`` happens one layer
+        further in, in evidence resolution (``ResolvedDumpRequest.headers`` /
+        ``.public_headers``, the same effective fields the real dump/extract
+        step reads) -- so this asserts on those, not the raw request.
+        """
         captured: dict[str, object] = {}
+        from abicheck.service_dump_pipeline import (
+            resolve_dump_request as _real_resolve_dump_request,
+        )
 
-        def _fake_resolve_input(
-            path: Path,
-            headers: list[Path],
-            includes: list[Path],
-            *args: object,
-            **kw: object,
-        ) -> AbiSnapshot:
-            if path == stranded:
-                captured["headers"] = headers
-                captured["includes"] = includes
-            return AbiSnapshot(library=path.name, version="1.0")
+        def _fake_resolve_dump_request(request: object) -> object:
+            resolved = _real_resolve_dump_request(request)  # type: ignore[arg-type]
+            if request.input.path == stranded:  # type: ignore[attr-defined]
+                captured["headers"] = list(resolved.headers)  # type: ignore[attr-defined]
+                captured["includes"] = list(request.input.includes)  # type: ignore[attr-defined]
+                captured["public_headers"] = list(resolved.public_headers)  # type: ignore[attr-defined]
+            return resolved
 
-        monkeypatch.setattr("abicheck.cli_resolve._resolve_input", _fake_resolve_input)
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline.resolve_dump_request",
+            _fake_resolve_dump_request,
+        )
         return captured
 
     def test_depth_binary_clears_headers_for_the_stranded_library(

--- a/tests/test_cli_project_validate_use_cases.py
+++ b/tests/test_cli_project_validate_use_cases.py
@@ -514,6 +514,15 @@ class TestUseCaseImpactOnCompare:
         res = _compare(
             manifest, old, new,
             "--profile", "quick",
+            # Explicit flag overrides the profile's own `depth=binary`
+            # (apply_compare_profile's documented precedence) -- this test's
+            # `--use-cases` needs the fixtures' `build_source.source_graph`
+            # (an L5 fact) to resolve entrypoints, which ADR-063 Phase 8's
+            # `--depth` ceiling (project_snapshot_to_depth) now correctly
+            # clears below `source`, same as a real `--depth binary` run
+            # would. `quick`'s one-line *format* is what this test
+            # exercises, not its depth.
+            "--depth", "source",
             "--write", f"json={secondary}",
         )
         assert res.exit_code == 4, res.output

--- a/tests/test_compare_profiles.py
+++ b/tests/test_compare_profiles.py
@@ -140,10 +140,17 @@ class TestProfileEndToEnd:
             main, ["compare", str(old_p), str(new_p), "--profile", "quick"]
         )
         assert result.exit_code == 0, result.output
-        # --profile quick sets --stat: output is the compact one-line summary
-        # (e.g. "NO_CHANGE: no changes (0 total)"), not the full report.
-        assert "total)" in result.output
-        assert result.output.strip().count("\n") == 0
+        # --profile quick sets --stat: stdout is the compact one-line summary
+        # (e.g. "NO_CHANGE: no changes (0 total)"), not the full report. Checked
+        # on `result.stdout`, not the stderr-mixed `result.output`: `quick`'s
+        # `depth=binary` (ADR-063 Phase 8's ceiling fix) means these synthetic
+        # header-derived fixtures no longer resolve a public-header surface at
+        # that depth either -- the resulting scope-fallback warning is by
+        # design routed to stderr specifically so it never corrupts this
+        # one-line stdout contract (see `frontends/cli/runtime.py`'s own
+        # comment on that `click.echo(..., err=True)` call).
+        assert "total)" in result.stdout
+        assert result.stdout.strip().count("\n") == 0
 
     def test_explicit_format_overrides_profile_e2e(self, tmp_path: Path) -> None:
         old_p, new_p = _write_snapshots(tmp_path)

--- a/tests/test_confidence_evidence.py
+++ b/tests/test_confidence_evidence.py
@@ -657,8 +657,13 @@ class TestNoteIfSameBinaryCompared:
             main, ["compare", str(old_p), str(new_p), "--profile", "quick"]
         )
         assert result.exit_code == 0, result.output
-        assert result.output.strip().count("\n") == 0, result.output
-        assert "Warning:" not in result.output, result.output
+        # stdout, not the stderr-mixed `result.output`: `quick`'s
+        # `depth=binary` (ADR-063 Phase 8's ceiling fix) means this
+        # unscoped-headers fixture no longer resolves a public-header
+        # surface at that depth either, and that scope-fallback warning is
+        # by design routed to stderr so it never corrupts this contract.
+        assert result.stdout.strip().count("\n") == 0, result.output
+        assert "Warning:" not in result.stdout, result.output
 
     def test_native_compare_cli_hashes_through_a_multi_hop_linker_script_chain(
         self, tmp_path, monkeypatch

--- a/tests/test_contract_coverage_exit.py
+++ b/tests/test_contract_coverage_exit.py
@@ -287,8 +287,13 @@ class TestTheGatingConditionIsVisible:
         # Confirms this really went through the one-line renderer (not, say,
         # a format that happens to also lack the ledger) -- the coverage
         # notice is appended after it, so the output leads with the
-        # one-liner's own verdict label (CodeRabbit review).
-        assert result.output.startswith("NO_CHANGE:"), result.output
+        # one-liner's own verdict label (CodeRabbit review). Checked on
+        # `result.stdout`, not the stderr-mixed `result.output`: `quick`'s
+        # `depth=binary` (ADR-063 Phase 8's ceiling fix) means this
+        # unscoped-headers fixture no longer resolves a public-header
+        # surface at that depth either, and that scope-fallback warning is
+        # by design routed to stderr so it never corrupts this contract.
+        assert result.stdout.startswith("NO_CHANGE:"), result.output
         assert "Contract coverage incomplete" in result.output
 
     def test_it_does_not_claim_a_floor_it_did_not_apply(self) -> None:

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -856,7 +856,7 @@ class TestCompareCommand:
         new_f = _write_snap(tmp_path / "new.json", new)
         result = _invoke("compare", str(old_f), str(new_f), "--profile", "quick")
         assert result.exit_code == 4
-        assert "\n" not in result.output.strip()
+        assert "\n" not in result.stdout.strip()  # stderr carries the scope warning
 
     def test_probe_matrix_one_side_usage_error(self, tmp_path: Path) -> None:
         snap = _snap()
@@ -1924,6 +1924,7 @@ class TestUsedByScoping:
         result = _invoke(
             "compare", str(old), str(new), "--used-by", str(app),
             "--profile", "quick",
+            "--depth", "headers",  # else ADR-063's ceiling fix demotes to FUNC_REMOVED_ELF_ONLY
         )
         assert result.exit_code == 4
         assert result.stdout.strip() == "BREAKING: 1 breaking (1 total)"

--- a/tests/test_depth_projection.py
+++ b/tests/test_depth_projection.py
@@ -49,7 +49,30 @@ Six real, review-caught gaps are pinned by name here so they don't recur:
 6. ``types``/``enums`` were kept or dropped by the whole-snapshot
    ``dwarf.has_dwarf`` flag rather than per-record evidence, so an
    uninstantiated header-only record sitting alongside unrelated real DWARF
-   content was incorrectly retained.
+   content was incorrectly retained. **Superseded by gap 7** (see below) --
+   a per-record ``DwarfMetadata.structs``/``.enums`` name check was the
+   fix attempted for this gap, but it was itself one level too narrow.
+7. A header-derived ``RecordType``/``EnumType`` was kept *wholesale*
+   whenever DWARF merely confirmed the same-named struct/enum *existed* --
+   DWARF confirming a struct's name says nothing about whether its
+   *fields* agree with the header's own spelling (DWARF only ever
+   backfills numeric layout onto a header-derived record, never its
+   field-level type text). Only a genuinely DWARF/symbols-only snapshot
+   (``from_headers is False``) may keep these wholesale; on a
+   header-derived snapshot they are now always fully cleared, relying on
+   the separate, untouched ``snap.dwarf`` fields (``diff_platform.
+   _diff_dwarf``) to still catch a real DWARF-visible layout change.
+8. A function/variable promoted from a header parser's own "declared
+   public, without contrary evidence" fallback (e.g. an un-emitted inline
+   constexpr customization-point object) was promoted to ``ELF_ONLY``
+   the same as a genuinely exported one, manufacturing a false
+   ``*_removed``/``*_removed_elf_only`` finding for a declaration no real
+   binary-only dump would ever have seen as a symbol at all.
+9. Nulling a ``BuildSourcePack``'s ``source_abi``/``source_graph`` between
+   ``build`` and ``source`` left their own ``LayerCoverage`` rows in
+   ``pack.manifest.coverage`` still claiming ``PRESENT``/``PARTIAL``, so a
+   report could still claim source-ABI/source-graph evidence backed a
+   comparison the depth ceiling actually excluded it from.
 """
 
 from __future__ import annotations
@@ -60,6 +83,9 @@ import pytest
 from click.testing import CliRunner
 
 from abicheck import checker
+from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+from abicheck.buildsource.pack import BuildSourcePack
+from abicheck.buildsource.source_abi import SourceAbiSurface
 from abicheck.cli import main
 from abicheck.model import (
     AbiSnapshot,
@@ -72,10 +98,14 @@ from abicheck.model import (
     Variable,
     Visibility,
 )
-from abicheck.model.dwarf_facts import DwarfMetadata, EnumInfo, StructLayout
+from abicheck.model.dwarf_facts import DwarfMetadata, FieldInfo, StructLayout
+from abicheck.model.elf_facts import ElfMetadata, ElfSymbol
 from abicheck.model.extraction_contract import ExtractionContract
 from abicheck.model.source_graph import SourceGraphSummary
-from abicheck.policy.depth_projection import project_snapshot_to_depth
+from abicheck.policy.depth_projection import (
+    project_build_source_pack_to_depth,
+    project_snapshot_to_depth,
+)
 from abicheck.serialization import save_snapshot
 
 
@@ -197,15 +227,21 @@ class TestBinaryDepthNoDwarf:
         assert var.visibility is Visibility.ELF_ONLY
 
 
-class TestBinaryDepthWithDwarf:
-    """DWARF-informed structural facts are an L0/L1 fact, kept at ``binary``."""
+class TestStructuralFactsRequireDwarfSourcing:
+    """Pinned gap 7: DWARF confirming a struct/enum by *name* does not
+    corroborate a header-derived RecordType/EnumType's own field-level
+    spelling -- only a genuinely DWARF/symbols-only snapshot
+    (``from_headers is False``) may keep ``types``/``enums``/... wholesale
+    at ``binary`` depth."""
 
-    def test_dwarf_visible_structural_break_still_detected(self) -> None:
-        # `structs={"S": ...}` -- DWARF specifically observed *this* record by
-        # name (`_dwarf_confirmed_names`'s real per-record evidence), not
-        # merely `has_dwarf=True` on the whole snapshot; a struct that isn't
-        # in this dict is a header-only fact even when its snapshot carries
-        # unrelated real DWARF content elsewhere (Codex review, third round).
+    def test_header_derived_field_diff_is_suppressed_even_with_dwarf(self) -> None:
+        # DWARF confirms a struct named "S" exists (`structs={"S": ...}`),
+        # but its own StructLayout carries no fields at all -- the field
+        # type difference below exists only in the header-parsed
+        # RecordType, so it must not survive a from_headers=True
+        # binary-depth projection (the review-caught bug: retaining a
+        # RecordType wholesale merely because DWARF confirmed the struct's
+        # *name*, not its field-level content).
         dwarf_meta = DwarfMetadata(
             has_dwarf=True,
             structs={"S": StructLayout(name="S", byte_size=8, fields=[])},
@@ -243,17 +279,113 @@ class TestBinaryDepthWithDwarf:
         old_b = project_snapshot_to_depth(old, "binary")
         new_b = project_snapshot_to_depth(new, "binary")
         result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.NO_CHANGE
+        assert result.changes == []
+
+    def test_genuine_dwarf_struct_break_is_still_caught_via_snap_dwarf(self) -> None:
+        # The identical field-type break, but expressed as a real
+        # difference between each side's own DWARF StructLayout (not
+        # merely the header-parsed RecordType) -- caught by the separate,
+        # DWARF-native `diff_platform._diff_dwarf` detector, which reads
+        # `snap.dwarf` directly and is never touched by this module.
+        old_layout = StructLayout(
+            name="S",
+            byte_size=8,
+            fields=[FieldInfo(name="x", type_name="int", byte_offset=0, byte_size=4)],
+        )
+        new_layout = StructLayout(
+            name="S",
+            byte_size=8,
+            fields=[
+                FieldInfo(name="x", type_name="double", byte_offset=0, byte_size=8)
+            ],
+        )
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="int")],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            from_headers=True,
+            dwarf=DwarfMetadata(has_dwarf=True, structs={"S": old_layout}),
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="int")],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            from_headers=True,
+            dwarf=DwarfMetadata(has_dwarf=True, structs={"S": new_layout}),
+        )
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict != checker.Verdict.NO_CHANGE
+        assert {c.kind.value for c in result.changes} == {"struct_field_type_changed"}
+
+    def test_dwarf_only_snapshot_keeps_types_wholesale(self) -> None:
+        # from_headers=False -- a genuinely DWARF/symbols-only dump, where
+        # `types` itself was populated FROM DWARF directly
+        # (dwarf_snapshot.py), so no header-vs-DWARF ambiguity exists.
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="int")],
+                    origin=ScopeOrigin.UNKNOWN,
+                )
+            ],
+            from_headers=False,
+            dwarf=DwarfMetadata(has_dwarf=True),
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="double")],
+                    origin=ScopeOrigin.UNKNOWN,
+                )
+            ],
+            from_headers=False,
+            dwarf=DwarfMetadata(has_dwarf=True),
+        )
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
         assert result.verdict == checker.Verdict.BREAKING
         assert {c.kind.value for c in result.changes} == {"type_field_type_changed"}
 
-    def test_header_only_fact_still_cleared(self) -> None:
+    def test_header_only_constant_still_cleared_with_dwarf_present(self) -> None:
         old, new = _headers_only_pair(dwarf=True)
         old_b = project_snapshot_to_depth(old, "binary")
         new_b = project_snapshot_to_depth(new, "binary")
         result = checker.compare(old_b, new_b)
-        # The pair differs only in `constants` (a header-only fact) -- with
-        # DWARF present, structural facts survive but the constant value
-        # must still be cleared, exactly the same as the no-DWARF case.
+        # The pair differs only in `constants` (a header-only fact, always
+        # cleared) -- `types`/`enums`/`typedefs` are identical between
+        # old/new here, so this doesn't exercise the from_headers gate
+        # above; it only pins that a from_headers=True snapshot's constants
+        # are still cleared with DWARF present.
         assert result.verdict == checker.Verdict.NO_CHANGE
 
 
@@ -425,92 +557,124 @@ class TestHiddenVisibilityDropped:
         assert result.changes == []
 
 
-class TestPerRecordDwarfConfirmation:
-    """Pinned gap 6: DWARF confirmation is per-record, not whole-snapshot."""
+class TestExportTableGatesVisibilityPromotion:
+    """Pinned gap 8: a header-declared-``PUBLIC``-without-evidence
+    declaration must not be promoted to ``ELF_ONLY`` unless the platform's
+    own export table actually confirms it."""
 
-    def _snap(self, *, field_type: str, member_value: int) -> AbiSnapshot:
-        # `dwarf.has_dwarf=True` alone (the old, coarser gate) would keep both
-        # `Confirmed` and `Unconfirmed` below; only `Confirmed`/`ConfirmedE`
-        # are in `structs`/`enums`, so only they should survive.
-        dwarf_meta = DwarfMetadata(
-            has_dwarf=True,
-            structs={
-                "Confirmed": StructLayout(name="Confirmed", byte_size=8, fields=[])
-            },
-            enums={
-                "ConfirmedE": EnumInfo(
-                    name="ConfirmedE", underlying_byte_size=4, members={}
+    def _snap(self, version: str, *, include_unconfirmed: bool) -> AbiSnapshot:
+        variables = [
+            Variable(
+                name="pub_v",
+                mangled="pub_v",
+                type="int",
+                visibility=Visibility.PUBLIC,
+                origin=ScopeOrigin.PUBLIC_HEADER,
+            )
+        ]
+        if include_unconfirmed:
+            # A header parser's own "declared public, without contrary
+            # evidence" fallback (dumper_castxml._variable_visibility's
+            # un-emitted-CPO case) -- PUBLIC, but the compiler never
+            # actually emitted a symbol for it, so it's absent below.
+            variables.append(
+                Variable(
+                    name="cpo",
+                    mangled="cpo",
+                    type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
                 )
-            },
-        )
+            )
+        elf = ElfMetadata(symbols=[ElfSymbol(name="pub_v", is_default=True)])
         return AbiSnapshot(
             library="lib",
-            version="1",
+            version=version,
             from_headers=True,
-            dwarf=dwarf_meta,
-            types=[
-                RecordType(
-                    name="Confirmed",
-                    kind="struct",
-                    size_bits=64,
-                    fields=[TypeField(name="x", type=field_type)],
-                    origin=ScopeOrigin.PUBLIC_HEADER,
-                ),
-                RecordType(
-                    name="Unconfirmed",
-                    kind="struct",
-                    size_bits=64,
-                    fields=[TypeField(name="x", type=field_type)],
-                    origin=ScopeOrigin.PUBLIC_HEADER,
-                ),
-            ],
-            enums=[
-                EnumType(
-                    name="ConfirmedE",
-                    members=[EnumMember(name="A", value=member_value)],
-                    origin=ScopeOrigin.PUBLIC_HEADER,
-                ),
-                EnumType(
-                    name="UnconfirmedE",
-                    members=[EnumMember(name="A", value=member_value)],
-                    origin=ScopeOrigin.PUBLIC_HEADER,
-                ),
-            ],
+            variables=variables,
+            elf=elf,
         )
 
-    def test_only_dwarf_confirmed_records_survive(self) -> None:
+    def test_unconfirmed_declaration_is_dropped(self) -> None:
         projected = project_snapshot_to_depth(
-            self._snap(field_type="int", member_value=0), "binary"
+            self._snap("1", include_unconfirmed=True), "binary"
         )
-        assert [t.name for t in projected.types] == ["Confirmed"]
-        assert [e.name for e in projected.enums] == ["ConfirmedE"]
+        assert [v.name for v in projected.variables] == ["pub_v"]
 
-    def test_unconfirmed_record_break_is_not_reported(self) -> None:
-        old = self._snap(field_type="int", member_value=0)
-        new = self._snap(field_type="double", member_value=1)
-        # Only the *unconfirmed* declarations differ between old/new.
-        old.types = [t for t in old.types if t.name == "Unconfirmed"]
-        new.types = [t for t in new.types if t.name == "Unconfirmed"]
-        old.enums = [e for e in old.enums if e.name == "UnconfirmedE"]
-        new.enums = [e for e in new.enums if e.name == "UnconfirmedE"]
+    def test_confirmed_declaration_still_promoted(self) -> None:
+        projected = project_snapshot_to_depth(
+            self._snap("1", include_unconfirmed=True), "binary"
+        )
+        assert projected.variables[0].visibility is Visibility.ELF_ONLY
+
+    def test_removing_an_unconfirmed_declaration_is_not_reported(self) -> None:
+        old = self._snap("1", include_unconfirmed=True)
+        new = self._snap("2", include_unconfirmed=False)
         old_b = project_snapshot_to_depth(old, "binary")
         new_b = project_snapshot_to_depth(new, "binary")
         result = checker.compare(old_b, new_b)
         assert result.verdict == checker.Verdict.NO_CHANGE
+        assert result.changes == []
 
-    def test_confirmed_record_break_is_still_reported(self) -> None:
-        old = self._snap(field_type="int", member_value=0)
-        new = self._snap(field_type="double", member_value=0)
-        # Only the *confirmed* struct's field type differs.
-        old.types = [t for t in old.types if t.name == "Confirmed"]
-        new.types = [t for t in new.types if t.name == "Confirmed"]
-        old.enums = []
-        new.enums = []
-        old_b = project_snapshot_to_depth(old, "binary")
-        new_b = project_snapshot_to_depth(new, "binary")
-        result = checker.compare(old_b, new_b)
-        assert result.verdict == checker.Verdict.BREAKING
-        assert {c.kind.value for c in result.changes} == {"type_field_type_changed"}
+    def test_no_platform_table_falls_back_to_looser_behavior(self) -> None:
+        # A synthetic/incomplete snapshot with no elf/pe/macho block at all
+        # keeps the pre-existing (looser) behavior rather than being
+        # stripped to nothing -- `_exported_symbol_names` returns `None`,
+        # not an empty set, precisely to make this distinction.
+        snap = AbiSnapshot(
+            library="lib",
+            version="1",
+            from_headers=True,
+            variables=[
+                Variable(
+                    name="cpo",
+                    mangled="cpo",
+                    type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+        )
+        projected = project_snapshot_to_depth(snap, "binary")
+        assert [v.name for v in projected.variables] == ["cpo"]
+        assert projected.variables[0].visibility is Visibility.ELF_ONLY
+
+
+class TestBuildSourcePackCoverageProjection:
+    """Pinned gap 9: a projected-away L4/L5 payload's own coverage row must
+    not still claim ``PRESENT``/``PARTIAL``."""
+
+    def _pack(self) -> BuildSourcePack:
+        pack = BuildSourcePack(root=Path("/tmp/pack"))
+        pack.source_abi = SourceAbiSurface()
+        pack.source_graph = SourceGraphSummary()
+        pack.manifest.coverage = [
+            LayerCoverage(
+                layer=DataLayer.L3_BUILD.value, status=CoverageStatus.PRESENT
+            ),
+            LayerCoverage(
+                layer=DataLayer.L4_SOURCE_ABI.value, status=CoverageStatus.PRESENT
+            ),
+            LayerCoverage(
+                layer=DataLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.PRESENT
+            ),
+        ]
+        return pack
+
+    def test_l4_l5_coverage_demoted_at_build_depth(self) -> None:
+        capped = project_build_source_pack_to_depth(self._pack(), "build")
+        assert capped is not None
+        rows = {row.layer: row.status for row in capped.manifest.coverage}
+        assert rows[DataLayer.L3_BUILD.value] == CoverageStatus.PRESENT
+        assert rows[DataLayer.L4_SOURCE_ABI.value] == CoverageStatus.NOT_COLLECTED
+        assert rows[DataLayer.L5_SOURCE_GRAPH.value] == CoverageStatus.NOT_COLLECTED
+
+    def test_coverage_untouched_at_source_depth(self) -> None:
+        capped = project_build_source_pack_to_depth(self._pack(), "source")
+        assert capped is not None
+        rows = {row.layer: row.status for row in capped.manifest.coverage}
+        assert rows[DataLayer.L4_SOURCE_ABI.value] == CoverageStatus.PRESENT
+        assert rows[DataLayer.L5_SOURCE_GRAPH.value] == CoverageStatus.PRESENT
 
 
 class TestOutOfBandPackCapping:

--- a/tests/test_depth_projection.py
+++ b/tests/test_depth_projection.py
@@ -22,7 +22,7 @@ and any requested depth rung, a classification's answer depends only on
 evidence at or below that rung -- never on evidence embedded in the
 resolved snapshot above it.
 
-Two real, review-caught gaps are pinned by name here so they don't recur:
+Six real, review-caught gaps are pinned by name here so they don't recur:
 
 1. The projection was only ever wired into the typed-API/release-fan-out
    chokepoint (``classify_compare_pair``); the native ``abicheck compare``
@@ -34,6 +34,22 @@ Two real, review-caught gaps are pinned by name here so they don't recur:
    carries DWARF. A purely header-derived snapshot with no DWARF at all
    still leaked full structural evidence through a ``binary``-depth
    projection.
+3. An explicit out-of-band ``--old/new-sources``/``--old/new-build-info``
+   pack directory is resolved separately from the snapshot object
+   ``project_pair_to_depth`` projects, so it bypassed the ceiling entirely
+   even after gap 1 was fixed.
+4. ``snap.contract`` (an ADR-050 ``ExtractionContract``) survived a
+   ``binary``-depth projection, so ``checker.compare()`` could still raise
+   a scope/profile mismatch error from two sides' original header scopes
+   even though a binary-only comparison never looks at either.
+5. A ``Visibility.HIDDEN`` (non-exported) function/variable was promoted to
+   ``ELF_ONLY`` instead of dropped, manufacturing a false
+   ``*_removed_elf_only`` finding for a declaration no real binary-only
+   dump would ever have seen as a symbol.
+6. ``types``/``enums`` were kept or dropped by the whole-snapshot
+   ``dwarf.has_dwarf`` flag rather than per-record evidence, so an
+   uninstantiated header-only record sitting alongside unrelated real DWARF
+   content was incorrectly retained.
 """
 
 from __future__ import annotations
@@ -56,7 +72,8 @@ from abicheck.model import (
     Variable,
     Visibility,
 )
-from abicheck.model.dwarf_facts import DwarfMetadata
+from abicheck.model.dwarf_facts import DwarfMetadata, EnumInfo, StructLayout
+from abicheck.model.extraction_contract import ExtractionContract
 from abicheck.model.source_graph import SourceGraphSummary
 from abicheck.policy.depth_projection import project_snapshot_to_depth
 from abicheck.serialization import save_snapshot
@@ -184,7 +201,15 @@ class TestBinaryDepthWithDwarf:
     """DWARF-informed structural facts are an L0/L1 fact, kept at ``binary``."""
 
     def test_dwarf_visible_structural_break_still_detected(self) -> None:
-        dwarf_meta = DwarfMetadata(has_dwarf=True)
+        # `structs={"S": ...}` -- DWARF specifically observed *this* record by
+        # name (`_dwarf_confirmed_names`'s real per-record evidence), not
+        # merely `has_dwarf=True` on the whole snapshot; a struct that isn't
+        # in this dict is a header-only fact even when its snapshot carries
+        # unrelated real DWARF content elsewhere (Codex review, third round).
+        dwarf_meta = DwarfMetadata(
+            has_dwarf=True,
+            structs={"S": StructLayout(name="S", byte_size=8, fields=[])},
+        )
         old = AbiSnapshot(
             library="lib",
             version="1",
@@ -309,3 +334,296 @@ class TestNativeCliComparePath:
         old_path, new_path = self._write_pair(tmp_path)
         code, _ = _invoke("compare", str(old_path), str(new_path))
         assert code == 2
+
+
+class TestExtractionContractCleared:
+    """Pinned gap 4: a stale ``contract`` must not survive a projection."""
+
+    def test_contract_cleared_below_headers(self) -> None:
+        snap = AbiSnapshot(
+            library="lib",
+            version="1",
+            from_headers=True,
+            contract=ExtractionContract(profile_fingerprint="p", scope_fingerprint="s"),
+        )
+        projected = project_snapshot_to_depth(snap, "binary")
+        assert projected.contract is None
+
+    @pytest.mark.parametrize("depth", ["headers", "build", "source"])
+    def test_contract_kept_at_or_above_headers(self, depth: str) -> None:
+        snap = AbiSnapshot(
+            library="lib",
+            version="1",
+            from_headers=True,
+            contract=ExtractionContract(profile_fingerprint="p", scope_fingerprint="s"),
+        )
+        projected = project_snapshot_to_depth(snap, depth)
+        assert projected.contract is not None
+
+
+class TestHiddenVisibilityDropped:
+    """Pinned gap 5: HIDDEN is dropped, never promoted to ELF_ONLY."""
+
+    def _snap(self) -> AbiSnapshot:
+        return AbiSnapshot(
+            library="lib",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="pub",
+                    mangled="_Z3pubv",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+                Function(
+                    name="hid",
+                    mangled="_Z3hidv",
+                    return_type="int",
+                    visibility=Visibility.HIDDEN,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+            ],
+            variables=[
+                Variable(
+                    name="pub_v",
+                    mangled="pub_v",
+                    type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+                Variable(
+                    name="hid_v",
+                    mangled="hid_v",
+                    type="int",
+                    visibility=Visibility.HIDDEN,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+            ],
+        )
+
+    def test_hidden_function_and_variable_dropped(self) -> None:
+        projected = project_snapshot_to_depth(self._snap(), "binary")
+        assert [f.name for f in projected.functions] == ["pub"]
+        assert [v.name for v in projected.variables] == ["pub_v"]
+
+    def test_surviving_public_declarations_still_demoted_to_elf_only(self) -> None:
+        projected = project_snapshot_to_depth(self._snap(), "binary")
+        assert projected.functions[0].visibility is Visibility.ELF_ONLY
+        assert projected.variables[0].visibility is Visibility.ELF_ONLY
+
+    def test_no_false_removal_finding_from_a_hidden_declaration(self) -> None:
+        old = self._snap()
+        new = self._snap()
+        new.functions = [f for f in new.functions if f.name != "hid"]
+        new.variables = [v for v in new.variables if v.name != "hid_v"]
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.NO_CHANGE
+        assert result.changes == []
+
+
+class TestPerRecordDwarfConfirmation:
+    """Pinned gap 6: DWARF confirmation is per-record, not whole-snapshot."""
+
+    def _snap(self, *, field_type: str, member_value: int) -> AbiSnapshot:
+        # `dwarf.has_dwarf=True` alone (the old, coarser gate) would keep both
+        # `Confirmed` and `Unconfirmed` below; only `Confirmed`/`ConfirmedE`
+        # are in `structs`/`enums`, so only they should survive.
+        dwarf_meta = DwarfMetadata(
+            has_dwarf=True,
+            structs={
+                "Confirmed": StructLayout(name="Confirmed", byte_size=8, fields=[])
+            },
+            enums={
+                "ConfirmedE": EnumInfo(
+                    name="ConfirmedE", underlying_byte_size=4, members={}
+                )
+            },
+        )
+        return AbiSnapshot(
+            library="lib",
+            version="1",
+            from_headers=True,
+            dwarf=dwarf_meta,
+            types=[
+                RecordType(
+                    name="Confirmed",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type=field_type)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+                RecordType(
+                    name="Unconfirmed",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type=field_type)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+            ],
+            enums=[
+                EnumType(
+                    name="ConfirmedE",
+                    members=[EnumMember(name="A", value=member_value)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+                EnumType(
+                    name="UnconfirmedE",
+                    members=[EnumMember(name="A", value=member_value)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                ),
+            ],
+        )
+
+    def test_only_dwarf_confirmed_records_survive(self) -> None:
+        projected = project_snapshot_to_depth(
+            self._snap(field_type="int", member_value=0), "binary"
+        )
+        assert [t.name for t in projected.types] == ["Confirmed"]
+        assert [e.name for e in projected.enums] == ["ConfirmedE"]
+
+    def test_unconfirmed_record_break_is_not_reported(self) -> None:
+        old = self._snap(field_type="int", member_value=0)
+        new = self._snap(field_type="double", member_value=1)
+        # Only the *unconfirmed* declarations differ between old/new.
+        old.types = [t for t in old.types if t.name == "Unconfirmed"]
+        new.types = [t for t in new.types if t.name == "Unconfirmed"]
+        old.enums = [e for e in old.enums if e.name == "UnconfirmedE"]
+        new.enums = [e for e in new.enums if e.name == "UnconfirmedE"]
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.NO_CHANGE
+
+    def test_confirmed_record_break_is_still_reported(self) -> None:
+        old = self._snap(field_type="int", member_value=0)
+        new = self._snap(field_type="double", member_value=0)
+        # Only the *confirmed* struct's field type differs.
+        old.types = [t for t in old.types if t.name == "Confirmed"]
+        new.types = [t for t in new.types if t.name == "Confirmed"]
+        old.enums = []
+        new.enums = []
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.BREAKING
+        assert {c.kind.value for c in result.changes} == {"type_field_type_changed"}
+
+
+class TestOutOfBandPackCapping:
+    """Pinned gap 3: an explicit --sources/--build-info pack must be capped too."""
+
+    def _write_pack(self, root: Path, *, macro_value: str) -> None:
+        from abicheck.buildsource import pack_io
+        from abicheck.buildsource.build_evidence import (
+            BuildEvidence,
+            BuildOption,
+            CompileUnit,
+        )
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
+
+        cu = CompileUnit(
+            id="cu1",
+            source="a.c",
+            output="a.o",
+            directory=".",
+            target_id="t",
+            compiler="gcc",
+            argv=["gcc"],
+        )
+        be = BuildEvidence(
+            compile_units=[cu],
+            build_options=[
+                BuildOption(
+                    key="cxx_flag:fno-rtti",
+                    value="on",
+                    abi_relevant=True,
+                    scope="global",
+                    raw="-fno-rtti",
+                )
+            ],
+        )
+        macro = SourceEntity(
+            id="macro:FOO",
+            kind="macro",
+            qualified_name="FOO",
+            mangled_name="",
+            signature_hash="",
+            body_hash="",
+            type_hash="",
+            value=macro_value,
+            api_relevant=True,
+            visibility="public",
+        )
+        surface = SourceAbiSurface(reachable_macros=[macro])
+        pack_io.write(BuildSourcePack(root=root, build_evidence=be, source_abi=surface))
+
+    def _write_pair(self, tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+        old = AbiSnapshot(library="lib", version="1", from_headers=False)
+        new = AbiSnapshot(library="lib", version="2", from_headers=False)
+        old_path = tmp_path / "old.json"
+        new_path = tmp_path / "new.json"
+        save_snapshot(old, old_path)
+        save_snapshot(new, new_path)
+        old_pack = tmp_path / "old_pack"
+        new_pack = tmp_path / "new_pack"
+        self._write_pack(old_pack, macro_value="1")
+        self._write_pack(new_pack, macro_value="2")
+        return old_path, new_path, old_pack, new_pack
+
+    def _invoke_with_pack(
+        self,
+        old_path: Path,
+        new_path: Path,
+        old_pack: Path,
+        new_pack: Path,
+        depth: str | None,
+    ) -> tuple[int, str]:
+        args = [
+            "compare",
+            str(old_path),
+            str(new_path),
+            "--sources",
+            f"old={old_pack}",
+            "--sources",
+            f"new={new_pack}",
+        ]
+        if depth is not None:
+            args += ["--depth", depth]
+        result = CliRunner().invoke(main, args)
+        return result.exit_code, result.stdout
+
+    def test_binary_depth_sees_neither_l3_nor_l4_pack_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        old_path, new_path, old_pack, new_pack = self._write_pair(tmp_path)
+        code, out = self._invoke_with_pack(
+            old_path, new_path, old_pack, new_pack, "binary"
+        )
+        assert code == 0
+        assert "fno-rtti" not in out.lower()
+        assert "foo" not in out.lower()
+
+    def test_build_depth_sees_l3_but_not_l4_pack_evidence(self, tmp_path: Path) -> None:
+        old_path, new_path, old_pack, new_pack = self._write_pair(tmp_path)
+        code, out = self._invoke_with_pack(
+            old_path, new_path, old_pack, new_pack, "build"
+        )
+        # An L3 build-flag drift finding is RISK-category, never BREAKING/
+        # API_BREAK on its own (ADR-028 D3), so this stays exit 0 -- the
+        # assertion that matters here is that the L4 macro finding (which
+        # *would* exit non-zero) is absent.
+        assert code == 0
+        assert "public_macro_value_changed" not in out.lower()
+
+    def test_source_depth_sees_the_l4_pack_evidence(self, tmp_path: Path) -> None:
+        old_path, new_path, old_pack, new_pack = self._write_pair(tmp_path)
+        code, out = self._invoke_with_pack(
+            old_path, new_path, old_pack, new_pack, "source"
+        )
+        assert code != 0
+        assert "public_macro_value_changed" in out.lower()

--- a/tests/test_depth_projection.py
+++ b/tests/test_depth_projection.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 8's ``--depth`` floor-vs-ceiling gap (Codex review, PR #1020).
+
+``project_snapshot_to_depth`` caps an already-resolved snapshot's evidence
+to what an explicit ``--depth`` requested. The general invariant this suite
+states as a property, not only pinned example inputs: for any snapshot pair
+and any requested depth rung, a classification's answer depends only on
+evidence at or below that rung -- never on evidence embedded in the
+resolved snapshot above it.
+
+Two real, review-caught gaps are pinned by name here so they don't recur:
+
+1. The projection was only ever wired into the typed-API/release-fan-out
+   chokepoint (``classify_compare_pair``); the native ``abicheck compare``
+   CLI (``cli_compare_helpers.run_compare``) calls ``compare_snapshots()``
+   directly and never saw it at all.
+2. The ``binary`` rung unconditionally kept structural facts (types, enums,
+   typedefs, function/variable signatures), on the theory those are an
+   L0/L1 (DWARF-visible) fact -- true only when the snapshot actually
+   carries DWARF. A purely header-derived snapshot with no DWARF at all
+   still leaked full structural evidence through a ``binary``-depth
+   projection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck import checker
+from abicheck.cli import main
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    RecordType,
+    ScopeOrigin,
+    TypeField,
+    Variable,
+    Visibility,
+)
+from abicheck.model.dwarf_facts import DwarfMetadata
+from abicheck.model.source_graph import SourceGraphSummary
+from abicheck.policy.depth_projection import project_snapshot_to_depth
+from abicheck.serialization import save_snapshot
+
+
+def _headers_only_pair(*, dwarf: bool) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Two snapshots differing across every header-level fact family.
+
+    *dwarf* controls whether both sides carry real DWARF debug info --
+    the axis the second pinned gap above depends on.
+    """
+    dwarf_meta = DwarfMetadata(has_dwarf=True) if dwarf else None
+
+    def _snap(version: str, *, field_type: str, const_value: str) -> AbiSnapshot:
+        return AbiSnapshot(
+            library="lib",
+            version=version,
+            functions=[
+                Function(
+                    name="f",
+                    mangled="_Z1fv",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            variables=[
+                Variable(
+                    name="g",
+                    mangled="g",
+                    type="int",
+                    visibility=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type=field_type)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            enums=[
+                EnumType(
+                    name="E",
+                    members=[EnumMember(name="A", value=0)],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            typedefs={"my_int": "int"},
+            constants={"FOO": const_value},
+            from_headers=True,
+            dwarf=dwarf_meta,
+        )
+
+    old = _snap("1", field_type="int", const_value="1")
+    new = _snap("2", field_type="int", const_value="2")
+    return old, new
+
+
+class TestProjectSnapshotToDepthNoOps:
+    def test_none_depth_returns_the_same_object(self) -> None:
+        snap = AbiSnapshot(library="lib", version="1")
+        assert project_snapshot_to_depth(snap, None) is snap
+
+    def test_unrecognized_depth_returns_the_same_object(self) -> None:
+        snap = AbiSnapshot(library="lib", version="1")
+        assert project_snapshot_to_depth(snap, "not-a-real-depth") is snap
+
+    def test_never_mutates_its_argument(self) -> None:
+        snap = AbiSnapshot(
+            library="lib", version="1", constants={"FOO": "1"}, from_headers=True
+        )
+        project_snapshot_to_depth(snap, "binary")
+        assert snap.constants == {"FOO": "1"}
+        assert snap.from_headers is True
+
+
+class TestBinaryDepthNoDwarf:
+    """Pinned gap 2: no DWARF means every structural fact came from headers."""
+
+    def test_no_header_derived_finding_survives(self) -> None:
+        old, new = _headers_only_pair(dwarf=False)
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.NO_CHANGE
+        assert result.changes == []
+
+    @pytest.mark.parametrize(
+        "attr,expected",
+        [
+            ("types", []),
+            ("enums", []),
+            ("typedefs", {}),
+            ("constants", {}),
+            ("python_api", None),
+            ("semantic_ir", None),
+            ("from_headers", False),
+            ("elf_only_mode", True),
+        ],
+    )
+    def test_snapshot_level_facts_cleared(self, attr: str, expected: object) -> None:
+        old, _ = _headers_only_pair(dwarf=False)
+        projected = project_snapshot_to_depth(old, "binary")
+        assert getattr(projected, attr) == expected
+
+    def test_function_and_variable_signatures_cleared(self) -> None:
+        old, _ = _headers_only_pair(dwarf=False)
+        projected = project_snapshot_to_depth(old, "binary")
+        fn = projected.functions[0]
+        assert fn.return_type == "?"
+        assert fn.params == []
+        assert fn.visibility is Visibility.ELF_ONLY
+        var = projected.variables[0]
+        assert var.type == "?"
+        assert var.is_const is False
+        assert var.value is None
+        assert var.visibility is Visibility.ELF_ONLY
+
+
+class TestBinaryDepthWithDwarf:
+    """DWARF-informed structural facts are an L0/L1 fact, kept at ``binary``."""
+
+    def test_dwarf_visible_structural_break_still_detected(self) -> None:
+        dwarf_meta = DwarfMetadata(has_dwarf=True)
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="int")],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            from_headers=True,
+            dwarf=dwarf_meta,
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            types=[
+                RecordType(
+                    name="S",
+                    kind="struct",
+                    size_bits=64,
+                    fields=[TypeField(name="x", type="double")],
+                    origin=ScopeOrigin.PUBLIC_HEADER,
+                )
+            ],
+            from_headers=True,
+            dwarf=dwarf_meta,
+        )
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        assert result.verdict == checker.Verdict.BREAKING
+        assert {c.kind.value for c in result.changes} == {"type_field_type_changed"}
+
+    def test_header_only_fact_still_cleared(self) -> None:
+        old, new = _headers_only_pair(dwarf=True)
+        old_b = project_snapshot_to_depth(old, "binary")
+        new_b = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_b, new_b)
+        # The pair differs only in `constants` (a header-only fact) -- with
+        # DWARF present, structural facts survive but the constant value
+        # must still be cleared, exactly the same as the no-DWARF case.
+        assert result.verdict == checker.Verdict.NO_CHANGE
+
+
+class TestDepthLadderMonotonicity:
+    """Each rung sees strictly more than the one below it, never less."""
+
+    @pytest.mark.parametrize("depth", ["headers", "build", "source"])
+    def test_header_level_fact_survives_at_or_above_headers(self, depth: str) -> None:
+        old, new = _headers_only_pair(dwarf=False)
+        old_p = project_snapshot_to_depth(old, depth)
+        new_p = project_snapshot_to_depth(new, depth)
+        result = checker.compare(old_p, new_p)
+        assert result.verdict != checker.Verdict.NO_CHANGE
+
+    def test_header_level_fact_does_not_survive_at_binary(self) -> None:
+        old, new = _headers_only_pair(dwarf=False)
+        old_p = project_snapshot_to_depth(old, "binary")
+        new_p = project_snapshot_to_depth(new, "binary")
+        result = checker.compare(old_p, new_p)
+        assert result.verdict == checker.Verdict.NO_CHANGE
+
+
+class TestSurfaceGraphIsAHeaderFact:
+    """``surface_graph`` is an L2 (header-only) fact -- ``_attach_header_graph``'s
+    own docstring -- not an L4/L5 one; an earlier version of this module gated
+    it to ``source`` on the wrong assumption (review-caught, same PR)."""
+
+    def _snap_with_graph(self) -> AbiSnapshot:
+        graph = SourceGraphSummary()
+        return AbiSnapshot(
+            library="lib", version="1", from_headers=True, surface_graph=graph
+        )
+
+    def test_cleared_below_headers(self) -> None:
+        snap = self._snap_with_graph()
+        projected = project_snapshot_to_depth(snap, "binary")
+        assert projected.surface_graph is None
+
+    @pytest.mark.parametrize("depth", ["headers", "build", "source"])
+    def test_kept_at_or_above_headers(self, depth: str) -> None:
+        snap = self._snap_with_graph()
+        projected = project_snapshot_to_depth(snap, depth)
+        assert projected.surface_graph is not None
+
+
+def _invoke(*args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(main, list(args))
+    return result.exit_code, result.output
+
+
+class TestNativeCliComparePath:
+    """Pinned gap 1: the native ``compare`` CLI must apply the ceiling too."""
+
+    def _write_pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        old = AbiSnapshot(
+            library="lib", version="1", constants={"FOO": "1"}, from_headers=True
+        )
+        new = AbiSnapshot(
+            library="lib", version="2", constants={"FOO": "2"}, from_headers=True
+        )
+        old_path = tmp_path / "old.json"
+        new_path = tmp_path / "new.json"
+        save_snapshot(old, old_path)
+        save_snapshot(new, new_path)
+        return old_path, new_path
+
+    def test_depth_binary_hides_the_header_only_break(self, tmp_path: Path) -> None:
+        old_path, new_path = self._write_pair(tmp_path)
+        code, _ = _invoke("compare", str(old_path), str(new_path), "--depth", "binary")
+        assert code == 0
+
+    def test_depth_headers_still_reports_it(self, tmp_path: Path) -> None:
+        old_path, new_path = self._write_pair(tmp_path)
+        code, _ = _invoke("compare", str(old_path), str(new_path), "--depth", "headers")
+        assert code == 2
+
+    def test_no_depth_flag_still_reports_it(self, tmp_path: Path) -> None:
+        old_path, new_path = self._write_pair(tmp_path)
+        code, _ = _invoke("compare", str(old_path), str(new_path))
+        assert code == 2

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1461,7 +1461,7 @@ class TestJUnitCLICompare:
             ],
         )
         assert result.exit_code == 0, result.output
-        root = xml_fromstring(result.output)
+        root = xml_fromstring(result.stdout)  # stderr carries the depth=binary scope warning
         assert root.tag == "testsuites"
 
     def test_format_junit_accepted_by_cli(self) -> None:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -391,8 +391,13 @@ def test_sc_ci_quick_profile(tmp_path: Path) -> None:
         "quick",
     )
     assert res.exit_code == 4
-    assert "total" in res.output
-    assert res.output.count("\n") <= 1  # one-line summary
+    # stdout, not the stderr-mixed `res.output`: `quick`'s `depth=binary`
+    # (ADR-063 Phase 8's ceiling fix) means this unscoped-headers fixture no
+    # longer resolves a public-header surface at that depth either, and that
+    # scope-fallback warning is by design routed to stderr so it never
+    # corrupts this one-line stdout contract.
+    assert "total" in res.stdout
+    assert res.stdout.count("\n") <= 1  # one-line summary
 
 
 def _strict_suppressions_config(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

Closes out the concretely-actionable ADR-063 Phase 8 open items: the
`--depth` floor-vs-ceiling gap, ADR-063 D1's second named exception
(`_resolve_stranded_library`), and a full per-item design for storage-v2's
remaining Phase 1 work (A1.1's `.tar.zst` transport, A1.4-A1.8).

## Motivation

A review of ADR-063 Phase 8's landing note and the storage-v2 plan found
most of the listed "open items" already explicitly, deliberately deferred
in the plan/code with reasoning recorded (`_collect_matrix_result()`,
binary-less `dump --sources`, `action/run.sh`'s exit-code branching, and
the multi-artifact/baseline-set/`.tar.zst` storage-v2 work all remain
correctly out of scope for a single PR). Two items were genuinely
actionable without a new ADR:

1. `--depth` was documented as "a floor, not a ceiling" — `compare
   old.json new.json --depth binary` could still emit real header-derived
   findings and publish `BREAKING`, because nothing capped a resolved
   snapshot's evidence down to what was requested. A prior review (PR
   #1016) had looked at this and correctly rejected two "obvious" fixes,
   leaving the real fix — a comparison-time projection — as a named,
   unattempted design question.
2. ADR-063 D1 named two `cli_compare_release.py` branches that bypass the
   typed request/plan pipeline as "a real, separate design question." One
   of them (`_resolve_stranded_library`) turned out to be exactly the same
   shape of check once looked at correctly (a single dump-shaped input);
   the other (`_collect_matrix_result`) genuinely has no request to plan
   for and stays as documented, now with that reasoning made explicit.

The remaining storage-v2 items (multi-artifact packages, baseline-set/
`BundleFacts` folding, `bundle_variants:` wiring, the `.tar.zst` transport
form) are real work the plan already correctly scopes as its own phase —
this PR gives that phase a full, reviewable design (Goal/Design/Files/
Tests/Acceptance criteria per item) rather than attempting a multi-quarter
implementation blind.

## Changes

- **`abicheck/policy/depth_projection.py`** (new): `project_snapshot_to_depth()`,
  a pure view-projection capping an `AbiSnapshot`'s evidence to a requested
  public depth rung, mirrored from `scripts/check_tier_accuracy.py`'s
  already-validated `project()` reference implementation.
- **`service_compare_pipeline.classify_compare_pair`**: applies the
  projection to a local `old`/`new` view right after `enforce_requested_
  depth` confirms the floor, gated on `request.depth is not None` — a
  no-op for every pre-existing caller that never sets `depth`. Covers both
  the single-pair and directory/package release-fan-out paths (both route
  through this one chokepoint).
- **`cli_compare_release.py`**: `_resolve_stranded_library` migrated from a
  direct `cli_resolve._resolve_input()` call (with a hand-rolled
  `depth=binary` header-clearing special-case) onto the shared
  `DumpRequest -> resolve_dump_request -> execute_dump_request` pipeline
  `dump`/`scan` already converge on — gaining a real `AnalysisPlanner.
  resolve()` pre-flight check and dropping the hand-copied depth rule,
  while keeping its existing degrade-to-ELF-only-on-failure fallback
  exactly as before.
- **Docs**: `docs/contribute/known-gaps.md`'s `--depth` entry marked
  fixed (history kept, per this repo's institutional-memory convention);
  ADR-063's D1 text and the implementation plan's matching section updated
  to reflect the migration; `docs/contribute/adr/062-project-snapshot-
  storage-v2.md`'s Status section corrected (the remaining work is Phase
  1's own remainder, not "Phase 2") and points at the new design;
  `docs/contribute/plans/storage-format-v2.md` gains full per-item designs
  for A1.1's `.tar.zst` remainder and A1.4-A1.8 — design only, nothing in
  this list is implemented by this PR.
- **Tests**: `tests/test_cli_compare_release_stranded_depth.py` updated to
  assert on the new call path's effective (post-resolution) header set
  rather than `_resolve_input`'s raw arguments, keeping the exact same
  behavioral contract (headers cleared at `--depth binary`, unaffected
  otherwise).

## Bug-fix test contract

- Bug class: `--depth` enforced as a floor (fail if evidence falls short)
  but never as a ceiling (nothing capped richer evidence down to what was
  requested) — a resolved `AbiSnapshot`, whether freshly extracted or
  loaded from an already-serialized JSON snapshot, always classified with
  its full embedded evidence regardless of an explicit `--depth`.
- Publicly observable failure: `compare old.json new.json --depth binary`
  over two snapshots differing only in a header-level fact (a macro/
  constexpr constant) still reports `constant_changed`/`API_BREAK`, and
  the same over a directory/package release fan-out.
- Regression test fails on base: yes — `project_snapshot_to_depth`
  is new; the `classify_compare_pair` wiring is what makes the difference,
  confirmed by running the reported scenario against the pre-fix code
  path (single-pair and directory/package) before this change.
- Negative control: `--depth headers`/`--depth build`/`--depth source`
  and no `--depth` at all still see the header-level fact — the
  projection only removes evidence above the requested rung, never below
  or at it.
- Public-surface test: exercised via `checker.compare()`'s real public
  API and `service.run_compare_request()`'s real JSON-snapshot round trip
  (`InputSpec.of(Path(...))` → `run_compare_request` → `CompareResult`),
  not an internal helper in isolation.
- Axes covered: `binary` (strips header scoping/constants/`python_api`/
  `semantic_ir`/`build_mode`/`build_source`), `headers` (keeps header
  facts, strips build/source), `build` (keeps L3 `build_evidence`, strips
  L4/L5), `source` (no-op); both the single-pair and directory/package
  release fan-out call paths; `dump`'s own `--depth` confirmed unaffected
  (still floor-only, per design).
- General invariant: for any `AbiSnapshot` pair and any requested depth
  rung, a classification's answer depends only on evidence at or below
  that rung — never on evidence embedded in the resolved snapshot above
  it, whether that snapshot came from live extraction or a pre-built file.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (known-gaps.md, ADR-062, ADR-063, both implementation plans)
- [x] `ruff check` / `ruff format --check` pass
- [x] `mypy abicheck/` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjcxiD7N7fSN1McqTmXW7u)_