### PR TITLE
fix(tests): read ast_resolved_standard through snapshot_from_dict in pvxs regression

### DIFF
--- a/tests/test_pvxs_regression.py
+++ b/tests/test_pvxs_regression.py
@@ -54,12 +54,13 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 from click.testing import CliRunner
 
 from abicheck.cli import main
+from abicheck.model import AbiSnapshot
+from abicheck.serialization import snapshot_from_dict
 
 pytestmark = [
     pytest.mark.integration,
@@ -115,7 +116,7 @@ def _build_lib(src_dir: Path, out_so: Path) -> None:
     )
 
 
-def _dump_snapshot(so_path: Path, header: Path, out_json: Path) -> dict[str, Any]:
+def _dump_snapshot(so_path: Path, header: Path, out_json: Path) -> AbiSnapshot:
     result = CliRunner().invoke(
         main,
         [
@@ -132,7 +133,13 @@ def _dump_snapshot(so_path: Path, header: Path, out_json: Path) -> dict[str, Any
         ],
     )
     assert result.exit_code == 0, result.output
-    return json.loads(out_json.read_text(encoding="utf-8"))
+    # `dump -o` writes the D8-sectioned on-disk shape (ADR-062/ADR-063 Phase
+    # 8), not a flat top-level dict -- ``ast_resolved_standard`` lives under
+    # ``sections.debug.payload`` there. ``snapshot_from_dict`` is the one
+    # maintained compatibility surface that reads either that shape or a
+    # legacy flat one, so go through it (and the real ``AbiSnapshot``
+    # attribute) rather than indexing the raw JSON directly.
+    return snapshot_from_dict(json.loads(out_json.read_text(encoding="utf-8")))
 
 
 def test_pvxs_error_requires_guard_does_not_force_cxx20(tmp_path: Path) -> None:
@@ -163,17 +170,11 @@ def test_pvxs_error_requires_guard_does_not_force_cxx20(tmp_path: Path) -> None:
     # forced to gnu++20" is asserted directly instead of "stayed None".
     old_snap = _dump_snapshot(old_so, old_dir / "pvxs.h", tmp_path / "old.abi.json")
     new_snap = _dump_snapshot(new_so, new_dir / "pvxs.h", tmp_path / "new.abi.json")
-    assert old_snap.get("ast_resolved_standard") != "gnu++20", old_snap.get(
-        "ast_resolved_standard"
-    )
-    assert new_snap.get("ast_resolved_standard") != "gnu++20", new_snap.get(
-        "ast_resolved_standard"
-    )
+    assert old_snap.ast_resolved_standard != "gnu++20", old_snap.ast_resolved_standard
+    assert new_snap.ast_resolved_standard != "gnu++20", new_snap.ast_resolved_standard
     # Both sides were built identically and dumped under the identical
     # resolved clang -- their (possibly probed) dialects must still agree.
-    assert old_snap.get("ast_resolved_standard") == new_snap.get(
-        "ast_resolved_standard"
-    )
+    assert old_snap.ast_resolved_standard == new_snap.ast_resolved_standard
 
     out_json = tmp_path / "report.json"
     result = CliRunner().invoke(
@@ -246,7 +247,9 @@ def test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides(
     _build_lib(old_dir, old_so)
     _build_lib(new_dir, new_so)
 
-    def _dump_with_explicit_gnu11(so_path: Path, header: Path, out_json: Path) -> dict:
+    def _dump_with_explicit_gnu11(
+        so_path: Path, header: Path, out_json: Path
+    ) -> AbiSnapshot:
         result = CliRunner().invoke(
             main,
             [
@@ -265,7 +268,10 @@ def test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides(
             ],
         )
         assert result.exit_code == 0, result.output
-        return json.loads(out_json.read_text(encoding="utf-8"))
+        # See `_dump_snapshot`'s own comment: `dump -o` writes the
+        # D8-sectioned on-disk shape, so read it back through
+        # `snapshot_from_dict` rather than indexing the raw JSON.
+        return snapshot_from_dict(json.loads(out_json.read_text(encoding="utf-8")))
 
     old_snap = _dump_with_explicit_gnu11(
         old_so, old_dir / "pvxs.h", tmp_path / "old-gnu11.abi.json"
@@ -275,15 +281,9 @@ def test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides(
     )
     # The decisive assertion: both sides actually resolved to gnu++11, not
     # merely "not gnu++20" -- and they agree with each other.
-    assert old_snap.get("ast_resolved_standard") == "gnu++11", old_snap.get(
-        "ast_resolved_standard"
-    )
-    assert new_snap.get("ast_resolved_standard") == "gnu++11", new_snap.get(
-        "ast_resolved_standard"
-    )
-    assert old_snap.get("ast_resolved_standard") == new_snap.get(
-        "ast_resolved_standard"
-    )
+    assert old_snap.ast_resolved_standard == "gnu++11", old_snap.ast_resolved_standard
+    assert new_snap.ast_resolved_standard == "gnu++11", new_snap.ast_resolved_standard
+    assert old_snap.ast_resolved_standard == new_snap.ast_resolved_standard
 
     out_json = tmp_path / "report-gnu11.json"
     result = CliRunner().invoke(


### PR DESCRIPTION
## Summary

Fixes the two failing `integration-tests` CI jobs (macos-latest, ubuntu-24.04) on `tests/test_pvxs_regression.py::test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides`, reproduced identically on a pristine `origin/main` checkout.

## Motivation

`dump -o` now writes the D8-sectioned on-disk shape (ADR-062/ADR-063 Phase 8) instead of a flat top-level dict. `ast_resolved_standard` moved from the JSON top level into `sections.debug.payload`, but both PVXS regression tests still read it with `raw_json_dict.get("ast_resolved_standard")` against the top level, which now always returns `None`.

- `test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides` asserts `== "gnu++11"`, so it now fails outright — this is the CI failure.
- Its sibling `test_pvxs_error_requires_guard_does_not_force_cxx20` asserts `!= "gnu++20"`, which `None` trivially satisfies — so it kept passing while silently asserting nothing, the same class of drift `AGENTS.md`'s own "Decision-making principles" section (and this module's docstring) warns about.

## Changes

- Both dump-and-read helpers in `tests/test_pvxs_regression.py` now parse the CLI's dumped JSON through `snapshot_from_dict` — the module's own documented compatibility surface for either the sectioned or a legacy flat on-disk shape — and assertions read the real `AbiSnapshot.ast_resolved_standard` attribute instead of indexing the raw dict by a hard-coded top-level key.
- Dropped the now-unused local `dict` return type / `typing.Any` import.

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: test-vs-schema drift — a test read a dump-JSON field via a hard-coded top-level key after the on-disk shape moved that field into a section, silently degrading one assertion to always-true and failing its sibling outright.
- Publicly observable failure: `integration-tests` (macos-latest, ubuntu-24.04) CI failing on `test_pvxs_explicit_gnu11_dialect_resolves_and_matches_on_both_sides`.
- Regression test fails on base: yes — reproduced on a pristine `origin/main` checkout before this fix; both PVXS tests pass after it.
- Negative control: the sibling test `test_pvxs_error_requires_guard_does_not_force_cxx20` demonstrates the other half of the same bug (a false negative that kept passing while testing nothing); it is fixed the same way and remains decisive afterward.
- Public-surface test: yes — both tests go through the real `abicheck dump` CLI's `-o` file output, not an internal shortcut.
- Axes covered: both the explicit-dialect (`-std=gnu++11`) and default/auto-detect (no explicit `-std`) sides of the same JSON-shape mismatch.
- General invariant: assertions against `dump`'s on-disk JSON must go through `snapshot_from_dict` (the maintained compatibility surface for both the sectioned and legacy flat shapes), not a hard-coded top-level key, so they keep working across future storage-shape migrations.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — N/A, this PR only touches `tests/`
- [x] Docs updated if user-visible behaviour changed — N/A, no user-visible behavior changed
- [x] `pre-commit run --all-files` passes locally (`ruff check`, `ruff format --check`, `mypy` all clean on the changed file)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ytqb9ass1fupg82GFkvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ytqb9ass1fupg82GFkvPY)_