### PR TITLE
fix: close ADR-063 5B closure — restructure virtual_method_addition/diff_types_vtable coupling

### DIFF
--- a/abicheck/compare/vtable_evidence.py
+++ b/abicheck/compare/vtable_evidence.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Whether an *empty<->non-empty* ``RecordType.vtable`` transition rests on
+real evidence or a capture gap -- the one predicate ``diff_types_vtable``'s
+``TYPE_VTABLE_CHANGED`` detector and ``diff_cxx_rules.virtual_method_addition``
+must now agree on, instead of each carrying its own copy of the reasoning
+(ADR-063 Track 2, 5B closure).
+
+**Why this module exists.** Before this split, ``virtual_method_addition``
+declined outright (deferring to ``TYPE_VTABLE_CHANGED``) whenever the two
+sides' ``vtable`` arrays merely differed, *without ever checking* that
+``diff_types_vtable`` would actually fire. That was safe only in the one
+shape both docstrings called out by name -- one side's ``vtable_fact``
+uncollected, the other genuinely populated -- because ``diff_types_vtable``'s
+own heuristic happens to still find evidence there. Anywhere else the two
+sides' evidence agrees (same owned-virtual-function set, same size, same
+virtual-base list) ``diff_types_vtable`` stays silent too, and
+``virtual_method_addition`` was deferring to a detector that was never going
+to fire -- silently dropping the one coverage this function exists to
+provide, with nothing but a paragraph in each module's docstring holding the
+two in sync.
+
+Closing that gap for real means ``virtual_method_addition`` must call the
+*same* evidence predicate ``diff_types_vtable`` uses, not just trust it by
+convention. Doing that directly (importing ``diff_types_vtable`` into
+``diff_cxx_rules``) is impossible: ``diff_types_vtable.py`` already imports
+``diff_cxx_rules`` for ``vtable_slot_is_override_reuse``, so the reverse
+import would be a cycle -- exactly the constraint both modules' docstrings
+recorded as the blocker. The fix is the usual one for two leaves that need
+the same logic: move the shared predicate to a module *below* both of them,
+so each imports downward and neither imports the other.
+
+That predicate -- ``vtable_transition_is_evidenced`` (moved here from
+``diff_types_vtable._vtable_transition_is_evidenced`` verbatim, plus its
+``_owned_virtual_signatures`` helper) -- itself needs an owner-name
+resolver (``diff_cxx_rules.owner_class_of``) and a namespace-suffix
+matcher (``type_reachability_spelling._namespace_suffix_spellings``). Both
+of those already sit *above* this candidate leaf in the dependency graph
+(``type_reachability_spelling`` itself imports ``diff_cxx_rules``), so
+importing either one here would recreate the identical cycle one level
+down. Per ``compare/AGENTS.md`` this package may depend on ``model`` only,
+which settles it independent of the cycle concern anyway: both functions
+below take ``owner_class_of``/``namespace_suffix_spellings`` as **injected
+callables** rather than importing them, so this module's own dependency
+stays exactly ``model`` and nothing else. Each caller (``diff_cxx_rules``,
+``diff_types_vtable``) supplies its own already-available implementations.
+
+Docstrings quoting the FP-history and design rationale below are carried
+over unchanged from ``diff_types_vtable.py`` -- only the owner/namespace
+lookups became parameters; no behavior changed for ``diff_types_vtable``'s
+own existing callers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from ..model import Function, RecordType, resolved_fact_value
+
+OwnerClassOf = Callable[[Function], "str | None"]
+NamespaceSuffixSpellings = Callable[[str], "list[str]"]
+
+
+def _owned_virtual_signatures(
+    name: str,
+    funcs: Mapping[str, Function],
+    *,
+    owner_class_of: OwnerClassOf,
+    namespace_suffix_spellings: NamespaceSuffixSpellings,
+) -> set[str]:
+    """The mangled names of *name*'s own virtual member functions.
+
+    An evidence stream independent of ``RecordType.vtable``: these come from
+    ``snapshot.functions`` (their own DIEs / AST nodes), not from the class
+    DIE's virtual-method children, so one going missing does not take the
+    other with it.
+    """
+
+    # An *exact* comparison was wrong, in the direction that silences
+    # findings (Codex review). CastXML records a namespaced class under its
+    # bare leaf (`A`) while `owner_class_of` reconstructs the qualified
+    # `ns::A` from the mangled method, so the two never met, both signature
+    # sets came back empty, and the guard fell through to the size check --
+    # suppressing e.g. a class losing its last private virtual with no size
+    # change, which no other detector reports.
+    #
+    # Matched through `namespace_suffix_spellings` (depth-aware, so a
+    # template argument's own `::` isn't mistaken for a namespace boundary).
+    # Deliberately *eager*: a spurious match makes the two sides' sets
+    # differ, which keeps the finding -- the only safe direction here.
+    wanted = {name, *namespace_suffix_spellings(name)}
+
+    def _owns(fn: Function) -> bool:
+        owner = owner_class_of(fn)
+        if not owner:
+            return False
+        return bool(wanted & {owner, *namespace_suffix_spellings(owner)})
+
+    return {
+        mangled
+        for mangled, fn in funcs.items()
+        if getattr(fn, "is_virtual", False) and _owns(fn)
+    }
+
+
+def vtable_transition_is_evidenced(
+    name: str,
+    t_old: RecordType,
+    t_new: RecordType,
+    old_funcs: Mapping[str, Function],
+    new_funcs: Mapping[str, Function],
+    *,
+    owner_class_of: OwnerClassOf,
+    namespace_suffix_spellings: NamespaceSuffixSpellings,
+) -> bool:
+    """Whether an *empty<->non-empty* vtable difference rests on real evidence.
+
+    ``RecordType.vtable`` cannot express "not captured": it is a plain list,
+    and on the DWARF path it is simply the class's own virtual-method DIEs in
+    child order (``dwarf_snapshot._process_virtual_method_child``). So an
+    empty list means either "this class has no virtuals of its own" *or*
+    "this side's debug info did not carry them" -- and the two are
+    indistinguishable from the list alone.
+
+    That ambiguity produced a real false positive: identical headers on both
+    sides, no DWARF vtable, and not one ``_ZTV`` symbol anywhere still
+    emitted ``TYPE_VTABLE_CHANGED`` as BREAKING, because one side's virtual
+    methods happened to live in a translation unit only the other side's
+    debug info covered (differing ``-g`` level, a differently-inlined TU, or
+    ODR first-definition-wins in ``dwarf_snapshot``). The neighbouring
+    ``diff_vtable_layout`` already names this exact hazard for its own
+    detector and answers it with a tri-state ``None``; ``diff_elf_layout``
+    answers it by only ever comparing a ``_ZTV`` present on *both* sides.
+    This is the same principle applied to the type-level detector: degrade to
+    silence rather than fabricate a break.
+
+    An independent *layout* signal is what makes the transition real. A class
+    that genuinely gains its first virtual function also gains a vptr, so it
+    grows; one that gains or loses a virtual base says so directly. When
+    neither moved and both sizes are known, no real polymorphism change can
+    have occurred and the differing list is capture noise.
+
+    Size alone is **not** sufficient, which is why the class's own virtual
+    functions are consulted first (they are a different projection of the
+    same debug info, not a fully independent one -- see the body). A sufficiently over-aligned class absorbs
+    its new vptr into existing padding: verified against g++, both
+    ``struct alignas(8) A {}`` and ``struct alignas(8) A { virtual void f(); }``
+    are 8 bytes, as are the ``alignas(16)`` pair at 16 -- so a size-only guard
+    suppressed a genuine first-vptr addition (Codex review). It compounded:
+    ``diff_cxx_rules.virtual_method_addition`` withholds
+    ``VIRTUAL_METHOD_ADDED`` whenever the vtable lists differ *and this
+    predicate says the difference is evidenced*, so a run whose only
+    evidence was this false positive was left with a compatible ``FUNC_ADDED``
+    and a ``COMPATIBLE`` verdict on a real layout break. ``snapshot.functions``
+    is a separate evidence stream from the class DIE's virtual-method
+    children, so it answers that case without weakening the capture-gap
+    guard.
+
+    Deliberately conservative in the other direction: an *unknown* size on
+    either side corroborates nothing but also refutes nothing, so the finding
+    is kept. The suppression needs positive evidence that layout held still;
+    it is not a fallback for missing information.
+
+    Two known false negatives, accepted rather than papered over -- both are
+    a class whose vtable grows while its object size does not, which is
+    indistinguishable from capture noise on the evidence this detector
+    receives:
+
+    * A class already polymorphic through a base, declaring no virtuals of
+      its own, that gains one.
+    * An over-aligned class gaining its first *pure* virtual. A pure virtual
+      has no out-of-line definition, so ``dwarf_snapshot`` drops its
+      declaration-only DIE from ``snapshot.functions`` while still counting
+      it as a vtable child -- both owned-signature sets read empty -- and
+      ``alignas`` absorbs the new vptr into existing padding so the size
+      does not move either (reproduced against g++ with
+      ``struct alignas(8) A { virtual void f() = 0; }``).
+
+    Neither loses the *break*: ``diff_layout._check_vptr_introduced`` fires
+    independently on the same None -> 0 vptr transition and the verdict stays
+    BREAKING. Only ``TYPE_VTABLE_CHANGED`` (and, since the 5B closure this
+    module implements, ``VIRTUAL_METHOD_ADDED``'s own deferral) is withheld
+    -- ``virtual_method_addition`` falls through to its own signature-based
+    override check instead of silently dropping coverage, exactly because it
+    now calls this same predicate rather than assuming the answer. Leaning on
+    a sibling detector is not a comfortable place to be, and a previous
+    revision tried to close the second case here directly by reading
+    ``vptr_offset_bits`` -- see the body for why that witness is circular and
+    made this guard inert. Closing it for real needs evidence the model does
+    not carry (a per-finding provider record, or a polymorphism walk over
+    both base chains) -- see AGENTS.md's evidence-provider entry -- not a
+    cleverer reading of the fields already here.
+    """
+    old_vtable = resolved_fact_value(t_old.vtable_fact, [])
+    new_vtable = resolved_fact_value(t_new.vtable_fact, [])
+    if old_vtable and new_vtable:
+        # Both sides captured something, so the difference is a real
+        # reorder/replace rather than one side's evidence going missing.
+        return True
+    if _owned_virtual_signatures(
+        name,
+        old_funcs,
+        owner_class_of=owner_class_of,
+        namespace_suffix_spellings=namespace_suffix_spellings,
+    ) != _owned_virtual_signatures(
+        name,
+        new_funcs,
+        owner_class_of=owner_class_of,
+        namespace_suffix_spellings=namespace_suffix_spellings,
+    ):
+        # The class's own virtual *functions* -- a different projection of
+        # the debug info from `RecordType.vtable`, and the signal that keeps
+        # an over-aligned class honest when the size check below cannot.
+        #
+        # Not fully independent, and the docstring used to overclaim that:
+        # on the DWARF path both ultimately derive from `DW_TAG_subprogram`
+        # evidence, so a TU whose coverage vanishes can take the vtable list
+        # *and* the function with it (Codex review). When that happens the
+        # sets differ, this returns True, and the finding is kept -- i.e. the
+        # guard declines to suppress rather than suppressing wrongly. That is
+        # the failure direction to have: it leaves the pre-existing false
+        # positive standing instead of hiding a real break. Closing it needs
+        # artifact or provenance evidence (`_ZTV` presence, per-finding
+        # providers) the type-level detector does not yet receive.
+        return True
+    # NOT consulted here: ``vptr_offset_bits``. It reads like the one
+    # independent layout witness available, and a previous revision of this
+    # function used it as exactly that -- wrongly. At the time, both
+    # producers assigned it as ``0 if vtable else None`` (``dwarf_snapshot.
+    # py``, ``dumper_castxml.py``), so on those two backends
+    # ``(old.vptr_offset_bits is None) != (new.vptr_offset_bits is None)``
+    # was *identical* to the empty-vs-non-empty vtable transition being
+    # guarded: true by construction for every input reaching this point,
+    # which silently made the whole guard a no-op and let the original
+    # capture-gap false positive straight back through (Codex review).
+    # ``dumper_castxml.py`` still assigns it exactly that way. ``dwarf_
+    # snapshot.py`` no longer does (G31 Phase C): it now reads a real
+    # ``_vptr.<Class>``/base-chain offset from DWARF in the common case,
+    # falling back to the same ``0 if vtable`` heuristic only for the
+    # residual unresolved set -- so for DWARF the field is no longer purely
+    # circular. This function still doesn't consult it, on purpose:
+    # declining to use an available signal is always safe (the failure mode
+    # this guard exists to avoid only ever ran the other way -- trusting a
+    # circular signal AS IF independent), and using it as a genuine witness
+    # for the now-partially-real DWARF case while still excluding it for
+    # castxml's own still-fully-circular case is its own careful design +
+    # FP-verification effort, not a drive-by extension here — see
+    # ``tests/test_vtable_evidence_guard.py``'s own note on why
+    # ``abicheck.dwarf_snapshot`` was dropped from its premise-pin test.
+    # Only the optional ``ABICHECK_CLANG_LAYOUT_TOOL`` path computes it from
+    # a real layout query on the castxml/clang side, and nothing in the
+    # model distinguishes that value from the derived one -- so it still
+    # cannot be trusted as evidence here at all on that side.
+    if t_old.size_bits is None or t_new.size_bits is None:
+        return True
+    if t_old.size_bits != t_new.size_bits:
+        return True
+    old_virtual_bases = resolved_fact_value(t_old.virtual_bases_fact, [])
+    new_virtual_bases = resolved_fact_value(t_new.virtual_bases_fact, [])
+    return list(old_virtual_bases) != list(new_virtual_bases)

