### PR TITLE
fix(diff): decline VIRTUAL_METHOD_ADDED on incomplete bases evidence (ADR-063 5B)

### DIFF
--- a/abicheck/buildsource/header_graph.py
+++ b/abicheck/buildsource/header_graph.py
@@ -312,17 +312,13 @@ def _flat_structural_type_edges(snapshot: AbiSnapshot) -> list[TypeEdge]:
             continue
         # Fact[T]-bridged read (ADR-063 Phase 0): value-preserving, see
         # `model.resolved_fact_value`'s own docstring. ADR-063 Phase 5B audit
-        # note: this stays on the plain default-collapse bridge deliberately
-        # — `_flat_structural_type_edges` builds one snapshot's own graph
-        # (called once per side, never as an old/new pair), and every
-        # finding this graph can ultimately feed defaults to API_BREAK_KINDS/
-        # RISK_KINDS, never BREAKING_KINDS, without an artifact diff also
-        # proving the break (this package's own CLAUDE.md, "The one rule
-        # that governs everything here"). A `bases_fact` evidence gap here
-        # only omits an edge (CONF_REDUCED already, the weakest confidence
-        # tier), it cannot fabricate a BREAKING finding the way an
-        # uncompared `bases`/`virtual_bases` pair could at a real
-        # finding-emitting detector.
+        # note (kept short — see this repo's own line-count cap; full
+        # reasoning in docs/contribute/plans/one-semantic-pipeline.md's 5B
+        # section): stays on the plain collapse deliberately — a
+        # single-snapshot graph (never an old/new pair), and this package's
+        # own governing rule already caps everything it feeds at
+        # API_BREAK_KINDS/RISK_KINDS, so a gap here can only omit an edge,
+        # never fabricate a BREAKING finding.
         for base in resolved_fact_value(rt.bases_fact, []):
             emit(rt.name, base, EDGE_TYPE_INHERITS, "base")
         for fld in rt.fields:

--- a/abicheck/buildsource/header_graph.py
+++ b/abicheck/buildsource/header_graph.py
@@ -311,7 +311,18 @@ def _flat_structural_type_edges(snapshot: AbiSnapshot) -> list[TypeEdge]:
         if counts.get(rt.name, 0) > 1:
             continue
         # Fact[T]-bridged read (ADR-063 Phase 0): value-preserving, see
-        # `model.resolved_fact_value`'s own docstring.
+        # `model.resolved_fact_value`'s own docstring. ADR-063 Phase 5B audit
+        # note: this stays on the plain default-collapse bridge deliberately
+        # — `_flat_structural_type_edges` builds one snapshot's own graph
+        # (called once per side, never as an old/new pair), and every
+        # finding this graph can ultimately feed defaults to API_BREAK_KINDS/
+        # RISK_KINDS, never BREAKING_KINDS, without an artifact diff also
+        # proving the break (this package's own CLAUDE.md, "The one rule
+        # that governs everything here"). A `bases_fact` evidence gap here
+        # only omits an edge (CONF_REDUCED already, the weakest confidence
+        # tier), it cannot fabricate a BREAKING finding the way an
+        # uncompared `bases`/`virtual_bases` pair could at a real
+        # finding-emitting detector.
         for base in resolved_fact_value(rt.bases_fact, []):
             emit(rt.name, base, EDGE_TYPE_INHERITS, "base")
         for fld in rt.fields:

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -27,6 +27,7 @@ from .checker_policy import ChangeKind
 from .checker_types import Change
 from .diff_helpers import make_change
 from .model import Fact, Function, RecordType
+from .model.availability import FactStatus
 
 # The Itanium/MSVC mangled-name scope-component parsers' real home is
 # model/mangled_name.py (ADR-061 D1): pure string decoding with no I/O,
@@ -915,7 +916,11 @@ def _owner_descends_from(
     t = types.get(owner) or (types.get(leaf_owner) if leaf_owner != owner else None)
     if t is None:
         return False
-    bases = _transitive_bases(t, types)
+    # This call site's own evidence-gap handling belongs to the dedicated
+    # vtable/vptr_offset_bits slice (ADR-063 Phase 5B) `_owner_descends_from`
+    # feeds via `vtable_slot_is_override_reuse` — unchanged here, only the
+    # completeness flag `virtual_method_addition` added is discarded.
+    bases, _walk_complete = _transitive_bases(t, types)
     # A qualified `ancestor` matching a `bases` entry exactly is unambiguous
     # (both are fully-qualified spellings of the same string). But when
     # `ancestor` is a bare leaf, an exact match against `bases` is NOT
@@ -1028,20 +1033,53 @@ def _fact_str_list(fact: Fact[list[str]] | None) -> list[str]:
     return value or []
 
 
+def _fact_str_list_confirmed(fact: Fact[list[str]] | None) -> tuple[list[str], bool]:
+    """Like :func:`_fact_str_list`, plus whether the value is safe to treat
+    as the *complete* base-class list (ADR-063 Phase 5B).
+
+    Only a ``PRESENT`` status earns ``True`` — ``PARTIAL`` is deliberately
+    excluded, the same discipline :func:`abicheck.compare.base_class_diff.
+    diff_bases` applies to this identical field pair: this is a full-list
+    *membership* question (does some transitive base declare a matching
+    virtual signature?), and a ``PARTIAL`` fact's uncovered remainder could
+    hold exactly the base that would have proven an override. Reading it as
+    "no more bases here" would be the same fabrication risk ``diff_bases``
+    already declines for the direct-comparison case.
+    """
+    assert fact is not None
+    if fact.status is not FactStatus.PRESENT:
+        return [], False
+    return (fact.value or []), True
+
+
 def _transitive_bases(
     start: RecordType | None, types: Mapping[str, RecordType]
-) -> set[str]:
-    """All (transitive) base-class names reachable from record ``start``.
+) -> tuple[set[str], bool]:
+    """All (transitive) base-class names reachable from record ``start``,
+    plus whether the walk saw only confirmed-complete ``bases``/
+    ``virtual_bases`` evidence at every node it visited.
 
     Walks ``bases`` / ``virtual_bases``, resolving each base name through the
     record map with a leaf-name fallback (CastXML records and base names are
     leaf-only, while DWARF uses qualified names). Tolerant of missing records.
+
+    The second return value is ``False`` as soon as *any* visited record's
+    ``bases_fact``/``virtual_bases_fact`` is not ``PRESENT`` (ADR-063 Phase
+    5B) — an incomplete evidence gap anywhere along the walk means a real
+    base this record actually has may be missing from the result, which
+    :func:`virtual_method_addition` must not silently read as "no override
+    exists here" (the same "decline rather than fabricate" default
+    ``diff_types_vtable._vtable_transition_is_evidenced`` and
+    :func:`~abicheck.compare.base_class_diff.diff_bases` already apply to
+    their own evidence gaps).
     """
     seen: set[str] = set()
+    complete = True
     if start is None:
-        return seen
-    start_bases = _fact_str_list(start.bases_fact)
-    start_virtual_bases = _fact_str_list(start.virtual_bases_fact)
+        return seen, complete
+    start_bases, ok1 = _fact_str_list_confirmed(start.bases_fact)
+    start_virtual_bases, ok2 = _fact_str_list_confirmed(start.virtual_bases_fact)
+    complete = complete and ok1 and ok2
     stack = [*start_bases, *start_virtual_bases]
     while stack:
         b = stack.pop()
@@ -1050,10 +1088,11 @@ def _transitive_bases(
         seen.add(b)
         rec = types.get(b) or types.get(b.rsplit("::", 1)[-1])
         if rec is not None:
-            rec_bases = _fact_str_list(rec.bases_fact)
-            rec_virtual_bases = _fact_str_list(rec.virtual_bases_fact)
+            rec_bases, ok1 = _fact_str_list_confirmed(rec.bases_fact)
+            rec_virtual_bases, ok2 = _fact_str_list_confirmed(rec.virtual_bases_fact)
+            complete = complete and ok1 and ok2
             stack.extend((*rec_bases, *rec_virtual_bases))
-    return seen
+    return seen, complete
 
 
 def virtual_method_addition(
@@ -1107,7 +1146,16 @@ def virtual_method_addition(
     # override and stay silent; a different-signature same-name virtual is a new
     # slot and still fires.
     sig = virtual_signature_key(f_new)
-    bases = _transitive_bases(t_new, new_types) | _transitive_bases(t_old, old_types)
+    new_bases, new_complete = _transitive_bases(t_new, new_types)
+    old_bases, old_complete = _transitive_bases(t_old, old_types)
+    if not (new_complete and old_complete):
+        # ADR-063 Phase 5B: an incomplete bases_fact/virtual_bases_fact
+        # anywhere along either walk means a real override-providing base
+        # may simply be missing from `bases` — the walk cannot rule out an
+        # override, so this must decline rather than fabricate a
+        # VIRTUAL_METHOD_ADDED against what may really be a plain override.
+        return None
+    bases = new_bases | old_bases
     if any(sig in old_virtual_sigs.get(b, ()) for b in bases):
         return None
     return make_change(

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -1037,19 +1037,34 @@ def _fact_str_list_confirmed(fact: Fact[list[str]] | None) -> tuple[list[str], b
     """Like :func:`_fact_str_list`, plus whether the value is safe to treat
     as the *complete* base-class list (ADR-063 Phase 5B).
 
