### PR TITLE
docs: regenerate stale python-api-reference.md

### DIFF
--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -191,6 +191,7 @@ Both sides of a comparison, resolved and ready to classify.
 | `new_fmt` | `str \| None` | *(required)* |
 | `old_evidence` | `SideEvidence` | *(required)* |
 | `new_evidence` | `SideEvidence` | *(required)* |
+| `resolved_execution_context` | `ResolvedExecutionContext \| None` | `None` |
 
 ## `ScanArtifactResult`
 


### PR DESCRIPTION
## Summary

All four `unit-tests` CI lanes on `main` (ubuntu 3.12/3.13/3.14, windows 3.13) were failing with the same root cause:

```
FAILED tests/test_python_api_reference.py::test_generated_reference_is_in_sync_with_service_all
AssertionError: docs/reference/python-api-reference.md is stale -- regenerate with `python scripts/gen_python_api_reference.py`
```

A recent merge added the `resolved_execution_context: ResolvedExecutionContext | None = None` field to `ResolvedComparePair` (in `service_compare_pipeline.py`, via commits `8af7088`/`01df5bb`) but the generated Python API reference doc was never regenerated to match, so the sync-check test failed on every lane.

## Fix

Ran `python scripts/gen_python_api_reference.py` to regenerate `docs/reference/python-api-reference.md`, which adds the single missing row for `resolved_execution_context` under `ResolvedComparePair`.

## Verification

```
$ pytest tests/test_python_api_reference.py -q
......                                                                   [100%]
6 passed in 1.36s
```

Docs-only change — no `abicheck/**/*.py` touched, so no changelog fragment is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab9DXb7BT1FLACDWSyVPAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab9DXb7BT1FLACDWSyVPAc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented an optional execution context field for resolved comparison pairs in the Python API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->