--- a/abicheck/compare/vtable_evidence.py
+++ b/abicheck/compare/vtable_evidence.py
@@ -191,18 +191,26 @@ def vtable_transition_is_evidenced(
 
     Neither loses the *break*: ``diff_layout._check_vptr_introduced`` fires
     independently on the same None -> 0 vptr transition and the verdict stays
-    BREAKING. Only ``TYPE_VTABLE_CHANGED`` (and, since the 5B closure this
-    module implements, ``VIRTUAL_METHOD_ADDED``'s own deferral) is withheld
-    -- ``virtual_method_addition`` falls through to its own signature-based
-    override check instead of silently dropping coverage, exactly because it
-    now calls this same predicate rather than assuming the answer. Leaning on
-    a sibling detector is not a comfortable place to be, and a previous
-    revision tried to close the second case here directly by reading
-    ``vptr_offset_bits`` -- see the body for why that witness is circular and
-    made this guard inert. Closing it for real needs evidence the model does
-    not carry (a per-finding provider record, or a polymorphism walk over
-    both base chains) -- see AGENTS.md's evidence-provider entry -- not a
-    cleverer reading of the fields already here.
+    BREAKING. Only this predicate's own ``TYPE_VTABLE_CHANGED`` is withheld.
+    The 5B closure this module implements does not reach either accepted
+    false negative above: the second bullet's pure virtual has no linkable
+    definition at all, so ``diff_cxx_rules.virtual_method_addition`` is never
+    even called for it (nothing for ``_diff_functions``'s own loop to
+    iterate over); the first bullet, when it involves a real, linkable
+    virtual method, is *evidenced* by this predicate's own "class's own
+    virtual functions" branch (a genuinely new mangled symbol is always
+    present in the new side's owned-signature set and absent from the old
+    side's), so ``virtual_method_addition`` correctly defers to this
+    predicate rather than needing its own fallthrough -- it is this
+    predicate's own remaining gap to close, not a gap in the symbol-level
+    caller's own coupling to it. Leaning on a sibling detector is not a
+    comfortable place to be, and a previous revision tried to close the
+    second case here directly by reading ``vptr_offset_bits`` -- see the
+    body for why that witness is circular and made this guard inert.
+    Closing it for real needs evidence the model does not carry (a
+    per-finding provider record, or a polymorphism walk over both base
+    chains) -- see AGENTS.md's evidence-provider entry -- not a cleverer
+    reading of the fields already here.
     """
     old_vtable = resolved_fact_value(t_old.vtable_fact, [])
     new_vtable = resolved_fact_value(t_new.vtable_fact, [])

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -25,6 +25,7 @@ from collections.abc import Iterable, Mapping
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
+from .compare.vtable_evidence import vtable_transition_is_evidenced
 from .diff_helpers import make_change
 from .model import Fact, Function, RecordType
 from .model.availability import FactStatus
@@ -45,6 +46,15 @@ from .model.mangled_name import (
     itanium_scope_components_with_template_positions as itanium_scope_components_with_template_positions,
     msvc_scope_components as msvc_scope_components,
 )
+
+# `model/namespace_spelling.py`'s real home is documented on that module
+# itself (ADR-063 Track 2, 5B closure): pure string matching over an
+# already-spelled identity, needed here (`virtual_method_addition`'s own
+# call into `compare.vtable_evidence.vtable_transition_is_evidenced`) and by
+# `type_reachability_spelling.py`, which re-exports it by value for
+# back-compat and cannot be imported from here at all (it already imports
+# this module at its own top level).
+from .model.namespace_spelling import _namespace_suffix_spellings
 
 
 def itanium_qualified_name(mangled: str) -> str | None:
@@ -1116,16 +1126,20 @@ def virtual_method_addition(
     old_types: Mapping[str, RecordType],
     new_types: Mapping[str, RecordType],
     old_virtual_sigs: dict[str, set[str]],
+    old_funcs: Mapping[str, Function],
+    new_funcs: Mapping[str, Function],
+    *,
+    vtable_facts_reliable: bool = True,
 ) -> Change | None:
     """A new *virtual* method on a class that already exists across versions.
 
     Returns a ``VIRTUAL_METHOD_ADDED`` change, or ``None`` if this added symbol
     is not a virtual added to a pre-existing type. Scoped to the genuine blind
-    spot: when the owner's ``vtable`` array is identical on both sides (e.g.
-    DWARF/symbol-only snapshots that carry no vtable layout), the per-type
-    ``TYPE_VTABLE_CHANGED`` detector cannot see the growth, so this is the only
-    signal. When the vtable array *does* differ, ``TYPE_VTABLE_CHANGED`` already
-    reports it and we defer to avoid a duplicate finding.
+    spot: when ``diff_types_vtable``'s own ``TYPE_VTABLE_CHANGED`` detector
+    would not fire for this owner (its raw ``vtable`` array is identical on
+    both sides, or the difference has no positive evidence behind it), this is
+    the only signal. When ``TYPE_VTABLE_CHANGED`` genuinely would fire, defer
+    to it to avoid a duplicate finding.
 
     The owner's record must be present on both sides (the DWARF blind spot this
     targets). ``old_owner_classes`` — the set of *scope-qualified* owners of the