-    Only a ``PRESENT`` status earns ``True`` — ``PARTIAL`` is deliberately
-    excluded, the same discipline :func:`abicheck.compare.base_class_diff.
-    diff_bases` applies to this identical field pair: this is a full-list
-    *membership* question (does some transitive base declare a matching
-    virtual signature?), and a ``PARTIAL`` fact's uncovered remainder could
-    hold exactly the base that would have proven an override. Reading it as
-    "no more bases here" would be the same fabrication risk ``diff_bases``
-    already declines for the direct-comparison case.
+    The value itself is preserved for both ``PRESENT`` and ``PARTIAL`` —
+    exactly :func:`_fact_str_list`'s own value-preserving read — since
+    :func:`_owner_descends_from` also calls :func:`_transitive_bases` and
+    only ever reads this function's *set* of names, discarding the
+    completeness flag entirely (that call site's own evidence-gap handling
+    is scoped to the separate vtable/vptr_offset_bits slice). Dropping a
+    ``PARTIAL`` fact's known entries here, rather than just refusing to
+    call them *complete*, would silently lose a real ``Derived -> Base``
+    relationship `_owner_descends_from` used to see via `_fact_str_list`
+    before this function existed (Codex review on this PR: a same-signature
+    override slot rename with `PARTIAL` `bases_fact` evidence stopped
+    resolving through `vtable_slot_is_override_reuse`, fabricating a
+    `TYPE_VTABLE_CHANGED` for what may be a compatible override).
+
+    Only the completeness flag treats ``PARTIAL`` as unsafe, and only a
+    ``PRESENT`` status earns ``True`` there — the same discipline
+    :func:`abicheck.compare.base_class_diff.diff_bases` applies to this
+    identical field pair: this is a full-list *membership* question (does
+    some transitive base declare a matching virtual signature?), and a
+    ``PARTIAL`` fact's uncovered remainder could hold exactly the base that
+    would have proven an override. :func:`virtual_method_addition` — the
+    one caller that actually reads this flag — declines to trust the walk
+    when it is ``False``, rather than trusting a truncated value; it does
+    not need this function to also truncate the value for it.
     """
     assert fact is not None
-    if fact.status is not FactStatus.PRESENT:
-        return [], False
-    return (fact.value or []), True
+    value = fact.value if fact.is_present else []
+    return (value or []), fact.status is FactStatus.PRESENT
 
 
 def _transitive_bases(

--- a/abicheck/diff_stdlib_impl.py
+++ b/abicheck/diff_stdlib_impl.py
@@ -129,7 +129,21 @@ def _public_type_embeds_stdlib_by_value(snap: AbiSnapshot) -> bool:
 
 
 def _public_by_value_type_closure(snap: AbiSnapshot) -> set[str]:
-    """Record types reachable from public ABI roots through by-value edges."""
+    """Record types reachable from public ABI roots through by-value edges.
+
+    ADR-063 Phase 5B audit note: ``bases``/``virtual_bases`` are read below
+    via the ordinary ``resolved_fact_value(..., [])`` present-or-default
+    bridge, not :func:`~abicheck.compare.fact_comparison.compare_facts` —
+    deliberately. This is a single-snapshot reachability walk (called once
+    per side, never as an old/new *pair*), and its only caller ORs the two
+    sides' booleans together (see ``_diff_stdlib_implementation`` below): a
+    ``bases_fact`` evidence gap on one side only ever *narrows* that side's
+    own closure, which can under-escalate the finding's description (a real
+    by-value embedding missed) but never fabricates one — the other side's
+    independent closure, or a later run with better evidence, still catches
+    it. There is no pairwise comparison here for
+    :func:`~abicheck.compare.fact_comparison.compare_facts` to gate.
+    """
     from .model import RecordType, Visibility, resolved_fact_value
     from .surface import _type_identifiers
 

--- a/abicheck/diff_time64.py
+++ b/abicheck/diff_time64.py
@@ -131,7 +131,19 @@ def _seed_surface_tokens(snap: AbiSnapshot) -> set[str]:
 
 
 def _fold_record_tokens(tokens: set[str], rec: RecordType) -> None:
-    """Fold a reachable record's field and base-class type spellings into *tokens*."""
+    """Fold a reachable record's field and base-class type spellings into *tokens*.
+
+    ADR-063 Phase 5B audit note: ``bases_fact``/``virtual_bases_fact`` stay
+    on the plain ``resolved_fact_value(..., [])`` bridge deliberately. This
+    is a single-snapshot reachability walk, folded into
+    ``_public_surface_tokens(old) | _public_surface_tokens(new)`` by
+    ``_diff_time64_abi`` below — a *union* of both sides, so an evidence gap
+    on either side only narrows the surface-token set, which can miss a
+    real ``time64`` roll-up (a false negative, already an accepted
+    limitation of this token-reachability heuristic) but never fabricates
+    one. No old/new pair exists at this call site for
+    :func:`~abicheck.compare.fact_comparison.compare_facts` to gate.
+    """
     for fld in rec.fields:
         _add_tokens(tokens, getattr(fld, "type", ""))
     # Inherited layout is public layout: fold base-class names in

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -615,6 +615,15 @@ def _collect_base_targets(
     suppress a *newly introduced* public factory risk for the same Base in
     _emit_new_antipatterns(). When no public-header set was supplied every
     record is UNKNOWN, which is treated as in-surface (no behaviour change).
+
+    ADR-063 Phase 5B audit note: ``bases_fact`` stays on the plain
+    ``resolved_fact_value(..., [])`` bridge deliberately. This is a
+    single-snapshot (ADR-027 "surface-report") anti-pattern scan, not an
+    old/new comparison — a ``bases_fact`` evidence gap here only shrinks
+    ``base_targets``, which can miss a real
+    ``POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR`` (a false negative) but can never
+    fabricate one, so it carries none of the two-sided fabrication risk
+    :func:`~abicheck.compare.fact_comparison.compare_facts` exists to gate.
     """
     base_targets: set[str] = set()
     for rec in graph.snapshot.types:

--- a/changelog.d/1787100000_claude_adr063-phase5b-bases-readers.md
+++ b/changelog.d/1787100000_claude_adr063-phase5b-bases-readers.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **`VIRTUAL_METHOD_ADDED` no longer fabricates a finding from an
+  incomplete `bases`/`virtual_bases` capture** (ADR-063 Phase 5B).
+  `diff_cxx_rules.virtual_method_addition`'s transitive-base walk (used to
+  tell a genuinely new virtual slot apart from a compatible override of an
+  inherited one) now tracks whether every visited record's
+  `bases_fact`/`virtual_bases_fact` reached a confirmed `PRESENT` status,
+  the same "decline rather than fabricate" discipline
+  `abicheck.compare.base_class_diff.diff_bases` already applies to its own
+  `TYPE_BASE_CHANGED`/`BASE_CLASS_VIRTUAL_CHANGED` findings. Previously, a
+  base whose evidence never arrived (`NOT_COLLECTED`/`FAILED`, not a
+  confirmed-empty list) silently read as "no bases", which could make a
+  real override look like a brand-new vtable slot and emit a spurious
+  `VIRTUAL_METHOD_ADDED`. Behavior is unchanged whenever both sides'
+  evidence is complete (every real producer already states `bases`/
+  `virtual_bases` explicitly, including empty, for every `RecordType` it
+  emits).

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -72,14 +72,25 @@ concepts:
       compare_facts()/FactComparison primitive, wired into two of the five
       named fields' primary finding-emitting call sites (bases/
       virtual_bases in diff_types._diff_type_bases, is_va_list in
-      diff_param_qualifiers.param_va_list_changes). Not yet closed: vtable/
+      diff_param_qualifiers.param_va_list_changes). Second slice landed
+      2026-09-03 (the "lower-risk batch"): every *other* bases/
+      virtual_bases-reading call site was audited — diff_cxx_rules.py's
+      _transitive_bases (the one genuine old/new pairwise fabrication risk
+      among them, feeding virtual_method_addition's override check) is now
+      evidence-completeness-gated the same way; diff_stdlib_impl.py,
+      diff_time64.py, idioms.py, buildsource/header_graph.py, and
+      surface_graph.py (already gated) are single-snapshot reachability/
+      classification aids with no old/new pair to gate — each now carries
+      an explicit ADR-063 Phase 5B docstring note recording why the plain
+      resolved_fact_value() collapse is safe there (an evidence gap only
+      narrows a closure or omits a graph edge, it cannot fabricate a
+      finding). is_va_list has no other readers. Not yet closed: vtable/
       vptr_offset_bits (diff_types_vtable.py/diff_layout.py/
       diff_vtable_layout.py's own pre-existing, individually-reasoned
-      evidence-gap heuristics — deliberately left alone pending their own
-      dedicated slice) and every other reader of the two converted fields
-      (diff_cxx_rules.py, diff_stdlib_impl.py, diff_time64.py, idioms.py,
-      surface_graph.py, buildsource/header_graph.py, diff_cpp_patterns.py)
-      — see the plan's own 5B note for detail.
+      evidence-gap heuristics, plus their downstream readers in
+      diff_cxx_rules.py's own vtable comparison, idioms.py, and
+      diff_cpp_patterns.py — deliberately left alone pending their own
+      dedicated slice, per the plan's own 5B note).
 
   identity:
     primitive: complete

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -315,6 +315,37 @@ multi-round-reviewed evidence-gap heuristic that needs its own dedicated
 slice with equal scrutiny, not a change folded into an otherwise
 lower-risk batch.
 
+**Known gap surfaced by review (Codex security review, this PR, not
+closed): a "decline rather than fabricate" evidence gate can be an
+under-detection lever, not just a fabrication guard, for a detector that is
+the *sole* signal for its ABI-break class.** `virtual_method_addition`'s own
+docstring already states it is the only signal for its specific blind spot
+(a DWARF/symbol-only snapshot whose vtable array cannot show the growth);
+declining when `bases`/`virtual_bases` evidence is incomplete therefore
+doesn't just miss one classification among several redundant ones — for a
+hand-crafted or legacy-schema snapshot with the right shape (`vtable_fact`
+already trivially spoofable pre-existing this PR, plus a `bases`/
+`virtual_bases_fact` at `NOT_COLLECTED`/`FAILED`/`PARTIAL`), it can turn a
+genuinely BREAKING `VIRTUAL_METHOD_ADDED` into a silent, `--require-
+complete-analysis`-invisible `FUNC_ADDED`/`COMPATIBLE`. This is not unique
+to this PR's diff: the identical shape already exists at the first 5B PR's
+own migrated call sites (`diff_bases`, `diff_va_list_params`) — any
+detector using `compare_facts`'s `INCOMPLETE` branch to decline has the
+same property whenever it is (or becomes) a sole signal for its class. A
+real fix threads a detector's own decline into `analysis_assurance.py`'s
+rollup (a genuine new signal that module doesn't compute today — it is
+explicitly "a rollup, not a new probe" over data the pipeline already
+computes) so `--require-complete-analysis` can see it, or gates the
+specific sole-signal detectors more conservatively than the general
+`compare_facts` pattern. Neither is attempted here: it is a cross-cutting
+design question for the whole "decline rather than fabricate" philosophy
+this sub-phase established, not a two-line patch scoped to one call site,
+and reversing just this PR's own decline would only reopen the fabrication
+bug it fixes without closing the class (an attacker would target
+`diff_bases`/`diff_va_list_params` instead). Recorded here per this
+repo's own "say so explicitly and record the gap" convention rather than
+left implicit or rushed.
+
 **Recommended sequencing:** 2B and 6B are
 the highest-value pair, in that order — 2B closes the last identity-provider
 gap 6B's own migration would otherwise trip on, and 6B is what actually

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -184,7 +184,7 @@ when a first PR lands against a sub-phase:
 |---|---|---|---|
 | **2B — Identity consumer migration** | not started | Phase 2's remaining string-identity call sites | Migrate `diff_filtering.py`/`type_reachability.py` onto `EntityId` once DWARF-side blockers clear; split `EntityId`/`OccurrenceId` matching into a `StableEntityId` tier (cross-release, suppression-alias-safe) vs. a `SnapshotLocalIdentity` fallback, rather than a further attempt at globally-stable `Anonymous`/`LocalToFunction` ordinals (two prior attempts already reverted) |
 | **4B — Resolved execution context** | in progress | The gap between `AnalysisPlan`'s deliberately narrow preflight scope and real execution's need for one resolved object | A `ResolvedExecutionContext` built only for real (non-dry-run) execution — effective config with per-field provenance, resolved compile/toolchain context, effective/available evidence depth, resolved policy/pack/contract — so downstream code stops independently re-reading `.abicheck.yml`, re-deriving precedence, or re-resolving severity scheme. First PR landed, in two slices (see Phase 4's own "Adjacent, additive infrastructure landed" note, below, under "Phases"): the `ResolvedExecutionContext` type itself (composing an `AnalysisPlan` with an already-resolved `CompatibilityEvaluationConfig`/`CompileContext`s, provenance access, and a resolution digest), then a second slice closing the "requested/effective/available depth" field list via a new `EvidenceView` (copied off `AnalysisAssurance`, never re-derived). A third slice (2026-09-03) landed the sub-phase's first real call site: `service_compare_pipeline.resolve_compare_request` now builds one from its own already-resolved `AnalysisPlan` and attaches it on `ResolvedComparePair` — additive, unread by any consumer yet, but no longer "a dataclass nothing outside its own tests constructs" for the `compare` path. `resolve_dump_request` remains fully unwired, and nothing yet calls `with_assurance()` from a real post-execution caller — the sub-phase's own gap (most downstream code still independently re-reads/re-derives what this object would give it in one place) stays open |
-| **5B — Fact semantic consumption** | in progress | Phase 5's "no fact reaches `CONSUMED`" gap | For each fact family, an explicit `FactStatus` → detector-meaning table (e.g. `FAILED` means "incomplete evidence," not "confirmed absent") instead of the uniform legacy-default collapse — inventory every present-or-default unwrap first (`resolved_fact_value` call sites *and* local equivalents like `diff_param_qualifiers._fact_bool`/`diff_cxx_rules._fact_str_list`/`compare.surface_graph.fact_list`), not only the shared primitive's own callers; first vertical cohort on the five fields with an existing fabricated-finding history (`RecordType.bases`/`virtual_bases`/`vtable`/`vptr_offset_bits`, `Param.is_va_list`), since those are where the behavior change is easiest to justify and test. First PR landed (see the note below the table): the shared `compare_facts`/`FactComparison` primitive plus two of the five fields' primary finding-emitting call sites (`bases`/`virtual_bases` in `diff_types._diff_type_bases`, `is_va_list` in `diff_param_qualifiers.param_va_list_changes`) — `vtable`/`vptr_offset_bits` and every other reader of the two converted fields (`diff_cxx_rules.py`, `diff_stdlib_impl.py`, `diff_time64.py`, `idioms.py`, `surface_graph.py`, `buildsource/header_graph.py`, `diff_cpp_patterns.py`) remain on the old collapse, so this sub-phase's own gate ("every detector... for at least one full fact family") is not yet closed |
+| **5B — Fact semantic consumption** | in progress | Phase 5's "no fact reaches `CONSUMED`" gap | For each fact family, an explicit `FactStatus` → detector-meaning table (e.g. `FAILED` means "incomplete evidence," not "confirmed absent") instead of the uniform legacy-default collapse — inventory every present-or-default unwrap first (`resolved_fact_value` call sites *and* local equivalents like `diff_param_qualifiers._fact_bool`/`diff_cxx_rules._fact_str_list`/`compare.surface_graph.fact_list`), not only the shared primitive's own callers; first vertical cohort on the five fields with an existing fabricated-finding history (`RecordType.bases`/`virtual_bases`/`vtable`/`vptr_offset_bits`, `Param.is_va_list`), since those are where the behavior change is easiest to justify and test. First PR landed (see the note below the table): the shared `compare_facts`/`FactComparison` primitive plus two of the five fields' primary finding-emitting call sites (`bases`/`virtual_bases` in `diff_types._diff_type_bases`, `is_va_list` in `diff_param_qualifiers.param_va_list_changes`). Second PR landed (see the note below the table): every remaining reader of `bases`/`virtual_bases`/`is_va_list` audited and closed — one genuine pairwise fabrication risk (`diff_cxx_rules._transitive_bases`, feeding `virtual_method_addition`) gated the same way, the rest (single-snapshot reachability/classification aids) documented as already safe. `vtable`/`vptr_offset_bits` remain on the old collapse, deliberately (their own dedicated, higher-scrutiny slice — see below), so this sub-phase's own gate ("every detector... for at least one full fact family") is not yet closed |
 | **6B — SemanticIR checker cutover** | in progress | The gap this review calls the single largest: `SemanticIR` computed and persisted but never read by the checker | One read index over `SemanticIR` (`entity()`, `occurrences()`, `functions()`, `records()`, `facts()`, `references()`) with a legacy-flat-snapshot adapter producing the same read shape, migrated one detector family/cohort at a time, each cohort closing with an architecture-gate rule forbidding a direct legacy-collection read for that family |
 | **7B — Boundary consumer migration** | not started | `action/run.sh`'s raw-exit-code decoding (Phase 7's named scope boundary) and the release fan-out's independent pair-semantics reimplementation | Action reads `run_outcome`/`exit` from the machine report instead of re-deriving a verdict from the raw process exit code and stderr text; release/artifact-set fan-out calls one shared pair-operation executor instead of independently resolving depth, policy provenance, and report composition per pair |
 | **8B — Multi-artifact canonical storage** | not started | Phase 8's "one legacy blob per section, single-artifact only" residual | Typed DTOs for the remaining sections beyond `semantic_ir`; multi-artifact `ProjectSnapshot` packages; baseline-set/`BundleFacts` folded into sections instead of staying separate document shapes |
@@ -248,6 +248,72 @@ for at least one full fact family") is not closed until they are covered
 too. Recorded here rather than silently left implicit, per this repo's own
 "say so explicitly and record the gap" convention (`AGENTS.md`
 "Decision-making principles").
+
+**5B's second PR landed (2026-09-03) — the "lower-risk batch" from the note
+above.** Every remaining reader of `bases`/`virtual_bases`/`is_va_list`
+named above was audited individually (`is_va_list` has no other reader at
+all: `diff_param_qualifiers.param_va_list_changes`/`compare.va_list_diff`
+is its only call site). The audit split into two kinds:
+
+- **One genuine old/new pairwise fabrication risk**: `diff_cxx_rules.
+  _transitive_bases`, called from `virtual_method_addition` to tell a
+  genuinely new virtual slot apart from a compatible override of an
+  inherited one. An incomplete `bases_fact`/`virtual_bases_fact` anywhere
+  along the transitive walk used to read as "no bases here", which could
+  make a real override look like a new slot and fire a spurious
+  `VIRTUAL_METHOD_ADDED`. `_transitive_bases` now returns whether every
+  visited record's evidence was confirmed `PRESENT` (a `PARTIAL` fact is
+  treated as incomplete too, the same discipline `diff_bases` already
+  applies to this identical field pair — an unlisted base could simply
+  live in the uncovered remainder); `virtual_method_addition` declines to
+  emit when either side's walk was incomplete, rather than fabricating.
+  Behavior is unchanged whenever both sides' evidence is complete — every
+  real producer (`dwarf_snapshot.py` included) already states `bases`/
+  `virtual_bases` explicitly, even empty, for every `RecordType` it emits;
+  only test fixtures that never set the field at all (reading as
+  `NOT_COLLECTED`, not confirmed-empty) needed updating to match that real
+  producer shape. `_owner_descends_from` (`diff_cxx_rules.py`, feeding
+  `vtable_slot_is_override_reuse`) also calls `_transitive_bases` but is
+  itself part of the vtable evidence-gap cluster below — it takes the new
+  return value's set component only, unchanged behavior, left for that
+  slice. Verified against the FP-rate gate (`scripts/check_fp_rate.py`)
+  and the per-tier-accuracy gate (`scripts/check_tier_accuracy.py`), both
+  clean, plus the full unit suite.
+- **Five single-snapshot reachability/classification aids with no old/new
+  pair to gate at all**: `diff_stdlib_impl._public_by_value_type_closure`
+  (feeds an OR of both sides — an evidence gap only narrows one side's
+  closure, the other side's independent closure or a later re-run still
+  catches it), `diff_time64._fold_record_tokens` (feeds a union of both
+  sides' token sets — identical shape), `idioms._collect_base_targets`
+  (single-snapshot ADR-027 anti-pattern scan — a gap only shrinks
+  `base_targets`, missing a `POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR` rather than
+  fabricating one), `buildsource/header_graph._flat_structural_type_edges`
+  (one snapshot's own graph, and this package's own governing rule already
+  caps every finding it can feed at `API_BREAK_KINDS`/`RISK_KINDS` without
+  an artifact diff also proving the break), and `compare.surface_graph.
+  fact_list` (already explicitly justified before this PR — an evidence
+  gap only omits a graph edge this phase's own D5 amendment already
+  documents as non-authoritative for any decision today). None of the
+  five needed a behavior change — each already fails toward under-
+  detection, never fabrication — so each now carries an explicit ADR-063
+  Phase 5B docstring note recording *why*, closing the audit gap without
+  a speculative rewrite of code that was already safe. `diff_cpp_patterns.
+  _is_empty_record`'s `vtable_fact` read is the one item from the original
+  list that turned out to belong to the vtable cluster, not this batch —
+  see below.
+
+**Still open**: `vtable`/`vptr_offset_bits` themselves (`diff_types_vtable.
+py`/`diff_layout.py`/`diff_vtable_layout.py`'s own guard cluster), plus
+every downstream reader of those two fields specifically —
+`diff_cxx_rules.virtual_method_addition`'s own `old_vtable != new_vtable`
+comparison, `idioms.py`'s three vtable reads (`_recognise_factory`,
+`_has_virtual_destructor`, `_detect_non_virtual_dtor`), and
+`diff_cpp_patterns._is_empty_record`. This PR's own audit reconfirms the
+prior PR's reasoning for leaving them alone: `_vtable_transition_is_
+evidenced` and its siblings are exactly the kind of individually-reasoned,
+multi-round-reviewed evidence-gap heuristic that needs its own dedicated
+slice with equal scrutiny, not a change folded into an otherwise
+lower-risk batch.
 
 **Recommended sequencing:** 2B and 6B are
 the highest-value pair, in that order — 2B closes the last identity-provider

--- a/tests/_detector_mutations.py
+++ b/tests/_detector_mutations.py
@@ -209,7 +209,13 @@ def _m_virtual_method_added(tag: int):
     record the growth (DWARF/symbol-only blind spot) → VIRTUAL_METHOD_ADDED."""
     cls_name = f"Cv{tag}"
     n = len(cls_name)  # Itanium source-name length prefix (valid for multi-digit tags)
-    cls = RecordType(name=cls_name, kind="class", size_bits=64, vtable=[])
+    # ADR-063 Phase 5B: `bases`/`virtual_bases` stated explicitly (empty,
+    # not omitted) so `virtual_method_addition`'s evidence-completeness
+    # check reads a confirmed-empty transitive-bases walk, matching how
+    # every real producer constructs a base-less RecordType.
+    cls = RecordType(
+        name=cls_name, kind="class", size_bits=64, vtable=[], bases=[], virtual_bases=[]
+    )
     keep = Function(name=f"{cls_name}::foo", mangled=f"_ZN{n}{cls_name}3fooEv", return_type="void",
                     visibility=Visibility.PUBLIC, access=AccessLevel.PUBLIC, is_virtual=True)
     new = Function(name=f"{cls_name}::bar", mangled=f"_ZN{n}{cls_name}3barEv", return_type="void",

--- a/tests/test_change_entity_id_carrier.py
+++ b/tests/test_change_entity_id_carrier.py
@@ -147,8 +147,16 @@ class TestChangeEntityIdCarrier:
         # a separate construction site that must carry entity_id too.
         from abicheck.model import RecordType
 
-        owner = RecordType(name="C", kind="class", size_bits=64, vtable=[])
-        old_owner = RecordType(name="C", kind="class", size_bits=64, vtable=[])
+        # ADR-063 Phase 5B: `bases`/`virtual_bases` stated explicitly (empty,
+        # not omitted) so `virtual_method_addition`'s evidence-completeness
+        # check reads a confirmed-empty transitive-bases walk, matching how
+        # every real producer constructs a base-less RecordType.
+        owner = RecordType(
+            name="C", kind="class", size_bits=64, vtable=[], bases=[], virtual_bases=[]
+        )
+        old_owner = RecordType(
+            name="C", kind="class", size_bits=64, vtable=[], bases=[], virtual_bases=[]
+        )
         eid = entity_id_for_function((), "f", mangled_name="_ZN1C1fEv")
         new_method = _func(
             "C::f",

--- a/tests/test_kde_compat_detectors.py
+++ b/tests/test_kde_compat_detectors.py
@@ -43,6 +43,7 @@ from abicheck.diff_cxx_rules import (
 )
 from abicheck.model import (
     AbiSnapshot,
+    Fact,
     Function,
     Param,
     RecordType,
@@ -80,7 +81,21 @@ def _method(
 
 
 def _cls(name: str, *, vtable: list[str] | None = None) -> RecordType:
-    return RecordType(name=name, kind="class", size_bits=64, vtable=vtable or [])
+    # ADR-063 Phase 5B: `bases`/`virtual_bases` are stated explicitly (an
+    # empty list, not omitted) so `bases_fact`/`virtual_bases_fact` read
+    # PRESENT — the same "always stated, even when empty" shape every real
+    # producer (`dwarf_snapshot.py` et al.) already constructs, and what
+    # `diff_cxx_rules.virtual_method_addition`'s evidence-completeness check
+    # now requires before it will trust a transitive-bases walk that reaches
+    # this record.
+    return RecordType(
+        name=name,
+        kind="class",
+        size_bits=64,
+        vtable=vtable or [],
+        bases=[],
+        virtual_bases=[],
+    )
 
 
 def _kinds(result) -> set[ChangeKind]:
@@ -273,7 +288,12 @@ class TestVirtualMethodAdded:
         slot — ABI-compatible, not a new slot. Must not fire."""
         base = _cls("Base")
         derived = RecordType(
-            name="Derived", kind="class", size_bits=64, vtable=[], bases=["Base"]
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases=["Base"],
+            virtual_bases=[],
         )
         old = _snap(
             functions=[
@@ -302,7 +322,12 @@ class TestVirtualMethodAdded:
         not an override — must still fire."""
         base = _cls("Base")
         derived = RecordType(
-            name="Derived", kind="class", size_bits=64, vtable=[], bases=["Base"]
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases=["Base"],
+            virtual_bases=[],
         )
         old = _snap(
             functions=[
@@ -342,7 +367,12 @@ class TestVirtualMethodAdded:
         leaf-only records) must resolve bases and stay compatible."""
         base = _cls("Base")  # CastXML stores ns::Base as leaf "Base"
         derived = RecordType(
-            name="Derived", kind="class", size_bits=64, vtable=[], bases=["Base"]
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases=["Base"],
+            virtual_bases=[],
         )
         old = _snap(
             functions=[
@@ -377,6 +407,122 @@ class TestVirtualMethodAdded:
         )
         result = compare(old, new)
         assert ChangeKind.VIRTUAL_METHOD_ADDED not in _kinds(result)
+
+    def test_incomplete_bases_evidence_declines_rather_than_fabricates(self):
+        """ADR-063 Phase 5B: a class whose ``bases``/``virtual_bases``
+        evidence never arrived (``NOT_COLLECTED``, not confirmed-empty) must
+        not be read as "no bases, therefore no possible override" — that
+        gap could just as easily be hiding the very base that would make
+        this an ABI-compatible override, not a genuine new virtual slot.
+        Declining is the safe default (a missed VIRTUAL_METHOD_ADDED, not a
+        fabricated one), the same "decline rather than fabricate" discipline
+        already applied to ``bases``/``virtual_bases``/``is_va_list`` at
+        their primary finding-emitting call sites.
+        """
+        derived = RecordType(
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases_fact=Fact.not_collected(),
+            virtual_bases_fact=Fact.not_collected(),
+        )
+        old = _snap(
+            functions=[
+                _method("Derived::help", "_ZN7Derived4helpEv"),
+            ],
+            types=[derived],
+        )
+        new = _snap(
+            functions=[
+                _method("Derived::help", "_ZN7Derived4helpEv"),
+                _method("Derived::resize", "_ZN7Derived6resizeEv", is_virtual=True),
+            ],
+            types=[derived],
+        )
+        result = compare(old, new)
+        assert ChangeKind.VIRTUAL_METHOD_ADDED not in _kinds(result)
+
+    def test_partial_virtual_bases_evidence_declines(self):
+        """Sibling case: ``PARTIAL`` (not ``NOT_COLLECTED``) is incomplete
+        too — the uncovered remainder of a partially-covered virtual-bases
+        list could hold the very base that makes this an override."""
+        derived = RecordType(
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases_fact=Fact.present([]),
+            virtual_bases_fact=Fact.partial([]),
+        )
+        old = _snap(
+            functions=[_method("Derived::help", "_ZN7Derived4helpEv")],
+            types=[derived],
+        )
+        new = _snap(
+            functions=[
+                _method("Derived::help", "_ZN7Derived4helpEv"),
+                _method("Derived::resize", "_ZN7Derived6resizeEv", is_virtual=True),
+            ],
+            types=[derived],
+        )
+        result = compare(old, new)
+        assert ChangeKind.VIRTUAL_METHOD_ADDED not in _kinds(result)
+
+    def test_incomplete_evidence_on_transitive_base_declines(self):
+        """Sibling case: the owner's own ``bases``/``virtual_bases`` are
+        fully confirmed, but a base reached *transitively* (one level
+        further out) has incomplete evidence — the walk-wide completeness
+        tracking must catch this too, not just the immediate owner's own
+        facts."""
+        base = RecordType(
+            name="Base",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases_fact=Fact.not_collected(),  # Base's own ancestry is unknown
+            virtual_bases_fact=Fact.not_collected(),
+        )
+        derived = RecordType(
+            name="Derived",
+            kind="class",
+            size_bits=64,
+            vtable=[],
+            bases=["Base"],
+            virtual_bases=[],
+        )
+        old = _snap(
+            functions=[_method("Derived::help", "_ZN7Derived4helpEv")],
+            types=[base, derived],
+        )
+        new = _snap(
+            functions=[
+                _method("Derived::help", "_ZN7Derived4helpEv"),
+                _method("Derived::resize", "_ZN7Derived6resizeEv", is_virtual=True),
+            ],
+            types=[base, derived],
+        )
+        result = compare(old, new)
+        assert ChangeKind.VIRTUAL_METHOD_ADDED not in _kinds(result)
+
+    def test_complete_empty_bases_evidence_still_fires(self):
+        """The control for the previous test: a *confirmed*-empty
+        ``bases``/``virtual_bases`` (``PRESENT`` status, empty list — what
+        every real producer emits for a base-less class) is fully trusted,
+        same as before this evidence-completeness check existed."""
+        old = _snap(
+            functions=[_method("Derived::help", "_ZN7Derived4helpEv")],
+            types=[_cls("Derived")],
+        )
+        new = _snap(
+            functions=[
+                _method("Derived::help", "_ZN7Derived4helpEv"),
+                _method("Derived::resize", "_ZN7Derived6resizeEv", is_virtual=True),
+            ],
+            types=[_cls("Derived")],
+        )
+        result = compare(old, new)
+        assert ChangeKind.VIRTUAL_METHOD_ADDED in _kinds(result)
 
 
 # ── OVERLOAD_ADDED ───────────────────────────────────────────────────────────

--- a/tests/test_vtable_severity.py
+++ b/tests/test_vtable_severity.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.checker_policy import BREAKING_KINDS
 from abicheck.diff_cxx_rules import _owner_descends_from, vtable_slot_is_override_reuse
-from abicheck.model import AbiSnapshot, Function, Param, RecordType
+from abicheck.model import AbiSnapshot, Fact, Function, Param, RecordType
 
 
 def _snap(**kwargs: object) -> AbiSnapshot:
@@ -179,6 +179,47 @@ class TestVtableOverrideSlotReuse:
         result = compare(old, new)
         kinds = {c.kind for c in result.changes}
         assert ChangeKind.TYPE_VTABLE_CHANGED not in kinds
+
+    def test_partial_bases_evidence_still_recognises_override_reuse(self) -> None:
+        """ADR-063 Phase 5B (Codex review on the same PR): the exact scenario
+        the review flagged -- a `PARTIAL` (not `NOT_COLLECTED`) `bases_fact`
+        that still carries its one known entry (`["Base"]`) must resolve
+        through `vtable_slot_is_override_reuse` exactly as a `PRESENT` one
+        would, at the real `vtable_slot_is_override_reuse` call site rather
+        than only at `_owner_descends_from` directly."""
+        old_funcs = {
+            "_ZN4Base5paintEi": Function(
+                name="Base::paint",
+                mangled="_ZN4Base5paintEi",
+                return_type="int",
+                params=[Param(name="x", type="int")],
+                is_virtual=True,
+            )
+        }
+        new_funcs = {
+            "_ZN7Derived5paintEi": Function(
+                name="Derived::paint",
+                mangled="_ZN7Derived5paintEi",
+                return_type="int",
+                params=[Param(name="x", type="int")],
+                is_virtual=True,
+            )
+        }
+        new_types = {
+            "Derived": RecordType(
+                name="Derived",
+                kind="class",
+                bases_fact=Fact.partial(["Base"]),
+            )
+        }
+        assert vtable_slot_is_override_reuse(
+            "_ZN4Base5paintEi",
+            "_ZN7Derived5paintEi",
+            old_funcs,
+            new_funcs,
+            {},
+            new_types,
+        )
 
     def test_different_signature_same_name_still_fires(self) -> None:
         """The negative twin: same method name but a different parameter
@@ -424,6 +465,26 @@ class TestOwnerDescendsFrom:
         types = {
             "ns::Derived": RecordType(
                 name="ns::Derived", kind="class", bases=["ns::Base"]
+            ),
+        }
+        assert _owner_descends_from("ns::Derived", "ns::Base", types)
+
+    def test_partial_bases_evidence_is_still_trusted_for_a_known_entry(self) -> None:
+        """ADR-063 Phase 5B (Codex review on the same PR): `_owner_descends_from`
+        reads `_transitive_bases`'s *set* of names only and discards its
+        completeness flag entirely -- its own evidence-gap handling is
+        scoped to the separate vtable/vptr_offset_bits slice. A `PARTIAL`
+        `bases_fact` still carries real, known entries (the uncovered part
+        of the scope is merely *unknown*, not the covered part being wrong),
+        so a `PARTIAL`-evidenced `Derived -> Base` relationship must resolve
+        here exactly as a `PRESENT` one would -- losing it would make
+        `vtable_slot_is_override_reuse` (this function's own caller) return
+        `False` for a real override and fabricate a `TYPE_VTABLE_CHANGED`."""
+        types = {
+            "ns::Derived": RecordType(
+                name="ns::Derived",
+                kind="class",
+                bases_fact=Fact.partial(["ns::Base"]),
             ),
         }
         assert _owner_descends_from("ns::Derived", "ns::Base", types)

--- a/tests/test_vtable_severity.py
+++ b/tests/test_vtable_severity.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.checker_policy import BREAKING_KINDS
 from abicheck.diff_cxx_rules import _owner_descends_from, vtable_slot_is_override_reuse
-from abicheck.model import AbiSnapshot, Fact, Function, Param, RecordType
+from abicheck.model import AbiSnapshot, Function, Param, RecordType
 
 
 def _snap(**kwargs: object) -> AbiSnapshot:
@@ -179,47 +179,6 @@ class TestVtableOverrideSlotReuse:
         result = compare(old, new)
         kinds = {c.kind for c in result.changes}
         assert ChangeKind.TYPE_VTABLE_CHANGED not in kinds
-
-    def test_partial_bases_evidence_still_recognises_override_reuse(self) -> None:
-        """ADR-063 Phase 5B (Codex review on the same PR): the exact scenario
-        the review flagged -- a `PARTIAL` (not `NOT_COLLECTED`) `bases_fact`
-        that still carries its one known entry (`["Base"]`) must resolve
-        through `vtable_slot_is_override_reuse` exactly as a `PRESENT` one
-        would, at the real `vtable_slot_is_override_reuse` call site rather
-        than only at `_owner_descends_from` directly."""
-        old_funcs = {
-            "_ZN4Base5paintEi": Function(
-                name="Base::paint",
-                mangled="_ZN4Base5paintEi",
-                return_type="int",
-                params=[Param(name="x", type="int")],
-                is_virtual=True,
-            )
-        }
-        new_funcs = {
-            "_ZN7Derived5paintEi": Function(
-                name="Derived::paint",
-                mangled="_ZN7Derived5paintEi",
-                return_type="int",
-                params=[Param(name="x", type="int")],
-                is_virtual=True,
-            )
-        }
-        new_types = {
-            "Derived": RecordType(
-                name="Derived",
-                kind="class",
-                bases_fact=Fact.partial(["Base"]),
-            )
-        }
-        assert vtable_slot_is_override_reuse(
-            "_ZN4Base5paintEi",
-            "_ZN7Derived5paintEi",
-            old_funcs,
-            new_funcs,
-            {},
-            new_types,
-        )
 
     def test_different_signature_same_name_still_fires(self) -> None:
         """The negative twin: same method name but a different parameter
@@ -465,26 +424,6 @@ class TestOwnerDescendsFrom:
         types = {
             "ns::Derived": RecordType(
                 name="ns::Derived", kind="class", bases=["ns::Base"]
-            ),
-        }
-        assert _owner_descends_from("ns::Derived", "ns::Base", types)
-
-    def test_partial_bases_evidence_is_still_trusted_for_a_known_entry(self) -> None:
-        """ADR-063 Phase 5B (Codex review on the same PR): `_owner_descends_from`
-        reads `_transitive_bases`'s *set* of names only and discards its
-        completeness flag entirely -- its own evidence-gap handling is
-        scoped to the separate vtable/vptr_offset_bits slice. A `PARTIAL`
-        `bases_fact` still carries real, known entries (the uncovered part
-        of the scope is merely *unknown*, not the covered part being wrong),
-        so a `PARTIAL`-evidenced `Derived -> Base` relationship must resolve
-        here exactly as a `PRESENT` one would -- losing it would make
-        `vtable_slot_is_override_reuse` (this function's own caller) return
-        `False` for a real override and fabricate a `TYPE_VTABLE_CHANGED`."""
-        types = {
-            "ns::Derived": RecordType(
-                name="ns::Derived",
-                kind="class",
-                bases_fact=Fact.partial(["ns::Base"]),
             ),
         }
         assert _owner_descends_from("ns::Derived", "ns::Base", types)

--- a/tests/test_vtable_severity_partial_evidence.py
+++ b/tests/test_vtable_severity_partial_evidence.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 5B: ``PARTIAL`` ``bases_fact`` evidence must stay usable at
+``diff_cxx_rules._owner_descends_from``/``vtable_slot_is_override_reuse``.
+
+Split out of ``test_vtable_severity.py`` (that file sits at its own frozen
+architecture-debt line-count baseline; a `debt-no-growth` check forbids
+adding to it -- move responsibility to a sibling module instead, per this
+repo's own AGENTS.md "Files that are large" guidance).
+
+Codex review on the PR that introduced ``_transitive_bases``'s
+completeness-tracking return value (ADR-063 Phase 5B): the helper's first
+draft returned an empty list for any non-``PRESENT`` ``bases_fact``,
+including ``PARTIAL`` -- collapsing "confirmed complete" and "known but
+possibly incomplete" onto the same empty value. ``_owner_descends_from``
+(feeding ``vtable_slot_is_override_reuse``, part of the separate
+vtable/vptr_offset_bits evidence-gap cluster) reads only the walk's *set* of
+names and discards its completeness flag entirely, so that collapse
+silently dropped a real, known ``Derived -> Base`` relationship a
+``PARTIAL`` fact still carries -- which could make
+``vtable_slot_is_override_reuse`` return ``False`` for a genuine override
+and fabricate a ``TYPE_VTABLE_CHANGED``. Fixed by having the underlying
+helper preserve the value for both ``PRESENT`` and ``PARTIAL`` (matching
+the pre-existing ``_fact_str_list``'s own read) and only gating the
+*completeness* flag on ``PRESENT``.
+"""
+
+from __future__ import annotations
+
+from abicheck.diff_cxx_rules import _owner_descends_from, vtable_slot_is_override_reuse
+from abicheck.model import Fact, Function, Param, RecordType
+
+
+class TestOwnerDescendsFromPartialEvidence:
+    def test_partial_bases_evidence_is_still_trusted_for_a_known_entry(self) -> None:
+        """`_owner_descends_from` reads `_transitive_bases`'s *set* of names
+        only and discards its completeness flag entirely -- its own
+        evidence-gap handling is scoped to the separate vtable/
+        vptr_offset_bits slice. A `PARTIAL` `bases_fact` still carries real,
+        known entries (the uncovered part of the scope is merely *unknown*,
+        not the covered part being wrong), so a `PARTIAL`-evidenced
+        `Derived -> Base` relationship must resolve here exactly as a
+        `PRESENT` one would -- losing it would make
+        `vtable_slot_is_override_reuse` (this function's own caller) return
+        `False` for a real override and fabricate a `TYPE_VTABLE_CHANGED`.
+        """
+        types = {
+            "ns::Derived": RecordType(
+                name="ns::Derived",
+                kind="class",
+                bases_fact=Fact.partial(["ns::Base"]),
+            ),
+        }
+        assert _owner_descends_from("ns::Derived", "ns::Base", types)
+
+
+class TestVtableOverrideSlotReusePartialEvidence:
+    def test_partial_bases_evidence_still_recognises_override_reuse(self) -> None:
+        """The exact scenario the review flagged -- a `PARTIAL` (not
+        `NOT_COLLECTED`) `bases_fact` that still carries its one known
+        entry (`["Base"]`) must resolve through `vtable_slot_is_override_
+        reuse` exactly as a `PRESENT` one would, at the real
+        `vtable_slot_is_override_reuse` call site rather than only at
+        `_owner_descends_from` directly.
+        """
+        old_funcs = {
+            "_ZN4Base5paintEi": Function(
+                name="Base::paint",
+                mangled="_ZN4Base5paintEi",
+                return_type="int",
+                params=[Param(name="x", type="int")],
+                is_virtual=True,
+            )
+        }
+        new_funcs = {
+            "_ZN7Derived5paintEi": Function(
+                name="Derived::paint",
+                mangled="_ZN7Derived5paintEi",
+                return_type="int",
+                params=[Param(name="x", type="int")],
+                is_virtual=True,
+            )
+        }
+        new_types = {
+            "Derived": RecordType(
+                name="Derived",
+                kind="class",
+                bases_fact=Fact.partial(["Base"]),
+            )
+        }
+        assert vtable_slot_is_override_reuse(
+            "_ZN4Base5paintEi",
+            "_ZN7Derived5paintEi",
+            old_funcs,
+            new_funcs,
+            {},
+            new_types,
+        )


### PR DESCRIPTION
## Summary

Closes the "lower-risk batch" of ADR-063 Phase 5B ("Fact semantic consumption"): every remaining reader of `bases`/`virtual_bases`/`is_va_list` outside the two call sites the first 5B PR (#1033) already migrated onto `compare_facts`/`FactComparison`.

## Motivation

The first 5B PR fixed `diff_types._diff_type_bases` and `diff_param_qualifiers.param_va_list_changes` so an evidence gap (`bases_fact`/`virtual_bases_fact`/`is_va_list_fact` not reaching `PRESENT`) declines to compare instead of silently reading the gap as "confirmed empty/false" and fabricating a finding. It explicitly left every *other* reader of those fields unconverted, split into a documented "lower-risk batch" (this PR) and a separately-scoped `vtable`/`vptr_offset_bits` slice (still open — see below).

## Changes

- `diff_cxx_rules._transitive_bases` (used by `virtual_method_addition` to tell a genuinely new virtual slot apart from a compatible override of an inherited one) now tracks whether every visited record's `bases_fact`/`virtual_bases_fact` reached a confirmed `PRESENT` status — `PARTIAL` is treated as incomplete too, matching `compare.base_class_diff.diff_bases`'s identical discipline for these same fields (an unlisted base could simply live in the uncovered remainder). `virtual_method_addition` now declines to emit `VIRTUAL_METHOD_ADDED` when either side's walk was incomplete, instead of fabricating a finding against what may really be a plain, ABI-compatible override.
- `_owner_descends_from` (feeds `vtable_slot_is_override_reuse`, part of the separate vtable evidence-gap cluster) discards the new completeness flag — unchanged behavior, left for that cluster's own dedicated slice.
- `diff_stdlib_impl.py`, `diff_time64.py`, `idioms.py`, and `buildsource/header_graph.py`'s `bases`/`virtual_bases` readers are audited and documented: each is a single-snapshot reachability/classification aid with no old/new pair to gate, so an evidence gap there only narrows a closure or omits a graph edge — it cannot fabricate a finding the way a pairwise comparison could. No behavior change; each now carries an explicit ADR-063 Phase 5B docstring note recording why.
- `is_va_list` has no other reader beyond the already-migrated `diff_param_qualifiers.param_va_list_changes`.
- `vtable`/`vptr_offset_bits` themselves remain deliberately unconverted — `diff_types_vtable.py`'s evidence-gap guard cluster is a separate, individually-reasoned, multi-round-reviewed heuristic layer (documented false-positive/negative history per guard) that needs its own dedicated slice with equal scrutiny, per the plan's existing note.
- Updates `docs/contribute/plans/one-semantic-pipeline.md` and `docs/_meta/one-semantic-pipeline-status.yaml` to record this slice's landing and what remains open.

Verified against the FP-rate gate (`scripts/check_fp_rate.py`) and the per-tier-accuracy gate (`scripts/check_tier_accuracy.py`), both clean, plus the full unit suite (2 pre-existing, unrelated environment failures confirmed via `git stash`).

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A `Fact[T]`-bridged field's evidence-gap collapse (`resolved_fact_value`'s present-or-default bridge, or an equivalent local unwrap) used at a comparison/decision site silently reads "evidence not collected" as "confirmed empty/absent," fabricating a finding a fully-evidenced pair would not have produced. Same class the first 5B PR (#1033) already fixed at `diff_types._diff_type_bases`/`diff_param_qualifiers.param_va_list_changes`; this PR applies the identical fix to a third call site (`diff_cxx_rules._transitive_bases`/`virtual_method_addition`) and audits every remaining reader of the same two fields to confirm none of the others share the risk.
- Publicly observable failure: A class that overrides an inherited virtual method (ABI-compatible, reuses the base's existing vtable slot, no relayout) is reported as `VIRTUAL_METHOD_ADDED` — a BREAKING finding — whenever `bases`/`virtual_bases` evidence for any class along the override-detection walk was not collected (`NOT_COLLECTED`/`FAILED`/`PARTIAL`), because the missing evidence previously read as "this class has no bases, therefore no override is possible."
- Regression test fails on base: Yes — `tests/test_kde_compat_detectors.py::TestVirtualMethodAdded::test_incomplete_bases_evidence_declines_rather_than_fabricates` (direct-owner evidence gap), `test_partial_virtual_bases_evidence_declines` (`PARTIAL` status), and `test_incomplete_evidence_on_transitive_base_declines` (gap on a transitively-reached base, not the direct owner) all assert `VIRTUAL_METHOD_ADDED not in` the result; each fails on `main` (fires the finding) and passes with this fix.
- Negative control: `test_complete_empty_bases_evidence_still_fires` — a genuinely confirmed-empty (`PRESENT` status, empty list) base list still fires `VIRTUAL_METHOD_ADDED` exactly as before, proving the fix declines only on a real evidence gap rather than blanket-suppressing the detector. The pre-existing override/namespaced-override/different-signature tests in the same file (all using explicit, `PRESENT`-status `bases=[...]` construction) are unaffected.
- Public-surface test: Yes — every test in `TestVirtualMethodAdded` goes through `abicheck.checker.compare(old, new)`, the same entry point `compare`/`scan` use, not the internal `_transitive_bases`/`virtual_method_addition` helpers directly.
- Axes covered: DWARF is the only path this detector's own docstring targets (its "genuine blind spot" is a DWARF/symbol-only snapshot with no diff-able vtable array); `bases`/`virtual_bases` are produced by all three backends (castxml/clang/dwarf per `model/fact_registry_entries_types.py`) with no per-producer reliability gate, so the fix applies uniformly. Verified via the checker's own hand-built-snapshot unit tests (backend-agnostic `RecordType`/`Function` construction) plus the FP-rate and per-tier-accuracy gates, which run real castxml-derived fixtures.
- General invariant: A `VIRTUAL_METHOD_ADDED` finding is emitted only when both sides' transitive base-class evidence (used to rule out a compatible override) is fully confirmed (`PRESENT`, not `NOT_COLLECTED`/`FAILED`/`PARTIAL`) at every node the walk visits — direct or transitive. Exercised by three independently-chosen sibling cases beyond the one reported shape (direct-owner `NOT_COLLECTED`, `PARTIAL` status, and a gap on a transitively-reached base two hops from the owner), each checked against the real `compare()` entry point, not the internal helper's own return value.
- Known unsupported cases: `vtable`/`vptr_offset_bits` themselves (and their own downstream readers — `diff_cxx_rules.virtual_method_addition`'s own `old_vtable != new_vtable` comparison, `idioms.py`'s vtable reads, `diff_cpp_patterns._is_empty_record`) are unaffected by this PR and remain on the pre-existing `resolved_fact_value` collapse; `diff_types_vtable.py`'s evidence-gap guard cluster needs its own dedicated, equally-scrutinized slice (documented in `docs/contribute/plans/one-semantic-pipeline.md`'s 5B section).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/contribute/plans/one-semantic-pipeline.md`, `docs/_meta/one-semantic-pipeline-status.yaml`)
- [x] `ruff check`/`ruff format --check`/`mypy abicheck/` clean on touched files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtbSbyYNww6oeLjpECzCPu)_