### PR TITLE
perf: eliminate redundant canonical_form traversals in object store

### DIFF
--- a/abicheck/storage/canonical.py
+++ b/abicheck/storage/canonical.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -56,8 +57,10 @@ __all__ = [
     "CAPTURE_METADATA_KEY",
     "canonical_form",
     "canonical_json",
+    "copy_of_canonical_form",
     "raw_digest",
     "semantic_digest",
+    "semantic_digest_of_canonical_form",
     "strip_capture_metadata",
 ]
 
@@ -176,6 +179,29 @@ def canonical_form(value: Any) -> Any:
         return value
     if isinstance(value, float):
         return _canonical_number(value)
+    # Fast path for the overwhelmingly common concrete `dict`/`list` shapes
+    # (every storage payload is built from these, not from a custom
+    # `Mapping`/`Sequence`), checked by exact `type()` ahead of the general
+    # `isinstance(..., Mapping)`/`isinstance(..., Sequence)` checks below.
+    # `isinstance` against an `abc`-registered protocol walks the class's
+    # MRO/registry on every call (`abc.ABCMeta.__instancecheck__`), which is
+    # measurably more expensive than a `type() is dict` identity check at
+    # the scale a large snapshot's canonical form is computed at — this
+    # changes no observable behavior, since the general branches below still
+    # handle every other `Mapping`/`Sequence` subtype exactly as before.
+    value_type = type(value)
+    if value_type is dict:
+        for raw_key in value:
+            if not isinstance(raw_key, str):
+                raise TypeError(
+                    f"mapping key {raw_key!r} is {type(raw_key).__name__}, not str; "
+                    "canonical storage form does not coerce keys"
+                )
+        return {
+            k: canonical_form(v) for k, v in sorted(value.items(), key=lambda kv: kv[0])
+        }
+    if value_type is list:
+        return [canonical_form(v) for v in value]
     if _is_binary_buffer(value):
         # `bytes` is a Sequence, so without this guard it would fall through
         # and encode as a list of integers — a silent, lossy reinterpretation
@@ -238,6 +264,28 @@ def canonical_form(value: Any) -> Any:
     )
 
 
+def copy_of_canonical_form(value: Any) -> Any:
+    """A fresh, deep copy of *value*, which must already be `canonical_form`'s
+    own output (only `dict`/`list`/`str`/`int`/`float`/`bool`/`None`, dict
+    keys already sorted).
+
+    Used where a caller needs an isolated copy of content it knows is
+    already canonical -- `InMemoryObjectStore.get()`'s "never the store's
+    own object" contract, for one -- without paying `canonical_form`'s own
+    cost again: no re-sorting, no dict-key type validation, and no
+    `isinstance` checks against `Mapping`/`Sequence`/`set`/`frozenset`,
+    since the input's shape is already known and none of that work can
+    change the result. Passing anything that is not already canonical is a
+    programming error; this function does not validate that, unlike
+    `canonical_form`, which is the whole reason it is faster.
+    """
+    if type(value) is dict:
+        return {k: copy_of_canonical_form(v) for k, v in value.items()}
+    if type(value) is list:
+        return [copy_of_canonical_form(v) for v in value]
+    return value
+
+
 def strip_capture_metadata(value: Any) -> Any:
     """Canonical form with the reserved root capture-metadata slot removed.
 
@@ -284,12 +332,20 @@ def canonical_json(
     )
 
 
+#: Compiled once rather than re-walking each string character-by-character
+#: in Python for every call — `_has_surrogate_pair` runs once per string in
+#: the entire document (via `_reject_surrogate_pairs`'s full traversal), so
+#: its per-call cost is directly the cost of hashing a large document. `re`'s
+#: matcher is implemented in C and short-circuits on the first match, same
+#: as the `any(...)` it replaces, with identical semantics: `text[index]` in
+#: `\ud800`-`\udbff` immediately followed by `text[index + 1]` in
+#: `\udc00`-`\udfff`.
+_SURROGATE_PAIR_RE = re.compile("[\ud800-\udbff][\udc00-\udfff]")
+
+
 def _has_surrogate_pair(text: str) -> bool:
     """Whether ``text`` contains a high surrogate followed by a low one."""
-    return any(
-        "\ud800" <= text[index] <= "\udbff" and "\udc00" <= text[index + 1] <= "\udfff"
-        for index in range(len(text) - 1)
-    )
+    return _SURROGATE_PAIR_RE.search(text) is not None
 
 
 def _reject_surrogate_pairs(value: Any) -> None:
@@ -373,9 +429,27 @@ def semantic_digest(value: Any, *, algorithm: str = "sha256") -> str:
     which is why it is settled now.
     """
     stripped = strip_capture_metadata(value)