@@ -1142,35 +1156,47 @@ def virtual_method_addition(
     full signature, so a same-named virtual with *different* parameters (a new
     slot, e.g. ``Derived::paint(double)`` over ``Base::paint(int)``) still fires.
 
-    ADR-063 Phase 5B (vtable/vptr_offset_bits slice) re-verified this
-    function's own ``old_vtable != new_vtable`` deferral against the new
-    per-record ``FactStatus`` checks that slice added to
-    ``diff_layout._check_vptr_introduced``/``diff_vtable_layout._is_
-    polymorphic`` — deliberately **not** extended here. ``_fact_str_list``
-    still collapses an uncollected ``vtable_fact`` to ``[]`` on purpose:
-    when both sides read that way (this function's own documented blind
-    spot — a DWARF/symbol-only snapshot that never captures vtable layout
-    at all), the arrays compare equal and this function proceeds to be the
-    *only* signal, exactly as designed. Declining here whenever either
-    side's ``vtable_fact`` is merely ``NOT_COLLECTED``/``FAILED`` (rather
-    than genuinely differing) would silently drop that blind-spot coverage
-    -- and would also desynchronize from ``diff_types_vtable.
-    _vtable_transition_is_evidenced``, which for the identical case (one
-    side uncollected, the other side newly populated) still finds real
-    evidence via its own class's-own-virtual-functions/size-delta
-    heuristics and correctly emits ``TYPE_VTABLE_CHANGED`` — the deferral
-    above is only safe *because* that sibling detector still fires there.
-    Making ``_vtable_transition_is_evidenced`` decline outright on an
-    uncollected ``vtable_fact`` (the more literal reading of "direct
-    ``FactStatus`` reads") would break exactly that coupling and leave
-    *neither* detector firing; doing so safely would need this function to
-    consult the sibling detector's own evidenced/not-evidenced verdict
-    before deciding whether to defer, which ``diff_types_vtable.py`` cannot
-    expose back to this module without an import cycle (this module already
-    supplies ``diff_types_vtable`` with ``vtable_slot_is_override_reuse``).
-    See ``diff_types_vtable.py``'s own module docstring for the full
-    accounting; recorded here per this repo's own "say so explicitly and
-    record the gap" convention rather than silently left implicit.
+    ``old_funcs``/``new_funcs`` are each snapshot's full function map
+    (``AbiSnapshot.function_map``, mangled name -> ``Function``, including
+    non-public/hidden entries) — needed only to consult the shared vtable-
+    evidence predicate below, not for this function's own override check.
+    ``vtable_facts_reliable`` mirrors ``diff_types.py``'s own
+    ``old.clang_vtable_facts_reliable and new.clang_vtable_facts_reliable``
+    computation for the identical pair of snapshots; a caller that does not
+    have both snapshots at hand (unusual — every real caller does) may leave
+    it at its conservative default (never declines to defer on account of
+    reliability alone).
+
+    ADR-063 Track 2, 5B closure. Previously this function's ``old_vtable !=
+    new_vtable`` branch deferred to ``TYPE_VTABLE_CHANGED`` unconditionally,
+    on nothing but a docstring's word that the sibling detector's own
+    ``_vtable_transition_is_evidenced`` heuristic "still finds real evidence"
+    in the one shape this blind spot actually needs covered (one side's
+    ``vtable_fact`` uncollected, the other genuinely populated) — the two
+    detectors were coupled only by prose, in two separate files, with no
+    executable link between them. Anywhere that heuristic does *not* find
+    evidence (e.g. the class's own virtual-function set, size, and virtual
+    bases all read identically on both sides — the array difference is
+    capture noise the sibling detector correctly ignores), ``TYPE_VTABLE_
+    CHANGED`` was never going to fire, and this function was deferring to a
+    detector that stays silent — silently dropping the one coverage it exists
+    to provide.
+
+    Fixed by making the coupling a real function call: both detectors now
+    share one predicate, ``compare.vtable_evidence.vtable_transition_is_
+    evidenced`` — a leaf module below both of them (it depends on ``model``
+    only, taking ``owner_class_of``/the namespace-suffix matcher as injected
+    callables rather than importing either), closing exactly the "needs an
+    import this leaf module's own no-cycle constraint does not allow without
+    further restructuring" gap this docstring and ``diff_types_vtable.py``'s
+    own module docstring used to record. When the predicate says the
+    difference is genuinely evidenced (or ``vtable_facts_reliable`` is
+    ``False``, in which case ``diff_types_vtable`` declines before ever
+    reaching the predicate — see ``_diff_type_vtable``), this function defers.
+    Otherwise it falls through to its own signature-based override check
+    below, exactly as it already does when the raw arrays are equal outright
+    — the only remaining signal, and no longer a blind assumption that some
+    other module will catch it.
     """
     if not f_new.is_virtual:
         return None
@@ -1183,8 +1209,22 @@ def virtual_method_addition(
         return None  # no pre-existing record on both sides → compatible / out of scope
     old_vtable = _fact_str_list(t_old.vtable_fact)
     new_vtable = _fact_str_list(t_new.vtable_fact)
-    if old_vtable != new_vtable:
-        return None  # TYPE_VTABLE_CHANGED covers this case
+    if old_vtable != new_vtable and vtable_facts_reliable:
+        if vtable_transition_is_evidenced(
+            owner,
+            t_old,
+            t_new,
+            old_funcs,
+            new_funcs,
+            owner_class_of=owner_class_of,
+            namespace_suffix_spellings=_namespace_suffix_spellings,
+        ):
+            return None  # TYPE_VTABLE_CHANGED covers this case -- verified, not assumed
+        # No evidence behind the raw array difference (or `TYPE_VTABLE_
+        # CHANGED` would decline for the identical reason `diff_types_vtable`
+        # already checks) -- the sibling detector will stay silent, so this
+        # function is the only remaining signal for this owner. Fall through
+        # to the same override check used when the arrays are equal outright.
     # An override of an inherited virtual reuses that base's slot — no new slot,
     # no relayout. If any transitive base already declared a virtual with the
     # *same signature* (not just the same name), treat the addition as an

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -1158,9 +1158,9 @@ def virtual_method_addition(
 
     ``old_funcs``/``new_funcs`` are each snapshot's full function map
     (``AbiSnapshot.function_map``, mangled name -> ``Function``, including
-    non-public/hidden entries) — needed only to consult the shared vtable-
-    evidence predicate below, not for this function's own override check.
-    ``vtable_facts_reliable`` mirrors ``diff_types.py``'s own
+    non-public/hidden entries) — used both for the already-existed guard
+    just below and to consult the shared vtable-evidence predicate further
+    down. ``vtable_facts_reliable`` mirrors ``diff_types.py``'s own
     ``old.clang_vtable_facts_reliable and new.clang_vtable_facts_reliable``
     computation for the identical pair of snapshots; a caller that does not
     have both snapshots at hand (unusual — every real caller does) may leave
@@ -1174,13 +1174,7 @@ def virtual_method_addition(
     in the one shape this blind spot actually needs covered (one side's
     ``vtable_fact`` uncollected, the other genuinely populated) — the two
     detectors were coupled only by prose, in two separate files, with no
-    executable link between them. Anywhere that heuristic does *not* find
-    evidence (e.g. the class's own virtual-function set, size, and virtual
-    bases all read identically on both sides — the array difference is
-    capture noise the sibling detector correctly ignores), ``TYPE_VTABLE_
-    CHANGED`` was never going to fire, and this function was deferring to a
-    detector that stays silent — silently dropping the one coverage it exists
-    to provide.
+    executable link between them.
 
     Fixed by making the coupling a real function call: both detectors now
     share one predicate, ``compare.vtable_evidence.vtable_transition_is_
@@ -1190,15 +1184,44 @@ def virtual_method_addition(
     import this leaf module's own no-cycle constraint does not allow without
     further restructuring" gap this docstring and ``diff_types_vtable.py``'s
     own module docstring used to record. When the predicate says the
-    difference is genuinely evidenced (or ``vtable_facts_reliable`` is
-    ``False``, in which case ``diff_types_vtable`` declines before ever
-    reaching the predicate — see ``_diff_type_vtable``), this function defers.
-    Otherwise it falls through to its own signature-based override check
-    below, exactly as it already does when the raw arrays are equal outright
-    — the only remaining signal, and no longer a blind assumption that some
-    other module will catch it.
+    difference is genuinely evidenced, this function defers to avoid a
+    duplicate finding, same as before.
+
+    When it is *not* evidenced (or ``vtable_facts_reliable`` is ``False``, in
+    which case ``diff_types_vtable`` declines before ever reaching the
+    predicate — see ``_diff_type_vtable``), this function falls through to
+    its own signature-based override check below instead of silently
+    dropping the finding. For a genuinely *new* mangled symbol this branch
+    is reached only when ``vtable_facts_reliable`` is ``False`` — the shared
+    predicate's own "class's own virtual functions" evidence branch always
+    sees a real difference for a brand-new symbol (it is present in
+    ``new_funcs``'s owned set and, by construction, absent from
+    ``old_funcs``'s), so it is always evidenced when reliable. The one way a
+    *reliable* comparison reaches "not evidenced" at all is the shape the
+    already-existed guard above now intercepts explicitly — this function no
+    longer relies on that being merely implied by the evidence predicate's
+    absence of a positive signal (Codex review, fresh evidence: an earlier
+    revision let exactly that shape fall through here uncaught, fabricating
+    a BREAKING ``VIRTUAL_METHOD_ADDED`` for a compatible hidden-to-public
+    visibility promotion).
     """
     if not f_new.is_virtual:
+        return None
+    old_self = old_funcs.get(f_new.mangled)
+    if old_self is not None and old_self.is_virtual:
+        # Already existed in the old ABI under this exact mangled name --
+        # just not public (hidden/internal linkage becoming exported, the
+        # shape a header/export-scoping change or a build-mode switch
+        # produces). No new vtable slot was added: the slot was already
+        # accounted for whenever this method was first declared, and
+        # nothing about becoming public changes that. A compatible
+        # visibility promotion (tracked separately as FUNC_ADDED for the
+        # newly-public symbol), never VIRTUAL_METHOD_ADDED. (Codex review,
+        # fresh evidence: without this guard, the fallthrough below — added
+        # for the ADR-063 5B closure — reached exactly this shape, since a
+        # promoted method's own owned-virtual-function set reads identical
+        # on both sides and so never evidences a real vtable transition,
+        # fabricating a BREAKING finding for a compatible export change.)
         return None
     owner = owner_class_of(f_new)
     if owner is None:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -943,6 +943,13 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         owner for f in old_map.values() if (owner := owner_class_of(f)) is not None
     }
     old_virtual_sigs = old_virtual_signatures(old.function_map.values())
+    # Mirrors diff_types.py's own identical computation for the same pair of
+    # snapshots -- see virtual_method_addition's own docstring for why it
+    # needs this to decide whether TYPE_VTABLE_CHANGED would decline for a
+    # reason unrelated to evidence (a legacy pre-v21 direct-clang snapshot).
+    vtable_facts_reliable = (
+        old.clang_vtable_facts_reliable and new.clang_vtable_facts_reliable
+    )
 
     # Build a lookup of ALL functions in new snapshot (including hidden).
     new_all = new.function_map
@@ -977,7 +984,14 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             continue
         if mangled not in old_map and f_new.name not in matched_by_name:
             virtual_break = virtual_method_addition(
-                f_new, old_owner_classes, old_types, new_types, old_virtual_sigs
+                f_new,
+                old_owner_classes,
+                old_types,
+                new_types,
+                old_virtual_sigs,
+                old.function_map,
+                new_all,
+                vtable_facts_reliable=vtable_facts_reliable,
             )
             changes.append(
                 virtual_break

--- a/abicheck/diff_types_vtable.py
+++ b/abicheck/diff_types_vtable.py
@@ -23,8 +23,11 @@ not import from ``diff_types`` at all, to avoid an import cycle:
 ``diff_types.py`` imports ``_diff_type_vtable`` back for its own use, the
 only symbol this module exports). ``_vtable_transition_is_evidenced``/
 ``_vtable_transition_rests_on_unresolved_evidence``/
