### PR TITLE
feat(workflows): wire ResolvedExecutionContext into resolve_compare_request

### DIFF
--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
 
     from .model import AbiSnapshot
     from .service_compare_evidence import SideEvidence
+    from .workflows.resolved_execution_context import ResolvedExecutionContext
 
 __all__ = [
     "ResolvedComparePair",
@@ -106,6 +107,26 @@ class ResolvedComparePair:
     end reporting on them) and each side's resolved
     :class:`~abicheck.service_compare_evidence.SideEvidence` (whose
     ``collect_mode`` drives the embedded build-source diff).
+
+    ``resolved_execution_context`` (One Semantic Pipeline PR 1, sub-phase 4B):
+    the :class:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext` built from this same request's own
+    :class:`~abicheck.workflows.plan.AnalysisPlan`
+    (:func:`resolve_compare_request` already calls ``AnalysisPlanner.resolve``
+    for its pre-flight check; this is that same, otherwise-discarded plan,
+    not a second resolution). Optional and additive — no existing consumer
+    reads it, and nothing here changes because of it — but every real
+    ``resolve_compare_request`` call now populates one from real production
+    inputs, closing 4B's own "no live caller wired yet" gap for the
+    ``compare`` path specifically. Carries no ``evaluation_config``/
+    ``compile_contexts`` yet: this seam resolves before ADR-049's D7
+    evaluation config exists for the native CLI (that resolution happens in
+    ``cli_compare_receipt.py``, one layer up, past a Click context this
+    shared pipeline does not have) and before any per-side
+    :class:`~abicheck.compile_context.CompileContext` is captured back out of
+    :func:`~abicheck.service_input_resolution.resolve_side_snapshot`'s own
+    internals — attaching either later, from whichever layer resolves it, is
+    follow-on work this field does not block.
     """
 
     old: AbiSnapshot
@@ -114,6 +135,7 @@ class ResolvedComparePair:
     new_fmt: str | None
     old_evidence: SideEvidence
     new_evidence: SideEvidence
+    resolved_execution_context: ResolvedExecutionContext | None = None
 
 
 def resolve_sides_sequentially(request: CompareRequest) -> bool:
@@ -302,7 +324,7 @@ def resolve_compare_request(
     # rather than discovering the gap mid-run or not at all. See
     # `abicheck.workflows.plan`'s own module docstring for exactly what this
     # does and does not check.
-    AnalysisPlanner.resolve(request)
+    plan = AnalysisPlanner.resolve(request)
     # validate() accepts lang case-insensitively; the ELF dump path does
     # case-sensitive `lang == "c"` checks, so normalise here. `android` (no
     # header-AST path) falls back to "auto" for the binary dump.
@@ -401,6 +423,8 @@ def resolve_compare_request(
     # gains nothing from the extraction threads.
     populate_pair_dependency_info(request, old, new, old_fmt=old_fmt, new_fmt=new_fmt)
     enforce_requested_depth(request.depth, (("old", old), ("new", new)))
+    from .workflows.resolved_execution_context import ResolvedExecutionContext
+
     return ResolvedComparePair(
         old=old,
         new=new,
@@ -408,6 +432,7 @@ def resolve_compare_request(
         new_fmt=new_fmt,
         old_evidence=old_evidence,
         new_evidence=new_evidence,
+        resolved_execution_context=ResolvedExecutionContext.from_plan(plan),
     )
 
 

--- a/abicheck/workflows/resolved_execution_context.py
+++ b/abicheck/workflows/resolved_execution_context.py
@@ -380,8 +380,9 @@ class ResolvedExecutionContext:
         """Compose a context from an already-resolved
         :class:`~abicheck.workflows.plan.AnalysisPlan` plus whatever
         evaluation config / compile contexts the caller separately resolved
-        for the same run. Reads *plan.operation*/*plan.requested_depth*
-        verbatim -- it does not re-run planning, and it does not require
+        for the same run. Reads *plan.operation* verbatim and
+        *plan.requested_depth* case-normalized (see below) -- it does not
+        re-run planning, and it does not require
         *plan* to be the source of the other two arguments (a caller that
         has not resolved a compile context for every side, or any
         evaluation config at all, simply omits them). *assurance*, when
@@ -395,11 +396,25 @@ class ResolvedExecutionContext:
         fallback, so a ``not_comparable`` assurance (whose own
         ``requested_depth`` reads ``None``) doesn't discard the genuinely
         known, already-resolved request (Codex review, PR #1027, fourth
-        round -- see that method's own docstring)."""
+        round -- see that method's own docstring). *plan.requested_depth*
+        is lower-cased here first (Codex review, PR #1031) -- unlike
+        *plan.operation*, ``AnalysisPlan.requested_depth`` is not itself
+        normalized (a typed-API caller can spell a valid depth
+        case-insensitively, e.g. ``"HEADERS"``, the same way
+        :func:`~abicheck.service_compare_pipeline.classify_compare_pair`'s
+        ``result.requested_depth = request.depth.lower()`` normalizes it for
+        ``DiffResult`` before this context exists), and this class's own
+        ``_AVAILABLE_DEPTHS``/:meth:`resolution_digest` are case-sensitive:
+        an unnormalized depth would both fail to appear in its own
+        :attr:`EvidenceView.available_depths` and hash differently from an
+        equivalent lower-case request."""
+        normalized_depth = (
+            plan.requested_depth.lower() if plan.requested_depth is not None else None
+        )
         evidence = (
-            EvidenceView.from_assurance(assurance, requested_depth=plan.requested_depth)
+            EvidenceView.from_assurance(assurance, requested_depth=normalized_depth)
             if assurance is not None
-            else EvidenceView.for_request(plan.requested_depth)
+            else EvidenceView.for_request(normalized_depth)
         )
         return cls(
             operation=plan.operation,

--- a/changelog.d/20260903_055531_noreply_pr_0_pr_1_completion_yqznne.md
+++ b/changelog.d/20260903_055531_noreply_pr_0_pr_1_completion_yqznne.md
@@ -1,0 +1,18 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **`resolve_compare_request` now attaches a real `ResolvedExecutionContext`** —
+  the One Semantic Pipeline PR 1 primitive (`workflows/resolved_execution_context.py`)
+  landed additively with no production caller; `compare`'s shared resolution
+  seam (`service_compare_pipeline.ResolvedComparePair.resolved_execution_context`)
+  now builds one from the same `AnalysisPlan` it already resolves, closing
+  sub-phase 4B's "no live caller wired yet" gap for the `compare` path. Purely
+  additive and behavior-preserving — no existing consumer reads the new field,
+  and no CLI/API output changes for any existing invocation.

--- a/changelog.d/20260903_055531_noreply_pr_0_pr_1_completion_yqznne.md
+++ b/changelog.d/20260903_055531_noreply_pr_0_pr_1_completion_yqznne.md
@@ -15,4 +15,9 @@ it should read in CHANGELOG.md. Delete the other sections.
   now builds one from the same `AnalysisPlan` it already resolves, closing
   sub-phase 4B's "no live caller wired yet" gap for the `compare` path. Purely
   additive and behavior-preserving — no existing consumer reads the new field,
-  and no CLI/API output changes for any existing invocation.
+  and no CLI/API output changes for any existing invocation. `ResolvedExecutionContext.from_plan`
+  now lower-cases `AnalysisPlan.requested_depth` before building the
+  `EvidenceView`, so a case-insensitively spelled depth (e.g. a typed-API
+  caller's `"HEADERS"`) matches `resolution_digest()`/`available_depths`
+  the same way its lower-case spelling does, instead of silently falling
+  outside the depth ladder.

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -51,8 +51,8 @@
 # merged) — never at a same-PR branch commit.
 
 schema_version: 1
-as_of_commit: bb14e8e
-as_of_date: "2026-09-02"
+as_of_commit: e254a9e
+as_of_date: "2026-09-03"
 
 concepts:
   facts:
@@ -123,7 +123,13 @@ concepts:
       Phase 4B (resolved-execution-context): a ResolvedExecutionContext
       built for real (non-dry-run) execution, carrying resolved
       policy/pack/contract/evidence-depth state so downstream code stops
-      independently re-resolving each of them per call site.
+      independently re-resolving each of them per call site. A first real
+      call site landed 2026-09-03: service_compare_pipeline.
+      resolve_compare_request builds one from its own already-resolved
+      AnalysisPlan and attaches it on ResolvedComparePair, additive and
+      unread by any consumer -- resolve_dump_request remains unwired, and
+      no evaluation_config/compile_contexts/with_assurance() caller exists
+      yet, so this gate stays open.
 
   run_outcome:
     primitive: complete

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -183,7 +183,7 @@ when a first PR lands against a sub-phase:
 | Sub-phase | Status | Closes | One-line goal |
 |---|---|---|---|
 | **2B — Identity consumer migration** | not started | Phase 2's remaining string-identity call sites | Migrate `diff_filtering.py`/`type_reachability.py` onto `EntityId` once DWARF-side blockers clear; split `EntityId`/`OccurrenceId` matching into a `StableEntityId` tier (cross-release, suppression-alias-safe) vs. a `SnapshotLocalIdentity` fallback, rather than a further attempt at globally-stable `Anonymous`/`LocalToFunction` ordinals (two prior attempts already reverted) |
-| **4B — Resolved execution context** | in progress | The gap between `AnalysisPlan`'s deliberately narrow preflight scope and real execution's need for one resolved object | A `ResolvedExecutionContext` built only for real (non-dry-run) execution — effective config with per-field provenance, resolved compile/toolchain context, effective/available evidence depth, resolved policy/pack/contract — so downstream code stops independently re-reading `.abicheck.yml`, re-deriving precedence, or re-resolving severity scheme. First PR landed, in two slices (see Phase 4's own "Adjacent, additive infrastructure landed" note, below, under "Phases"): the `ResolvedExecutionContext` type itself (composing an `AnalysisPlan` with an already-resolved `CompatibilityEvaluationConfig`/`CompileContext`s, provenance access, and a resolution digest), then a second slice closing the "requested/effective/available depth" field list via a new `EvidenceView` (copied off `AnalysisAssurance`, never re-derived). The type is now fully shaped per its own original description — no live caller wired yet, so the sub-phase's own gap (downstream code still independently re-reads/re-derives what this object would give it in one place) stays open |
+| **4B — Resolved execution context** | in progress | The gap between `AnalysisPlan`'s deliberately narrow preflight scope and real execution's need for one resolved object | A `ResolvedExecutionContext` built only for real (non-dry-run) execution — effective config with per-field provenance, resolved compile/toolchain context, effective/available evidence depth, resolved policy/pack/contract — so downstream code stops independently re-reading `.abicheck.yml`, re-deriving precedence, or re-resolving severity scheme. First PR landed, in two slices (see Phase 4's own "Adjacent, additive infrastructure landed" note, below, under "Phases"): the `ResolvedExecutionContext` type itself (composing an `AnalysisPlan` with an already-resolved `CompatibilityEvaluationConfig`/`CompileContext`s, provenance access, and a resolution digest), then a second slice closing the "requested/effective/available depth" field list via a new `EvidenceView` (copied off `AnalysisAssurance`, never re-derived). A third slice (2026-09-03) landed the sub-phase's first real call site: `service_compare_pipeline.resolve_compare_request` now builds one from its own already-resolved `AnalysisPlan` and attaches it on `ResolvedComparePair` — additive, unread by any consumer yet, but no longer "a dataclass nothing outside its own tests constructs" for the `compare` path. `resolve_dump_request` remains fully unwired, and nothing yet calls `with_assurance()` from a real post-execution caller — the sub-phase's own gap (most downstream code still independently re-reads/re-derives what this object would give it in one place) stays open |
 | **5B — Fact semantic consumption** | not started | Phase 5's "no fact reaches `CONSUMED`" gap | For each fact family, an explicit `FactStatus` → detector-meaning table (e.g. `FAILED` means "incomplete evidence," not "confirmed absent") instead of the uniform legacy-default collapse — inventory every present-or-default unwrap first (`resolved_fact_value` call sites *and* local equivalents like `diff_param_qualifiers._fact_bool`/`diff_cxx_rules._fact_str_list`/`compare.surface_graph.fact_list`), not only the shared primitive's own callers; first vertical cohort on the five fields with an existing fabricated-finding history (`RecordType.bases`/`virtual_bases`/`vtable`/`vptr_offset_bits`, `Param.is_va_list`), since those are where the behavior change is easiest to justify and test |
 | **6B — SemanticIR checker cutover** | not started | The gap this review calls the single largest: `SemanticIR` computed and persisted but never read by the checker | One read index over `SemanticIR` (`entity()`, `occurrences()`, `functions()`, `records()`, `facts()`, `references()`) with a legacy-flat-snapshot adapter producing the same read shape, migrated one detector family/cohort at a time, each cohort closing with an architecture-gate rule forbidding a direct legacy-collection read for that family |
 | **7B — Boundary consumer migration** | not started | `action/run.sh`'s raw-exit-code decoding (Phase 7's named scope boundary) and the release fan-out's independent pair-semantics reimplementation | Action reads `run_outcome`/`exit` from the machine report instead of re-deriving a verdict from the raw process exit code and stderr text; release/artifact-set fan-out calls one shared pair-operation executor instead of independently resolving depth, policy provenance, and report composition per pair |
@@ -12639,16 +12639,35 @@ for a caller resolving the context after a run has already completed.
 fingerprint of the resolved *input* (pinned by
 `test_unaffected_by_effective_depth_alone`).
 
-**Still open, and not attempted here:** wiring a real call site
-(`cli_compare_receipt.resolve_and_apply`/`resolve_dump_request` are the
-two places an `AnalysisPlan` and a resolved `CompatibilityEvaluationConfig`
-are both already available in the same call, but neither is changed to
-construct a `ResolvedExecutionContext` yet, nor does anything call
-`with_assurance()` once a real `AnalysisAssurance` exists), and everything
-the review's "PR 2"-onward sequence describes (a semantic consumer
-cutover, `FactStatus`-aware detectors, and the rest) — this slice closes
-the "one resolved context type exists, fully shaped, and is tested" step
-for real, not consumer migration.
+**A first real call site landed in a follow-up slice** (independent
+verification pass over this plan, 2026-09-03): `service_compare_pipeline.
+resolve_compare_request` — the one resolution implementation every front
+end (`compare`'s native CLI, the typed Python API, and directory/package
+fan-out) already calls through — now builds a `ResolvedExecutionContext`
+via `ResolvedExecutionContext.from_plan()` from the same `AnalysisPlan` it
+already resolves for its ADR-063 Phase 4 pre-flight check (previously
+discarded), and attaches it on the new `ResolvedComparePair.
+resolved_execution_context` field. This is additive and behavior-preserving
+— the field is optional, nothing downstream reads it, and no existing
+invocation's output changes — but it closes the literal "a type nothing
+outside its own tests constructs" gap for the `compare` path specifically:
+every real `compare` now builds one from real production inputs, not only
+from a hand-built `AnalysisPlan` inside a test.
+
+**Still open, and not attempted here:** the context built at this seam
+carries no `evaluation_config`/`compile_contexts` (this resolution runs
+before ADR-049 D7's evaluation config exists for the native CLI, and before
+any per-side `CompileContext` is captured back out of
+`resolve_side_snapshot`'s own internals — see the field's own docstring on
+`ResolvedComparePair`); nothing calls `with_assurance()` once a real
+`AnalysisAssurance` exists; `resolve_dump_request` remains fully unwired
+(its own `ResolvedDumpRequest` object has its own deliberately-scoped
+exclusions documented in its docstring, so folding this in needs the same
+kind of considered pass, not a copy-paste of this slice); and everything the
+review's "PR 2"-onward sequence describes (a semantic consumer cutover,
+`FactStatus`-aware detectors, and the rest) is still future work. This
+slice closes one real call site for `compare`, not consumer migration or
+full wiring.
 
 ---
 

--- a/tests/test_service_compare_pipeline.py
+++ b/tests/test_service_compare_pipeline.py
@@ -112,3 +112,85 @@ class TestResolveSidesSequentially:
         assert len(spans) == 2
         (_old_v, _old_start, old_end), (_new_v, new_start, _new_end) = spans
         assert new_start >= old_end
+
+
+class TestResolvedExecutionContextWiring:
+    """One Semantic Pipeline PR 1, sub-phase 4B: :func:`resolve_compare_request`
+    now attaches a real :class:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext` built from the same :class:`~abicheck.workflows.
+    plan.AnalysisPlan` the function already resolves for its pre-flight
+    check, rather than discarding it. This is the "real, callable projection
+    function with a real call site" requirement -- not a type nothing ever
+    constructs outside its own tests -- landed additively: nothing here reads
+    the new field back to change behaviour, so it must never affect
+    ``old``/``new``/``old_fmt``/``new_fmt``/``old_evidence``/``new_evidence``.
+    """
+
+    def _request(self, tmp_path, *, depth=None):
+        old_p = tmp_path / "old.so"
+        new_p = tmp_path / "new.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        new_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        return CompareRequest(
+            old=InputSpec(path=old_p, version="old"),
+            new=InputSpec(path=new_p, version="new"),
+            depth=depth,
+        )
+
+    def _resolve(self, request, monkeypatch):
+        from abicheck import service as service_mod
+        from abicheck.service import resolve_compare_request
+
+        def _fake_resolve(path, headers, includes, version, lang, **kwargs):
+            return AbiSnapshot(library="libtest", version=version)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve)
+        return resolve_compare_request(request)
+
+    def test_pair_carries_a_populated_resolved_execution_context(
+        self, tmp_path, monkeypatch
+    ):
+        from abicheck.workflows.resolved_execution_context import (
+            ResolvedExecutionContext,
+        )
+
+        pair = self._resolve(self._request(tmp_path), monkeypatch)
+
+        assert isinstance(pair.resolved_execution_context, ResolvedExecutionContext)
+        assert pair.resolved_execution_context.operation == "compare"
+
+    @pytest.mark.parametrize("depth", [None, "binary"])
+    def test_requested_depth_matches_the_request(self, tmp_path, monkeypatch, depth):
+        # Only depths the fake binary-only `resolve_input` stand-in can
+        # actually satisfy -- `enforce_requested_depth`'s floor check (see
+        # its own docstring) rejects `headers`/`build`/`source` here for the
+        # identical reason it would reject them against a real ELF-only
+        # snapshot; that check is orthogonal to what this test verifies.
+        pair = self._resolve(self._request(tmp_path, depth=depth), monkeypatch)
+
+        assert pair.resolved_execution_context.requested_depth == depth
+        assert pair.resolved_execution_context.evidence.requested_depth == depth
+
+    def test_no_evaluation_config_or_compile_contexts_resolved_here(
+        self, tmp_path, monkeypatch
+    ):
+        """This seam resolves before ADR-049 D7 evaluation config exists for
+        the native CLI (see the field's own docstring on ``ResolvedComparePair``)
+        -- asserted explicitly so a future change that starts silently
+        fabricating either is caught rather than passing by accident."""
+        pair = self._resolve(self._request(tmp_path), monkeypatch)
+
+        assert pair.resolved_execution_context.evaluation_config is None
+        assert dict(pair.resolved_execution_context.compile_contexts) == {}
+
+    def test_wiring_does_not_change_the_resolved_snapshots_or_formats(
+        self, tmp_path, monkeypatch
+    ):
+        """Behaviour-preservation: attaching the new field changes nothing
+        about what the pair already carried."""
+        pair = self._resolve(self._request(tmp_path), monkeypatch)
+
+        assert pair.old.library == "libtest"
+        assert pair.new.library == "libtest"
+        assert pair.old.version == "old"
+        assert pair.new.version == "new"

--- a/tests/unit/workflows/test_resolved_execution_context.py
+++ b/tests/unit/workflows/test_resolved_execution_context.py
@@ -15,9 +15,11 @@
 """Primitive-level tests for :mod:`abicheck.workflows.resolved_execution_context`
 -- ``one-semantic-pipeline.md``'s plan, "PR 1". Pins the type's shape and its
 composition-only contract directly (construct a few contexts by hand), the
-way ``model/semantic_ir.py`` was pinned before any consumer migrated onto it
--- this module has no live caller yet, so these tests are the only thing
-guarding its shape.
+way ``model/semantic_ir.py`` was pinned before any consumer migrated onto it.
+``service_compare_pipeline.resolve_compare_request`` is now the first real
+call site (see ``TestResolvedExecutionContextWiring`` in
+``tests/test_service_compare_pipeline.py``); these tests still cover the
+primitive directly, unit-style, rather than only through that one caller.
 """
 
 from __future__ import annotations
@@ -520,6 +522,36 @@ class TestResolvedExecutionContextEvidenceIntegration:
         ctx = ResolvedExecutionContext.from_plan(plan)
         assert ctx.evidence.requested_depth == "source"
         assert ctx.evidence.effective_depth is None
+
+    def test_from_plan_lower_cases_a_case_insensitive_plan_depth(self):
+        """A typed-API caller can spell a valid ``--depth`` value
+        case-insensitively (e.g. ``"HEADERS"``) and ``AnalysisPlan`` itself
+        does not normalize it -- ``service_compare_pipeline.classify_
+        compare_pair`` only normalizes ``DiffResult.requested_depth`` later,
+        after this context already exists. Without normalizing here too,
+        the mixed-case value both fails to appear in its own
+        ``available_depths`` (the ladder is lower-case) and hashes
+        differently from an equivalent lower-case request in
+        ``resolution_digest()`` (Codex review, PR #1031)."""
+        plan = _plan(requested_depth="HEADERS")
+        ctx = ResolvedExecutionContext.from_plan(plan)
+        assert ctx.evidence.requested_depth == "headers"
+        assert ctx.evidence.requested_depth in ctx.evidence.available_depths
+
+        lower_ctx = ResolvedExecutionContext.from_plan(_plan(requested_depth="headers"))
+        assert ctx.resolution_digest() == lower_ctx.resolution_digest()
+
+    def test_from_plan_normalized_depth_is_the_from_assurance_fallback(self):
+        """The lower-cased plan depth also feeds ``EvidenceView.from_assurance``'s
+        fallback (used when *assurance* itself carries no ``requested_depth``,
+        e.g. a ``not_comparable`` short-circuit) -- so that path can't
+        reintroduce the same mixed-case leak through the back door."""
+        from abicheck.analysis_assurance import AnalysisAssurance
+
+        plan = _plan(requested_depth="HEADERS")
+        assurance = AnalysisAssurance(requested_depth=None, effective_depth=None)
+        ctx = ResolvedExecutionContext.from_plan(plan, assurance=assurance)
+        assert ctx.evidence.requested_depth == "headers"
 
     def test_from_plan_with_assurance_builds_the_full_post_execution_view(self):
         from abicheck.analysis_assurance import AnalysisAssurance


### PR DESCRIPTION
## Summary

Independent verification of "One Semantic Pipeline PR 0 / PR 1" (as described by an external architectural analysis) against the actual current state of `main` found that **both were already fully implemented and merged** by prior sessions, before this branch was created. This PR documents that finding and closes the one genuine gap it surfaced: `ResolvedExecutionContext`/`EvidenceView` had zero production call sites.

## Motivation

The task asked me to implement PR 0 (ADR-063/plan-doc roadmap ownership fix) and PR 1 (`ResolvedExecutionContext` + `EvidenceView` infrastructure), per an analysis whose PR numbers and claims about "current main" were flagged as possibly stale. I was asked to verify independently rather than trust it at face value.

**What I found:**

- **PR 0 is done.** `docs/contribute/adr/063-one-semantic-pipeline.md` no longer carries duplicated per-phase status prose (points to the plan doc + `docs/_meta/one-semantic-pipeline-status.yaml` instead). The plan doc's "Phase 2B-8B: consumer-cutover extension" section already defines all six missing sub-phases (2B Identity consumer migration, 4B Resolved execution context, 5B Fact semantic consumption, 6B SemanticIR checker cutover, 7B Boundary consumer migration, 8B Multi-artifact canonical storage) with descriptions, status, and what each closes.
- **PR 1 is done, mostly.** `abicheck/workflows/resolved_execution_context.py` defines both `ResolvedExecutionContext` (composing an `AnalysisPlan` with a resolved `CompatibilityEvaluationConfig`/`CompileContext`s and a `resolution_digest()`) and `EvidenceView` (the requested/effective/available `--depth` axis, copied off `AnalysisAssurance`, never re-derived), both with a real primitive-level test suite (`tests/unit/workflows/test_resolved_execution_context.py`).
- **One real gap:** neither type had *any* production call site — only their own unit tests constructed them. That is exactly the "dataclass no one constructs" anti-pattern the task explicitly warned against.
- **A naming/scope discrepancy worth flagging:** the task (following the analysis) describes `EvidenceView` as *"given a snapshot and a requested depth, expose `visible_facts`/`available_facts`/`missing_facts` so a snapshot containing deeper evidence than requested doesn't leak into detectors requesting less depth."* That specific mechanism — preventing deeper evidence from leaking into a lower-depth request — is **already fully implemented and wired at every `compare_snapshots()` call site**, under a different name: `abicheck/policy/depth_projection.py`'s `project_snapshot_to_depth()`/`project_pair_to_depth()` (see git history: "enforce `--depth` as a ceiling, not only a floor, in compare" and its follow-up fix). The already-merged `EvidenceView` class is a *different*, complementary concept (depth-ladder request/effective/available metadata, not fact filtering). Per ADR-063's own governing invariant ("one concept, one representation, never two"), adding a second, redundant fact-visibility filter under the `EvidenceView` name would have duplicated existing, reviewed, production code rather than closing a real gap — so I did not do that.

## Changes

- `abicheck/service_compare_pipeline.py`: `resolve_compare_request` now captures the `AnalysisPlan` returned by `AnalysisPlanner.resolve(request)` (previously discarded) and attaches `ResolvedExecutionContext.from_plan(plan)` on a new, optional `ResolvedComparePair.resolved_execution_context` field. Additive and behavior-preserving — the field defaults to `None`-shaped construction everywhere else, nothing downstream reads it yet, and no existing invocation's output changes.
- `docs/contribute/plans/one-semantic-pipeline.md`: updated sub-phase 4B's table row and its "Adjacent, additive infrastructure landed" section to record this real call site and its still-open scope (no `evaluation_config`/`compile_contexts` attached at this seam yet; `resolve_dump_request` remains unwired; nothing calls `with_assurance()` from a real post-execution caller).
- `docs/_meta/one-semantic-pipeline-status.yaml`: updated `analysis_plan`'s `removal_gate` to match, bumped `as_of_commit`/`as_of_date`.
- `tests/test_service_compare_pipeline.py`: new `TestResolvedExecutionContextWiring` class — asserts the field is populated with a real `ResolvedExecutionContext`, `requested_depth` matches the request, no `evaluation_config`/`compile_contexts` are fabricated at this seam, and the wiring doesn't change the resolved snapshots/formats.
- `changelog.d/`: fragment via `scriv create`.

## Verification

- `mypy abicheck/` — clean (611 files, 0 errors)
- `python scripts/check_architecture.py` — 0 errors
- `python scripts/check_ai_readiness.py` — 0 errors, 142 pre-existing warnings (unchanged baseline; confirmed the 12 errors seen on a shallow clone were a local-checkout artifact, not real — they cleared after `git fetch --unshallow`)
- `python scripts/check_docs_contract.py` — 0 errors, 0 warnings
- `pytest tests/test_service_compare_pipeline.py -q` — 14 passed
- Full `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — running; this sandbox is running it far slower than the ~43s AGENTS.md documents (CPU-bound, not this change), so it had not finished as of this PR's creation. Will report back if it surfaces anything.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (plan doc + status ledger, in the same PR per repo convention)
- [x] No new `mypy` errors introduced
- [ ] `ruff`/full local suite — pending full-suite completion noted above

This is a `feat:` PR with no bug being fixed, so the bug-fix test contract section doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQejyigSc9DGg9379KcG8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQejyigSc9DGg9379KcG8J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compare requests now include resolved execution context details.
  - Depth requests are handled consistently regardless of letter casing.

- **Bug Fixes**
  - Case-insensitive depth values now correctly match available evidence levels and resolution details.

- **Documentation**
  - Updated project documentation and changelog to reflect resolved execution context support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->