-    _reject_surrogate_pairs(stripped)
+    return semantic_digest_of_canonical_form(stripped, algorithm=algorithm)
+
+
+def semantic_digest_of_canonical_form(
+    canonical_stripped: Any, *, algorithm: str
+) -> str:
+    """:func:`semantic_digest`'s hashing half, given an already-canonical,
+    capture-metadata-stripped value.
+
+    Split out so a caller that has *already* produced this exact form (e.g.
+    `InMemoryObjectStore.put`, which calls :func:`strip_capture_metadata`
+    itself to snapshot what it stores before hashing it -- see that call
+    site's own comment) can hash it without a second, redundant
+    `canonical_form` traversal of content that is already canonical.
+    `semantic_digest` itself still always re-derives the canonical form from
+    whatever it is given, since its public contract is "the digest of this
+    value's canonical form" for an arbitrary, possibly non-canonical input.
+    """
+    _reject_surrogate_pairs(canonical_stripped)
     payload = json.dumps(
-        stripped,
+        canonical_stripped,
         ensure_ascii=True,
         sort_keys=True,
         separators=(",", ":"),

--- a/abicheck/storage/canonical.py
+++ b/abicheck/storage/canonical.py
@@ -57,10 +57,8 @@ __all__ = [
     "CAPTURE_METADATA_KEY",
     "canonical_form",
     "canonical_json",
-    "copy_of_canonical_form",
     "raw_digest",
     "semantic_digest",
-    "semantic_digest_of_canonical_form",
     "strip_capture_metadata",
 ]
 

--- a/abicheck/storage/package.py
+++ b/abicheck/storage/package.py
@@ -775,14 +775,9 @@ class InMemoryObjectStore:
             if digest not in self._objects:
                 self._objects[digest] = payload
             return digest
-        # Normalize once, then hash and store from that same snapshot -- a
-        # second independent traversal of a stateful `Mapping` could digest
-        # different content than what gets stored (Codex review). `stripped`
-        # is already `canonical_form`'s output, so hashing goes straight
-        # through `semantic_digest_of_canonical_form` rather than
-        # `semantic_digest`, which would otherwise re-run `canonical_form`
-        # over content that is already canonical -- a second full traversal
-        # of every section on every `put()` call that bought nothing.
+        # Normalize once, then hash and store from that same snapshot -- a second independent traversal of a
+        # stateful `Mapping` could digest different content than what gets stored (Codex review). Hashed via
+        # `semantic_digest_of_canonical_form`, not `semantic_digest`, since `stripped` is already canonical.
         stripped = strip_capture_metadata(content)
         digest = semantic_digest_of_canonical_form(stripped, algorithm=algorithm)
         if digest not in self._objects:
@@ -797,12 +792,8 @@ class InMemoryObjectStore:
             raise KeyError(f"no object stored under digest {digest!r}") from None
         if isinstance(stored, bytes):
             return stored  # immutable already -- no copy needed
-        # An isolated copy, not the store's own object -- else a caller
-        # could mutate it in place, uncorrectably (Codex review). `stored`
-        # is already `canonical_form`'s own output (that's exactly what
-        # `put()` stored), so `copy_of_canonical_form` gives the same
-        # isolation without `canonical_form`'s redundant re-sort/re-validate
-        # pass over content that is already known canonical.
+        # An isolated copy, not the store's own object -- else a caller could mutate it in place, uncorrectably
+        # (Codex review). `stored` is already canonical, so `copy_of_canonical_form`'s plain copy suffices.
         return copy_of_canonical_form(stored)
 
     def has(self, digest: str) -> bool:

--- a/abicheck/storage/package.py
+++ b/abicheck/storage/package.py
@@ -65,9 +65,9 @@ from types import MappingProxyType
 from typing import Any, Protocol, runtime_checkable
 
 from .canonical import (
-    canonical_form,
+    copy_of_canonical_form,
     raw_digest,
-    semantic_digest,
+    semantic_digest_of_canonical_form,
     strip_capture_metadata,
 )
 from .guards import (
@@ -777,9 +777,14 @@ class InMemoryObjectStore:
             return digest
         # Normalize once, then hash and store from that same snapshot -- a
         # second independent traversal of a stateful `Mapping` could digest
-        # different content than what gets stored (Codex review).
+        # different content than what gets stored (Codex review). `stripped`
+        # is already `canonical_form`'s output, so hashing goes straight
+        # through `semantic_digest_of_canonical_form` rather than
+        # `semantic_digest`, which would otherwise re-run `canonical_form`
+        # over content that is already canonical -- a second full traversal
+        # of every section on every `put()` call that bought nothing.
         stripped = strip_capture_metadata(content)
-        digest = semantic_digest(stripped, algorithm=algorithm)
+        digest = semantic_digest_of_canonical_form(stripped, algorithm=algorithm)
         if digest not in self._objects:
             self._objects[digest] = stripped
         return digest
@@ -793,8 +798,12 @@ class InMemoryObjectStore:
         if isinstance(stored, bytes):
             return stored  # immutable already -- no copy needed
         # An isolated copy, not the store's own object -- else a caller
-        # could mutate it in place, uncorrectably (Codex review).
-        return canonical_form(stored)
+        # could mutate it in place, uncorrectably (Codex review). `stored`
+        # is already `canonical_form`'s own output (that's exactly what
+        # `put()` stored), so `copy_of_canonical_form` gives the same
+        # isolation without `canonical_form`'s redundant re-sort/re-validate
+        # pass over content that is already known canonical.
+        return copy_of_canonical_form(stored)
 
     def has(self, digest: str) -> bool:
         return _identity_text(digest, "digest") in self._objects

--- a/changelog.d/1788600000_claude_serialization-roundtrip-perf.md
+++ b/changelog.d/1788600000_claude_serialization-roundtrip-perf.md
@@ -1,0 +1,17 @@
+### Performance
+
+- **Cut redundant `canonical_form` traversals in the storage object store.**
+  `abicheck.storage.package.InMemoryObjectStore.put()`/`get()` were each
+  re-running a full `canonical_form` pass over content that was already
+  canonical (once to normalize for storage, again inside `semantic_digest`
+  to hash it, and a third time on `get()` just to hand back an isolated
+  copy) — pure duplicated work with no effect on the result. `put()`/`get()`
+  now go through the new `semantic_digest_of_canonical_form`/
+  `copy_of_canonical_form` helpers in `abicheck.storage.canonical`, which
+  skip the redundant re-normalization. `canonical_form` itself also gets a
+  fast path for the overwhelmingly common concrete `dict`/`list` shapes
+  (ahead of the general `Mapping`/`Sequence` `isinstance` checks), and
+  `_has_surrogate_pair`'s per-string scan now uses a compiled regex instead
+  of a Python-level loop. Snapshot serialization round-trip time for a
+  1000-function/500-type snapshot dropped from ~2.6s to under 1.5s, with no
+  change to stored content or digests.

--- a/tests/unit/storage/test_canonical.py
+++ b/tests/unit/storage/test_canonical.py
@@ -791,3 +791,70 @@ class TestAlgorithmPortability:
         # The control: this isn't "reject everything", only what isn't
         # guaranteed portable.
         assert semantic_digest({"x": 1}, algorithm="sha3_256").startswith("sha3_256:")
+
+
+class TestAlreadyCanonicalHelpers:
+    """`InMemoryObjectStore.put()`/`get()` (`abicheck.storage.package`) hash
+    and copy content they already normalized via `canonical_form` themselves
+    -- re-running `canonical_form` on that same output a second time is a
+    wasted traversal, since `canonical_form` is idempotent and pure.
+    `semantic_digest_of_canonical_form`/`copy_of_canonical_form` exist to
+    skip that redundant pass. This is a call-site-independent property of
+    `canonical_form` itself (`canonical_form(canonical_form(x)) ==
+    canonical_form(x)` for every value in its accepted domain), not specific
+    to any one snapshot shape, so it is tested here directly against
+    Hypothesis-generated values rather than only through one benchmark.
+    """
+
+    @given(_json_values)
+    def test_hashing_an_already_canonical_value_matches_semantic_digest(
+        self, value: object
+    ) -> None:
+        from abicheck.storage.canonical import semantic_digest_of_canonical_form
+
+        canonical = canonical_form(value)
+        assert semantic_digest_of_canonical_form(
+            canonical, algorithm="sha256"
+        ) == semantic_digest(value)
+
+    @given(_json_values)
+    def test_copying_an_already_canonical_value_matches_canonical_form(
+        self, value: object
+    ) -> None:
+        from abicheck.storage.canonical import copy_of_canonical_form
+
+        canonical = canonical_form(value)
+        assert copy_of_canonical_form(canonical) == canonical_form(value)
+
+    def test_the_copy_is_isolated_from_the_original(self) -> None:
+        """The property `InMemoryObjectStore.get()` actually depends on:
+        mutating the returned copy must never reach the stored object."""
+        from abicheck.storage.canonical import copy_of_canonical_form
+
+        original = canonical_form({"a": [1, 2, {"b": 3}]})
+        copy = copy_of_canonical_form(original)
+        assert copy == original
+        assert copy is not original
+
+        copy["a"].append(4)
+        copy["a"][2]["b"] = 99
+        assert original == {"a": [1, 2, {"b": 3}]}
+
+    def test_a_mapping_and_a_custom_mapping_subtype_still_agree(self) -> None:
+        """`canonical_form`'s `dict`/`list` fast path is keyed on exact
+        `type()`, ahead of the general `isinstance(..., Mapping)` branch --
+        so a non-`dict` `Mapping` (here, `MappingProxyType`) must still take
+        the general branch and produce the identical canonical form a plain
+        `dict` with the same content does."""
+        from types import MappingProxyType
+
+        plain = {"b": 2, "a": 1}
+        proxy = MappingProxyType({"b": 2, "a": 1})
+        assert canonical_form(proxy) == canonical_form(plain)
+        assert semantic_digest(proxy) == semantic_digest(plain)
+
+    def test_a_tuple_and_a_list_still_agree(self) -> None:
+        """Same fast-path-vs-general-branch concern, for sequences: a
+        `tuple` (not `list`) must still take the general `Sequence` branch
+        and canonicalize identically to the equivalent `list`."""
+        assert canonical_form((1, "x", {"a": 2})) == canonical_form([1, "x", {"a": 2}])

--- a/tests/unit/storage/test_canonical.py
+++ b/tests/unit/storage/test_canonical.py
@@ -812,7 +812,12 @@ class TestAlreadyCanonicalHelpers:
     ) -> None:
         from abicheck.storage.canonical import semantic_digest_of_canonical_form
 
-        canonical = canonical_form(value)
+        # `strip_capture_metadata`, not bare `canonical_form`: `semantic_digest`
+        # strips the root capture-metadata block before hashing, so the input
+        # here must match what `InMemoryObjectStore.put()` actually feeds this
+        # helper (CodeRabbit review) -- otherwise a generated `value` carrying
+        # a root `"capture"` key would make this assertion false.
+        canonical = strip_capture_metadata(value)
         assert semantic_digest_of_canonical_form(
             canonical, algorithm="sha256"
         ) == semantic_digest(value)


### PR DESCRIPTION
## Summary

Fixes the failing `TestSerializationBenchmark::test_serialization_roundtrip_under_2_seconds` perf test by removing genuinely redundant work in the storage object store, not by loosening the budget.

## Motivation

CI reported:

```
AssertionError: Round-trip took 2.65s, expected < 2s
```

for `tests/test_performance.py::TestSerializationBenchmark::test_serialization_roundtrip_under_2_seconds` (a 1000-function/500-type snapshot round-tripped through `snapshot_to_json`/`snapshot_from_dict`).

## Root cause

`snapshot_to_json`/`snapshot_from_dict` route through the ADR-062 sectioned-document/object-store machinery (`abicheck/storage/package.py`'s `InMemoryObjectStore`). Its `put()`/`get()` were each re-running a full `canonical_form` pass (a recursive, sorting normalization) over content that was **already canonical**:

- `put()` canonicalized the content once via `strip_capture_metadata`, then called `semantic_digest()`, which canonicalized the *same* value again internally to compute the digest.
- `get()` re-ran `canonical_form` a second time purely to hand back an isolated copy of content that was already canonical.

With 14 sections per snapshot round-trip, this compounded into ~1.3M `canonical_form` calls for one call to `snapshot_to_json`/`snapshot_from_dict`.

## Changes

- Split `semantic_digest` into a canonicalize-then-hash public function and a new `semantic_digest_of_canonical_form` that hashes already-canonical input directly (`abicheck/storage/canonical.py`). `InMemoryObjectStore.put()` now uses the latter, cutting one redundant full traversal per stored object.
- Added `copy_of_canonical_form`, a cheap deep copy for content already known to be canonical (no re-sort/re-validate). `InMemoryObjectStore.get()` uses it instead of re-running `canonical_form`.
- Added a `type(value) is dict` / `type(value) is list` fast path in `canonical_form`, ahead of the general `isinstance(..., Mapping)`/`isinstance(..., Sequence)` ABC checks that dominated profiled time (profiling showed ~6.7M `isinstance` calls, over 1M of them via `abc.ABCMeta.__instancecheck__`). The general `Mapping`/`Sequence` branches are unchanged and still handle every non-`dict`/`list` shape (`MappingProxyType`, `tuple`, custom subtypes).
- Replaced `_has_surrogate_pair`'s Python-level per-character loop with a compiled regex (`re.compile("[\ud800-\udbff][\udc00-\udfff]")`), matched against `abicheck/storage/canonical.py`'s existing semantics.
- Added `TestAlreadyCanonicalHelpers` to `tests/unit/storage/test_canonical.py`: Hypothesis-backed property tests that `semantic_digest_of_canonical_form`/`copy_of_canonical_form` agree with `semantic_digest`/`canonical_form` on arbitrary already-canonical input, that the returned copy is isolated from the original (the property `InMemoryObjectStore.get()` actually depends on), and that the new `dict`/`list` fast path still agrees with the general `Mapping`/`Sequence` branch for `MappingProxyType` and `tuple`.

None of this changes what gets stored, what digest is produced, or `canonical_form`'s public contract — every branch still handles the exact same shapes the same way; only the redundant re-traversal is removed.

## Result

Round-trip time for the 1000-function/500-type benchmark snapshot dropped from ~2.65s to ~1.3s locally (profiled cumulative time for the same call also dropped, from 8.7s to 5.3s under `cProfile`, i.e. the actual work performed shrank, not just noise).

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: Redundant full-tree re-normalization — a caller that already holds `canonical_form`'s output re-running `canonical_form` (or an equivalent full traversal) on that same output again, multiplying an O(n) content-store operation by an avoidable constant factor per redundant pass.
- Publicly observable failure: `tests/test_performance.py::TestSerializationBenchmark::test_serialization_roundtrip_under_2_seconds` — round-tripping a 1000-function/500-type `AbiSnapshot` through the public `snapshot_to_json`/`snapshot_from_dict` entry points took 2.65s against the stated <2s budget.
- Regression test fails on base: Yes — the pre-existing perf test already fails on `main`/base (the reported CI failure this PR fixes) without any change; it now passes unmodified. In addition, `tests/unit/storage/test_canonical.py::TestAlreadyCanonicalHelpers` is new: its property tests exercise the general invariant directly and would fail against any implementation of `semantic_digest_of_canonical_form`/`copy_of_canonical_form` that diverged from `semantic_digest`/`canonical_form`, or against a `dict`/`list` fast path that disagreed with the general `Mapping`/`Sequence` branch.
- Negative control: N/A — this is a pure performance fix with no suppression/detection behavior; `canonical_form`'s output and every downstream digest are unchanged (verified by the full existing `abicheck/storage` canonical/package/DTO test suite passing unmodified against the new code path — 1116+ tests, plus the new property tests above).
- Public-surface test: The original regression test drives only the public `snapshot_to_json`/`json.loads`/`snapshot_from_dict` entry points end-to-end. The new property tests target the module's actual public entry points too (`canonical_form`, `semantic_digest`, and the two new helper functions), not private internals.
- Axes covered: Wall-clock elapsed time of the full JSON round trip at a production-representative scale (1000 functions + 500 types) is the one axis the perf-budget test exercises. Content/digest correctness across arbitrary shapes (mappings, sequences, sets, floats, capture metadata, surrogate handling, `MappingProxyType`, `tuple`) is covered by the new Hypothesis property tests plus the unchanged existing `tests/unit/storage/test_canonical.py`, `tests/test_package.py`, `tests/test_serialization_roundtrip.py`, and wider storage/dto suites.
- General invariant: `canonical_form` is idempotent and pure — `canonical_form(canonical_form(x)) == canonical_form(x)` for every value in its accepted domain — so hashing or copying an already-canonical value via `semantic_digest_of_canonical_form`/`copy_of_canonical_form` yields exactly what `semantic_digest`/`canonical_form` would recompute, without recomputing it. `TestAlreadyCanonicalHelpers` states this as an executable Hypothesis property (not just prose), against `semantic_digest`/`canonical_form` as the oracle, generalizing well beyond the one reported snapshot shape.

## Checklist

- [x] Tests added / updated for new behaviour — `tests/unit/storage/test_canonical.py::TestAlreadyCanonicalHelpers` (new, Hypothesis property tests); the pre-existing perf-budget test is the regression coverage for the reported failure and now passes unmodified.
- [x] Changelog fragment added (`scriv create`) — `changelog.d/1788600000_claude_serialization-roundtrip-perf.md`
- [ ] Docs updated — not applicable; no user-visible behavior changed
- [x] `ruff check`/`ruff format --check`/`mypy abicheck/storage/canonical.py abicheck/storage/package.py` pass locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LWxrSmw8F2jMXAk4XtY2v

---
_Generated by [Claude Code](https://claude.ai/code/session_018LWxrSmw8F2jMXAk4XtY2v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved storage serialization and snapshot round-trip performance, reducing typical processing time from approximately 2.6 seconds to under 1.5 seconds.
  * Optimized canonicalization and digest generation while preserving stored content and digest results.

* **Reliability**
  * Added safeguards to ensure copied stored values remain isolated from their originals.

* **Tests**
  * Expanded coverage for canonicalization, digest consistency, deep-copy behavior, and supported mapping and sequence types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->