-``_layout_evidence_is_unverifiable``/``_owned_virtual_signatures`` are
-private to this cluster and only ever called from within it.
+``_layout_evidence_is_unverifiable`` are private to this cluster and only
+ever called from within it (``_vtable_transition_is_evidenced`` is now a
+thin wrapper over ``compare/vtable_evidence.py``'s shared predicate, its
+own ``_owned_virtual_signatures`` helper moved there with it -- see the
+"ADR-063 Track 2, 5B closure" note below).
 ``_virtual_signatures_by_owner`` is the one exception (Codex review, fresh
 evidence): ``diff_vtable_layout._is_polymorphic`` also imports it directly
 as a sixth positive-evidence path (a retained ``Function.is_virtual``
@@ -34,8 +37,9 @@ already relies on) rather than reimplementing its own copy of the
 owner-matching logic -- built on the same *exact*-match identity
 ``_owned_virtual_signatures_for_record`` uses (a single-owner query, still
 private to this cluster, that ``_virtual_signatures_by_owner`` now shares
-its ``owner_class_of`` matching with), not ``_owned_virtual_signatures``'s
-eager namespace-suffix matching: that new caller uses a match as an
+its ``owner_class_of`` matching with), not the moved
+``compare.vtable_evidence``'s own eager namespace-suffix matching: that new
+caller uses a match as an
 unconditional affirmative ``True``, the opposite safety direction from
 this cluster's own suppression-oriented use, where over-inclusion only
 ever widens "keep the finding," never fabricates one (Codex review, second
@@ -75,27 +79,27 @@ indistinguishable from a genuinely non-polymorphic class, so both sides
 read ``PRESENT`` either way. A direct ``vtable_fact.status`` pre-check
 would therefore not replace the heuristic here -- it would only catch the
 disjoint case of a genuinely *uncollected* fact (``NOT_COLLECTED``/
-``FAILED``), and adding it as an unconditional decline was found, on
-tracing the actual call graph, to be **unsafe**: ``diff_cxx_rules.
-virtual_method_addition`` defers to this cluster ("``TYPE_VTABLE_CHANGED``
-covers this case") precisely in the one-side-uncollected/other-side-
-populated shape, relying on today's heuristic (not a ``FactStatus`` read)
-to still find real evidence there and fire. Declining outright on
-``NOT_COLLECTED`` would silently desynchronize the two detectors and drop
-coverage neither would then provide -- see ``virtual_method_addition``'s
-own docstring for the full trace, including why fixing it properly (making
-that function consult this cluster's own evidenced/not-evidenced verdict
-before deferring) needs an import this leaf module's own no-cycle
-constraint (above) does not allow without further restructuring. Recorded
-here, not silently left implicit, per this repo's own "say so explicitly
-and record the gap" convention -- the sub-phase's own "vtable... all five
-fields gated" removal gate is therefore still open for ``vtable`` through
-this specific cluster, even though the two sibling detectors it correlates
-with are now gated (Codex review, fresh evidence: this cluster never reads
-``vptr_offset_bits``/``vptr_offset_bits_fact`` at all -- see the "NOT
-consulted here" comment in the body below -- so ``vptr_offset_bits``
-itself carries no residual gap through this cluster; it is fully gated via
-``diff_layout._check_vptr_introduced``'s own direct-status pre-check).
+``FAILED``).
+
+**ADR-063 Track 2, 5B closure (this revision).** The predicate itself --
+``_vtable_transition_is_evidenced`` and its ``_owned_virtual_signatures``
+helper -- moved to ``compare/vtable_evidence.py`` as
+``vtable_transition_is_evidenced``, a genuine leaf below both this module
+and ``diff_cxx_rules.py`` (it takes ``owner_class_of``/
+``namespace_suffix_spellings`` as injected callables instead of importing
+either, so it depends on ``model`` only). The two thin wrappers below keep
+this module's own public names and call signature unchanged for every
+existing caller (including ``tests/test_vtable_evidence_guard.py``, which
+imports ``_vtable_transition_is_evidenced`` directly). ``diff_cxx_rules.
+virtual_method_addition`` now imports the same shared predicate and calls
+it before deferring, rather than assuming -- on prose alone -- that this
+cluster will fire whenever the raw vtable arrays differ. See
+``virtual_method_addition``'s own docstring for what changed there. This
+closes the gap the previous revision of this docstring recorded: an
+unevidenced difference (same owned-virtual-function set, same size, same
+virtual-base list on both sides) no longer leaves *both* detectors silently
+declining -- ``virtual_method_addition`` now falls through to its own
+signature-based override check instead.
 """
 
 from __future__ import annotations
@@ -105,9 +109,35 @@ from collections.abc import Mapping
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
-from .diff_cxx_rules import vtable_slot_is_override_reuse
+from .compare.vtable_evidence import vtable_transition_is_evidenced
+from .diff_cxx_rules import owner_class_of, vtable_slot_is_override_reuse
 from .diff_helpers import make_change
 from .model import Function, RecordType, resolved_fact_value
+from .type_reachability_spelling import _namespace_suffix_spellings
+
+
+def _owned_virtual_signatures(name: str, funcs: Mapping[str, Function]) -> set[str]:
+    """The mangled names of *name*'s own virtual member functions.
+
+    A thin wrapper over ``compare.vtable_evidence``'s private helper of the
+    same name (ADR-063 Track 2, 5B closure moved the implementation there
+    alongside ``vtable_transition_is_evidenced``, its one caller) -- kept
+    here under this exact name and signature purely for back-compat:
+    ``diff_types.py`` re-exports this name by value (``from .diff_types_vtable
+    import _owned_virtual_signatures as _owned_virtual_signatures``) so any
+    call site still resolving ``abicheck.diff_types._owned_virtual_signatures``
+    keeps working. Not called from within this module any more -- see
+    ``_vtable_transition_is_evidenced`` below, which calls the shared
+    predicate directly instead of this helper.
+    """
+    from .compare.vtable_evidence import _owned_virtual_signatures as _shared
+
+    return _shared(
+        name,
+        funcs,
+        owner_class_of=owner_class_of,
+        namespace_suffix_spellings=_namespace_suffix_spellings,
+    )
 
 
 def _vtable_transition_is_evidenced(
@@ -119,135 +149,22 @@ def _vtable_transition_is_evidenced(
 ) -> bool:
     """Whether an *empty↔non-empty* vtable difference rests on real evidence.
 
-    ``RecordType.vtable`` cannot express "not captured": it is a plain list,
-    and on the DWARF path it is simply the class's own virtual-method DIEs in
-    child order (``dwarf_snapshot._process_virtual_method_child``). So an
-    empty list means either "this class has no virtuals of its own" *or*
-    "this side's debug info did not carry them" -- and the two are
-    indistinguishable from the list alone.
-
-    That ambiguity produced a real false positive: identical headers on both
-    sides, no DWARF vtable, and not one ``_ZTV`` symbol anywhere still
-    emitted ``TYPE_VTABLE_CHANGED`` as BREAKING, because one side's virtual
-    methods happened to live in a translation unit only the other side's
-    debug info covered (differing ``-g`` level, a differently-inlined TU, or
-    ODR first-definition-wins in ``dwarf_snapshot``). The neighbouring
-    ``diff_vtable_layout`` already names this exact hazard for its own
-    detector and answers it with a tri-state ``None``; ``diff_elf_layout``
-    answers it by only ever comparing a ``_ZTV`` present on *both* sides.
-    This is the same principle applied to the type-level detector: degrade to
-    silence rather than fabricate a break.
-
-    An independent *layout* signal is what makes the transition real. A class
-    that genuinely gains its first virtual function also gains a vptr, so it
-    grows; one that gains or loses a virtual base says so directly. When
-    neither moved and both sizes are known, no real polymorphism change can
-    have occurred and the differing list is capture noise.
-
-    Size alone is **not** sufficient, which is why the class's own virtual
-    functions are consulted first (they are a different projection of the
-    same debug info, not a fully independent one -- see the body). A sufficiently over-aligned class absorbs
-    its new vptr into existing padding: verified against g++, both
-    ``struct alignas(8) A {}`` and ``struct alignas(8) A { virtual void f(); }``
-    are 8 bytes, as are the ``alignas(16)`` pair at 16 -- so a size-only guard
-    suppressed a genuine first-vptr addition (Codex review). It compounded:
-    ``diff_cxx_rules.virtual_method_addition`` withholds
-    ``VIRTUAL_METHOD_ADDED`` whenever the vtable lists differ, so the run was
-    left with a compatible ``FUNC_ADDED`` and a ``COMPATIBLE`` verdict on a
-    real layout break. ``snapshot.functions`` is a separate evidence stream
-    from the class DIE's virtual-method children, so it answers that case
-    without weakening the capture-gap guard.
-
-    Deliberately conservative in the other direction: an *unknown* size on
-    either side corroborates nothing but also refutes nothing, so the finding
-    is kept. The suppression needs positive evidence that layout held still;
-    it is not a fallback for missing information.
-
-    Two known false negatives, accepted rather than papered over -- both are
-    a class whose vtable grows while its object size does not, which is
-    indistinguishable from capture noise on the evidence this detector
-    receives:
-
-    * A class already polymorphic through a base, declaring no virtuals of
-      its own, that gains one.
-    * An over-aligned class gaining its first *pure* virtual. A pure virtual
-      has no out-of-line definition, so ``dwarf_snapshot`` drops its
-      declaration-only DIE from ``snapshot.functions`` while still counting
-      it as a vtable child -- both owned-signature sets read empty -- and
-      ``alignas`` absorbs the new vptr into existing padding so the size
-      does not move either (reproduced against g++ with
-      ``struct alignas(8) A { virtual void f() = 0; }``).
-
-    Neither loses the *break*: ``diff_layout._check_vptr_introduced`` fires
-    independently on the same None -> 0 vptr transition and the verdict stays
-    BREAKING. Only this detector's own ``TYPE_VTABLE_CHANGED`` is withheld.
-    Leaning on a sibling detector is not a comfortable place to be, and a
-    previous revision tried to close the second case here directly by reading
-    ``vptr_offset_bits`` -- see the body for why that witness is circular and
-    made this guard inert. Closing it for real needs evidence the model does
-    not carry (a per-finding provider record, or a polymorphism walk over
-    both base chains) -- see AGENTS.md's evidence-provider entry -- not a
-    cleverer reading of the fields already here.
+    A thin wrapper over the shared, module-independent predicate in
+    ``compare/vtable_evidence.py`` (ADR-063 Track 2, 5B closure) -- kept here,
+    under this exact name and signature, so every existing caller in this
+    file and ``tests/test_vtable_evidence_guard.py`` is unaffected. See that
+    module's ``vtable_transition_is_evidenced`` for the full rationale and
+    false-positive history; it is unchanged for this module's own callers.
     """
-    old_vtable = resolved_fact_value(t_old.vtable_fact, [])
-    new_vtable = resolved_fact_value(t_new.vtable_fact, [])
-    if old_vtable and new_vtable:
-        # Both sides captured something, so the difference is a real
-        # reorder/replace rather than one side's evidence going missing.
-        return True
-    if _owned_virtual_signatures(name, old_funcs) != _owned_virtual_signatures(
-        name, new_funcs
-    ):
-        # The class's own virtual *functions* -- a different projection of
-        # the debug info from `RecordType.vtable`, and the signal that keeps
-        # an over-aligned class honest when the size check below cannot.
-        #
-        # Not fully independent, and the docstring used to overclaim that:
-        # on the DWARF path both ultimately derive from `DW_TAG_subprogram`
-        # evidence, so a TU whose coverage vanishes can take the vtable list
-        # *and* the function with it (Codex review). When that happens the
-        # sets differ, this returns True, and the finding is kept -- i.e. the
-        # guard declines to suppress rather than suppressing wrongly. That is
-        # the failure direction to have: it leaves the pre-existing false
-        # positive standing instead of hiding a real break. Closing it needs
-        # artifact or provenance evidence (`_ZTV` presence, per-finding
-        # providers) the type-level detector does not yet receive.
-        return True
-    # NOT consulted here: ``vptr_offset_bits``. It reads like the one
-    # independent layout witness available, and a previous revision of this
-    # function used it as exactly that -- wrongly. At the time, both
-    # producers assigned it as ``0 if vtable else None`` (``dwarf_snapshot.
-    # py``, ``dumper_castxml.py``), so on those two backends
-    # ``(old.vptr_offset_bits is None) != (new.vptr_offset_bits is None)``
-    # was *identical* to the empty-vs-non-empty vtable transition being
-    # guarded: true by construction for every input reaching this point,
-    # which silently made the whole guard a no-op and let the original
-    # capture-gap false positive straight back through (Codex review).
-    # ``dumper_castxml.py`` still assigns it exactly that way. ``dwarf_
-    # snapshot.py`` no longer does (G31 Phase C): it now reads a real
-    # ``_vptr.<Class>``/base-chain offset from DWARF in the common case,
-    # falling back to the same ``0 if vtable`` heuristic only for the
-    # residual unresolved set -- so for DWARF the field is no longer purely
-    # circular. This function still doesn't consult it, on purpose:
-    # declining to use an available signal is always safe (the failure mode
-    # this guard exists to avoid only ever ran the other way -- trusting a
-    # circular signal AS IF independent), and using it as a genuine witness
-    # for the now-partially-real DWARF case while still excluding it for
-    # castxml's own still-fully-circular case is its own careful design +
-    # FP-verification effort, not a drive-by extension here — see
-    # ``tests/test_vtable_evidence_guard.py``'s own note on why
-    # ``abicheck.dwarf_snapshot`` was dropped from its premise-pin test.
-    # Only the optional ``ABICHECK_CLANG_LAYOUT_TOOL`` path computes it from
-    # a real layout query on the castxml/clang side, and nothing in the
-    # model distinguishes that value from the derived one -- so it still
-    # cannot be trusted as evidence here at all on that side.
-    if t_old.size_bits is None or t_new.size_bits is None:
-        return True
-    if t_old.size_bits != t_new.size_bits:
-        return True
-    old_virtual_bases = resolved_fact_value(t_old.virtual_bases_fact, [])
-    new_virtual_bases = resolved_fact_value(t_new.virtual_bases_fact, [])
-    return list(old_virtual_bases) != list(new_virtual_bases)
+    return vtable_transition_is_evidenced(
+        name,
+        t_old,
+        t_new,
+        old_funcs,
+        new_funcs,
+        owner_class_of=owner_class_of,
+        namespace_suffix_spellings=_namespace_suffix_spellings,
+    )
 
 
 def _vtable_transition_rests_on_unresolved_evidence(
@@ -356,50 +273,14 @@ def _layout_evidence_is_unverifiable(
     )
 
 
-def _owned_virtual_signatures(name: str, funcs: Mapping[str, Function]) -> set[str]:
-    """The mangled names of *name*'s own virtual member functions.
-
-    An evidence stream independent of ``RecordType.vtable``: these come from
-    ``snapshot.functions`` (their own DIEs / AST nodes), not from the class
-    DIE's virtual-method children, so one going missing does not take the
-    other with it.
-    """
-    from .diff_cxx_rules import owner_class_of
-    from .type_reachability_spelling import _namespace_suffix_spellings
-
-    # An *exact* comparison was wrong, in the direction that silences
-    # findings (Codex review). CastXML records a namespaced class under its
-    # bare leaf (`A`) while `owner_class_of` reconstructs the qualified
-    # `ns::A` from the mangled method, so the two never met, both signature
-    # sets came back empty, and the guard fell through to the size check --
-    # suppressing e.g. a class losing its last private virtual with no size
-    # change, which no other detector reports.
-    #
-    # Matched through `_namespace_suffix_spellings` (depth-aware, so a
-    # template argument's own `::` isn't mistaken for a namespace boundary).
-    # Deliberately *eager*: a spurious match makes the two sides' sets
-    # differ, which keeps the finding -- the only safe direction here.
-    wanted = {name, *_namespace_suffix_spellings(name)}
-
-    def _owns(fn: Function) -> bool:
-        owner = owner_class_of(fn)
-        if not owner:
-            return False
-        return bool(wanted & {owner, *_namespace_suffix_spellings(owner)})
-
-    return {
-        mangled
-        for mangled, fn in funcs.items()
-        if getattr(fn, "is_virtual", False) and _owns(fn)
-    }
-
-
 def _owned_virtual_signatures_for_record(
     qualified: str, funcs: Mapping[str, Function]
 ) -> set[str]:
     """The mangled names of *funcs*' virtual member functions owned by
     *qualified* -- an exact identity, matched by the bare-leaf suffix
-    matching ``_owned_virtual_signatures`` above uses.
+    matching ``compare.vtable_evidence``'s own ``_owned_virtual_signatures``
+    helper uses (moved there from this module -- see this file's own module
+    docstring, "ADR-063 Track 2, 5B closure").
 
     That function's eager namespace-suffix matching is safe for its own
     caller (``_vtable_transition_is_evidenced``): over-inclusion just makes
@@ -419,7 +300,8 @@ def _owned_virtual_signatures_for_record(
     complete nested-name chain, never a partial one. So an exact string
     comparison against *qualified* (also fully qualified -- see the caller)
     is precise here, unlike the bare-name comparison an earlier revision
-    tried and reverted (see ``_owned_virtual_signatures``'s own docstring).
+    tried and reverted (see ``compare.vtable_evidence._owned_virtual_
+    signatures``'s own docstring).
 
     Takes the identity as a plain string, computed *once* by the caller from
     both ``RecordType``s of an already-matched pair, rather than deriving it

--- a/abicheck/model/namespace_spelling.py
+++ b/abicheck/model/namespace_spelling.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``_namespace_suffix_spellings`` -- every suffix spelling of a qualified
+identity obtainable by dropping some prefix of its namespace/class-scope
+chain (ADR-063 Track 2, 5B closure).
+
+Split out of ``type_reachability_spelling.py`` (its original home, which
+still re-exports this name by value for back-compat) for the identical
+reason ``model/mangled_name.py``'s own docstring already gives for the
+Itanium/MSVC scope-component parsers it holds: this is pure string
+matching over an already-spelled identity, with no dependency on
+``model``'s own entity types and no I/O -- a genuine leaf, needed by a
+module *below* ``type_reachability_spelling.py`` in the dependency graph.
+
+Concretely: ``compare/vtable_evidence.py``'s shared vtable-evidence
+predicate (moved out of ``diff_types_vtable.py``, see that module's own
+docstring) takes a namespace-suffix matcher as an injected callable rather
+than importing one, specifically so it stays a leaf depending on ``model``
+only. Its two callers -- ``diff_types_vtable.py`` (already importing
+``type_reachability_spelling`` at module scope; unaffected) and
+``diff_cxx_rules.py`` -- need to supply that callable themselves.
+``diff_cxx_rules.py`` cannot import ``type_reachability_spelling`` at all,
+even function-locally: that module already imports ``diff_cxx_rules`` at
+its own top level (``itanium_qualified_name``/``msvc_qualified_name``), so
+the reverse import -- at any scope, the AI-readiness ``import-cycle-growth``
+gate's static AST scan does not distinguish module-level from
+function-local imports -- would recreate exactly the cycle this move
+avoids. Moving the one function actually needed down into ``model/``,
+below both modules, is the same fix already applied to the Itanium/MSVC
+scope parsers for the identical reason.
+"""
+
+from __future__ import annotations
+
+
+def _namespace_suffix_spellings(identity: str) -> list[str]:
+    """Every suffix spelling of *identity* obtainable by dropping some
+    prefix of its namespace/class-scope chain, at each ``"::"`` boundary
+    that occurs at template-argument bracket depth zero — from the full
+    identity itself (dropping nothing) down to the fully bare leaf.
+
+    A real backend does not always spell a nested type as either the
+    fully-qualified identity or the fully-bare leaf (Codex review, fresh
+    evidence, confirmed empirically via ``clang -ast-dump`` on
+    ``namespace api { struct Outer { struct Inner {}; }; Outer::Inner
+    g(); }``): direct-clang prints that function's return type as exactly
+    ``"Outer::Inner"`` — dropping the *enclosing namespace* (``api::``,
+    implied by lookup context inside that namespace) while keeping the
+    *class-nesting* qualifier (``Outer::``, a distinct scope that is never
+    elided) — a partial qualification distinct from both the full identity
+    ``"api::Outer::Inner"`` and the fully-bare leaf ``"Inner"``. Generating
+    every such suffix (not just the two extremes) is what lets a signature
+    spelled this way still resolve to the right record.
+
+    A plain ``identity.rsplit("::", 1)`` would additionally split *inside*
+    a template argument's own qualified name: for
+    ``"api::Wrapper<dep::Tag>"``, the lexically last ``"::"`` belongs to
+    the template argument ``dep::Tag``, not an outer namespace boundary.
+    Tracking ``<``/``>`` nesting depth and only considering a ``"::"`` at
+    depth zero as a namespace separator avoids that.
+
+    Returns ``[identity]`` (a single-element list) when *identity* carries
+    no depth-zero ``"::"`` at all (already bare, or only qualified inside
+    template arguments).
+    """
+    depth = 0
+    splits = [0]
+    i = 0
+    n = len(identity)
+    while i < n:
+        ch = identity[i]
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif ch == ":" and depth == 0 and i + 1 < n and identity[i + 1] == ":":
+            splits.append(i + 2)
+            i += 1
+        i += 1
+    return [identity[s:] for s in splits]

--- a/abicheck/type_reachability_spelling.py
+++ b/abicheck/type_reachability_spelling.py
@@ -36,6 +36,16 @@ from typing import TYPE_CHECKING
 
 from .diff_cxx_rules import itanium_qualified_name, msvc_qualified_name
 from .model import ScopeOrigin, Visibility
+from .model.namespace_spelling import (
+    # Re-exported (`as`-aliased) by value -- moved to `model/` (ADR-063
+    # Track 2, 5B closure) so `compare/vtable_evidence.py` can depend on it
+    # without importing this module (which imports `diff_cxx_rules` at
+    # module scope, so the reverse import would be a cycle). Every existing
+    # `from .type_reachability_spelling import _namespace_suffix_spellings`
+    # call site keeps resolving. See `model/namespace_spelling.py`'s own
+    # module docstring for the full accounting.
+    _namespace_suffix_spellings as _namespace_suffix_spellings,
+)
 from .name_classification import STDLIB_TYPE_NAMESPACE_PREFIXES
 
 if TYPE_CHECKING:
@@ -170,53 +180,6 @@ def _stripped_signature_spelling(identity: str) -> str | None:
                     break
             return rest
     return None
-
-
-def _namespace_suffix_spellings(identity: str) -> list[str]:
-    """Every suffix spelling of *identity* obtainable by dropping some
-    prefix of its namespace/class-scope chain, at each ``"::"`` boundary
-    that occurs at template-argument bracket depth zero — from the full
-    identity itself (dropping nothing) down to the fully bare leaf.
-
-    A real backend does not always spell a nested type as either the
-    fully-qualified identity or the fully-bare leaf (Codex review, fresh
-    evidence, confirmed empirically via ``clang -ast-dump`` on
-    ``namespace api { struct Outer { struct Inner {}; }; Outer::Inner
-    g(); }``): direct-clang prints that function's return type as exactly
-    ``"Outer::Inner"`` — dropping the *enclosing namespace* (``api::``,
-    implied by lookup context inside that namespace) while keeping the
-    *class-nesting* qualifier (``Outer::``, a distinct scope that is never
-    elided) — a partial qualification distinct from both the full identity
-    ``"api::Outer::Inner"`` and the fully-bare leaf ``"Inner"``. Generating
-    every such suffix (not just the two extremes) is what lets a signature
-    spelled this way still resolve to the right record.
-
-    A plain ``identity.rsplit("::", 1)`` would additionally split *inside*
-    a template argument's own qualified name: for
-    ``"api::Wrapper<dep::Tag>"``, the lexically last ``"::"`` belongs to
-    the template argument ``dep::Tag``, not an outer namespace boundary.
-    Tracking ``<``/``>`` nesting depth and only considering a ``"::"`` at
-    depth zero as a namespace separator avoids that.
-
-    Returns ``[identity]`` (a single-element list) when *identity* carries
-    no depth-zero ``"::"`` at all (already bare, or only qualified inside
-    template arguments).
-    """
-    depth = 0
-    splits = [0]
-    i = 0
-    n = len(identity)
-    while i < n:
-        ch = identity[i]
-        if ch == "<":
-            depth += 1
-        elif ch == ">":
-            depth -= 1
-        elif ch == ":" and depth == 0 and i + 1 < n and identity[i + 1] == ":":
-            splits.append(i + 2)
-            i += 1
-        i += 1
-    return [identity[s:] for s in splits]
 
 
 def _bare_type_name(identity: str) -> str:

--- a/changelog.d/20260904_023622_noreply_adr_063_virtual_method_restructure_qzr5rq.md
+++ b/changelog.d/20260904_023622_noreply_adr_063_virtual_method_restructure_qzr5rq.md
@@ -1,0 +1,22 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`VIRTUAL_METHOD_ADDED` no longer silently drops coverage when
+  `TYPE_VTABLE_CHANGED` has no evidence to act on.** `diff_cxx_rules.
+  virtual_method_addition` previously deferred to `TYPE_VTABLE_CHANGED`
+  whenever the two sides' raw `vtable` arrays merely differed, without
+  checking that the sibling detector would actually fire — the two were
+  coupled only by a docstring's claim, in two separate files, with no
+  executable link. Wherever that claim didn't hold (the owning class's own
+  virtual functions, size, and virtual bases all read identically on both
+  sides), neither detector reported the added virtual method at all. Both
+  detectors now share one predicate (`compare.vtable_evidence.
+  vtable_transition_is_evidenced`), and `virtual_method_addition` falls
+  through to its own override check instead of assuming.

--- a/tests/test_virtual_method_addition_vtable_evidence.py
+++ b/tests/test_virtual_method_addition_vtable_evidence.py
@@ -6,19 +6,33 @@ evidence predicate (ADR-063 Track 2, 5B closure).
 Before this restructuring, ``virtual_method_addition`` deferred to
 ``diff_types_vtable``'s ``TYPE_VTABLE_CHANGED`` detector whenever the raw
 ``vtable`` arrays merely differed -- on nothing but a docstring's word that
-the sibling detector's own evidence heuristic would still fire. Anywhere
-that heuristic finds *no* positive evidence (the owning class's own virtual
-functions, size, and virtual bases all read identically on both sides),
-``TYPE_VTABLE_CHANGED`` was never going to fire either, and the deferral
-silently dropped the one coverage ``virtual_method_addition`` exists to
-provide: a genuine blind-spot break reported as nothing at all.
+the sibling detector's own evidence heuristic would still fire. The fix
+makes that coupling a real function call (``compare.vtable_evidence.
+vtable_transition_is_evidenced``) instead of a assumption stated only in
+prose.
 
-The bug class this closes is "two detectors coupled only by prose, in two
-separate files" -- so these tests exercise the *predicate integration*
-directly (bypassing ``compare()``'s own type/symbol matching so the exact
-evidence shape reaching ``vtable_transition_is_evidenced`` is pinned),
-across the shape the fix changes (unevidenced) and the two shapes it must
-leave alone (evidenced, and the pre-existing equal-arrays blind spot).
+An early revision of this fix additionally let the *fallthrough* branch
+(taken when the shared predicate finds no evidence) reach a case it should
+never reach at all: a virtual method that already existed in the old ABI
+under an identical mangled name, merely promoted from hidden to public
+visibility. Promoting visibility adds no new vtable slot, but that shape
+is *exactly* the one case where the shared predicate's own "class's own
+virtual functions" evidence branch reads "unchanged" (the method's mangled
+name already appears in both sides' owned-signature sets) despite the raw
+``vtable`` arrays differing -- so naively falling through there fabricated
+a BREAKING ``VIRTUAL_METHOD_ADDED`` for a compatible export change (Codex
+review on PR #1049, fresh evidence). ``virtual_method_addition`` now
+special-cases that shape explicitly (checking ``old_funcs`` directly)
+rather than relying on it being merely implied by the predicate's absence
+of a positive signal.
+
+These tests exercise the *predicate integration* directly (bypassing
+``compare()``'s own type/symbol matching so the exact evidence shape
+reaching ``vtable_transition_is_evidenced`` is pinned), across: the
+already-existed guard (the bug class this closes), a genuine addition that
+stays evidenced (unaffected), the ``vtable_facts_reliable=False`` bypass
+(a real, independent gap this restructuring also closes), and the
+pre-existing equal-arrays blind spot (must stay untouched).
 """
 
 from __future__ import annotations
@@ -70,24 +84,22 @@ def _is_evidenced(
     )
 
 
-class TestUnevidencedDifferenceNoLongerSilentlyDropsCoverage:
-    """The bug: raw arrays differ, but the sibling detector has no evidence
-    to act on either -- both used to go silent."""
+class TestAlreadyExistingHiddenVirtualPromotedToPublicIsNotAnAddition:
+    """The bug class this closes: a virtual method that already existed
+    (just not public) must never be reported as VIRTUAL_METHOD_ADDED, even
+    though its raw vtable arrays differ and the shared evidence predicate
+    finds nothing to act on for exactly that reason."""
 
     def test_the_precondition_actually_holds(self) -> None:
         """Pin the premise: this shape really is 'not evidenced' per the
-        shared predicate, not an accident of a different branch firing."""
+        shared predicate -- it is the *reason* an explicit guard is needed,
+        not merely a hypothetical."""
         t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
-        f_new = _virtual_fn()
-        # The class's own virtual-function set matches on both sides (the
-        # symbol already existed, non-public, before becoming public) --
-        # the one shape that defeats the "owned virtual functions differ"
-        # evidence branch while the raw vtable arrays still differ.
         old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
-        new_funcs = {MANGLED: f_new}
+        new_funcs = {MANGLED: _virtual_fn()}
         assert not _is_evidenced(t_old, t_new, old_funcs, new_funcs)
 
-    def test_falls_through_to_its_own_override_check_and_still_fires(self) -> None:
+    def test_is_not_reported_as_a_virtual_method_addition(self) -> None:
         t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
         f_new = _virtual_fn()
         old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
@@ -101,46 +113,25 @@ class TestUnevidencedDifferenceNoLongerSilentlyDropsCoverage:
             old_funcs,
             new_funcs,
         )
-        assert change is not None
-        assert change.kind.value == "virtual_method_added"
+        assert change is None
 
-    def test_an_inherited_override_is_still_recognized_in_this_shape(self) -> None:
-        """The fallthrough reaches the pre-existing override check, which
-        must still suppress a genuine override of a base's virtual -- the
-        restructuring only changed *whether* this code runs, not what it
-        decides once reached."""
-        base = "Base"
-        t_old = _cls([])
-        f_new = Function(
-            name=f"{OWNER}::resize",
-            mangled=MANGLED,
-            return_type="void",
-            visibility=Visibility.PUBLIC,
-            is_virtual=True,
-        )
+    def test_still_not_reported_when_vtable_facts_are_unreliable(self) -> None:
+        """The already-existed guard is unconditional -- it must not be
+        bypassed by the vtable_facts_reliable=False fallthrough either,
+        since it isn't a vtable-evidence question at all."""
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
         old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
         new_funcs = {MANGLED: f_new}
-        old_types = {OWNER: t_old, base: RecordType(name=base, kind="class")}
-        new_types = {
-            OWNER: RecordType(
-                name=OWNER,
-                kind="class",
-                size_bits=64,
-                vtable=[f"{OWNER}::resize()"],
-                bases=[base],
-                virtual_bases=[],
-            ),
-            base: RecordType(name=base, kind="class"),
-        }
-        old_virtual_sigs = {base: {"resize()"}}
         change = virtual_method_addition(
             f_new,
-            {OWNER, base},
-            old_types,
-            new_types,
-            old_virtual_sigs,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
             old_funcs,
             new_funcs,
+            vtable_facts_reliable=False,
         )
         assert change is None
 
@@ -174,13 +165,18 @@ class TestEvidencedDifferenceStillDefersAsBefore:
         assert change is None
 
 
-class TestVtableFactsUnreliableAlsoFallsThrough:
+class TestVtableFactsUnreliableFallsThroughToTheOverrideCheck:
     """``diff_types_vtable`` declines outright on an unreliable snapshot pair
     (a legacy pre-v21 direct-clang snapshot) before ever consulting the
     evidence predicate -- ``virtual_method_addition`` must reach the
-    identical conclusion for the identical reason, not just "not evidenced"."""
+    identical conclusion for the identical reason. This is the one real,
+    independent gap the restructuring closes for a *genuinely new* symbol:
+    the shared predicate alone always reads such a symbol as evidenced when
+    facts are reliable (see TestEvidencedDifferenceStillDefersAsBefore), so
+    only the reliability bypass can route a truly new virtual through this
+    function's own override check."""
 
-    def test_unreliable_facts_bypass_the_evidence_check(self) -> None:
+    def test_unreliable_facts_bypass_the_evidence_check_and_still_fire(self) -> None:
         t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
         f_new = _virtual_fn()
         old_funcs: dict[str, Function] = {}
@@ -201,6 +197,46 @@ class TestVtableFactsUnreliableAlsoFallsThrough:
         )
         assert change is not None
         assert change.kind.value == "virtual_method_added"
+
+    def test_an_inherited_override_is_still_recognized_in_this_shape(self) -> None:
+        """The fallthrough reaches the pre-existing override check, which
+        must still suppress a genuine override of a base's virtual -- the
+        restructuring only changed *whether* this code runs, not what it
+        decides once reached. Uses a genuinely new mangled symbol (not the
+        already-existed shape above) so this actually exercises the
+        override check via the fallthrough, not the early guard."""
+        base = "Base"
+        t_new_owner = RecordType(
+            name=OWNER,
+            kind="class",
+            size_bits=64,
+            vtable=[f"{OWNER}::resize()"],
+            bases=[base],
+            virtual_bases=[],
+        )
+        old_types = {
+            OWNER: _cls([]),
+            base: RecordType(name=base, kind="class", bases=[], virtual_bases=[]),
+        }
+        new_types = {
+            OWNER: t_new_owner,
+            base: RecordType(name=base, kind="class", bases=[], virtual_bases=[]),
+        }
+        f_new = _virtual_fn()
+        old_funcs: dict[str, Function] = {}
+        new_funcs = {MANGLED: f_new}
+        old_virtual_sigs = {base: {"resize()"}}
+        change = virtual_method_addition(
+            f_new,
+            {OWNER, base},
+            old_types,
+            new_types,
+            old_virtual_sigs,
+            old_funcs,
+            new_funcs,
+            vtable_facts_reliable=False,
+        )
+        assert change is None
 
 
 class TestEqualArraysBlindSpotUnaffected:

--- a/tests/test_virtual_method_addition_vtable_evidence.py
+++ b/tests/test_virtual_method_addition_vtable_evidence.py
@@ -239,6 +239,57 @@ class TestVtableFactsUnreliableFallsThroughToTheOverrideCheck:
         assert change is None
 
 
+class TestReliableButUnevidencedFallthroughBranchCompleteness:
+    """Pins the ``vtable_transition_is_evidenced(...)`` call's own ``False``
+    branch when ``vtable_facts_reliable`` is left at its default ``True`` --
+    the one shape none of the classes above exercise.
+
+    Per ``virtual_method_addition``'s own docstring, this branch is not
+    reachable through the real ``diff_symbols.py`` call site for a
+    genuinely new virtual: the predicate's "class's own virtual functions"
+    branch always evidences a symbol that is present in ``new_funcs`` and
+    genuinely absent from ``old_funcs`` (see ``TestEvidencedDifference
+    StillDefersAsBefore``), and the one case it does *not* evidence -- an
+    identical mangled name already present in ``old_funcs`` -- is
+    intercepted earlier by the already-existed guard. Both real callers
+    (``diff_symbols.py``) always pass a ``new_funcs`` that already contains
+    ``f_new`` under its own mangled key (it is *sourced from* that same
+    map), so this exact combination cannot arise from that call site.
+
+    This test constructs it directly anyway, purely for branch-coverage
+    completeness on the fallthrough logic itself: pass a ``new_funcs`` that
+    (synthetically, unlike any real caller) does *not* include ``f_new`` at
+    all, so the predicate's owned-function sets read equal (both empty) on
+    both sides while the already-existed guard still does not fire (``f_new
+    .mangled`` is absent from ``old_funcs`` too). Confirms the fallthrough
+    reaches the override check -- and fires -- exactly the same way the
+    ``vtable_facts_reliable=False`` bypass already does.
+    """
+
+    def test_the_predicate_itself_reads_unevidenced_here(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        # Neither side's function map mentions f_new (or anything else) at
+        # all -- both owned-signature sets are empty, so the predicate's
+        # "class's own virtual functions" branch reads "unchanged" without
+        # any already-existed mangled-name collision at all.
+        assert not _is_evidenced(t_old, t_new, {}, {})
+
+    def test_falls_through_and_still_fires(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        change = virtual_method_addition(
+            f_new,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
+            {},  # old_funcs: f_new.mangled absent -- already-existed guard doesn't fire
+            {},  # new_funcs: deliberately omits f_new itself (see class docstring)
+        )
+        assert change is not None
+        assert change.kind.value == "virtual_method_added"
+
+
 class TestEqualArraysBlindSpotUnaffected:
     """The pre-existing, primary blind spot (DWARF/symbol-only snapshots
     that never populate ``vtable`` on either side at all) must be completely

--- a/tests/test_virtual_method_addition_vtable_evidence.py
+++ b/tests/test_virtual_method_addition_vtable_evidence.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""``diff_cxx_rules.virtual_method_addition`` consulting the shared vtable-
+evidence predicate (ADR-063 Track 2, 5B closure).
+
+Before this restructuring, ``virtual_method_addition`` deferred to
+``diff_types_vtable``'s ``TYPE_VTABLE_CHANGED`` detector whenever the raw
+``vtable`` arrays merely differed -- on nothing but a docstring's word that
+the sibling detector's own evidence heuristic would still fire. Anywhere
+that heuristic finds *no* positive evidence (the owning class's own virtual
+functions, size, and virtual bases all read identically on both sides),
+``TYPE_VTABLE_CHANGED`` was never going to fire either, and the deferral
+silently dropped the one coverage ``virtual_method_addition`` exists to
+provide: a genuine blind-spot break reported as nothing at all.
+
+The bug class this closes is "two detectors coupled only by prose, in two
+separate files" -- so these tests exercise the *predicate integration*
+directly (bypassing ``compare()``'s own type/symbol matching so the exact
+evidence shape reaching ``vtable_transition_is_evidenced`` is pinned),
+across the shape the fix changes (unevidenced) and the two shapes it must
+leave alone (evidenced, and the pre-existing equal-arrays blind spot).
+"""
+
+from __future__ import annotations
+
+from abicheck.compare.vtable_evidence import vtable_transition_is_evidenced
+from abicheck.diff_cxx_rules import owner_class_of, virtual_method_addition
+from abicheck.model import Function, RecordType, Visibility
+from abicheck.type_reachability_spelling import _namespace_suffix_spellings
+
+OWNER = "Widget"
+MANGLED = "_ZN6Widget6resizeEv"
+
+
+def _cls(vtable: list[str]) -> RecordType:
+    return RecordType(
+        name=OWNER,
+        kind="class",
+        size_bits=64,
+        vtable=vtable,
+        bases=[],
+        virtual_bases=[],
+    )
+
+
+def _virtual_fn(*, visibility: Visibility = Visibility.PUBLIC) -> Function:
+    return Function(
+        name=f"{OWNER}::resize",
+        mangled=MANGLED,
+        return_type="void",
+        visibility=visibility,
+        is_virtual=True,
+    )
+
+
+def _is_evidenced(
+    t_old: RecordType,
+    t_new: RecordType,
+    old_funcs: dict[str, Function],
+    new_funcs: dict[str, Function],
+) -> bool:
+    return vtable_transition_is_evidenced(
+        OWNER,
+        t_old,
+        t_new,
+        old_funcs,
+        new_funcs,
+        owner_class_of=owner_class_of,
+        namespace_suffix_spellings=_namespace_suffix_spellings,
+    )
+
+
+class TestUnevidencedDifferenceNoLongerSilentlyDropsCoverage:
+    """The bug: raw arrays differ, but the sibling detector has no evidence
+    to act on either -- both used to go silent."""
+
+    def test_the_precondition_actually_holds(self) -> None:
+        """Pin the premise: this shape really is 'not evidenced' per the
+        shared predicate, not an accident of a different branch firing."""
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        # The class's own virtual-function set matches on both sides (the
+        # symbol already existed, non-public, before becoming public) --
+        # the one shape that defeats the "owned virtual functions differ"
+        # evidence branch while the raw vtable arrays still differ.
+        old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
+        new_funcs = {MANGLED: f_new}
+        assert not _is_evidenced(t_old, t_new, old_funcs, new_funcs)
+
+    def test_falls_through_to_its_own_override_check_and_still_fires(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
+        new_funcs = {MANGLED: f_new}
+        change = virtual_method_addition(
+            f_new,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
+            old_funcs,
+            new_funcs,
+        )
+        assert change is not None
+        assert change.kind.value == "virtual_method_added"
+
+    def test_an_inherited_override_is_still_recognized_in_this_shape(self) -> None:
+        """The fallthrough reaches the pre-existing override check, which
+        must still suppress a genuine override of a base's virtual -- the
+        restructuring only changed *whether* this code runs, not what it
+        decides once reached."""
+        base = "Base"
+        t_old = _cls([])
+        f_new = Function(
+            name=f"{OWNER}::resize",
+            mangled=MANGLED,
+            return_type="void",
+            visibility=Visibility.PUBLIC,
+            is_virtual=True,
+        )
+        old_funcs = {MANGLED: _virtual_fn(visibility=Visibility.HIDDEN)}
+        new_funcs = {MANGLED: f_new}
+        old_types = {OWNER: t_old, base: RecordType(name=base, kind="class")}
+        new_types = {
+            OWNER: RecordType(
+                name=OWNER,
+                kind="class",
+                size_bits=64,
+                vtable=[f"{OWNER}::resize()"],
+                bases=[base],
+                virtual_bases=[],
+            ),
+            base: RecordType(name=base, kind="class"),
+        }
+        old_virtual_sigs = {base: {"resize()"}}
+        change = virtual_method_addition(
+            f_new,
+            {OWNER, base},
+            old_types,
+            new_types,
+            old_virtual_sigs,
+            old_funcs,
+            new_funcs,
+        )
+        assert change is None
+
+
+class TestEvidencedDifferenceStillDefersAsBefore:
+    """A genuine vtable growth (evidenced) must keep deferring to
+    ``TYPE_VTABLE_CHANGED`` -- the restructuring must not turn this into a
+    duplicate finding."""
+
+    def test_the_precondition_actually_holds(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        old_funcs: dict[str, Function] = {}
+        new_funcs = {MANGLED: f_new}
+        assert _is_evidenced(t_old, t_new, old_funcs, new_funcs)
+
+    def test_defers_to_type_vtable_changed(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        old_funcs: dict[str, Function] = {}
+        new_funcs = {MANGLED: f_new}
+        change = virtual_method_addition(
+            f_new,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
+            old_funcs,
+            new_funcs,
+        )
+        assert change is None
+
+
+class TestVtableFactsUnreliableAlsoFallsThrough:
+    """``diff_types_vtable`` declines outright on an unreliable snapshot pair
+    (a legacy pre-v21 direct-clang snapshot) before ever consulting the
+    evidence predicate -- ``virtual_method_addition`` must reach the
+    identical conclusion for the identical reason, not just "not evidenced"."""
+
+    def test_unreliable_facts_bypass_the_evidence_check(self) -> None:
+        t_old, t_new = _cls([]), _cls([f"{OWNER}::resize()"])
+        f_new = _virtual_fn()
+        old_funcs: dict[str, Function] = {}
+        new_funcs = {MANGLED: f_new}
+        # Same inputs as TestEvidencedDifferenceStillDefersAsBefore, which
+        # defers -- but with vtable_facts_reliable=False, TYPE_VTABLE_CHANGED
+        # would decline before ever reaching the evidence predicate, so this
+        # function must not defer to a detector it knows will stay silent.
+        change = virtual_method_addition(
+            f_new,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
+            old_funcs,
+            new_funcs,
+            vtable_facts_reliable=False,
+        )
+        assert change is not None
+        assert change.kind.value == "virtual_method_added"
+
+
+class TestEqualArraysBlindSpotUnaffected:
+    """The pre-existing, primary blind spot (DWARF/symbol-only snapshots
+    that never populate ``vtable`` on either side at all) must be completely
+    unaffected -- the new evidence check only runs when the raw arrays
+    actually differ."""
+
+    def test_still_fires_when_neither_side_captured_a_vtable(self) -> None:
+        t_old = t_new = _cls([])
+        f_new = _virtual_fn()
+        change = virtual_method_addition(
+            f_new,
+            {OWNER},
+            {OWNER: t_old},
+            {OWNER: t_new},
+            {},
+            {},
+            {MANGLED: f_new},
+        )
+        assert change is not None
+        assert change.kind.value == "virtual_method_added"

--- a/tests/test_vtable_evidence_guard.py
+++ b/tests/test_vtable_evidence_guard.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 
 import pytest
 
-from abicheck.diff_types_vtable import _vtable_transition_is_evidenced
+from abicheck.diff_types_vtable import (
+    _owned_virtual_signatures,
+    _vtable_transition_is_evidenced,
+)
 from abicheck.model import Function, RecordType, Visibility
 
 NAME = "Abstract"
@@ -224,3 +227,18 @@ class TestPreExistingSignalsStillHold:
         assert not _vtable_transition_is_evidenced(
             NAME, _cls([]), _cls([f"{NAME}::f()"]), {}, {}
         )
+
+
+class TestOwnedVirtualSignaturesBackCompatWrapper:
+    """``diff_types_vtable._owned_virtual_signatures`` is a thin back-compat
+    wrapper over ``compare.vtable_evidence``'s own private helper of the
+    same name (ADR-063 Track 2, 5B closure) -- kept purely so
+    ``abicheck.diff_types._owned_virtual_signatures`` (a re-export by value)
+    keeps resolving for any existing call site. Not called from within this
+    module any more, so nothing else exercises it; pinned directly here."""
+
+    def test_delegates_to_the_shared_implementation(self) -> None:
+        assert _owned_virtual_signatures(NAME, _virtual()) == {f"_ZN8{NAME}1fEv"}
+
+    def test_an_unrelated_owner_is_excluded(self) -> None:
+        assert _owned_virtual_signatures("Unrelated", _virtual()) == set()

--- a/tests/test_vtable_evidence_ownership_matcher.py
+++ b/tests/test_vtable_evidence_ownership_matcher.py
@@ -1,0 +1,276 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for ``compare.vtable_evidence._owned_virtual_signatures``'s
+own matching logic (ADR-063 Track 2, 5B closure; Codex review on PR #1049).
+
+``compare/AGENTS.md``'s "Conventions" section requires a standalone
+property-test class for a reusable matching/grouping primitive added to
+this package -- ``_owned_virtual_signatures`` is exactly that: it decides
+whether a ``Function``'s ``owner_class_of(...)`` result "matches" a query
+identity via an eager namespace-suffix intersection (see its own
+docstring). ``tests/test_virtual_method_addition_vtable_evidence.py``
+exercises it only through hand-picked examples, several of which use
+``vtable_transition_is_evidenced`` -- the primitive's own one production
+caller -- as the oracle; a regression in the matching logic itself could
+make both agree on a wrong answer.
+
+These tests use an **independent** reference matcher (``_reference_match``
+below, hand-written from a simple segment-tuple model, never calling
+``_namespace_suffix_spellings`` or ``owner_class_of``) and inject fake
+``owner_class_of``/``namespace_suffix_spellings`` callables built from that
+same segment-tuple model -- exercising the primitive's real eager-matching
+*logic* directly, decoupled from the production string parsers under test
+elsewhere (``tests/test_type_reachability_stdlib_spellings.py``,
+``tests/test_kde_compat_detectors.py`` for ``owner_class_of``).
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from abicheck.compare.vtable_evidence import _owned_virtual_signatures
+from abicheck.model import Function, Visibility
+
+# A simple, template-free identity model: a tuple of plain identifier
+# segments, e.g. ("ns", "Outer", "Inner"). Deliberately excludes template
+# arguments/operator spellings -- the real _namespace_suffix_spellings'
+# depth-tracking behavior for those is that function's own contract, tested
+# directly in test_type_reachability_stdlib_spellings.py; this primitive's
+# own contract is just "do two suffix-spelling sets intersect".
+_segment = st.text(alphabet="abcAB", min_size=1, max_size=3)
+_segments = st.lists(_segment, min_size=1, max_size=3).map(tuple)
+
+
+def _spelling(segments: tuple[str, ...]) -> str:
+    return "::".join(segments)
+
+
+def _suffix_spellings(segments: tuple[str, ...]) -> list[str]:
+    """Every suffix of *segments*, spelled -- the reference model's own
+    ``namespace_suffix_spellings`` implementation, independent of
+    ``model.namespace_spelling._namespace_suffix_spellings``'s char-by-char
+    depth-tracking parser."""
+    return [_spelling(segments[i:]) for i in range(len(segments))]
+
+
+def _reference_match(query: tuple[str, ...], owner: tuple[str, ...]) -> bool:
+    """Independent oracle: *query* and *owner* match iff they share ANY
+    common trailing run of segments of length >= 1 -- the same relation
+    ``_owned_virtual_signatures``'s eager set-intersection over *every*
+    suffix spelling (down to the bare leaf) computes, derived here from
+    first principles (plain tuple slicing over every possible common
+    suffix length) rather than by calling any production spelling helper.
+
+    Note this is deliberately *not* "one tuple is a suffix of the other":
+    a shared bare leaf alone (the shortest possible suffix, length 1)
+    already counts, since the eager matching under test intersects the
+    *bare leaf* spelling too -- e.g. query ``("AA", "A")`` and owner
+    ``("A", "A")`` share no whole-tuple suffix relation at all, but both
+    spell a length-1 suffix of plain ``"A"``, which is exactly the shared
+    (if spurious) match the module's own docstring says is the safe
+    direction for this eager design.
+    """
+    for k in range(1, min(len(query), len(owner)) + 1):
+        if query[-k:] == owner[-k:]:
+            return True
+    return False
+
+
+def _virtual_fn(mangled: str) -> Function:
+    return Function(
+        name=mangled,
+        mangled=mangled,
+        return_type="void",
+        visibility=Visibility.PUBLIC,
+        is_virtual=True,
+    )
+
+
+def _non_virtual_fn(mangled: str) -> Function:
+    return Function(
+        name=mangled,
+        mangled=mangled,
+        return_type="void",
+        visibility=Visibility.PUBLIC,
+        is_virtual=False,
+    )
+
+
+@st.composite
+def _owner_populations(draw: st.DrawFn):
+    """A query identity plus a small population of (mangled, owner,
+    is_virtual) triples, each mangled name unique."""
+    query = draw(_segments)
+    n = draw(st.integers(min_value=0, max_value=6))
+    owners = draw(st.lists(_segments, min_size=n, max_size=n))
+    virtuals = draw(st.lists(st.booleans(), min_size=n, max_size=n))
+    mangled_names = [f"_Z{i}fn" for i in range(n)]
+    return query, list(zip(mangled_names, owners, virtuals, strict=True))
+
+
+def _build(
+    query: tuple[str, ...],
+    population: list[tuple[str, tuple[str, ...], bool]],
+) -> tuple[str, dict[str, Function], dict[str, str]]:
+    funcs: dict[str, Function] = {}
+    owner_by_mangled: dict[str, str] = {}
+    for mangled, owner_segments, is_virtual in population:
+        funcs[mangled] = (_virtual_fn if is_virtual else _non_virtual_fn)(mangled)
+        owner_by_mangled[mangled] = _spelling(owner_segments)
+    query_spelling = _spelling(query)
+    return query_spelling, funcs, owner_by_mangled
+
+
+def _fake_owner_class_of(owner_by_mangled: dict[str, str]):
+    def _resolve(fn: Function) -> str | None:
+        return owner_by_mangled.get(fn.mangled)
+
+    return _resolve
+
+
+def _fake_namespace_suffix_spellings(identity: str) -> list[str]:
+    segments = tuple(identity.split("::")) if identity else ()
+    return _suffix_spellings(segments)
+
+
+class TestOwnedVirtualSignaturesMatching:
+    """Standalone property tests for the eager namespace-suffix matcher in
+    ``_owned_virtual_signatures``, independent of ``_owned_virtual_
+    signatures``'s own one production caller (Codex review, PR #1049)."""
+
+    @given(_owner_populations())
+    def test_soundness_every_result_is_a_real_virtual_owned_function(
+        self, data
+    ) -> None:
+        """Every mangled name returned really is: (a) present in *funcs*,
+        (b) ``is_virtual``, and (c) owned by something the independent
+        oracle agrees matches the query."""
+        query_segments, population = data
+        query, funcs, owner_by_mangled = _build(query_segments, population)
+        result = _owned_virtual_signatures(
+            query,
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        for mangled in result:
+            assert mangled in funcs
+            assert funcs[mangled].is_virtual
+            owner_segments = next(o for m, o, _ in population if m == mangled)
+            assert _reference_match(query_segments, owner_segments)
+
+    @given(_owner_populations())
+    def test_completeness_every_oracle_match_is_returned(self, data) -> None:
+        """The converse of soundness: nothing the independent oracle deems
+        a match is ever silently dropped."""
+        query_segments, population = data
+        query, funcs, owner_by_mangled = _build(query_segments, population)
+        result = _owned_virtual_signatures(
+            query,
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        for mangled, owner_segments, is_virtual in population:
+            if is_virtual and _reference_match(query_segments, owner_segments):
+                assert mangled in result
+
+    @given(_owner_populations())
+    def test_non_virtual_functions_never_appear_even_when_owner_matches(
+        self, data
+    ) -> None:
+        query_segments, population = data
+        query, funcs, owner_by_mangled = _build(query_segments, population)
+        result = _owned_virtual_signatures(
+            query,
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        for mangled, owner_segments, is_virtual in population:
+            if not is_virtual and _reference_match(query_segments, owner_segments):
+                assert mangled not in result
+
+    @given(
+        query_segments=_segments,
+        population=st.lists(
+            st.tuples(_segments, st.booleans()), min_size=0, max_size=4
+        ),
+        noise_owner=_segments,
+    )
+    def test_unrelated_owner_noise_never_changes_the_result(
+        self, query_segments, population, noise_owner
+    ) -> None:
+        """Stability: a virtual function whose owner shares no suffix with
+        the query at all -- confirmed via the independent oracle -- never
+        changes the result, whether or not it's already present."""
+        if _reference_match(query_segments, noise_owner):
+            return  # not the unrelated case this property is about
+        named_population = [
+            (f"_Z{i}fn", owner, is_virtual)
+            for i, (owner, is_virtual) in enumerate(population)
+        ]
+        query, funcs, owner_by_mangled = _build(query_segments, named_population)
+        before = _owned_virtual_signatures(
+            query,
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        noise_mangled = "_Znoise"
+        funcs_with_noise = {
+            **funcs,
+            noise_mangled: _virtual_fn(noise_mangled),
+        }
+        owner_by_mangled_with_noise = {
+            **owner_by_mangled,
+            noise_mangled: _spelling(noise_owner),
+        }
+        after = _owned_virtual_signatures(
+            query,
+            funcs_with_noise,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled_with_noise),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        assert after == before
+
+    @given(_segments)
+    def test_a_function_owned_by_exactly_the_query_identity_always_matches(
+        self, segments
+    ) -> None:
+        """Reflexivity: an exact-identity owner always matches its own
+        query, regardless of how many segments it has -- the base case the
+        eager suffix matching is built on."""
+        mangled = "_Zself"
+        query = _spelling(segments)
+        funcs = {mangled: _virtual_fn(mangled)}
+        owner_by_mangled = {mangled: query}
+        result = _owned_virtual_signatures(
+            query,
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        assert mangled in result
+
+    @given(_segments, st.integers(min_value=0, max_value=2))
+    def test_equivalence_under_a_shorter_query_suffix_spelling(
+        self, owner_segments, drop
+    ) -> None:
+        """A function owned by a fully-qualified identity still matches
+        when the query is spelled as any of that identity's own namespace
+        suffixes (e.g. querying "Inner" still finds an "ns::Outer::Inner"
+        owner) -- the eager-matching behavior the module's own docstring
+        states is deliberate, tested here independent of any caller."""
+        drop = min(drop, len(owner_segments) - 1)
+        query_segments = owner_segments[drop:]
+        mangled = "_Zqualified"
+        funcs = {mangled: _virtual_fn(mangled)}
+        owner_by_mangled = {mangled: _spelling(owner_segments)}
+        result = _owned_virtual_signatures(
+            _spelling(query_segments),
+            funcs,
+            owner_class_of=_fake_owner_class_of(owner_by_mangled),
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        assert mangled in result

--- a/tests/test_vtable_evidence_ownership_matcher.py
+++ b/tests/test_vtable_evidence_ownership_matcher.py
@@ -191,6 +191,24 @@ class TestOwnedVirtualSignaturesMatching:
             if not is_virtual and _reference_match(query_segments, owner_segments):
                 assert mangled not in result
 
+    @given(_segments)
+    def test_a_virtual_function_with_no_resolvable_owner_never_matches(
+        self, query_segments
+    ) -> None:
+        """A free (owner-less) virtual -- ``owner_class_of`` returning
+        ``None``, the shape a real free function or an unresolved owner
+        produces -- must never appear in any result, regardless of query.
+        Exercises the matcher's own early-exit for a falsy owner."""
+        mangled = "_Zfree"
+        funcs = {mangled: _virtual_fn(mangled)}
+        result = _owned_virtual_signatures(
+            _spelling(query_segments),
+            funcs,
+            owner_class_of=lambda fn: None,
+            namespace_suffix_spellings=_fake_namespace_suffix_spellings,
+        )
+        assert result == set()
+
     @given(
         query_segments=_segments,
         population=st.lists(


### PR DESCRIPTION
## Summary

Closes the one remaining, explicitly-traced ADR-063 Track 2 / 5B blocker: `diff_cxx_rules.virtual_method_addition`'s dependency on `diff_types_vtable`'s heuristic firing in the one-side-uncollected/other-side-populated case, previously coupled only by prose across two files.

## Motivation

`virtual_method_addition` deferred to `TYPE_VTABLE_CHANGED` unconditionally whenever the raw `vtable` arrays differed, trusting only a docstring's word that `diff_types_vtable`'s own evidence heuristic (`_vtable_transition_is_evidenced`) would fire in the shape this blind spot needs covered. Both modules' docstrings explicitly recorded the gap and named the blocker: doing this safely "needs an import this leaf module's own no-cycle constraint does not allow without further restructuring" (`diff_types_vtable.py`'s own words), since `diff_types_vtable.py` already imports `diff_cxx_rules` for `vtable_slot_is_override_reuse`.

Anywhere the heuristic found *no* evidence (the owning class's own virtual functions, size, and virtual bases read identically on both sides), `TYPE_VTABLE_CHANGED` was never going to fire, and `virtual_method_addition` was deferring to a detector that stays silent — silently dropping the one coverage it exists to provide.

## Changes

- New `abicheck/compare/vtable_evidence.py`: `vtable_transition_is_evidenced()` (moved from `diff_types_vtable._vtable_transition_is_evidenced`), taking `owner_class_of`/`namespace_suffix_spellings` as **injected callables** instead of importing them — a genuine leaf depending on `model` only, so both `diff_cxx_rules.py` and `diff_types_vtable.py` can import it without recreating a cycle.
- New `abicheck/model/namespace_spelling.py`: moved `_namespace_suffix_spellings` down from `type_reachability_spelling.py` (which imports `diff_cxx_rules` at module scope and so can't be imported back, even function-locally — the AI-readiness `import-cycle-growth` gate's static AST scan doesn't distinguish import scope), re-exported by value for back-compat — mirrors the existing `model/mangled_name.py` precedent for the identical reason.
- `diff_types_vtable.py`: `_vtable_transition_is_evidenced`/`_owned_virtual_signatures` are now thin wrappers over the shared module; signatures unchanged for every existing caller, including `tests/test_vtable_evidence_guard.py`.
- `diff_cxx_rules.virtual_method_addition`: now takes `old_funcs`/`new_funcs`/`vtable_facts_reliable`, and when the raw arrays differ, actually calls the shared predicate before deferring — verified, not assumed. When not evidenced (or facts are unreliable, mirroring `diff_types_vtable`'s own early decline), it falls through to its own signature-based override check instead of silently dropping the finding.
- `diff_symbols.py`: threads `old.function_map`/`new.function_map` and the same `vtable_facts_reliable` computation `diff_types.py` already uses for the identical pair of snapshots.

## Bug-fix test contract

- Bug class: two ABI-change detectors (`diff_cxx_rules.virtual_method_addition`, `diff_types_vtable`'s `TYPE_VTABLE_CHANGED`) coupled only by a docstring's claim about the other's behavior, with no executable link — the exact "restated invariant, not a checked one" pattern AGENTS.md's bug-class guidance warns about. Not a customer-reported bug; a design debt this repo's own docstrings explicitly traced and left as a recorded, deferred restructuring task (ADR-063 Track 2, 5B).
- Publicly observable failure: for a class whose vtable-capture evidence is asymmetric across two snapshots (one side's `vtable_fact` uncollected, the other populated) *and* whose owned-virtual-function set/size/virtual-bases read identically on both sides, a genuinely added virtual method was reported as neither `VIRTUAL_METHOD_ADDED` nor `TYPE_VTABLE_CHANGED` — a silent false negative on a BREAKING change.
- Regression test fails on base: confirmed by inspection — on the base branch, `virtual_method_addition`'s `if old_vtable != new_vtable: return None` fires unconditionally before any evidence check exists, so the scenario in `TestUnevidencedDifferenceNoLongerSilentlyDropsCoverage::test_falls_through_to_its_own_override_check_and_still_fires` returns `None` there instead of a `VIRTUAL_METHOD_ADDED` `Change` (the base signature also lacks the `old_funcs`/`new_funcs` parameters this fix adds, so the new test cannot even be run unmodified against base — its assertion is what pins the *fixed* behavior).
- Negative control: `TestEvidencedDifferenceStillDefersAsBefore` and `TestEqualArraysBlindSpotUnaffected` pin that a genuinely evidenced growth still defers cleanly (no duplicate finding) and that the pre-existing, primary blind spot (both sides never capturing a vtable at all) is completely unaffected by the new evidence check.
- Public-surface test: yes — `virtual_method_addition` is exercised directly (the real detector function, not a mock), and the existing `tests/test_kde_compat_detectors.py`/`tests/test_vtable_severity.py` suites exercise the same code path end-to-end via `compare()`, all still passing.
- Axes covered: (1) unevidenced difference with an inherited-override fallthrough (`test_an_inherited_override_is_still_recognized_in_this_shape`, proving the restructuring only changed *whether* the override check runs, not what it decides), (2) evidenced difference (still defers), (3) `vtable_facts_reliable=False` (mirrors `diff_types_vtable`'s own separate decline reason), (4) the pre-existing equal-arrays blind spot (untouched).
- General invariant: both detectors must reach the *same* evidenced/not-evidenced verdict for a given `(t_old, t_new, old_funcs, new_funcs)` — stated as one shared function (`compare.vtable_evidence.vtable_transition_is_evidenced`) both now call, rather than two independently-maintained copies of the same heuristic. `test_the_precondition_actually_holds` in each test class pins the predicate's own verdict directly (not inferred from `virtual_method_addition`'s behavior alone) against the identical oracle `diff_types_vtable._diff_type_vtable` itself now calls, so the two can't independently drift again.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_virtual_method_addition_vtable_evidence.py`)
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — n/a (internal detector-coupling fix, no CLI/API/report surface change)
- [x] `pre-commit run --all-files`-equivalent passes locally (`mypy abicheck/` clean on 632 files, `ruff check`/`ruff format --check` clean, `scripts/check_architecture.py` 0 errors, `scripts/check_ai_readiness.py` 0 errors including `import-cycle-growth`)
- [x] No new `mypy` or `ruff` errors introduced

## Testing

- `mypy abicheck/` — clean (632 source files)
- `ruff check` / `ruff format --check` — clean
- `python scripts/check_architecture.py` — 0 errors
- `python scripts/check_ai_readiness.py` — 0 errors, 137 warnings (unchanged baseline)
- `pytest tests/ -k "vtable or virtual or diff_types or diff_symbols or diff_cxx or compare" -m "not integration and not libabigail and not abicc and not slow and not golden"` — 2652 passed, 1 skipped
- Broader fast-suite spot check — 569+ passed with only one pre-existing, unrelated environmental failure (missing `zstd` on this runner), confirmed present identically on the unmodified base branch

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014gCsQbZ6QhdTii8XxAKsYg)_