### PR TITLE
feat(workflows): wire ResolvedExecutionContext onto dump, converge contract.mode

### DIFF
--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1938,6 +1938,13 @@ def run_compare(
     # Reporting reads the severity config only under the severity exit scheme;
     # resolved once here rather than re-spelled at each of the five consumers.
     report_severity = sev_config if resolved_cfg.exit_code_scheme == "severity" else None
+    # One Semantic Pipeline plan, 4B: `evaluation_config` already carries D7's
+    # resolved `contract.mode` -- use it, not the stale pre-resolution local.
+    resolved_contract_mode = (
+        evaluation_config.contract.mode
+        if evaluation_config is not None
+        else contract_mode
+    )
     from .service import compare_snapshots, load_env_matrix
     try:
         env_matrix = load_env_matrix(env_matrix_path)
@@ -1957,7 +1964,7 @@ def run_compare(
             reconcile_build_context=reconcile_build_context,
             diagnostic_comparison=diagnostic_comparison,
             contract_evaluation=contract_evaluation,
-            contract_mode=contract_mode,
+            contract_mode=resolved_contract_mode,
         )
     except (ProfileMismatchError, ScopeMismatchError) as exc:
         _report_not_comparable(exc, old, new, fmt=fmt, output=output)

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1938,11 +1938,12 @@ def run_compare(
     # Reporting reads the severity config only under the severity exit scheme;
     # resolved once here rather than re-spelled at each of the five consumers.
     report_severity = sev_config if resolved_cfg.exit_code_scheme == "severity" else None
-    # One Semantic Pipeline plan, 4B: `evaluation_config` already carries D7's
-    # resolved `contract.mode` -- use it, not the stale pre-resolution local.
+    # One Semantic Pipeline plan, 4B: use evaluation_config's resolved
+    # contract.mode -- but only under contract_evaluation itself, since a
+    # --pack-only run resolves a non-None config with a concrete mode too.
     resolved_contract_mode = (
         evaluation_config.contract.mode
-        if evaluation_config is not None
+        if evaluation_config is not None and contract_evaluation
         else contract_mode
     )
     from .service import compare_snapshots, load_env_matrix

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -724,14 +724,23 @@ def execute_dump_request(
         # Codex review, PR #1037: `with_assurance()` alone leaves
         # `compile_contexts` empty. `resolution.effective_compile_context`,
         # when the P0.3 fold produced one AND a header-AST parse actually
-        # consumed it (`snap.from_headers`), is what
-        # `ResolvedExecutionContext.compile_contexts`'s own docstring wants
-        # here -- that field is documented absent, not placeholder-valued,
-        # for a binary-only depth (second Codex round: the fold can resolve
-        # a real `CompileContext` from `-p`/`--compile-db` alone even with no
-        # headers in play, which `DumpResult.effective_compile_context` -- a
-        # separate, unconditional field -- still carries either way).
-        if resolution.effective_compile_context is not None and snap.from_headers:
+        # ran *this invocation*, is what `ResolvedExecutionContext.
+        # compile_contexts`'s own docstring wants -- documented absent, not
+        # placeholder-valued, when no header-AST context was resolved.
+        # `snap.from_headers` alone is not enough (third Codex round): a
+        # JSON-snapshot `resolved.fmt is None` input short-circuits straight
+        # to the persisted snapshot in `resolve_input` (no header-AST parse
+        # at all), yet the *loaded* snapshot can itself carry a stale
+        # `from_headers=True` from whatever dump originally produced it --
+        # `resolved.fmt is not None` (a real ELF/PE/Mach-O magic-byte match)
+        # is what actually gates a header-AST parse having run here.
+        # `DumpResult.effective_compile_context` stays unconditional either
+        # way (a separate, pre-existing field).
+        if (
+            resolution.effective_compile_context is not None
+            and snap.from_headers
+            and resolved.fmt is not None
+        ):
             resolved_execution_context = dataclasses.replace(
                 resolved_execution_context,
                 compile_contexts={"input": resolution.effective_compile_context},

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from .compile_context import CompileContext
     from .model import AbiSnapshot
     from .service_compare_evidence import SideEvidence
+    from .workflows.resolved_execution_context import ResolvedExecutionContext
 
 __all__ = [
     "DumpResult",
@@ -133,6 +134,30 @@ class ResolvedDumpRequest:
     instance -- silently breaking equality-based comparison or caching for
     every existing and future caller of this frozen dataclass, over a field
     that is itself inert today.
+
+    ``resolved_execution_context`` (One Semantic Pipeline plan, sub-phase 4B
+    -- ``dump``'s own slice of the gap
+    :class:`~abicheck.service_compare_pipeline.ResolvedComparePair`'s
+    identically-named field already closed for ``compare``): the
+    :class:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext` built from this same call's own, otherwise-
+    discarded :class:`~abicheck.workflows.plan.AnalysisPlan`
+    (:func:`resolve_dump_request` already calls ``AnalysisPlanner.resolve``
+    for its ADR-063 Phase 4 pre-flight check -- this is not a second
+    resolution). ``operation`` reads ``"dump"`` off the plan; ``evidence``
+    carries only ``requested_depth``/``available_depths`` at this point --
+    the pre-execution view, via :meth:`~abicheck.workflows.
+    resolved_execution_context.ResolvedExecutionContext.from_plan` with no
+    *assurance*. Optional and additive: excluded from ``compare=False`` for
+    the same reason ``artifact_plan`` is -- a fresh, distinct
+    ``ResolvedExecutionContext`` instance must not make two structurally
+    identical resolutions compare unequal. Carries no ``evaluation_config``/
+    ``compile_contexts`` yet, for the identical reason
+    ``ResolvedComparePair.resolved_execution_context`` does not: neither
+    resolves at this seam. See :func:`execute_dump_request` for the
+    post-execution counterpart, attached via
+    :meth:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext.with_assurance`.
     """
 
     request: DumpRequest
@@ -170,6 +195,9 @@ class ResolvedDumpRequest:
     public_headers: tuple[Path, ...]
     public_header_dirs: tuple[Path, ...]
     artifact_plan: ResolvedArtifactPlan | None = field(default=None, compare=False)
+    resolved_execution_context: ResolvedExecutionContext | None = field(
+        default=None, compare=False
+    )
 
     @property
     def collect_mode(self) -> str:
@@ -239,6 +267,25 @@ class DumpResult:
     is exactly the sort of pair-aware/lifetime redesign PR 3A's "Known gaps"
     entry already scopes as its own follow-up, not settled by exposing these
     fields alone.
+
+    ``resolved_execution_context`` (One Semantic Pipeline plan, sub-phase
+    4B): ``resolved.resolved_execution_context`` (the pre-execution view),
+    completed via
+    :meth:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext.with_assurance` once this object's own
+    ``effective_depth`` -- the one fact ``dump`` can compute that ``compare``
+    computes via a real
+    :class:`~abicheck.analysis_assurance.AnalysisAssurance` -- is known.
+    ``dump`` has no comparison pair, so there is no real ``AnalysisAssurance``
+    to attach; :func:`execute_dump_request` instead builds
+    :class:`_DumpAssuranceView`, a minimal object carrying exactly the three
+    attributes :meth:`~abicheck.workflows.resolved_execution_context.
+    EvidenceView.from_assurance` reads (``requested_depth``,
+    ``effective_depth``, ``depth_satisfied``) -- see that class for why this
+    is a real post-execution fact, not a synthesized stand-in. ``None`` only
+    when ``resolved.resolved_execution_context`` was itself ``None`` (a
+    caller that hand-built a ``ResolvedDumpRequest`` bypassing
+    :func:`resolve_dump_request`).
     """
 
     resolved: ResolvedDumpRequest
@@ -246,6 +293,7 @@ class DumpResult:
     effective_depth: str
     effective_includes: tuple[Path, ...] = ()
     effective_compile_context: CompileContext | None = None
+    resolved_execution_context: ResolvedExecutionContext | None = None
 
 
 def _reject_unsupported_frontends(
@@ -344,8 +392,10 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     # combination can satisfy before any extraction runs (PlanningError),
     # rather than discovering the gap mid-run or not at all. See
     # `abicheck.workflows.plan`'s own module docstring for exactly what this
-    # does and does not check.
-    AnalysisPlanner.resolve(request)
+    # does and does not check. The returned `AnalysisPlan` is also what
+    # feeds `ResolvedExecutionContext.from_plan` below (One Semantic
+    # Pipeline plan, sub-phase 4B) -- not a second resolution.
+    plan = AnalysisPlanner.resolve(request)
     # validate() accepts lang case-insensitively; the ELF dump path does
     # case-sensitive `lang == "c"` checks, so normalise here. `android` (no
     # header-AST path) falls back to "auto" for the binary dump.
@@ -432,6 +482,8 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
         public_headers=tuple(public_headers),
         public_header_dirs=tuple(public_header_dirs),
     )
+    from .workflows.resolved_execution_context import ResolvedExecutionContext
+
     return ResolvedDumpRequest(
         request=request,
         lang=lang,
@@ -445,7 +497,34 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
         public_headers=tuple(public_headers),
         public_header_dirs=tuple(public_header_dirs),
         artifact_plan=artifact_plan,
+        resolved_execution_context=ResolvedExecutionContext.from_plan(plan),
     )
+
+
+@dataclass(frozen=True)
+class _DumpAssuranceView:
+    """The minimal shape :meth:`~abicheck.workflows.resolved_execution_context.
+    EvidenceView.from_assurance` reads via ``getattr`` -- ``requested_depth``/
+    ``effective_depth``/``depth_satisfied`` -- built from a completed
+    :class:`DumpResult`'s own facts rather than a real
+    :class:`~abicheck.analysis_assurance.AnalysisAssurance`.
+
+    ``AnalysisAssurance`` is comparison-shaped: pair symmetry (L0/header/DWARF
+    context drift between two sides), target/TU/export accounting, fact-set
+    comparability -- none of it meaningful for a single ``dump`` with no other
+    side to compare against. But the one axis ``AnalysisAssurance`` and a
+    single dump genuinely share -- "did the requested ``--depth`` get
+    reached" -- *is* knowable here, from :func:`execute_dump_request`'s own
+    already-computed ``effective_depth`` (a real post-execution fact, the
+    identical value :class:`DumpResult` itself carries), so this class states
+    exactly that axis rather than leaving :meth:`~abicheck.workflows.
+    resolved_execution_context.ResolvedExecutionContext.with_assurance`
+    fully unwired for ``dump``.
+    """
+
+    requested_depth: str | None
+    effective_depth: str | None
+    depth_satisfied: bool | None
 
 
 def execute_dump_request(
@@ -532,7 +611,7 @@ def execute_dump_request(
         SnapshotError: If the input cannot be loaded.
     """
     from .dependency_info import populate_side_dependency_info
-    from .evidence_depth import gated_source_label
+    from .evidence_depth import depth_rank, gated_source_label
 
     request = resolved.request
     side = request.input
@@ -615,10 +694,37 @@ def execute_dump_request(
         effective_depth = gated_source_label(snap.build_source, snap)
     except (TypeError, ValueError, OverflowError):
         effective_depth = "headers" if snap.from_headers else "binary"
+
+    # One Semantic Pipeline plan, sub-phase 4B: the real post-execution
+    # `with_assurance()` caller `resolve_dump_request`'s own docstring named
+    # as the still-open half. `resolved.requested_depth` is lower-cased
+    # first, matching `ResolvedExecutionContext.from_plan`'s own
+    # case-normalization (see that method's docstring) -- `DumpRequest.depth`
+    # is not itself normalized, and both `depth_rank` and the ladder
+    # `EvidenceView.available_depths` states are case-sensitive.
+    resolved_execution_context = None
+    if resolved.resolved_execution_context is not None:
+        requested_depth = (
+            resolved.requested_depth.lower()
+            if resolved.requested_depth is not None
+            else None
+        )
+        resolved_execution_context = resolved.resolved_execution_context.with_assurance(
+            _DumpAssuranceView(
+                requested_depth=requested_depth,
+                effective_depth=effective_depth,
+                depth_satisfied=(
+                    None
+                    if requested_depth is None
+                    else depth_rank(effective_depth) >= depth_rank(requested_depth)
+                ),
+            )
+        )
     return DumpResult(
         resolved=resolved,
         snapshot=snap,
         effective_depth=effective_depth,
         effective_includes=resolution.effective_includes,
         effective_compile_context=resolution.effective_compile_context,
+        resolved_execution_context=resolved_execution_context,
     )

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -611,6 +611,7 @@ def execute_dump_request(
             :func:`~abicheck.cli_buildsource.dump_source_only`).
         SnapshotError: If the input cannot be loaded.
     """
+    from . import service
     from .dependency_info import populate_side_dependency_info
     from .evidence_depth import depth_rank, gated_source_label
 
@@ -721,23 +722,36 @@ def execute_dump_request(
                 ),
             )
         )
-        # Codex review, PR #1037: `with_assurance()` alone leaves
-        # `compile_contexts` empty. `resolution.effective_compile_context`,
-        # when the P0.3 fold produced one AND a header-AST parse actually
-        # ran *this invocation*, is what `ResolvedExecutionContext.
-        # compile_contexts`'s own docstring wants -- documented absent, not
-        # placeholder-valued, when no header-AST context was resolved.
-        # `snap.from_headers` alone is not enough (third Codex round): a
-        # JSON-snapshot `resolved.fmt is None` input short-circuits straight
-        # to the persisted snapshot in `resolve_input` (no header-AST parse
-        # at all), yet the *loaded* snapshot can itself carry a stale
-        # `from_headers=True` from whatever dump originally produced it --
-        # `resolved.fmt is not None` (a real ELF/PE/Mach-O magic-byte match)
-        # is what actually gates a header-AST parse having run here.
-        # `DumpResult.effective_compile_context` stays unconditional either
-        # way (a separate, pre-existing field).
+        # Codex review, PR #1037 (five rounds -- see git history for the
+        # narrower, now-superseded gates this replaced): `with_assurance()`
+        # alone leaves `compile_contexts` empty. `resolution.
+        # effective_compile_context`, when the P0.3 fold produced one AND a
+        # header-AST parse actually ran *this invocation*, is what
+        # `ResolvedExecutionContext.compile_contexts`'s own docstring wants
+        # -- documented absent, not placeholder-valued, when no header-AST
+        # context was resolved. `DumpResult.effective_compile_context` stays
+        # unconditional either way (a separate, pre-existing field).
         #
-        # `request.input.dump_manifest is None` (fourth Codex round):
+        # "Did a header-AST parse run" cannot be answered from `resolved.fmt`
+        # (computed from the *raw*, pre-resolution input path): a JSON
+        # snapshot or ABICC Perl dump input short-circuits straight to a
+        # loaded/imported snapshot in `resolve_input` with no parse at all,
+        # while a GNU ld linker script input resolves `fmt=None` on its own
+        # text-file path yet `resolve_input` follows it and *does* run a
+        # real parse against the real target underneath. Nor can it be
+        # answered from `snap.from_headers`/`snap.platform` alone: both are
+        # ordinary persisted `AbiSnapshot` fields, so a loaded JSON snapshot
+        # can carry an equally stale `True`/`"elf"` from whatever dump
+        # originally produced the file, not from this invocation.
+        # `resolve_linker_script_chain` is the identical primitive
+        # `checker.compare`'s own same-binary hashing already uses to answer
+        # "what does this input actually resolve to" for the identical
+        # multi-hop-script reason -- detecting *that* target's binary format
+        # is a real, per-invocation fact no persisted snapshot field can
+        # misreport, and it agrees with `resolved.fmt` for every input that
+        # isn't itself a linker script.
+        #
+        # `side.dump_manifest is None` (fourth Codex round):
         # `resolution.effective_compile_context` is derived from the
         # request/InputSpec's own compile settings only, but a manifest-
         # driven dump's real header-AST parse runs under
@@ -750,10 +764,17 @@ def execute_dump_request(
         # attempted here; the manifest path already has no
         # `resolved_execution_context.evaluation_config`/other resolved
         # fields either (see this pipeline's own "Not in scope" notes).
+        parsed_fmt = None
+        if side.path is not None:
+            from .binary_utils import resolve_linker_script_chain
+
+            parsed_fmt = service.detect_binary_format(
+                resolve_linker_script_chain(side.path)
+            )
         if (
             resolution.effective_compile_context is not None
             and snap.from_headers
-            and resolved.fmt is not None
+            and parsed_fmt is not None
             and side.dump_manifest is None
         ):
             resolved_execution_context = dataclasses.replace(

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -44,6 +44,7 @@ import cycle.
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -720,6 +721,20 @@ def execute_dump_request(
                 ),
             )
         )
+        # Codex review, PR #1037: `with_assurance()` alone leaves
+        # `compile_contexts` at the empty mapping `resolve_dump_request` built
+        # it with (nothing is knowable pre-execution -- see that field's own
+        # docstring on `ResolvedDumpRequest`). This resolution's own
+        # `effective_compile_context`, when the P0.3 fold produced one, is
+        # exactly the resolved L2 compile-context input the field exists to
+        # carry, under the one label a dump has (mirroring
+        # `ResolvedComparePair.resolved_execution_context`'s `"old"`/`"new"`
+        # side labels with `dump`'s own single side).
+        if resolution.effective_compile_context is not None:
+            resolved_execution_context = dataclasses.replace(
+                resolved_execution_context,
+                compile_contexts={"input": resolution.effective_compile_context},
+            )
     return DumpResult(
         resolved=resolved,
         snapshot=snap,

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -722,55 +722,53 @@ def execute_dump_request(
                 ),
             )
         )
-        # Codex review, PR #1037 (five rounds -- see git history for the
+        # Codex review, PR #1037 (six rounds -- see git history for the
         # narrower, now-superseded gates this replaced): `with_assurance()`
         # alone leaves `compile_contexts` empty. `resolution.
         # effective_compile_context`, when the P0.3 fold produced one AND a
         # header-AST parse actually ran *this invocation*, is what
         # `ResolvedExecutionContext.compile_contexts`'s own docstring wants
-        # -- documented absent, not placeholder-valued, when no header-AST
-        # context was resolved. `DumpResult.effective_compile_context` stays
-        # unconditional either way (a separate, pre-existing field).
+        # -- documented absent, not placeholder-valued, otherwise.
+        # `DumpResult.effective_compile_context` stays unconditional either
+        # way (a separate, pre-existing field).
         #
-        # "Did a header-AST parse run" cannot be answered from `resolved.fmt`
-        # (computed from the *raw*, pre-resolution input path): a JSON
-        # snapshot or ABICC Perl dump input short-circuits straight to a
-        # loaded/imported snapshot in `resolve_input` with no parse at all,
-        # while a GNU ld linker script input resolves `fmt=None` on its own
-        # text-file path yet `resolve_input` follows it and *does* run a
-        # real parse against the real target underneath. Nor can it be
-        # answered from `snap.from_headers`/`snap.platform` alone: both are
-        # ordinary persisted `AbiSnapshot` fields, so a loaded JSON snapshot
-        # can carry an equally stale `True`/`"elf"` from whatever dump
-        # originally produced the file, not from this invocation.
-        # `resolve_linker_script_chain` is the identical primitive
-        # `checker.compare`'s own same-binary hashing already uses to answer
-        # "what does this input actually resolve to" for the identical
-        # multi-hop-script reason -- detecting *that* target's binary format
-        # is a real, per-invocation fact no persisted snapshot field can
-        # misreport, and it agrees with `resolved.fmt` for every input that
-        # isn't itself a linker script.
+        # "Did a header-AST parse run" is answered by detecting the format of
+        # the *actually-resolved* target, mirroring `resolve_input`'s own
+        # dispatch order rather than any single proxy: `resolved.fmt`/
+        # `snap.from_headers`/`snap.platform` each disagree with reality for
+        # some input shape (a loaded JSON/Perl snapshot short-circuits with
+        # no parse at all, yet can carry a stale `from_headers=True`/
+        # `platform` from whatever dump produced the file; a GNU ld linker
+        # script resolves `fmt=None` on its own text path even though
+        # `resolve_input` follows it and does run a real parse on the target
+        # underneath). `sniff_text_format` first rules out the two verbatim-
+        # load formats (same check `resolve_input` itself applies first, so
+        # a JSON snapshot whose own bytes coincidentally contain literal
+        # `INPUT(...)`-shaped text is never fed to the linker-script probe);
+        # only then does `resolve_linker_script_chain` -- the identical
+        # primitive `checker.compare`'s own same-binary hashing already uses
+        # for "what does this input actually resolve to" -- follow any
+        # script to its real target for detection.
         #
-        # `side.dump_manifest is None` (fourth Codex round):
-        # `resolution.effective_compile_context` is derived from the
-        # request/InputSpec's own compile settings only, but a manifest-
-        # driven dump's real header-AST parse runs under
-        # `dumper_manifest.resolve_header_ast_result`'s own manifest-
-        # authoritative `dump_manifest.frontend_context` instead (e.g.
-        # `"device"`) -- reproducing that resolution here, rather than
-        # excluding it, risks recording a wrong (`"host"`) context that
-        # actively misleads a consumer, which is worse than the field
-        # staying absent for this one input shape. A documented gap, not
-        # attempted here; the manifest path already has no
-        # `resolved_execution_context.evaluation_config`/other resolved
-        # fields either (see this pipeline's own "Not in scope" notes).
+        # `side.dump_manifest is None`: a manifest-driven dump's real
+        # header-AST parse runs under its own manifest-authoritative
+        # `dump_manifest.frontend_context` (e.g. `"device"`), not the
+        # request-derived context resolved here -- recording it would risk a
+        # wrong (`"host"`) toolchain, so this case is excluded rather than
+        # reconstructed (a documented gap; the manifest path already carries
+        # no `evaluation_config`/other resolved fields either).
         parsed_fmt = None
         if side.path is not None:
-            from .binary_utils import resolve_linker_script_chain
+            parsed_fmt = service.detect_binary_format(side.path)
+            if parsed_fmt is None and service.sniff_text_format(side.path) not in (
+                "json",
+                "perl",
+            ):
+                from .binary_utils import resolve_linker_script_chain
 
-            parsed_fmt = service.detect_binary_format(
-                resolve_linker_script_chain(side.path)
-            )
+                parsed_fmt = service.detect_binary_format(
+                    resolve_linker_script_chain(side.path)
+                )
         if (
             resolution.effective_compile_context is not None
             and snap.from_headers

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -736,10 +736,25 @@ def execute_dump_request(
         # is what actually gates a header-AST parse having run here.
         # `DumpResult.effective_compile_context` stays unconditional either
         # way (a separate, pre-existing field).
+        #
+        # `request.input.dump_manifest is None` (fourth Codex round):
+        # `resolution.effective_compile_context` is derived from the
+        # request/InputSpec's own compile settings only, but a manifest-
+        # driven dump's real header-AST parse runs under
+        # `dumper_manifest.resolve_header_ast_result`'s own manifest-
+        # authoritative `dump_manifest.frontend_context` instead (e.g.
+        # `"device"`) -- reproducing that resolution here, rather than
+        # excluding it, risks recording a wrong (`"host"`) context that
+        # actively misleads a consumer, which is worse than the field
+        # staying absent for this one input shape. A documented gap, not
+        # attempted here; the manifest path already has no
+        # `resolved_execution_context.evaluation_config`/other resolved
+        # fields either (see this pipeline's own "Not in scope" notes).
         if (
             resolution.effective_compile_context is not None
             and snap.from_headers
             and resolved.fmt is not None
+            and side.dump_manifest is None
         ):
             resolved_execution_context = dataclasses.replace(
                 resolved_execution_context,

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -757,18 +757,18 @@ def execute_dump_request(
         # wrong (`"host"`) toolchain, so this case is excluded rather than
         # reconstructed (a documented gap; the manifest path already carries
         # no `evaluation_config`/other resolved fields either).
-        parsed_fmt = None
-        if side.path is not None:
-            parsed_fmt = service.detect_binary_format(side.path)
-            if parsed_fmt is None and service.sniff_text_format(side.path) not in (
-                "json",
-                "perl",
-            ):
-                from .binary_utils import resolve_linker_script_chain
+        # `side.path` is guaranteed non-None here -- the `is None` branch
+        # above already raised before this point.
+        parsed_fmt = service.detect_binary_format(side.path)
+        if parsed_fmt is None and service.sniff_text_format(side.path) not in (
+            "json",
+            "perl",
+        ):
+            from .binary_utils import resolve_linker_script_chain
 
-                parsed_fmt = service.detect_binary_format(
-                    resolve_linker_script_chain(side.path)
-                )
+            parsed_fmt = service.detect_binary_format(
+                resolve_linker_script_chain(side.path)
+            )
         if (
             resolution.effective_compile_context is not None
             and snap.from_headers

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -722,15 +722,16 @@ def execute_dump_request(
             )
         )
         # Codex review, PR #1037: `with_assurance()` alone leaves
-        # `compile_contexts` at the empty mapping `resolve_dump_request` built
-        # it with (nothing is knowable pre-execution -- see that field's own
-        # docstring on `ResolvedDumpRequest`). This resolution's own
-        # `effective_compile_context`, when the P0.3 fold produced one, is
-        # exactly the resolved L2 compile-context input the field exists to
-        # carry, under the one label a dump has (mirroring
-        # `ResolvedComparePair.resolved_execution_context`'s `"old"`/`"new"`
-        # side labels with `dump`'s own single side).
-        if resolution.effective_compile_context is not None:
+        # `compile_contexts` empty. `resolution.effective_compile_context`,
+        # when the P0.3 fold produced one AND a header-AST parse actually
+        # consumed it (`snap.from_headers`), is what
+        # `ResolvedExecutionContext.compile_contexts`'s own docstring wants
+        # here -- that field is documented absent, not placeholder-valued,
+        # for a binary-only depth (second Codex round: the fold can resolve
+        # a real `CompileContext` from `-p`/`--compile-db` alone even with no
+        # headers in play, which `DumpResult.effective_compile_context` -- a
+        # separate, unconditional field -- still carries either way).
+        if resolution.effective_compile_context is not None and snap.from_headers:
             resolved_execution_context = dataclasses.replace(
                 resolved_execution_context,
                 compile_contexts={"input": resolution.effective_compile_context},

--- a/changelog.d/20260903_164520_noreply_adr_063_track_3_resolved_context_rcsoyf.md
+++ b/changelog.d/20260903_164520_noreply_adr_063_track_3_resolved_context_rcsoyf.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **`ResolvedExecutionContext` now covers `dump`, and `compare`'s native CLI
+  stops re-deriving an already-resolved `contract.mode`** — One Semantic
+  Pipeline plan, sub-phase 4B. `resolve_dump_request` builds the same
+  pre-execution `ResolvedExecutionContext` `compare`'s pipeline already
+  attaches, and `execute_dump_request` is now a real post-execution
+  `with_assurance()` caller, completing the context's evidence view from the
+  dump's own achieved depth. `abicheck compare` also now hands
+  `checker.compare` its already-resolved ADR-049 `contract.mode` instead of
+  letting `contract_pipeline.build_contract_stage` re-derive the identical
+  legacy-alias domain a second time — no observable behavior change, since
+  the two computations always agreed, but the redundant resolution is gone.

--- a/tests/test_cli_compare_contract_mode_wiring.py
+++ b/tests/test_cli_compare_contract_mode_wiring.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One Semantic Pipeline plan, sub-phase 4B: the native ``compare`` CLI stops
+independently re-deriving ``contract.mode`` once it already resolved an
+ADR-049 D7 ``CompatibilityEvaluationConfig`` for this invocation.
+
+Before this migration, ``cli_compare_helpers.run_compare`` always passed the
+raw, pre-resolution ``contract_mode`` local (``None`` whenever no explicit
+``--contract`` was typed) into ``compare_snapshots``/``checker.compare``, so
+``contract_pipeline.build_contract_stage`` re-derived the identical domain a
+second time via ``compatibility_evaluation_wiring.resolve_legacy_contract_mode``
+-- that function's own documented fallback for a caller with no D7 config to
+read at all. The two computations agree for every input reachable today
+(``contract.mode`` is deliberately not pack-routable, and the legacy-alias
+boolean both sides read is already CLI/``.abicheck.yml``-merged by the time
+either sees it -- see ``CONTRACT_PACK_FIELD_ROUTES``'s own docstring), so
+this is not a behavior fix for any real run; it closes the redundant second
+resolution so the two cannot silently start disagreeing the next time either
+side's own precedence changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import abicheck.cli_compare_helpers as cch
+from abicheck.cli import main
+from abicheck.contract_relevance_types import ContractMode
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+def _fn(name: str, mangled: str, ret: str = "int") -> Function:
+    return Function(
+        name=name, mangled=mangled, return_type=ret, visibility=Visibility.PUBLIC
+    )
+
+
+def _write_pair(tmp_path: Path) -> tuple[Path, Path]:
+    old = AbiSnapshot(
+        library="libfoo.so.1",
+        version="1.0",
+        functions=[_fn("api_a", "_Z5api_av"), _fn("api_b", "_Z5api_bv")],
+        from_headers=True,
+    )
+    new = AbiSnapshot(
+        library="libfoo.so.1",
+        version="2.0",
+        functions=[_fn("api_a", "_Z5api_av")],
+        from_headers=True,
+    )
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(old), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(new), encoding="utf-8")
+    return old_p, new_p
+
+
+class TestResolvedContractModeWiring:
+    def test_compare_snapshots_receives_the_resolved_evaluation_configs_mode(
+        self, tmp_path, monkeypatch
+    ):
+        """``checker.compare`` must be handed ``evaluation_config``'s own
+        resolved ``contract.mode`` -- not the raw, pre-resolution local --
+        so a caller holding the already-resolved config never has that
+        answer silently second-guessed one layer down.
+        ``_resolve_evaluation_config`` is stubbed to return a config whose
+        ``contract.mode`` deliberately disagrees with the raw ``--contract``
+        value this invocation types, so this fails immediately if a future
+        edit reverts to threading the stale local through instead.
+        """
+        old_p, new_p = _write_pair(tmp_path)
+        real_resolve = cch._resolve_evaluation_config
+
+        def _diverging_resolve(*args, **kwargs):
+            evaluation_config, pf, resolved_cfg = real_resolve(*args, **kwargs)
+            assert evaluation_config is not None
+            assert evaluation_config.contract.mode == ContractMode.PUBLIC
+            diverged = replace(
+                evaluation_config,
+                contract=replace(evaluation_config.contract, mode=ContractMode.EXPORTS),
+            )
+            return diverged, pf, resolved_cfg
+
+        monkeypatch.setattr(cch, "_resolve_evaluation_config", _diverging_resolve)
+
+        captured: dict[str, object] = {}
+        from abicheck.service import compare_snapshots as _real_compare_snapshots
+
+        def _capturing_compare_snapshots(*args, **kwargs):
+            captured["contract_mode"] = kwargs.get("contract_mode")
+            return _real_compare_snapshots(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "abicheck.service.compare_snapshots", _capturing_compare_snapshots
+        )
+
+        result = CliRunner().invoke(
+            main,
+            ["compare", str(old_p), str(new_p), "--contract", "public"],
+        )
+        # exit 1: floored by the orthogonal contract-coverage axis, since
+        # `--contract exports`'s evidence (an export table) is unresolvable
+        # against a bare JSON snapshot -- irrelevant to what this test pins.
+        assert result.exit_code in (0, 1, 2, 4), result.output
+        assert captured["contract_mode"] == ContractMode.EXPORTS
+
+    def test_explicit_contract_flag_is_unaffected(self, tmp_path, monkeypatch):
+        """An explicit ``--contract`` value already reaches
+        ``build_contract_stage`` as a non-``None`` local, which takes the
+        ``coerce_contract_mode`` branch, not the legacy-alias fallback --
+        unaffected by this migration either way. Pinned so a future change
+        can't silently start overriding an explicit flag with
+        ``evaluation_config`` instead of merely converging the *redundant*
+        no-explicit-flag path with it.
+        """
+        old_p, new_p = _write_pair(tmp_path)
+
+        captured: dict[str, object] = {}
+        from abicheck.service import compare_snapshots as _real_compare_snapshots
+
+        def _capturing_compare_snapshots(*args, **kwargs):
+            captured["contract_mode"] = kwargs.get("contract_mode")
+            return _real_compare_snapshots(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "abicheck.service.compare_snapshots", _capturing_compare_snapshots
+        )
+
+        result = CliRunner().invoke(
+            main,
+            ["compare", str(old_p), str(new_p), "--contract", "exports"],
+        )
+        assert result.exit_code in (0, 1, 2, 4), result.output
+        assert captured["contract_mode"] == ContractMode.EXPORTS

--- a/tests/test_cli_compare_contract_mode_wiring.py
+++ b/tests/test_cli_compare_contract_mode_wiring.py
@@ -149,3 +149,56 @@ class TestResolvedContractModeWiring:
         )
         assert result.exit_code in (0, 1, 2, 4), result.output
         assert captured["contract_mode"] == ContractMode.EXPORTS
+
+    def test_pack_only_run_with_no_contract_flag_stays_none(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression (full-suite run, fresh evidence): a ``--pack``-only run
+        with no ``--contract`` still resolves a non-``None``
+        ``evaluation_config`` (``resolve_and_apply``'s early-return only skips
+        when *neither* ``contract_evaluation`` nor a pack applies), and
+        ``ContractConfig.mode`` always carries a concrete default -- so
+        naively threading ``evaluation_config.contract.mode`` through
+        unconditionally passed a non-``None`` ``contract_mode`` into
+        ``compare_snapshots`` while ``contract_evaluation`` stayed ``False``,
+        tripping its own "contract_mode requires contract_evaluation"
+        usage-error guard for every such run. Must stay ``contract_mode=None``
+        (and exit 0), the same as before this migration.
+        """
+        old_p, new_p = _write_pair(tmp_path)
+        pack_dir = tmp_path / "pack"
+        pack_dir.mkdir()
+        pack_path = pack_dir / "pack.yml"
+        pack_path.write_text(
+            "id: p\nversion: 1\nkind: policy\nassignments:\n  func_removed: ignore\n",
+            encoding="utf-8",
+        )
+
+        captured: dict[str, object] = {}
+        from abicheck.service import compare_snapshots as _real_compare_snapshots
+
+        def _capturing_compare_snapshots(*args, **kwargs):
+            captured["contract_mode"] = kwargs.get("contract_mode")
+            captured["contract_evaluation"] = kwargs.get("contract_evaluation")
+            return _real_compare_snapshots(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "abicheck.service.compare_snapshots", _capturing_compare_snapshots
+        )
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--pack",
+                str(pack_path),
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["contract_evaluation"] is False
+        assert captured["contract_mode"] is None

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -426,3 +426,71 @@ class TestExecuteDumpRequestWithAssurance:
 
         assert result.effective_compile_context == fake_ctx
         assert dict(result.resolved_execution_context.compile_contexts) == {}
+
+    def test_compile_context_excluded_for_an_abicc_perl_dump(
+        self, tmp_path, monkeypatch
+    ):
+        """The other verbatim-load format `sniff_text_format` must rule out
+        before the linker-script probe runs (mirroring `resolve_input`'s own
+        dispatch order): an ABICC Perl dump (`$VAR1` prefix) is imported
+        directly, with no header-AST parse."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        dump_p = tmp_path / "dump.perl.txt"
+        dump_p.write_text("$VAR1 = {};\n", encoding="utf-8")
+
+        request = DumpRequest(input=InputSpec(path=dump_p))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}
+
+    def test_compile_context_excluded_when_target_is_not_a_binary_format(
+        self, tmp_path, monkeypatch
+    ):
+        """Neither `resolved.fmt`'s own magic-byte check nor the
+        linker-script probe resolves a real binary format for arbitrary,
+        unrecognized text -- `parsed_fmt` stays `None` and the compile
+        context is excluded, the same as for every other non-parse path."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        garbage_p = tmp_path / "notes.txt"
+        garbage_p.write_text("just some notes, not a linker script\n", encoding="utf-8")
+
+        request = DumpRequest(input=InputSpec(path=garbage_p))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -169,3 +169,36 @@ class TestExecuteDumpRequestWithAssurance:
         result = execute_dump_request(bare)
 
         assert result.resolved_execution_context is None
+
+    def test_result_carries_the_resolved_compile_context(self, snap_path, monkeypatch):
+        """Codex review, PR #1037: `with_assurance()` alone leaves
+        `compile_contexts` empty even when the P0.3 fold produced a real
+        `effective_compile_context` -- `DumpResult.resolved_execution_context`
+        must carry it too, under the `"input"` label, so a consumer reading
+        through the unified context sees the same toolchain
+        `DumpResult.effective_compile_context` itself exposes."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {
+            "input": fake_ctx
+        }

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One Semantic Pipeline plan, sub-phase 4B, ``dump``'s own slice.
+
+Mirrors ``test_service_compare_pipeline.py::TestResolvedExecutionContextWiring``
+for :func:`abicheck.service_dump_pipeline.resolve_dump_request` /
+:func:`abicheck.service_dump_pipeline.execute_dump_request`: both closed the
+identical "no real caller" gap ``ResolvedComparePair.resolved_execution_context``
+closed for ``compare`` (``resolve_dump_request`` wires the pre-execution view;
+``execute_dump_request`` is the real post-execution ``with_assurance()``
+caller the plan's own tracking row named as still open for every operation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.api_types import DumpRequest, InputSpec
+from abicheck.model import AbiSnapshot, Function
+from abicheck.serialization import snapshot_to_json
+from abicheck.service_dump_pipeline import (
+    ResolvedDumpRequest,
+    execute_dump_request,
+    resolve_dump_request,
+)
+from abicheck.workflows.resolved_execution_context import ResolvedExecutionContext
+
+
+def _snapshot(version: str = "1.0") -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so.1",
+        version=version,
+        functions=[Function(name="foo", mangled="foo", return_type="void", params=[])],
+    )
+
+
+@pytest.fixture()
+def snap_path(tmp_path: Path) -> Path:
+    p = tmp_path / "lib.abi.json"
+    p.write_text(snapshot_to_json(_snapshot()), encoding="utf-8")
+    return p
+
+
+class TestResolveDumpRequestWiring:
+    """``resolve_dump_request`` now attaches a real ``ResolvedExecutionContext``
+    (the pre-execution view) built from the same ``AnalysisPlan`` it already
+    resolves for its ADR-063 Phase 4 pre-flight check — not a second
+    resolution, and additive: nothing here reads the field back to change
+    behaviour, so it must not affect any other field ``resolve_dump_request``
+    already returns.
+    """
+
+    def test_resolved_request_carries_a_populated_context(self, snap_path: Path):
+        resolved = resolve_dump_request(DumpRequest(input=InputSpec(path=snap_path)))
+
+        assert isinstance(resolved.resolved_execution_context, ResolvedExecutionContext)
+        assert resolved.resolved_execution_context.operation == "dump"
+
+    @pytest.mark.parametrize("depth", [None, "binary"])
+    def test_requested_depth_matches_the_request(self, snap_path: Path, depth):
+        resolved = resolve_dump_request(
+            DumpRequest(input=InputSpec(path=snap_path), depth=depth)
+        )
+
+        assert resolved.resolved_execution_context.requested_depth == depth
+        assert resolved.resolved_execution_context.evidence.requested_depth == depth
+        # Pre-execution: nothing has run yet, so the achieved-depth axis is
+        # still unknown (see EvidenceView's own docstring).
+        assert resolved.resolved_execution_context.evidence.effective_depth is None
+        assert resolved.resolved_execution_context.evidence.depth_satisfied is None
+
+    def test_no_evaluation_config_or_compile_contexts_resolved_here(
+        self, snap_path: Path
+    ):
+        """Neither resolves at this seam, for the identical reason
+        ``ResolvedComparePair.resolved_execution_context`` carries neither
+        (see that field's own docstring)."""
+        resolved = resolve_dump_request(DumpRequest(input=InputSpec(path=snap_path)))
+
+        assert resolved.resolved_execution_context.evaluation_config is None
+        assert dict(resolved.resolved_execution_context.compile_contexts) == {}
+
+    def test_wiring_does_not_change_other_resolved_fields(self, snap_path: Path):
+        request = DumpRequest(input=InputSpec(path=snap_path), depth="binary")
+        resolved = resolve_dump_request(request)
+
+        assert resolved.request is request
+        assert resolved.requested_depth == "binary"
+        assert resolved.collect_mode == "off"
+
+    def test_two_independent_resolutions_of_the_same_request_still_compare_equal(
+        self, snap_path: Path
+    ):
+        """``resolved_execution_context`` is excluded from the generated
+        ``__eq__`` (``compare=False``), the same way ``artifact_plan`` already
+        is — a fresh, distinct ``ResolvedExecutionContext`` instance must not
+        make two structurally identical resolutions compare unequal."""
+        request = DumpRequest(input=InputSpec(path=snap_path))
+
+        a = resolve_dump_request(request)
+        b = resolve_dump_request(request)
+
+        assert a.resolved_execution_context is not b.resolved_execution_context
+        assert a == b
+
+
+class TestExecuteDumpRequestWithAssurance:
+    """``execute_dump_request`` is the real post-execution ``with_assurance()``
+    caller the plan's tracking row named as still open — ``dump`` has no
+    comparison pair, so there is no real ``AnalysisAssurance`` to attach, but
+    the one axis it shares with a comparison (whether the requested ``--depth``
+    was reached) is a genuine post-execution fact, sourced from this same
+    call's own ``effective_depth``.
+    """
+
+    def test_result_carries_a_completed_context(self, snap_path: Path):
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        result = execute_dump_request(resolve_dump_request(request))
+
+        assert isinstance(result.resolved_execution_context, ResolvedExecutionContext)
+        assert result.resolved_execution_context.operation == "dump"
+        assert (
+            result.resolved_execution_context.evidence.effective_depth
+            == result.effective_depth
+        )
+
+    def test_depth_satisfied_true_when_requested_depth_is_reached(
+        self, snap_path: Path
+    ):
+        request = DumpRequest(input=InputSpec(path=snap_path), depth="binary")
+        result = execute_dump_request(resolve_dump_request(request))
+
+        assert result.resolved_execution_context.requested_depth == "binary"
+        assert result.resolved_execution_context.evidence.depth_satisfied is True
+
+    def test_depth_satisfied_none_when_no_depth_was_requested(self, snap_path: Path):
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        result = execute_dump_request(resolve_dump_request(request))
+
+        assert result.resolved_execution_context.requested_depth is None
+        assert result.resolved_execution_context.evidence.depth_satisfied is None
+
+    def test_context_is_none_when_resolved_carries_none(self, snap_path: Path):
+        """A caller that hand-builds a ``ResolvedDumpRequest`` bypassing
+        ``resolve_dump_request`` (``resolved_execution_context=None``, the
+        dataclass default) gets ``None`` back too, rather than a crash."""
+        from dataclasses import replace
+
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        resolved = resolve_dump_request(request)
+        bare = replace(resolved, resolved_execution_context=None)
+        assert isinstance(bare, ResolvedDumpRequest)
+
+        result = execute_dump_request(bare)
+
+        assert result.resolved_execution_context is None

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -41,11 +41,12 @@ from abicheck.service_dump_pipeline import (
 from abicheck.workflows.resolved_execution_context import ResolvedExecutionContext
 
 
-def _snapshot(version: str = "1.0") -> AbiSnapshot:
+def _snapshot(version: str = "1.0", *, from_headers: bool = False) -> AbiSnapshot:
     return AbiSnapshot(
         library="libfoo.so.1",
         version=version,
         functions=[Function(name="foo", mangled="foo", return_type="void", params=[])],
+        from_headers=from_headers,
     )
 
 
@@ -173,10 +174,12 @@ class TestExecuteDumpRequestWithAssurance:
     def test_result_carries_the_resolved_compile_context(self, snap_path, monkeypatch):
         """Codex review, PR #1037: `with_assurance()` alone leaves
         `compile_contexts` empty even when the P0.3 fold produced a real
-        `effective_compile_context` -- `DumpResult.resolved_execution_context`
-        must carry it too, under the `"input"` label, so a consumer reading
-        through the unified context sees the same toolchain
-        `DumpResult.effective_compile_context` itself exposes."""
+        `effective_compile_context` that a header-AST parse actually
+        consumed (`snap.from_headers`) -- `DumpResult.
+        resolved_execution_context` must carry it too, under the `"input"`
+        label, so a consumer reading through the unified context sees the
+        same toolchain `DumpResult.effective_compile_context` itself
+        exposes."""
         from abicheck.compile_context import CompileContext
         from abicheck.workflows.artifact.execute import SideResolution
 
@@ -186,7 +189,7 @@ class TestExecuteDumpRequestWithAssurance:
 
         def _fake_resolve(*args, **kwargs):
             return SideResolution(
-                snapshot=_snapshot(),
+                snapshot=_snapshot(from_headers=True),
                 effective_includes=(),
                 effective_compile_context=fake_ctx,
             )
@@ -202,3 +205,38 @@ class TestExecuteDumpRequestWithAssurance:
         assert dict(result.resolved_execution_context.compile_contexts) == {
             "input": fake_ctx
         }
+
+    def test_compile_context_excluded_for_a_binary_only_depth(
+        self, snap_path, monkeypatch
+    ):
+        """Codex review, PR #1037, second round: the P0.3 fold can resolve a
+        real `CompileContext` even for a binary-only dump (e.g. from
+        `-p`/`--compile-db` alone, with no headers ever parsed) --
+        `ResolvedExecutionContext.compile_contexts`'s own docstring documents
+        that field as absent, not placeholder-valued, for exactly this case.
+        `DumpResult.effective_compile_context` itself stays unconditional
+        (a different, pre-existing field), so only the unified context's
+        view is gated here."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=False),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -296,3 +296,42 @@ class TestExecuteDumpRequestWithAssurance:
 
         assert result.effective_compile_context == fake_ctx
         assert dict(result.resolved_execution_context.compile_contexts) == {}
+
+    def test_compile_context_excluded_for_a_manifest_driven_dump(
+        self, elf_path, tmp_path, monkeypatch
+    ):
+        """Codex review, PR #1037, fourth round: a manifest-driven dump's
+        real header-AST parse runs under its own manifest-authoritative
+        ``dump_manifest.frontend_context`` (e.g. ``"device"``), not the
+        request/``InputSpec``-derived ``resolution.effective_compile_context``
+        this pipeline resolves independently of the manifest. Reproducing
+        the manifest's own resolution here is a documented gap, not
+        attempted -- recording the request-derived (possibly wrong, e.g.
+        ``"host"``) context instead would actively mislead a consumer,
+        which is worse than the field staying absent for this one input
+        shape."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.dump_manifest import DumpManifest
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        manifest = DumpManifest(base_dir=tmp_path, frontend_context="device")
+        request = DumpRequest(input=InputSpec(path=elf_path, dump_manifest=manifest))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -335,3 +335,47 @@ class TestExecuteDumpRequestWithAssurance:
 
         assert result.effective_compile_context == fake_ctx
         assert dict(result.resolved_execution_context.compile_contexts) == {}
+
+    def test_compile_context_included_for_a_followed_linker_script(
+        self, tmp_path, monkeypatch
+    ):
+        """Codex review, PR #1037, fifth round: a GNU ld linker script input
+        resolves ``resolved.fmt is None`` on its own text-file path (not
+        ELF/PE/Mach-O magic bytes), but ``resolve_input`` follows it and
+        runs a real parse against the real ELF target underneath --
+        ``resolved.fmt`` alone wrongly excluded this genuinely-participating
+        compile context. Detecting the format of the *followed* target
+        (``resolve_linker_script_chain``, the identical primitive
+        ``checker.compare``'s own same-binary hashing already uses) is what
+        correctly includes it."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        target = tmp_path / "libfoo.so.1"
+        target.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        script = tmp_path / "libfoo.so"
+        script.write_text("INPUT(libfoo.so.1)\n", encoding="utf-8")
+
+        request = DumpRequest(input=InputSpec(path=script))
+        resolved = resolve_dump_request(request)
+        assert resolved.fmt is None  # the raw linker-script path itself
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {
+            "input": fake_ctx
+        }

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -379,3 +379,50 @@ class TestExecuteDumpRequestWithAssurance:
         assert dict(result.resolved_execution_context.compile_contexts) == {
             "input": fake_ctx
         }
+
+    def test_compile_context_excluded_for_a_json_snapshot_with_ld_script_looking_text(
+        self, tmp_path, monkeypatch
+    ):
+        """Codex review, PR #1037, sixth round: `resolve_linker_script_chain`'s
+        own text-content probe has no way to know a call already established
+        the input is a serialized JSON snapshot -- `resolve_input` itself
+        never reaches linker-script handling for JSON (it short-circuits
+        earlier in its own dispatch order), but calling the chain resolver
+        independently, with no such short-circuit, risked a false positive
+        on a snapshot whose own bytes coincidentally contain an
+        ``INPUT(...)``-shaped literal naming a real co-located file.
+        ``sniff_text_format`` (the same check ``resolve_input`` itself
+        applies first) must exclude "json"/"perl" before the chain resolver
+        ever runs."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        # A real file the coincidental "INPUT(...)" text would resolve to,
+        # if the linker-script probe were reached at all.
+        (tmp_path / "libfoo.so.1").write_bytes(b"\x7fELF" + b"\x00" * 200)
+        snap_p = tmp_path / "lib.abi.json"
+        snap_p.write_text(
+            snapshot_to_json(_snapshot(version="INPUT(libfoo.so.1) note")),
+            encoding="utf-8",
+        )
+
+        request = DumpRequest(input=InputSpec(path=snap_p))
+        resolved = resolve_dump_request(request)
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}

--- a/tests/test_dump_resolved_execution_context.py
+++ b/tests/test_dump_resolved_execution_context.py
@@ -57,6 +57,17 @@ def snap_path(tmp_path: Path) -> Path:
     return p
 
 
+@pytest.fixture()
+def elf_path(tmp_path: Path) -> Path:
+    """A real ELF magic-byte prefix -- `resolved.fmt` resolves to `"elf"`
+    (distinct from `snap_path`'s JSON, whose `resolved.fmt` is `None`), so a
+    faked `_resolve_side_snapshot_impl` behind it exercises the
+    header-AST-parse-capable path without needing a real toolchain."""
+    p = tmp_path / "lib.so"
+    p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+    return p
+
+
 class TestResolveDumpRequestWiring:
     """``resolve_dump_request`` now attaches a real ``ResolvedExecutionContext``
     (the pre-execution view) built from the same ``AnalysisPlan`` it already
@@ -171,20 +182,24 @@ class TestExecuteDumpRequestWithAssurance:
 
         assert result.resolved_execution_context is None
 
-    def test_result_carries_the_resolved_compile_context(self, snap_path, monkeypatch):
+    def test_result_carries_the_resolved_compile_context(self, elf_path, monkeypatch):
         """Codex review, PR #1037: `with_assurance()` alone leaves
         `compile_contexts` empty even when the P0.3 fold produced a real
         `effective_compile_context` that a header-AST parse actually
-        consumed (`snap.from_headers`) -- `DumpResult.
-        resolved_execution_context` must carry it too, under the `"input"`
-        label, so a consumer reading through the unified context sees the
-        same toolchain `DumpResult.effective_compile_context` itself
-        exposes."""
+        consumed (`snap.from_headers`, `resolved.fmt` a real binary format)
+        -- `DumpResult.resolved_execution_context` must carry it too, under
+        the `"input"` label, so a consumer reading through the unified
+        context sees the same toolchain `DumpResult.effective_compile_context`
+        itself exposes. Uses `elf_path`, not `snap_path`: a JSON-snapshot
+        input's `resolved.fmt is None` is exactly the case a sibling test
+        (`test_compile_context_excluded_for_a_loaded_json_snapshot`) asserts
+        stays excluded."""
         from abicheck.compile_context import CompileContext
         from abicheck.workflows.artifact.execute import SideResolution
 
-        request = DumpRequest(input=InputSpec(path=snap_path))
+        request = DumpRequest(input=InputSpec(path=elf_path))
         resolved = resolve_dump_request(request)
+        assert resolved.fmt == "elf"
         fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
 
         def _fake_resolve(*args, **kwargs):
@@ -207,7 +222,7 @@ class TestExecuteDumpRequestWithAssurance:
         }
 
     def test_compile_context_excluded_for_a_binary_only_depth(
-        self, snap_path, monkeypatch
+        self, elf_path, monkeypatch
     ):
         """Codex review, PR #1037, second round: the P0.3 fold can resolve a
         real `CompileContext` even for a binary-only dump (e.g. from
@@ -216,17 +231,58 @@ class TestExecuteDumpRequestWithAssurance:
         that field as absent, not placeholder-valued, for exactly this case.
         `DumpResult.effective_compile_context` itself stays unconditional
         (a different, pre-existing field), so only the unified context's
-        view is gated here."""
+        view is gated here. Uses `elf_path` (`resolved.fmt == "elf"`), not
+        `snap_path`, so this failure mode (real binary, no headers) stays
+        distinct from the JSON-snapshot-input failure mode a sibling test
+        covers."""
         from abicheck.compile_context import CompileContext
         from abicheck.workflows.artifact.execute import SideResolution
 
-        request = DumpRequest(input=InputSpec(path=snap_path))
+        request = DumpRequest(input=InputSpec(path=elf_path))
         resolved = resolve_dump_request(request)
         fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
 
         def _fake_resolve(*args, **kwargs):
             return SideResolution(
                 snapshot=_snapshot(from_headers=False),
+                effective_includes=(),
+                effective_compile_context=fake_ctx,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline._resolve_side_snapshot_impl",
+            _fake_resolve,
+        )
+
+        result = execute_dump_request(resolved)
+
+        assert result.effective_compile_context == fake_ctx
+        assert dict(result.resolved_execution_context.compile_contexts) == {}
+
+    def test_compile_context_excluded_for_a_loaded_json_snapshot(
+        self, snap_path, monkeypatch
+    ):
+        """Codex review, PR #1037, third round: a JSON-snapshot input
+        (`resolved.fmt is None` -- no ELF/PE/Mach-O magic bytes) short-
+        circuits straight to the persisted snapshot in `resolve_input`, with
+        no header-AST parse this invocation. The loaded snapshot can itself
+        carry a stale `from_headers=True` from whatever dump originally
+        produced it, so `snap.from_headers` alone is not a safe gate --
+        `resolved.fmt is not None` (a real header-AST-capable binary format)
+        is what must additionally hold."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.workflows.artifact.execute import SideResolution
+
+        request = DumpRequest(input=InputSpec(path=snap_path))
+        resolved = resolve_dump_request(request)
+        assert resolved.fmt is None  # the JSON `snap_path` fixture itself
+        fake_ctx = CompileContext(gcc_option_tokens=("-std=c++20",))
+
+        def _fake_resolve(*args, **kwargs):
+            # The loaded snapshot's own stale, persisted from_headers=True --
+            # no header-AST parse ran to produce it *this* invocation.
+            return SideResolution(
+                snapshot=_snapshot(from_headers=True),
                 effective_includes=(),
                 effective_compile_context=fake_ctx,
             )


### PR DESCRIPTION
## Summary

One Semantic Pipeline plan, sub-phase 4B ("Resolved execution context") — wires `resolve_dump_request` onto `ResolvedExecutionContext`, adds a real post-execution `with_assurance()` caller, and starts migrating downstream code off independent `contract.mode` re-resolution.

## Motivation

The plan's own tracking row for 4B named two concrete open gaps after its first landed PR: `resolve_dump_request` remained fully unwired, and nothing yet called `with_assurance()` from a real post-execution caller. It also names the broader goal: "downstream code stops independently re-reading `.abicheck.yml`, re-deriving precedence, or re-resolving severity scheme." This PR closes the first two gaps for `dump` and makes a first, concrete start on the third for `compare`'s native CLI.

## Changes

- `service_dump_pipeline.resolve_dump_request` now attaches a real `ResolvedExecutionContext` (the pre-execution view) built from the same `AnalysisPlan` it already resolves for its ADR-063 Phase 4 pre-flight check — `dump`'s own slice of the gap `ResolvedComparePair.resolved_execution_context` already closed for `compare`.
- `execute_dump_request` is the real post-execution `with_assurance()` caller the plan's tracking row named as still open. `dump` has no comparison pair to build a real `AnalysisAssurance` from, so a minimal `_DumpAssuranceView` carries the one axis it genuinely shares with a comparison (whether the requested `--depth` was reached), sourced from this same call's own `effective_depth`.
- The native `compare` CLI now hands `checker.compare` its already-resolved ADR-049 D7 `contract.mode` (`evaluation_config.contract.mode`) instead of the raw pre-resolution local, so `contract_pipeline.build_contract_stage` no longer re-derives the identical legacy-alias domain a second time via `resolve_legacy_contract_mode`. No observable behavior change today — `contract.mode` is deliberately not pack-routable and the two computations always agreed on every reachable input — but the redundant resolution is gone, so the two cannot silently start disagreeing the next time either side's own precedence changes.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_dump_resolved_execution_context.py`, `tests/test_cli_compare_contract_mode_wiring.py`)
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — no user-visible behavior changed
- [x] `pre-commit run --all-files`-equivalent checks pass locally (`ruff check`, `mypy abicheck/`, `scripts/check_ai_readiness.py`, `scripts/check_architecture.py`, targeted `pytest`)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfgciGRQWnGDnCs7zqg6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_018SfgciGRQWnGDnCs7zqg6Q)_