### PR TITLE
feat(compare): stored/stored BundleFacts comparison (CLI cleanup phase two, PR I)

### DIFF
--- a/abicheck/bundle_facts.py
+++ b/abicheck/bundle_facts.py
@@ -52,6 +52,7 @@ from .storage.bundle_facts_validation import (
     validate_bundle_archive_artifact_type,
     validated_alias_map,
     validated_filename_map,
+    validated_variant_fingerprint,
 )
 
 if TYPE_CHECKING:
@@ -786,9 +787,7 @@ def read_bundle_facts_archive(
             instantiation_manifest = manifest_from_dict(_load_blob_json(raw_manifest, "manifest_blob"))
         return BundleFacts(
             schema_version=bundle_facts_schema_version,
-            variant_fingerprint=str(
-                manifest.get("variant_fingerprint", DEFAULT_VARIANT_FINGERPRINT)
-            ),
+            variant_fingerprint=validated_variant_fingerprint(manifest.get("variant_fingerprint", DEFAULT_VARIANT_FINGERPRINT)),
             per_library_snapshots=per_library_snapshots,
             manifest=instantiation_manifest,
             filesystem_aliases=validated_alias_map(

--- a/abicheck/bundle_facts.py
+++ b/abicheck/bundle_facts.py
@@ -259,6 +259,7 @@ def compare_bundle_from_facts(
     policy: str = "strict_abi",
     policy_file: Any = None,
     new_signature_evidence: dict[str, Any] | None = None,
+    old_signature_evidence: dict[str, Any] | None = None,
 ) -> BundleDiffResult:
     """Bundle-level comparison with the *old* side loaded from a stored
     :class:`BundleFacts` instead of live ``.so`` files (G38 Phase 2).
@@ -275,18 +276,17 @@ def compare_bundle_from_facts(
     ``compare_bundle()``'s own ``manifest=`` parameter); otherwise the
     manifest captured in *old_facts* is reused.
 
-    *new_signature_evidence* (G38 stabilization Phase 12), when given and
-    non-empty, is the NEW side's bundle-canonical-key -> ``AbiSnapshot``
-    map for ``find_unverified_signature_findings`` -- the OLD side's own
-    map is always *old_facts.per_library_snapshots* itself. Omitted (the
-    default): the Phase 4 gate does not run, matching every pre-Phase-12
-    caller -- there is not yet a CLI producer for a live NEW-side evidence
-    map here (G38 Phase 13 is separate, not-yet-implemented).
+    *new_signature_evidence* (G38 Phase 12) is the NEW side's bundle-
+    canonical-key -> ``AbiSnapshot`` map for ``find_unverified_signature_
+    findings``. *old_signature_evidence* (Codex review, PR #1060, round 6)
+    overrides the OLD side's map, falling back to *old_facts.per_library_
+    snapshots* -- needed by a depth-projecting caller. Omitted: no gate.
     """
     from .bundle_analysis import analyze_bundle
 
     old_snapshot = bundle_snapshot_from_facts(old_facts)
     effective_manifest = manifest if manifest is not None else old_facts.manifest
+    effective_old_evidence = old_facts.per_library_snapshots if old_signature_evidence is None else old_signature_evidence
     return analyze_bundle(
         old_snapshot,
         new_snapshot,
@@ -296,7 +296,7 @@ def compare_bundle_from_facts(
         cohorts=cohorts,
         policy=policy,
         policy_file=policy_file,
-        old_signature_evidence=old_facts.per_library_snapshots,
+        old_signature_evidence=effective_old_evidence,
         new_signature_evidence=new_signature_evidence,
     )
 

--- a/abicheck/bundle_facts_serialization.py
+++ b/abicheck/bundle_facts_serialization.py
@@ -303,7 +303,7 @@ def bundle_facts_from_dict(d: dict[str, Any]) -> BundleFacts:
     return BundleFacts(
         schema_version=schema_version,
         variant_fingerprint=validated_variant_fingerprint(
-            d.get("variant_fingerprint"), default=DEFAULT_VARIANT_FINGERPRINT
+            d.get("variant_fingerprint", DEFAULT_VARIANT_FINGERPRINT)
         ),
         per_library_snapshots={
             name: snapshot_from_dict(sd) for name, sd in raw_snapshots.items()

--- a/abicheck/bundle_facts_serialization.py
+++ b/abicheck/bundle_facts_serialization.py
@@ -202,6 +202,7 @@ def bundle_facts_from_dict(d: dict[str, Any]) -> BundleFacts:
     from .storage.bundle_facts_validation import (
         validated_alias_map,
         validated_filename_map,
+        validated_variant_fingerprint,
     )
 
     schema_version = int(d.get("schema_version", BUNDLE_FACTS_SCHEMA_VERSION))
@@ -301,8 +302,8 @@ def bundle_facts_from_dict(d: dict[str, Any]) -> BundleFacts:
     raw_manifest = d.get("manifest")
     return BundleFacts(
         schema_version=schema_version,
-        variant_fingerprint=str(
-            d.get("variant_fingerprint", DEFAULT_VARIANT_FINGERPRINT)
+        variant_fingerprint=validated_variant_fingerprint(
+            d.get("variant_fingerprint"), default=DEFAULT_VARIANT_FINGERPRINT
         ),
         per_library_snapshots={
             name: snapshot_from_dict(sd) for name, sd in raw_snapshots.items()

--- a/abicheck/bundle_side_input.py
+++ b/abicheck/bundle_side_input.py
@@ -64,8 +64,22 @@ in-flight comparison needs), and calls
 ``bundle_facts.compare_bundle_from_facts()`` with that real
 ``new_signature_evidence`` populated -- closing the literal gap Phase 12's own
 "Known gap" note named: "no end-to-end CLI invocation" exercising the Phase 4
-parity guarantee. It is reachable from a real Python caller today; it is not
-reachable from ``abicheck compare ...`` yet.
+parity guarantee. Reachable from ``abicheck compare ...`` since CLI cleanup
+phase two, PR I (``frontends/cli/commands/compare_bundle_facts.py``), which
+routes to it whenever OLD_INPUT classifies as a stored ``BundleFacts``
+document and NEW_INPUT does not.
+
+:func:`compare_stored_bundle_facts_pair` is PR I's stored/stored sibling --
+both sides already resolved, persisted ``BundleFacts`` documents, so it
+reads no binaries and parses no header AST on either side at all: a pure
+in-memory per-library diff plus the same shared
+``bundle_facts.compare_bundle_from_facts()`` bundle-level call. Also
+reachable from ``abicheck compare ...`` (the same dispatch module, once
+NEW_INPUT classifies as stored too). The remaining operand shape --
+live/stored (OLD_INPUT live, NEW_INPUT a stored document) -- has no driver
+yet and is rejected outright by ``compare_bundle_operand_dispatch.py``; see
+that module's own docstring and PR I's tracking in
+``docs/contribute/plans/cli-cleanup-phase-two.md``.
 """
 
 from __future__ import annotations
@@ -480,4 +494,100 @@ def compare_release_against_bundle_facts(
         policy=policy,
         policy_file=policy_file,
         new_signature_evidence=dict(new_signature_evidence),
+    )
+
+
+def compare_stored_bundle_facts_pair(
+    old_facts_path: Path,
+    new_facts_path: Path,
+    *,
+    manifest_path: Path | None = None,
+    system_providers: list[str] | None = None,
+    cohorts: list[str] | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+    suppress: SuppressionList | None = None,
+    old_max_json_object_nodes: int | None = None,
+    new_max_json_object_nodes: int | None = None,
+) -> BundleDiffResult:
+    """End-to-end driver: two stored ``BundleFacts`` documents compared
+    against each other -- the stored/stored operand shape (CLI cleanup
+    phase two, PR I).
+
+    No binaries are read and no header AST is parsed on either side --
+    both sides are already resolved, per-library ``AbiSnapshot``s, so this
+    driver is a pure in-memory diff: matched-key intersection, then one
+    ``service.compare_snapshots()`` call per matched library, exactly the
+    same Tier-2 chokepoint every other comparison entry point in this
+    codebase uses (never ``checker.compare`` directly). Mirrors
+    :func:`compare_release_against_bundle_facts`'s own final step (a direct
+    call into :func:`~abicheck.bundle_facts.compare_bundle_from_facts`,
+    never :func:`compare_bundle_sides`/:func:`resolve_bundle_side`) for the
+    identical reason documented there: each stored document is already
+    loaded in memory for the per-library matching loop below, and routing
+    through ``StoredBundleFactsInput``/``resolve_bundle_side`` instead would
+    reload and re-parse both documents from disk a second time for no
+    benefit.
+
+    A library present in only one of the two documents' own
+    ``per_library_snapshots`` is simply not diffed, the same "not itself a
+    release fan-out's ``--fail-on-removed-library``/added-library
+    accounting" narrowing :func:`compare_release_against_bundle_facts`'s
+    own docstring already states for its NEW-live side -- neither stored
+    side can name a *set* of on-disk libraries to fail on the absence of,
+    both are already a fixed, resolved snapshot.
+
+    *old_max_json_object_nodes*/*new_max_json_object_nodes*, each when
+    given, override ``bundle_facts.DEFAULT_MAX_JSON_OBJECT_NODES`` for that
+    side's own load -- forwarded to ``serialization.load_bundle_facts``,
+    mirroring :class:`StoredBundleFactsInput`'s own field of the same
+    purpose. ``None`` (the default) uses the library default for that side.
+
+    *manifest_path*/*system_providers*/*cohorts*/*policy*/*policy_file*/
+    *suppress* all mean exactly what they mean on
+    :func:`compare_release_against_bundle_facts` -- see that function's own
+    docstring for the full account of each. *policy*/*policy_file* are
+    forwarded to every per-library ``service.compare_snapshots()`` call
+    *and* to the final ``compare_bundle_from_facts()`` call, so
+    ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
+    every per-library diff, not just the live-NEW-side driver's own case.
+    """
+    from . import service
+    from .bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
+    from .bundle_manifest import load_manifest
+    from .serialization import load_bundle_facts
+
+    old_facts = load_bundle_facts(
+        old_facts_path, max_json_object_nodes=old_max_json_object_nodes
+    )
+    new_facts = load_bundle_facts(
+        new_facts_path, max_json_object_nodes=new_max_json_object_nodes
+    )
+
+    matched_keys = sorted(
+        set(old_facts.per_library_snapshots) & set(new_facts.per_library_snapshots)
+    )
+    per_library_results: list[DiffResult] = []
+    for key in matched_keys:
+        diff = service.compare_snapshots(
+            old_facts.per_library_snapshots[key],
+            new_facts.per_library_snapshots[key],
+            suppress,
+            policy=policy,
+            policy_file=policy_file,
+        )
+        per_library_results.append(diff)
+
+    manifest = load_manifest(manifest_path) if manifest_path is not None else None
+    new_bundle_snapshot = bundle_snapshot_from_facts(new_facts)
+    return compare_bundle_from_facts(
+        old_facts,
+        new_bundle_snapshot,
+        per_library_results,
+        manifest=manifest,
+        system_providers=system_providers,
+        cohorts=cohorts,
+        policy=policy,
+        policy_file=policy_file,
+        new_signature_evidence=dict(new_facts.per_library_snapshots),
     )

--- a/abicheck/bundle_side_input.py
+++ b/abicheck/bundle_side_input.py
@@ -69,17 +69,22 @@ phase two, PR I (``frontends/cli/commands/compare_bundle_facts.py``), which
 routes to it whenever OLD_INPUT classifies as a stored ``BundleFacts``
 document and NEW_INPUT does not.
 
-:func:`compare_stored_bundle_facts_pair` is PR I's stored/stored sibling --
-both sides already resolved, persisted ``BundleFacts`` documents, so it
-reads no binaries and parses no header AST on either side at all: a pure
-in-memory per-library diff plus the same shared
+:func:`~abicheck.workflows.bundle_stored_pair_compare.
+compare_stored_bundle_facts_pair` is PR I's stored/stored sibling -- both
+sides already resolved, persisted ``BundleFacts`` documents, so it reads no
+binaries and parses no header AST on either side at all: a pure in-memory
+per-library diff plus the same shared
 ``bundle_facts.compare_bundle_from_facts()`` bundle-level call. Also
-reachable from ``abicheck compare ...`` (the same dispatch module, once
-NEW_INPUT classifies as stored too). The remaining operand shape --
-live/stored (OLD_INPUT live, NEW_INPUT a stored document) -- has no driver
-yet and is rejected outright by ``compare_bundle_operand_dispatch.py``; see
-that module's own docstring and PR I's tracking in
-``docs/contribute/plans/cli-cleanup-phase-two.md``.
+reachable from ``abicheck compare ...`` (via ``compare_bundle_facts.py``,
+once NEW_INPUT classifies as stored too). Lives in the real
+``abicheck/workflows/`` package rather than here -- it coordinates a
+compare workflow rather than sharing this module's own "one live/stored
+resolution primitive" scope, so it doesn't extend this file's own
+grandfathered-legacy footprint (Codex review). The remaining operand
+shape -- live/stored (OLD_INPUT live, NEW_INPUT a stored document) -- has
+no driver yet and is rejected outright by
+``compare_bundle_operand_dispatch.py``; see that module's own docstring
+and PR I's tracking in ``docs/contribute/plans/cli-cleanup-phase-two.md``.
 """
 
 from __future__ import annotations
@@ -494,100 +499,4 @@ def compare_release_against_bundle_facts(
         policy=policy,
         policy_file=policy_file,
         new_signature_evidence=dict(new_signature_evidence),
-    )
-
-
-def compare_stored_bundle_facts_pair(
-    old_facts_path: Path,
-    new_facts_path: Path,
-    *,
-    manifest_path: Path | None = None,
-    system_providers: list[str] | None = None,
-    cohorts: list[str] | None = None,
-    policy: str = "strict_abi",
-    policy_file: PolicyFile | None = None,
-    suppress: SuppressionList | None = None,
-    old_max_json_object_nodes: int | None = None,
-    new_max_json_object_nodes: int | None = None,
-) -> BundleDiffResult:
-    """End-to-end driver: two stored ``BundleFacts`` documents compared
-    against each other -- the stored/stored operand shape (CLI cleanup
-    phase two, PR I).
-
-    No binaries are read and no header AST is parsed on either side --
-    both sides are already resolved, per-library ``AbiSnapshot``s, so this
-    driver is a pure in-memory diff: matched-key intersection, then one
-    ``service.compare_snapshots()`` call per matched library, exactly the
-    same Tier-2 chokepoint every other comparison entry point in this
-    codebase uses (never ``checker.compare`` directly). Mirrors
-    :func:`compare_release_against_bundle_facts`'s own final step (a direct
-    call into :func:`~abicheck.bundle_facts.compare_bundle_from_facts`,
-    never :func:`compare_bundle_sides`/:func:`resolve_bundle_side`) for the
-    identical reason documented there: each stored document is already
-    loaded in memory for the per-library matching loop below, and routing
-    through ``StoredBundleFactsInput``/``resolve_bundle_side`` instead would
-    reload and re-parse both documents from disk a second time for no
-    benefit.
-
-    A library present in only one of the two documents' own
-    ``per_library_snapshots`` is simply not diffed, the same "not itself a
-    release fan-out's ``--fail-on-removed-library``/added-library
-    accounting" narrowing :func:`compare_release_against_bundle_facts`'s
-    own docstring already states for its NEW-live side -- neither stored
-    side can name a *set* of on-disk libraries to fail on the absence of,
-    both are already a fixed, resolved snapshot.
-
-    *old_max_json_object_nodes*/*new_max_json_object_nodes*, each when
-    given, override ``bundle_facts.DEFAULT_MAX_JSON_OBJECT_NODES`` for that
-    side's own load -- forwarded to ``serialization.load_bundle_facts``,
-    mirroring :class:`StoredBundleFactsInput`'s own field of the same
-    purpose. ``None`` (the default) uses the library default for that side.
-
-    *manifest_path*/*system_providers*/*cohorts*/*policy*/*policy_file*/
-    *suppress* all mean exactly what they mean on
-    :func:`compare_release_against_bundle_facts` -- see that function's own
-    docstring for the full account of each. *policy*/*policy_file* are
-    forwarded to every per-library ``service.compare_snapshots()`` call
-    *and* to the final ``compare_bundle_from_facts()`` call, so
-    ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
-    every per-library diff, not just the live-NEW-side driver's own case.
-    """
-    from . import service
-    from .bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
-    from .bundle_manifest import load_manifest
-    from .serialization import load_bundle_facts
-
-    old_facts = load_bundle_facts(
-        old_facts_path, max_json_object_nodes=old_max_json_object_nodes
-    )
-    new_facts = load_bundle_facts(
-        new_facts_path, max_json_object_nodes=new_max_json_object_nodes
-    )
-
-    matched_keys = sorted(
-        set(old_facts.per_library_snapshots) & set(new_facts.per_library_snapshots)
-    )
-    per_library_results: list[DiffResult] = []
-    for key in matched_keys:
-        diff = service.compare_snapshots(
-            old_facts.per_library_snapshots[key],
-            new_facts.per_library_snapshots[key],
-            suppress,
-            policy=policy,
-            policy_file=policy_file,
-        )
-        per_library_results.append(diff)
-
-    manifest = load_manifest(manifest_path) if manifest_path is not None else None
-    new_bundle_snapshot = bundle_snapshot_from_facts(new_facts)
-    return compare_bundle_from_facts(
-        old_facts,
-        new_bundle_snapshot,
-        per_library_results,
-        manifest=manifest,
-        system_providers=system_providers,
-        cohorts=cohorts,
-        policy=policy,
-        policy_file=policy_file,
-        new_signature_evidence=dict(new_facts.per_library_snapshots),
     )

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1402,21 +1402,38 @@ from .frontends.cli.options.release import (  # noqa: E402
 
 
 def _profile_targets_set_input(kwargs: dict[str, object]) -> bool:
-    """True when the ``compare`` operands are a directory/package (set) input.
+    """True when the ``compare`` operands are a directory/package (set)
+    input, *or* either operand is itself a stored ``BundleFacts`` document
+    (Codex review, PR #1060, round 13).
 
     Mirrors the ADR-037 D7 dispatch (:func:`cli_resolve.classify_compare_operand`)
     so profile handling matches how ``run_compare`` will actually route the
-    comparison, without duplicating the classification rules.
+    comparison, without duplicating the classification rules. A stored
+    ``BundleFacts`` document is not itself a directory/package operand --
+    ``classify_compare_operand`` reports it as an ordinary ``"file"`` -- but
+    it represents a whole multi-library bundle exactly the same way a
+    directory/package does, and is dispatched to the identical multi-
+    library ``compare_bundle_facts`` engine (``workflows.bundle_compare_
+    operand``), never the single-pair path a profile's knobs (``--depth``,
+    ``--exit-code-scheme``, the ``review`` format) were designed for.
+    Without this, ``--profile quick`` on a stored/stored pair silently
+    injected e.g. ``depth="binary"`` into every library's evidence depth
+    instead of being rejected the same way a directory/package operand
+    already is.
     """
     from .cli_resolve import classify_compare_operand
+    from .workflows.bundle_compare_operand import looks_like_stored_bundle_facts
 
     kinds: set[str] = set()
     for key in ("old_input", "new_input"):
         operand = kwargs.get(key)
         if operand is None:
             continue
+        path = Path(str(operand))
+        if looks_like_stored_bundle_facts(path):
+            return True
         try:
-            kinds.add(classify_compare_operand(Path(str(operand))))
+            kinds.add(classify_compare_operand(path))
         except Exception:  # noqa: BLE001 - classification is best-effort here
             # Logged rather than swallowed silently (bandit B112): an operand
             # this classifier cannot read contributes no kind, and the real
@@ -1462,7 +1479,8 @@ def apply_compare_profile(ctx: object, kwargs: dict[str, object]) -> None:
     if _profile_targets_set_input(kwargs):
         raise click.UsageError(
             f"--profile {name} is not supported for directory/package (release) "
-            "comparisons: profiles bundle single-pair-only knobs (--depth, "
+            "comparisons, or when either operand is a stored BundleFacts "
+            "document: profiles bundle single-pair-only knobs (--depth, "
             "--exit-code-scheme, the 'review' format). Configure release defaults "
             "in .abicheck.yml (the fan-out reads format/severity/scheme from it), "
             "or compare the libraries individually to use a profile."

--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -741,15 +741,16 @@ def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:
     # CLI cleanup phase two, PR I: OLD_INPUT/NEW_INPUT are classified
     # automatically for bundle-facts routing, replacing the removed
     # --old-bundle-facts flag -- see compare_bundle_operand_dispatch.py's
-    # own docstring (a stored NEW_INPUT is rejected there; OLD_INPUT
-    # classified as stored short-circuits the ordinary live-binary/
-    # directory dispatch entirely, never reaching run_compare/
-    # _dispatch_release_compare -- see compare_bundle_facts.py's own
-    # module docstring for why that lives here rather than as a branch
-    # inside cli_compare_helpers.run_compare itself).
+    # own docstring (stored NEW_INPUT + live OLD_INPUT is rejected there;
+    # OLD_INPUT classified as stored -- alone, or with NEW_INPUT stored
+    # too -- short-circuits the ordinary live-binary/directory dispatch
+    # entirely, never reaching run_compare/_dispatch_release_compare -- see
+    # compare_bundle_facts.py's own module docstring for why that lives
+    # here rather than as a branch inside cli_compare_helpers.run_compare).
     from .compare_bundle_operand_dispatch import resolve_bundle_compare_dispatch
 
-    if resolve_bundle_compare_dispatch(kwargs["old_input"], kwargs["new_input"]):
+    _bundle_operands = resolve_bundle_compare_dispatch(kwargs["old_input"], kwargs["new_input"])
+    if _bundle_operands.old_is_stored:
         from ....cli_helpers_compare import discover_project_config
         from ....cli_options import resolve_compile_context
         from .compare_bundle_facts import (
@@ -792,7 +793,7 @@ def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:
         # re-derivation from raw kwargs silently drop them.
         kwargs["includes"] = tuple(_merged_includes)
         kwargs["new_includes_only"] = ()
-        dispatch_bundle_facts(compile_context=_compile_context, **kwargs)
+        dispatch_bundle_facts(compile_context=_compile_context, new_is_stored=_bundle_operands.new_is_stored, **kwargs)
         return
     kwargs.pop("max_json_object_nodes", None)
     reject_bundle_facts_manifest_without_old_bundle_facts(kwargs)

--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -751,48 +751,18 @@ def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:
 
     _bundle_operands = resolve_bundle_compare_dispatch(kwargs["old_input"], kwargs["new_input"])
     if _bundle_operands.old_is_stored:
-        from ....cli_helpers_compare import discover_project_config
-        from ....cli_options import resolve_compile_context
         from .compare_bundle_facts import (
-            _resolve_new_side_headers_includes,
             dispatch as dispatch_bundle_facts,
+            resolve_dispatch_compile_context,
         )
 
         # Codex review: mirrors run_compare's own explicit-vs-default --lang
         # detection -- otherwise indistinguishable from Click's own default.
         _lang_src = ctx.get_parameter_source("lang")
         kwargs["lang_explicit"] = _lang_src == click.core.ParameterSource.COMMANDLINE
-        _headers, _includes = _resolve_new_side_headers_includes(kwargs)
-        _header_backend = kwargs.get("new_header_backend") or kwargs.get("header_backend") or "auto"
-        # Codex review: mirror run_compare's own cwd-upward cfg_path fallback
-        # (_resolve_compare_config) -- resolve_compile_context alone never
-        # auto-discovers without a --sources tree. Overwriting kwargs
-        # ["config"] means dispatch()'s own config check (cli_options is
-        # kept out of that sibling module's own imports -- see its
-        # docstring) covers an auto-discovered .abicheck.yml too.
-        _cfg_path = kwargs.get("config") or discover_project_config()
-        kwargs["config"] = _cfg_path
-        _compile_context, _merged_includes = resolve_compile_context(
-            ctx,
-            sysroot=kwargs.get("sysroot"),
-            nostdinc=bool(kwargs.get("nostdinc", False)),
-            header_backend=_header_backend,
-            includes=tuple(_includes),
-            build_config=_cfg_path,
-            frontend_context=kwargs.get("frontend_context", "host"),
-            compiler_path=kwargs.get("compiler_path"),
-            compiler_prefix=kwargs.get("compiler_prefix"),
-            compiler_option_tokens=tuple(kwargs.get("compiler_option_tokens") or ()),
+        _compile_context = resolve_dispatch_compile_context(
+            ctx, kwargs, new_is_stored=_bundle_operands.new_is_stored
         )
-        # Forward the *merged* include list (Codex review), not the raw
-        # kwargs `resolve_compile_context` was given -- when `.abicheck.yml`
-        # supplies `compile.include_dirs`, `_merged_includes` is `_includes`
-        # extended with those config-derived roots, and the side-scoped
-        # `new_includes_only` override (already folded into `_includes`
-        # above) would otherwise make `dispatch()`'s own independent
-        # re-derivation from raw kwargs silently drop them.
-        kwargs["includes"] = tuple(_merged_includes)
-        kwargs["new_includes_only"] = ()
         dispatch_bundle_facts(compile_context=_compile_context, new_is_stored=_bundle_operands.new_is_stored, **kwargs)
         return
     kwargs.pop("max_json_object_nodes", None)

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -116,13 +116,16 @@ def resolve_dispatch_compile_context(ctx: click.Context, kwargs: dict[str, Any],
     invocation run from a project directory with a compile: block (Codex
     review, PR #1060). ``kwargs["config"]`` is still resolved either way,
     since the config-block rejection checks in that same module still
-    apply. An *explicit* ``--config`` whose own ``compile:`` block declares
-    real settings is
-    rejected too, via ``compare_bundle_facts_rejections.
-    reject_explicit_compile_config_for_stored_pair`` (Codex review, PR
-    #1060, fresh evidence) -- unlike an auto-discovered ambient one.
-    """
+    apply. An *explicit* ``--config`` with a real ``compile:`` block, and
+    the expose_value=False ``--allow-ast-frontend-fallback``/
+    ``--allow-unsupported-castxml`` flags, are rejected too (that module's
+    ``reject_explicit_compile_config_for_stored_pair``/
+    ``reject_ast_override_flags_for_stored_pair``)."""
     from ....cli_helpers_compare import discover_project_config
+    from .compare_bundle_facts_rejections import (
+        reject_ast_override_flags_for_stored_pair,
+        reject_explicit_compile_config_for_stored_pair,
+    )
 
     # Codex review: mirror run_compare's own cwd-upward cfg_path fallback --
     # resolve_compile_context alone never auto-discovers without a
@@ -131,11 +134,8 @@ def resolve_dispatch_compile_context(ctx: click.Context, kwargs: dict[str, Any],
     kwargs["config"] = kwargs.get("config") or discover_project_config()
     if new_is_stored:
         if _config_explicit and kwargs["config"] is not None:
-            from .compare_bundle_facts_rejections import (
-                reject_explicit_compile_config_for_stored_pair,
-            )
-
             reject_explicit_compile_config_for_stored_pair(kwargs["config"])
+        reject_ast_override_flags_for_stored_pair(ctx)
         return None
 
     from ....cli_options import resolve_compile_context

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -346,8 +346,8 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
         # comments explain each of these four exception types).
         except (SnapshotError, TypeError, ValueError, OSError) as exc:
             raise click.ClickException(str(exc)) from exc
-        except (ProfileMismatchError, ScopeMismatchError) as exc:
-            exit_bundle_facts_not_comparable(exc)  # not caught above (round 12)
+        except (ProfileMismatchError, ScopeMismatchError) as exc:  # round 12/14
+            exit_bundle_facts_not_comparable(exc, fmt=fmt, output=kwargs.get("output"))
     else:
         # Codex review: NEW_INPUT is documented ("a live release directory/
         # package") to accept a package archive (wheel/deb/rpm/tar), but
@@ -512,8 +512,8 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
                 # click.Path(exists=True) argument, not dir_okay=False -- turns out
                 # to be a directory or otherwise unreadable file.
                 raise click.ClickException(str(exc)) from exc
-            except (ProfileMismatchError, ScopeMismatchError) as exc:
-                exit_bundle_facts_not_comparable(exc)  # round 12, see above
+            except (ProfileMismatchError, ScopeMismatchError) as exc:  # round 12/14
+                exit_bundle_facts_not_comparable(exc, fmt=fmt, output=kwargs.get("output"))
         finally:
             # Mirrors the live release fan-out's own --keep-extracted handling
             # (_cleanup_temp_dirs): remove the package-extraction tempdir unless

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -108,17 +108,16 @@ def resolve_dispatch_compile_context(ctx: click.Context, kwargs: dict[str, Any],
 
     When *new_is_stored* (CLI cleanup phase two, PR I's stored/stored
     shape), this skips ``resolve_compile_context`` entirely and returns
-    ``None``: neither side does any header-frontend extraction, so there is
-    no compile context to resolve, and running it anyway would merge
-    ``.abicheck.yml``'s own ``compile.include_dirs`` into
-    ``kwargs["includes"]`` -- which the stored/stored NEW-side rejections
-    (``compare_bundle_facts_rejections.py``) would then wrongly refuse as
-    an *explicit* ``--include``, breaking every stored/stored invocation
-    run from an ordinary project directory that happens to declare a
-    compile: block (Codex review, PR #1060). ``kwargs["config"]`` is still
-    resolved either way, since the config-block rejection checks in that
-    same module still apply to a stored/stored comparison. An *explicit*
-    ``--config`` whose own ``compile:`` block declares real settings is
+    ``None``: neither side does any header-frontend extraction, so running
+    it anyway would merge ``.abicheck.yml``'s own ``compile.include_dirs``
+    into ``kwargs["includes"]`` -- which the stored/stored NEW-side
+    rejections (``compare_bundle_facts_rejections.py``) would then wrongly
+    refuse as an *explicit* ``--include``, breaking every stored/stored
+    invocation run from a project directory with a compile: block (Codex
+    review, PR #1060). ``kwargs["config"]`` is still resolved either way,
+    since the config-block rejection checks in that same module still
+    apply. An *explicit* ``--config`` whose own ``compile:`` block declares
+    real settings is
     rejected too, via ``compare_bundle_facts_rejections.
     reject_explicit_compile_config_for_stored_pair`` (Codex review, PR
     #1060, fresh evidence) -- unlike an auto-discovered ambient one.
@@ -341,6 +340,7 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
                 suppress=suppression,
                 old_max_json_object_nodes=kwargs.get("max_json_object_nodes"),
                 new_max_json_object_nodes=kwargs.get("max_json_object_nodes"),
+                depth=kwargs.get("depth"),
             )
         # Same CLI-boundary translation the stored/live branch below applies
         # to compare_release_against_bundle_facts() -- see its own comments

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -153,12 +153,12 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
 
     *new_is_stored* (CLI cleanup phase two, PR I), when true, means
     NEW_INPUT classified as a stored BundleFacts document too -- both sides
-    are then diffed by
-    ``bundle_side_input.compare_stored_bundle_facts_pair`` (a pure in-memory
-    per-library diff, no binaries read, no header AST parsed on either
-    side) instead of ``compare_release_against_bundle_facts`` (which
-    extracts and dumps NEW_INPUT as a live directory/package). The default
-    ``False`` is the original stored/live shape, unchanged.
+    are then diffed by ``workflows.bundle_stored_pair_compare.
+    compare_stored_bundle_facts_pair`` (a pure in-memory per-library diff,
+    no binaries read, no header AST parsed on either side) instead of
+    ``compare_release_against_bundle_facts`` (which extracts and dumps
+    NEW_INPUT as a live directory/package). The default ``False`` is the
+    original stored/live shape, unchanged.
 
     *kwargs* is ``compare_cmd``'s already-parsed, already-``normalize_sided_
     options``-processed option dict -- the same dict that would otherwise be
@@ -197,9 +197,17 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
         _bundle_side_input.compare_release_against_bundle_facts
     )
     # PR I: same importlib indirection as compare_release_against_bundle_
-    # facts above, and for the identical reason -- both live in
-    # bundle_side_input.py.
-    compare_stored_bundle_facts_pair = _bundle_side_input.compare_stored_bundle_facts_pair
+    # facts above, and for the identical reason -- workflows.bundle_stored_
+    # pair_compare also transitively imports `service` (Codex review moved
+    # the function itself out of bundle_side_input.py into this real
+    # workflows/ module, but the import-cycle-growth concern documented
+    # above is unrelated to which module hosts the function).
+    _bundle_stored_pair_compare = importlib.import_module(
+        "abicheck.workflows.bundle_stored_pair_compare"
+    )
+    compare_stored_bundle_facts_pair = (
+        _bundle_stored_pair_compare.compare_stored_bundle_facts_pair
+    )
     from ....cli_compare_release_helpers import _exit_compare_release
 
     # known_libraries_for_new_side lives in workflows/bundle_facts_library_

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -101,13 +101,10 @@ def _resolve_new_side_headers_includes(
     return headers, includes
 
 
-def resolve_dispatch_compile_context(
-    ctx: click.Context, kwargs: dict[str, Any], *, new_is_stored: bool
-) -> Any:
+def resolve_dispatch_compile_context(ctx: click.Context, kwargs: dict[str, Any], *, new_is_stored: bool) -> Any:
     """Resolve ``dispatch()``'s ``compile_context`` argument, mutating
-    *kwargs* the same way ``compare_cmd`` itself used to before delegating
-    here -- split out purely to keep ``compare.py`` under its own
-    architecture cap, not for any independent reason.
+    *kwargs* the same way ``compare_cmd`` used to before delegating here --
+    split out purely to keep ``compare.py`` under its architecture cap.
 
     When *new_is_stored* (CLI cleanup phase two, PR I's stored/stored
     shape), this skips ``resolve_compile_context`` entirely and returns
@@ -120,19 +117,26 @@ def resolve_dispatch_compile_context(
     run from an ordinary project directory that happens to declare a
     compile: block (Codex review, PR #1060). ``kwargs["config"]`` is still
     resolved either way, since the config-block rejection checks in that
-    same module (severity:/scope:/suppression:/... ) still apply to a
-    stored/stored comparison.
+    same module still apply to a stored/stored comparison. An *explicit*
+    ``--config`` whose own ``compile:`` block declares real settings is
+    rejected too, via ``compare_bundle_facts_rejections.
+    reject_explicit_compile_config_for_stored_pair`` (Codex review, PR
+    #1060, fresh evidence) -- unlike an auto-discovered ambient one.
     """
     from ....cli_helpers_compare import discover_project_config
 
-    # Codex review: mirror run_compare's own cwd-upward cfg_path fallback
-    # (_resolve_compare_config) -- resolve_compile_context alone never
-    # auto-discovers without a --sources tree. Overwriting kwargs["config"]
-    # means dispatch()'s own config check (cli_options is kept out of that
-    # sibling module's own imports -- see its docstring) covers an
-    # auto-discovered .abicheck.yml too.
+    # Codex review: mirror run_compare's own cwd-upward cfg_path fallback --
+    # resolve_compile_context alone never auto-discovers without a
+    # --sources tree.
+    _config_explicit = ctx.get_parameter_source("config") == click.core.ParameterSource.COMMANDLINE
     kwargs["config"] = kwargs.get("config") or discover_project_config()
     if new_is_stored:
+        if _config_explicit and kwargs["config"] is not None:
+            from .compare_bundle_facts_rejections import (
+                reject_explicit_compile_config_for_stored_pair,
+            )
+
+            reject_explicit_compile_config_for_stored_pair(kwargs["config"])
         return None
 
     from ....cli_options import resolve_compile_context
@@ -152,12 +156,9 @@ def resolve_dispatch_compile_context(
         compiler_option_tokens=tuple(kwargs.get("compiler_option_tokens") or ()),
     )
     # Forward the *merged* include list (Codex review), not the raw kwargs
-    # resolve_compile_context was given -- when .abicheck.yml supplies
-    # compile.include_dirs, merged_includes is _includes extended with
-    # those config-derived roots, and the side-scoped new_includes_only
-    # override (already folded into _includes above) would otherwise make
-    # dispatch()'s own independent re-derivation from raw kwargs silently
-    # drop them.
+    # resolve_compile_context was given -- .abicheck.yml's compile.
+    # include_dirs would otherwise be dropped by dispatch()'s own
+    # independent re-derivation from raw kwargs.
     kwargs["includes"] = tuple(merged_includes)
     kwargs["new_includes_only"] = ()
     return compile_context

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -101,6 +101,68 @@ def _resolve_new_side_headers_includes(
     return headers, includes
 
 
+def resolve_dispatch_compile_context(
+    ctx: click.Context, kwargs: dict[str, Any], *, new_is_stored: bool
+) -> Any:
+    """Resolve ``dispatch()``'s ``compile_context`` argument, mutating
+    *kwargs* the same way ``compare_cmd`` itself used to before delegating
+    here -- split out purely to keep ``compare.py`` under its own
+    architecture cap, not for any independent reason.
+
+    When *new_is_stored* (CLI cleanup phase two, PR I's stored/stored
+    shape), this skips ``resolve_compile_context`` entirely and returns
+    ``None``: neither side does any header-frontend extraction, so there is
+    no compile context to resolve, and running it anyway would merge
+    ``.abicheck.yml``'s own ``compile.include_dirs`` into
+    ``kwargs["includes"]`` -- which the stored/stored NEW-side rejections
+    (``compare_bundle_facts_rejections.py``) would then wrongly refuse as
+    an *explicit* ``--include``, breaking every stored/stored invocation
+    run from an ordinary project directory that happens to declare a
+    compile: block (Codex review, PR #1060). ``kwargs["config"]`` is still
+    resolved either way, since the config-block rejection checks in that
+    same module (severity:/scope:/suppression:/... ) still apply to a
+    stored/stored comparison.
+    """
+    from ....cli_helpers_compare import discover_project_config
+
+    # Codex review: mirror run_compare's own cwd-upward cfg_path fallback
+    # (_resolve_compare_config) -- resolve_compile_context alone never
+    # auto-discovers without a --sources tree. Overwriting kwargs["config"]
+    # means dispatch()'s own config check (cli_options is kept out of that
+    # sibling module's own imports -- see its docstring) covers an
+    # auto-discovered .abicheck.yml too.
+    kwargs["config"] = kwargs.get("config") or discover_project_config()
+    if new_is_stored:
+        return None
+
+    from ....cli_options import resolve_compile_context
+
+    _headers, _includes = _resolve_new_side_headers_includes(kwargs)
+    header_backend = kwargs.get("new_header_backend") or kwargs.get("header_backend") or "auto"
+    compile_context, merged_includes = resolve_compile_context(
+        ctx,
+        sysroot=kwargs.get("sysroot"),
+        nostdinc=bool(kwargs.get("nostdinc", False)),
+        header_backend=header_backend,
+        includes=tuple(_includes),
+        build_config=kwargs["config"],
+        frontend_context=kwargs.get("frontend_context", "host"),
+        compiler_path=kwargs.get("compiler_path"),
+        compiler_prefix=kwargs.get("compiler_prefix"),
+        compiler_option_tokens=tuple(kwargs.get("compiler_option_tokens") or ()),
+    )
+    # Forward the *merged* include list (Codex review), not the raw kwargs
+    # resolve_compile_context was given -- when .abicheck.yml supplies
+    # compile.include_dirs, merged_includes is _includes extended with
+    # those config-derived roots, and the side-scoped new_includes_only
+    # override (already folded into _includes above) would otherwise make
+    # dispatch()'s own independent re-derivation from raw kwargs silently
+    # drop them.
+    kwargs["includes"] = tuple(merged_includes)
+    kwargs["new_includes_only"] = ()
+    return compile_context
+
+
 def _load_library_overrides(
     manifest_path: Path,
     *,

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -147,9 +147,18 @@ def _load_library_overrides(
     return overrides.headers, overrides.includes, overrides.compile
 
 
-def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
-    """Handle a ``compare OLD_FACTS NEW_DIR`` invocation where OLD_FACTS
+def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any) -> None:
+    """Handle a ``compare OLD_FACTS NEW_INPUT`` invocation where OLD_FACTS
     classified as a stored BundleFacts document.
+
+    *new_is_stored* (CLI cleanup phase two, PR I), when true, means
+    NEW_INPUT classified as a stored BundleFacts document too -- both sides
+    are then diffed by
+    ``bundle_side_input.compare_stored_bundle_facts_pair`` (a pure in-memory
+    per-library diff, no binaries read, no header AST parsed on either
+    side) instead of ``compare_release_against_bundle_facts`` (which
+    extracts and dumps NEW_INPUT as a live directory/package). The default
+    ``False`` is the original stored/live shape, unchanged.
 
     *kwargs* is ``compare_cmd``'s already-parsed, already-``normalize_sided_
     options``-processed option dict -- the same dict that would otherwise be
@@ -187,6 +196,10 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
     compare_release_against_bundle_facts = (
         _bundle_side_input.compare_release_against_bundle_facts
     )
+    # PR I: same importlib indirection as compare_release_against_bundle_
+    # facts above, and for the identical reason -- both live in
+    # bundle_side_input.py.
+    compare_stored_bundle_facts_pair = _bundle_side_input.compare_stored_bundle_facts_pair
     from ....cli_compare_release_helpers import _exit_compare_release
 
     # known_libraries_for_new_side lives in workflows/bundle_facts_library_
@@ -203,7 +216,7 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
     from ..options.params import _load_suppression_and_policy
     from .compare_bundle_facts_rejections import reject_unsupported_options
 
-    reject_unsupported_options(kwargs)
+    reject_unsupported_options(kwargs, new_is_stored=new_is_stored)
 
     old_facts_path: Path = kwargs["old_input"]
     new_dir: Path = kwargs["new_input"]
@@ -235,198 +248,230 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
         if s.strip()
     ]
 
-    # Codex review: NEW_INPUT is documented ("a live release directory/
-    # package") to accept a package archive (wheel/deb/rpm/tar), but
-    # compare_release_against_bundle_facts() treats any non-directory path
-    # as a single library file -- a package operand silently produced zero
-    # matches instead of the shared libraries inside it. Extract it first,
-    # the same way the live release fan-out does (_extract_if_package),
-    # sharing that primitive rather than re-implementing package detection
-    # here. --devel-pkg new=... is honored the same way too (its header_dir
-    # becomes the NEW-side header root when no explicit --new-header was
-    # given, and its discovered include roots are appended) -- --debug-info
-    # is rejected above rather than silently dropped, since this driver has
-    # no debug-dir parameter to forward it to.
-    from ....cli_compare_release_helpers import (
-        _discover_include_roots,
-        _extract_if_package,
-    )
-    from ....errors import SnapshotError
-    from ....workflows.extraction import detect_extractor, is_package
+    if new_is_stored:
+        # PR I stored/stored: NEW_INPUT is itself a stored BundleFacts
+        # document too -- no extraction, no header AST, no live NEW-side
+        # resolution at all (compare_stored_bundle_facts_pair() is a pure
+        # in-memory diff of both sides' already-persisted per-library
+        # AbiSnapshots). --max-json-object-nodes applies to *both* sides'
+        # load here (there is only the one, unscoped flag) rather than just
+        # OLD_INPUT's, unlike the stored/live branch below.
+        from ....errors import SnapshotError
 
-    _temp_dir_paths: list[str] = []
-
-    def _make_temp_dir(prefix: str) -> Path:
-        import tempfile
-
-        path = tempfile.mkdtemp(prefix=prefix)
-        _temp_dir_paths.append(path)
-        return Path(path)
-
-    try:
-        # Codex review: extraction itself must be inside this scope --
-        # make_temp_dir() records the directory before extractor.extract()
-        # runs, so a malformed/corrupt archive that matches a known
-        # extension (a real format, bad content) raises *after* the temp
-        # dir already exists; extracting outside this try/finally leaked it
-        # even without --keep-extracted. It also must be inside the
-        # except (SnapshotError, ValueError) boundary just below (Codex
-        # review, fresh evidence) -- _extract_if_package raises
-        # SnapshotError for a malformed-but-recognized archive, and that
-        # used to propagate past this function as a raw Python traceback
-        # instead of the clean CLI error every other SnapshotError here
-        # produces.
         try:
-            lib_dir, _new_debug_dir, header_dir, _new_symbols_file = (
-                _extract_if_package(
-                    new_dir,
-                    None,
-                    kwargs.get("devel_pkg2"),
-                    _make_temp_dir,
-                    is_package,
-                    detect_extractor,
-                )
-            )
-            if header_dir is not None and depth != "binary":
-                # Codex review: --depth binary's uniform `headers = []`
-                # clear above (dispatch()'s own comment) must survive
-                # package/--devel-pkg extraction too -- without this guard,
-                # a NEW_INPUT package (or `--devel-pkg new=...`) that
-                # discovers its own header_dir would reassign `headers`
-                # right back to a non-empty list here, silently re-enabling
-                # L2 header extraction for that library under a depth that
-                # promises pure L0/L1 evidence with no header AST at all.
-                if not headers:
-                    headers = [header_dir]
-                includes = includes + _discover_include_roots(header_dir)
-
-            per_library_headers: dict[str, list[Path]] | None = None
-            per_library_includes: dict[str, list[Path]] | None = None
-            per_library_compile: dict[str, Any] | None = None
-            manifest_path = kwargs.get("bundle_facts_library_manifest")
-            if manifest_path is not None:
-                # G38 Phase 17: known_libraries is derived from the same
-                # primitives compare_release_against_bundle_facts() itself
-                # uses on this identical lib_dir, so a manifest entry naming
-                # a library outside the bundle is a hard, immediate error
-                # instead of silently never being looked up.
-                include_private_dso = bool(kwargs.get("include_private_dso", False))
-                new_library_paths = known_libraries_for_new_side(
-                    lib_dir, include_private_dso=include_private_dso
-                )
-                per_library_headers, per_library_includes, per_library_compile = (
-                    _load_library_overrides(
-                        Path(manifest_path),
-                        known_libraries=set(new_library_paths),
-                        selected_paths=new_library_paths,
-                    )
-                )
-                if depth == "binary":
-                    # Codex review: the uniform `headers` clear above only
-                    # covers the uniform operand -- a manifest-supplied
-                    # per-library header root would otherwise still run L2
-                    # extraction for that one library under --depth binary,
-                    # reporting findings outside the requested depth.
-                    per_library_headers = {}
-                    per_library_includes = {}
-                    per_library_compile = {}
-
-            result = compare_release_against_bundle_facts(
+            result = compare_stored_bundle_facts_pair(
                 old_facts_path,
-                lib_dir,
-                headers=headers or None,
-                includes=includes or None,
-                per_library_headers=per_library_headers,
-                per_library_includes=per_library_includes,
-                per_library_compile=per_library_compile,
-                header_backend=header_backend,
-                compile=compile_context,
-                new_version=kwargs.get("new_version", "new"),
-                lang=kwargs.get("lang", "c++"),
-                # Codex review, fresh evidence: kwargs["lang_explicit"] is
-                # compare_cmd's own ctx.get_parameter_source("lang") ==
-                # COMMANDLINE detection (compare.py, mirroring run_compare's
-                # identical lang_explicit computation) -- without threading
-                # it through, an explicit --lang c++ on a language-ambiguous
-                # NEW-side header was indistinguishable from Click's own
-                # default and silently let resolve_input() auto-detect past
-                # it, which can change the extracted API and findings.
-                lang_explicit=bool(kwargs.get("lang_explicit", False)),
-                include_private_dso=bool(kwargs.get("include_private_dso", False)),
+                new_dir,
                 manifest_path=kwargs.get("manifest_path"),
                 system_providers=bundle_system_providers or None,
                 cohorts=list(kwargs.get("bundle_cohorts") or ()) or None,
                 policy=kwargs["policy"],
                 policy_file=policy_file,
                 suppress=suppression,
-                include_dependencies=bool(kwargs.get("include_dependencies", False)),
-                max_json_object_nodes=kwargs.get("max_json_object_nodes"),
+                old_max_json_object_nodes=kwargs.get("max_json_object_nodes"),
+                new_max_json_object_nodes=kwargs.get("max_json_object_nodes"),
             )
-        except BundleFactsLibraryOverridesError as exc:
-            # Codex review, fresh evidence: compare_release_against_bundle_
-            # facts() itself re-validates the manifest's per-library keys
-            # against the libraries actually matched between OLD_FACTS and
-            # NEW_INPUT (a check known_libraries_for_new_side()'s earlier,
-            # NEW-side-only pass cannot make) -- this is a malformed-CLI-
-            # input case exactly like every other BundleFactsLibraryOverrides
-            # Error in this module, so it gets the same exit-64 usage-error
-            # translation rather than falling into the generic ValueError
-            # clause below (exit 1).
-            raise click.UsageError(str(exc)) from exc
-        # TypeError (Codex review, fresh evidence): a malformed nested
-        # build_mode/contract field inside one of OLD_FACTS's per-library
-        # snapshots is rejected rather than coerced at the storage boundary
-        # (storage AGENTS.md invariant 6) -- bundle_facts_from_dict()'s own
-        # per_library_snapshots comprehension calls snapshot_from_dict()
-        # with no nested guard, so that TypeError propagates all the way
-        # here and must be caught alongside ValueError like every other
-        # malformed-OLD_FACTS shape.
+        # Same CLI-boundary translation the stored/live branch below applies
+        # to compare_release_against_bundle_facts() -- see its own comments
+        # for exactly why each of these four exception types is caught here.
         except (SnapshotError, TypeError, ValueError, OSError) as exc:
-            # Same CLI-boundary translation every other SnapshotError-raising
-            # entry point uses (cli_resolve.py et al.) -- without this, a
-            # container-node-budget rejection (or any other SnapshotError) would
-            # surface as a raw Python traceback instead of a clean CLI error.
-            # Also catches ValueError (Codex review): a malformed-but-parseable
-            # OLD_FACTS document -- missing/wrong-shaped 'per_library_snapshots',
-            # a bad 'filesystem_aliases'/'library_filenames' entry
-            # (bundle_facts_serialization.bundle_facts_from_dict and
-            # storage.bundle_facts_validation's validators all raise plain
-            # ValueError, not SnapshotError, for these) -- would otherwise leak
-            # the same raw traceback. json.JSONDecodeError (genuinely malformed
-            # JSON, from the plain-JSON load path) is itself a ValueError
-            # subclass, so it's covered by the same clause. OSError (Codex
-            # review, fresh evidence) covers load_bundle_facts()'s own
-            # IsADirectoryError/PermissionError/etc when OLD_INPUT -- a plain
-            # click.Path(exists=True) argument, not dir_okay=False, since the
-            # ordinary live-directory compare mode needs a directory there --
-            # turns out to be a directory or otherwise unreadable file.
             raise click.ClickException(str(exc)) from exc
-    finally:
-        # Mirrors the live release fan-out's own --keep-extracted handling
-        # (_cleanup_temp_dirs): remove the package-extraction tempdir unless
-        # the caller asked to keep it for debugging.
-        import shutil as _shutil
+    else:
+        # Codex review: NEW_INPUT is documented ("a live release directory/
+        # package") to accept a package archive (wheel/deb/rpm/tar), but
+        # compare_release_against_bundle_facts() treats any non-directory path
+        # as a single library file -- a package operand silently produced zero
+        # matches instead of the shared libraries inside it. Extract it first,
+        # the same way the live release fan-out does (_extract_if_package),
+        # sharing that primitive rather than re-implementing package detection
+        # here. --devel-pkg new=... is honored the same way too (its header_dir
+        # becomes the NEW-side header root when no explicit --new-header was
+        # given, and its discovered include roots are appended) -- --debug-info
+        # is rejected above rather than silently dropped, since this driver has
+        # no debug-dir parameter to forward it to.
+        from ....cli_compare_release_helpers import (
+            _discover_include_roots,
+            _extract_if_package,
+        )
+        from ....errors import SnapshotError
+        from ....workflows.extraction import detect_extractor, is_package
 
-        if not kwargs.get("keep_extracted"):
-            for _td in _temp_dir_paths:
-                _shutil.rmtree(_td, ignore_errors=True)
-        elif _temp_dir_paths:
-            click.echo(
-                f"Extracted files kept in: {', '.join(_temp_dir_paths)}", err=True
-            )
+        _temp_dir_paths: list[str] = []
+
+        def _make_temp_dir(prefix: str) -> Path:
+            import tempfile
+
+            path = tempfile.mkdtemp(prefix=prefix)
+            _temp_dir_paths.append(path)
+            return Path(path)
+
+        try:
+            # Codex review: extraction itself must be inside this scope --
+            # make_temp_dir() records the directory before extractor.extract()
+            # runs, so a malformed/corrupt archive that matches a known
+            # extension (a real format, bad content) raises *after* the temp
+            # dir already exists; extracting outside this try/finally leaked it
+            # even without --keep-extracted. It also must be inside the
+            # except (SnapshotError, ValueError) boundary just below (Codex
+            # review, fresh evidence) -- _extract_if_package raises
+            # SnapshotError for a malformed-but-recognized archive, and that
+            # used to propagate past this function as a raw Python traceback
+            # instead of the clean CLI error every other SnapshotError here
+            # produces.
+            try:
+                lib_dir, _new_debug_dir, header_dir, _new_symbols_file = (
+                    _extract_if_package(
+                        new_dir,
+                        None,
+                        kwargs.get("devel_pkg2"),
+                        _make_temp_dir,
+                        is_package,
+                        detect_extractor,
+                    )
+                )
+                if header_dir is not None and depth != "binary":
+                    # Codex review: --depth binary's uniform `headers = []`
+                    # clear above (dispatch()'s own comment) must survive
+                    # package/--devel-pkg extraction too -- without this guard,
+                    # a NEW_INPUT package (or `--devel-pkg new=...`) that
+                    # discovers its own header_dir would reassign `headers`
+                    # right back to a non-empty list here, silently re-enabling
+                    # L2 header extraction for that library under a depth that
+                    # promises pure L0/L1 evidence with no header AST at all.
+                    if not headers:
+                        headers = [header_dir]
+                    includes = includes + _discover_include_roots(header_dir)
+
+                per_library_headers: dict[str, list[Path]] | None = None
+                per_library_includes: dict[str, list[Path]] | None = None
+                per_library_compile: dict[str, Any] | None = None
+                manifest_path = kwargs.get("bundle_facts_library_manifest")
+                if manifest_path is not None:
+                    # G38 Phase 17: known_libraries is derived from the same
+                    # primitives compare_release_against_bundle_facts() itself
+                    # uses on this identical lib_dir, so a manifest entry naming
+                    # a library outside the bundle is a hard, immediate error
+                    # instead of silently never being looked up.
+                    include_private_dso = bool(kwargs.get("include_private_dso", False))
+                    new_library_paths = known_libraries_for_new_side(
+                        lib_dir, include_private_dso=include_private_dso
+                    )
+                    per_library_headers, per_library_includes, per_library_compile = (
+                        _load_library_overrides(
+                            Path(manifest_path),
+                            known_libraries=set(new_library_paths),
+                            selected_paths=new_library_paths,
+                        )
+                    )
+                    if depth == "binary":
+                        # Codex review: the uniform `headers` clear above only
+                        # covers the uniform operand -- a manifest-supplied
+                        # per-library header root would otherwise still run L2
+                        # extraction for that one library under --depth binary,
+                        # reporting findings outside the requested depth.
+                        per_library_headers = {}
+                        per_library_includes = {}
+                        per_library_compile = {}
+
+                result = compare_release_against_bundle_facts(
+                    old_facts_path,
+                    lib_dir,
+                    headers=headers or None,
+                    includes=includes or None,
+                    per_library_headers=per_library_headers,
+                    per_library_includes=per_library_includes,
+                    per_library_compile=per_library_compile,
+                    header_backend=header_backend,
+                    compile=compile_context,
+                    new_version=kwargs.get("new_version", "new"),
+                    lang=kwargs.get("lang", "c++"),
+                    # Codex review, fresh evidence: kwargs["lang_explicit"] is
+                    # compare_cmd's own ctx.get_parameter_source("lang") ==
+                    # COMMANDLINE detection (compare.py, mirroring run_compare's
+                    # identical lang_explicit computation) -- without threading
+                    # it through, an explicit --lang c++ on a language-ambiguous
+                    # NEW-side header was indistinguishable from Click's own
+                    # default and silently let resolve_input() auto-detect past
+                    # it, which can change the extracted API and findings.
+                    lang_explicit=bool(kwargs.get("lang_explicit", False)),
+                    include_private_dso=bool(kwargs.get("include_private_dso", False)),
+                    manifest_path=kwargs.get("manifest_path"),
+                    system_providers=bundle_system_providers or None,
+                    cohorts=list(kwargs.get("bundle_cohorts") or ()) or None,
+                    policy=kwargs["policy"],
+                    policy_file=policy_file,
+                    suppress=suppression,
+                    include_dependencies=bool(kwargs.get("include_dependencies", False)),
+                    max_json_object_nodes=kwargs.get("max_json_object_nodes"),
+                )
+            except BundleFactsLibraryOverridesError as exc:
+                # Codex review, fresh evidence: compare_release_against_bundle_
+                # facts() itself re-validates the manifest's per-library keys
+                # against the libraries actually matched between OLD_FACTS and
+                # NEW_INPUT (a check known_libraries_for_new_side()'s earlier,
+                # NEW-side-only pass cannot make) -- this is a malformed-CLI-
+                # input case exactly like every other BundleFactsLibraryOverrides
+                # Error in this module, so it gets the same exit-64 usage-error
+                # translation rather than falling into the generic ValueError
+                # clause below (exit 1).
+                raise click.UsageError(str(exc)) from exc
+            # TypeError (Codex review, fresh evidence): a malformed nested
+            # build_mode/contract field inside one of OLD_FACTS's per-library
+            # snapshots is rejected rather than coerced at the storage boundary
+            # (storage AGENTS.md invariant 6) -- bundle_facts_from_dict()'s own
+            # per_library_snapshots comprehension calls snapshot_from_dict()
+            # with no nested guard, so that TypeError propagates all the way
+            # here and must be caught alongside ValueError like every other
+            # malformed-OLD_FACTS shape.
+            except (SnapshotError, TypeError, ValueError, OSError) as exc:
+                # Same CLI-boundary translation every other SnapshotError-raising
+                # entry point uses (cli_resolve.py et al.) -- without this, a
+                # container-node-budget rejection (or any other SnapshotError) would
+                # surface as a raw Python traceback instead of a clean CLI error.
+                # Also catches ValueError (Codex review): a malformed-but-parseable
+                # OLD_FACTS document -- missing/wrong-shaped 'per_library_snapshots',
+                # a bad 'filesystem_aliases'/'library_filenames' entry
+                # (bundle_facts_serialization.bundle_facts_from_dict and
+                # storage.bundle_facts_validation's validators all raise plain
+                # ValueError, not SnapshotError, for these) -- would otherwise leak
+                # the same raw traceback. json.JSONDecodeError (genuinely malformed
+                # JSON, from the plain-JSON load path) is itself a ValueError
+                # subclass, so it's covered by the same clause. OSError (Codex
+                # review, fresh evidence) covers load_bundle_facts()'s own
+                # IsADirectoryError/PermissionError/etc when OLD_INPUT -- a plain
+                # click.Path(exists=True) argument, not dir_okay=False, since the
+                # ordinary live-directory compare mode needs a directory there --
+                # turns out to be a directory or otherwise unreadable file.
+                raise click.ClickException(str(exc)) from exc
+        finally:
+            # Mirrors the live release fan-out's own --keep-extracted handling
+            # (_cleanup_temp_dirs): remove the package-extraction tempdir unless
+            # the caller asked to keep it for debugging.
+            import shutil as _shutil
+
+            if not kwargs.get("keep_extracted"):
+                for _td in _temp_dir_paths:
+                    _shutil.rmtree(_td, ignore_errors=True)
+            elif _temp_dir_paths:
+                click.echo(
+                    f"Extracted files kept in: {', '.join(_temp_dir_paths)}", err=True
+                )
 
     if not result.per_library:
         # Codex review: an empty NEW_INPUT (or one whose canonical library
         # keys match none of OLD_FACTS's per_library_snapshots) makes
-        # compare_release_against_bundle_facts() return with an empty
-        # per_library list -- nothing was actually compared, yet
-        # _exit_compare_release below would score that as NO_CHANGE (exit
-        # 0), reporting a successful compatibility result for a comparison
-        # that never ran. Fail loudly instead: this is a usage/operational
-        # error (a wrong NEW_INPUT, a canonical-key mismatch), not a clean
-        # bill of health.
+        # compare_release_against_bundle_facts()/compare_stored_bundle_
+        # facts_pair() return with an empty per_library list -- nothing was
+        # actually compared, yet _exit_compare_release below would score
+        # that as NO_CHANGE (exit 0), reporting a successful compatibility
+        # result for a comparison that never ran. Fail loudly instead: this
+        # is a usage/operational error (a wrong NEW_INPUT, a canonical-key
+        # mismatch), not a clean bill of health.
+        _new_desc = (
+            f"{new_dir}'s stored per_library_snapshots" if new_is_stored else str(new_dir)
+        )
         raise click.ClickException(
-            f"No library in {new_dir} matched any library in "
+            f"No library in {_new_desc} matched any library in "
             f"{old_facts_path}'s stored per_library_snapshots -- nothing "
             "was compared. Check that NEW_INPUT and OLD_FACTS reference "
             "the same release."
@@ -525,7 +570,9 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
             # disk, or a non-directory *parent* path component.
             raise click.ClickException(f"Cannot create {output_dir}: {exc}") from exc
 
-    text = _render(result, fmt, old_facts_path=old_facts_path, new_dir=new_dir)
+    text = _render(
+        result, fmt, old_facts_path=old_facts_path, new_dir=new_dir, new_is_stored=new_is_stored
+    )
     if output is not None:
         _safe_write_output(Path(output), text)
     else:
@@ -537,7 +584,11 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
         # secondary format can legitimately differ from the primary one.
         assert secondary_fmt is not None
         secondary_text = _render(
-            result, secondary_fmt, old_facts_path=old_facts_path, new_dir=new_dir
+            result,
+            secondary_fmt,
+            old_facts_path=old_facts_path,
+            new_dir=new_dir,
+            new_is_stored=new_is_stored,
         )
         _safe_write_output(Path(secondary_output), secondary_text)
     if output_dir is not None:
@@ -572,13 +623,21 @@ def dispatch(*, compile_context: Any, **kwargs: Any) -> None:
     _exit_compare_release(result.verdict.value, fail_on_removed=False, removed_keys=[])
 
 
-def _render(result: Any, fmt: str, *, old_facts_path: Path, new_dir: Path) -> str:
+def _render(
+    result: Any, fmt: str, *, old_facts_path: Path, new_dir: Path, new_is_stored: bool = False
+) -> str:
     if fmt == "markdown":
-        return _render_markdown(result, old_facts_path=old_facts_path, new_dir=new_dir)
-    return _render_json(result, old_facts_path=old_facts_path, new_dir=new_dir)
+        return _render_markdown(
+            result, old_facts_path=old_facts_path, new_dir=new_dir, new_is_stored=new_is_stored
+        )
+    return _render_json(
+        result, old_facts_path=old_facts_path, new_dir=new_dir, new_is_stored=new_is_stored
+    )
 
 
-def _render_json(result: Any, *, old_facts_path: Path, new_dir: Path) -> str:
+def _render_json(
+    result: Any, *, old_facts_path: Path, new_dir: Path, new_is_stored: bool = False
+) -> str:
     from ....report.run_outcome import run_outcome_dict_for_diff_result
     from ....reporter import to_json
 
@@ -605,7 +664,14 @@ def _render_json(result: Any, *, old_facts_path: Path, new_dir: Path) -> str:
     summary: dict[str, object] = {
         "mode": "bundle_facts",
         "old_bundle_facts": str(old_facts_path),
+        # PR I stored/stored: `new_dir` keeps its established key/meaning
+        # even when NEW_INPUT is itself a stored document too (its path,
+        # not a live release directory) -- `new_is_stored` is the new,
+        # additive signal a consumer checks to tell the two shapes apart,
+        # rather than a field rename that would break an existing consumer
+        # keyed on `new_dir`.
         "new_dir": str(new_dir),
+        "new_is_stored": new_is_stored,
         "verdict": result.verdict.value,
         "per_library_verdict": result.per_library_verdict.value,
         "bundle_verdict": result.bundle_verdict.value,
@@ -629,14 +695,17 @@ def _render_json(result: Any, *, old_facts_path: Path, new_dir: Path) -> str:
     return json.dumps(summary, indent=2)
 
 
-def _render_markdown(result: Any, *, old_facts_path: Path, new_dir: Path) -> str:
+def _render_markdown(
+    result: Any, *, old_facts_path: Path, new_dir: Path, new_is_stored: bool = False
+) -> str:
     from ....bundle import render_bundle_findings_markdown
 
+    new_label = "stored facts" if new_is_stored else "release directory"
     lines = [
         "# Bundle-facts comparison",
         "",
         f"- OLD (stored facts): `{old_facts_path}`",
-        f"- NEW (release directory): `{new_dir}`",
+        f"- NEW ({new_label}): `{new_dir}`",
         f"- **Verdict:** `{result.verdict.value}`",
         f"- Per-library verdict: `{result.per_library_verdict.value}`",
         f"- Bundle verdict: `{result.bundle_verdict.value}`",

--- a/abicheck/frontends/cli/commands/compare_bundle_facts.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts.py
@@ -321,12 +321,12 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
     if new_is_stored:
         # PR I stored/stored: NEW_INPUT is itself a stored BundleFacts
         # document too -- no extraction, no header AST, no live NEW-side
-        # resolution at all (compare_stored_bundle_facts_pair() is a pure
-        # in-memory diff of both sides' already-persisted per-library
-        # AbiSnapshots). --max-json-object-nodes applies to *both* sides'
-        # load here (there is only the one, unscoped flag) rather than just
-        # OLD_INPUT's, unlike the stored/live branch below.
-        from ....errors import SnapshotError
+        # resolution (compare_stored_bundle_facts_pair() is a pure in-memory
+        # diff of both sides' already-persisted per-library AbiSnapshots).
+        # --max-json-object-nodes applies to *both* sides' load here (one
+        # unscoped flag), unlike the stored/live branch below.
+        from ....errors import ProfileMismatchError, ScopeMismatchError, SnapshotError
+        from .compare_bundle_facts_rejections import exit_bundle_facts_not_comparable
 
         try:
             result = compare_stored_bundle_facts_pair(
@@ -342,11 +342,12 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
                 new_max_json_object_nodes=kwargs.get("max_json_object_nodes"),
                 depth=kwargs.get("depth"),
             )
-        # Same CLI-boundary translation the stored/live branch below applies
-        # to compare_release_against_bundle_facts() -- see its own comments
-        # for exactly why each of these four exception types is caught here.
+        # Same translation the stored/live branch below applies (its own
+        # comments explain each of these four exception types).
         except (SnapshotError, TypeError, ValueError, OSError) as exc:
             raise click.ClickException(str(exc)) from exc
+        except (ProfileMismatchError, ScopeMismatchError) as exc:
+            exit_bundle_facts_not_comparable(exc)  # not caught above (round 12)
     else:
         # Codex review: NEW_INPUT is documented ("a live release directory/
         # package") to accept a package archive (wheel/deb/rpm/tar), but
@@ -358,14 +359,14 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
         # here. --devel-pkg new=... is honored the same way too (its header_dir
         # becomes the NEW-side header root when no explicit --new-header was
         # given, and its discovered include roots are appended) -- --debug-info
-        # is rejected above rather than silently dropped, since this driver has
-        # no debug-dir parameter to forward it to.
+        # is rejected above, since this driver has no debug-dir param for it.
         from ....cli_compare_release_helpers import (
             _discover_include_roots,
             _extract_if_package,
         )
-        from ....errors import SnapshotError
+        from ....errors import ProfileMismatchError, ScopeMismatchError, SnapshotError
         from ....workflows.extraction import detect_extractor, is_package
+        from .compare_bundle_facts_rejections import exit_bundle_facts_not_comparable
 
         _temp_dir_paths: list[str] = []
 
@@ -505,15 +506,14 @@ def dispatch(*, compile_context: Any, new_is_stored: bool = False, **kwargs: Any
                 # (bundle_facts_serialization.bundle_facts_from_dict and
                 # storage.bundle_facts_validation's validators all raise plain
                 # ValueError, not SnapshotError, for these) -- would otherwise leak
-                # the same raw traceback. json.JSONDecodeError (genuinely malformed
-                # JSON, from the plain-JSON load path) is itself a ValueError
-                # subclass, so it's covered by the same clause. OSError (Codex
-                # review, fresh evidence) covers load_bundle_facts()'s own
-                # IsADirectoryError/PermissionError/etc when OLD_INPUT -- a plain
-                # click.Path(exists=True) argument, not dir_okay=False, since the
-                # ordinary live-directory compare mode needs a directory there --
-                # turns out to be a directory or otherwise unreadable file.
+                # the same raw traceback. json.JSONDecodeError (malformed JSON) is
+                # itself a ValueError subclass. OSError covers load_bundle_facts()'s
+                # own IsADirectoryError/PermissionError/etc when OLD_INPUT -- a plain
+                # click.Path(exists=True) argument, not dir_okay=False -- turns out
+                # to be a directory or otherwise unreadable file.
                 raise click.ClickException(str(exc)) from exc
+            except (ProfileMismatchError, ScopeMismatchError) as exc:
+                exit_bundle_facts_not_comparable(exc)  # round 12, see above
         finally:
             # Mirrors the live release fan-out's own --keep-extracted handling
             # (_cleanup_temp_dirs): remove the package-extraction tempdir unless

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -734,7 +734,9 @@ def reject_ast_override_flags_for_stored_pair(ctx: click.Context) -> None:
             )
 
 
-def exit_bundle_facts_not_comparable(exc: Exception) -> None:
+def exit_bundle_facts_not_comparable(
+    exc: Exception, *, fmt: str = "markdown", output: Path | None = None
+) -> None:
     """Translate a ``ProfileMismatchError``/``ScopeMismatchError`` raised
     from inside a per-library ``compare_snapshots()`` call into a clean CLI
     failure, exit 16 -- the same code native ``compare``'s own ADR-050 D2
@@ -747,14 +749,28 @@ def exit_bundle_facts_not_comparable(exc: Exception) -> None:
     reached neither clause and surfaced as a raw traceback instead. Shared
     by both the stored/stored and stored/live dispatch branches, which both
     diff each matched library through the identical ``compare_snapshots()``
-    chokepoint. Deliberately narrower than native compare's own
-    ``_report_not_comparable`` (no SARIF/JUnit rendering, no schema-
-    conformant JSON envelope): this dispatcher's own JSON output is the
-    simpler ``mode: "bundle_facts"`` shape, which has no not-comparable
-    document convention of its own to fabricate one for -- a clear stderr
-    message is what every non-JSON native-compare format already gets too."""
+    chokepoint.
+
+    *fmt*/*output* (Codex review, PR #1060, round 14), when ``fmt ==
+    "json"``, get a machine-readable refusal document written the same way
+    an ordinary successful comparison's JSON would be (``-o`` or stdout) --
+    a stored-pair refusal must be consumable by the same scripts/report
+    aggregator native compare's own ``_report_not_comparable`` JSON output
+    already is; silently leaving the requested report file unwritten (the
+    prior stderr-only behavior) was itself a gap this round found. The
+    envelope mirrors this dispatcher's own ordinary ``mode: "bundle_facts"``
+    shape rather than native compare's schema-versioned ``compare_report.
+    schema.json`` document -- the two were never the same schema even for a
+    successful comparison here, so inventing schema conformance only for
+    the refusal case would be a new, undocumented contract, not a fix.
+    Every other format (``markdown``/``html``/``review``, and the default)
+    gets only the stderr message, matching native compare's own identical
+    "no equivalent document convention" choice for those formats."""
     import sys
 
+    from ....errors import ProfileMismatchError
+
+    kind = "profile_mismatch" if isinstance(exc, ProfileMismatchError) else "scope_mismatch"
     click.echo(
         f"Error: not comparable: {exc}\n"
         "Two matched libraries were not extracted under a comparable "
@@ -762,4 +778,16 @@ def exit_bundle_facts_not_comparable(exc: Exception) -> None:
         "produced for this bundle.",
         err=True,
     )
+    if fmt == "json":
+        import json as _json
+
+        from ....frontends.cli.runtime import _write_or_echo
+
+        document = {
+            "mode": "bundle_facts",
+            "verdict": None,
+            "not_comparable": True,
+            "reason": {"kind": kind, "message": str(exc)},
+        }
+        _write_or_echo(output, _json.dumps(document, indent=2))
     sys.exit(16)

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -493,6 +493,20 @@ def reject_unsupported_options(kwargs: dict[str, Any], *, new_is_stored: bool = 
             "a stored-bundle-facts OLD_INPUT: OLD_FACTS is already a resolved, stored "
             "snapshot with no header re-extraction available."
         )
+    if kwargs.get("old_version") not in (None, "", "old"):
+        # Codex review, fresh evidence: neither compare_release_against_
+        # bundle_facts() nor compare_stored_bundle_facts_pair() has an
+        # old_version parameter at all -- OLD_INPUT is always a stored,
+        # already-resolved document in this dispatcher (regardless of
+        # whether NEW_INPUT is too), and its per-library snapshots already
+        # carry whatever version they were captured with, so a requested
+        # --version old=... was silently discarded rather than applied or
+        # rejected, on either side of this shape.
+        raise click.UsageError(
+            "--version old=... is not supported together with "
+            "a stored-bundle-facts OLD_INPUT: OLD_FACTS's own per-library "
+            "snapshots already carry whatever version they were captured with."
+        )
     if kwargs.get("demangle") is not None:
         # Codex review, fresh evidence: --demangle/--no-demangle is
         # documented to apply to markdown output, but this dispatcher's
@@ -634,4 +648,42 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
             "stored BundleFacts documents: neither side's language is "
             "re-detected or re-parsed from headers, so there is nothing "
             "left for it to select."
+        )
+
+
+def reject_explicit_compile_config_for_stored_pair(config_path: Path) -> None:
+    """Raise ``click.UsageError`` when *config_path* -- an *explicitly*
+    given ``--config`` (Click parameter-source COMMANDLINE, checked by the
+    caller, ``compare_bundle_facts.resolve_dispatch_compile_context``)
+    -- declares real ``compile:`` settings that a stored/stored comparison
+    has no channel to honor (Codex review, PR #1060). An *ambient*,
+    auto-discovered ``.abicheck.yml`` is deliberately not checked this way
+    at all -- see that function's own docstring for why the two cases
+    differ: an explicit ``--config`` is a request the user expects
+    honored, while an ambient one silently applying nothing is exactly the
+    point of not letting an unrelated project default break a stored/
+    stored comparison. Lives here rather than in ``compare_bundle_facts.py``
+    purely to keep that file under its own architecture line cap -- this
+    module already owns every other stored/stored-specific rejection."""
+    from ....workflows.extraction import load_build_config
+
+    try:
+        bc = load_build_config(Path(config_path))
+    except ValueError as exc:
+        raise click.UsageError(f"cannot parse build config {config_path}: {exc}") from exc
+    if (
+        bc.compile_frontend is not None
+        or bc.compile_std is not None
+        or bc.compile_include_dirs
+        or bc.compile_defines
+        or bc.compile_sysroot is not None
+        or bc.compile_nostdinc is not None
+    ):
+        raise click.UsageError(
+            f"{config_path} declares compile: settings, which are not "
+            "supported when both OLD_INPUT and NEW_INPUT are stored "
+            "BundleFacts documents: neither side runs any header-frontend "
+            "extraction for them to configure. Omit --config to let an "
+            "ambient project config, if any, stay harmlessly unused here "
+            "instead, or use a --config that declares no compile: block."
         )

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -585,6 +585,22 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
             "and NEW_INPUT are stored BundleFacts documents: neither side "
             "discovers shared libraries from a live directory/package."
         )
+    if kwargs.get("dso_only"):
+        # Codex review, PR #1060, round 7: the live release fan-out
+        # (cli_compare_release.py's _prepare_compare_release_inputs)
+        # explicitly filters both old/new library maps to skip executables
+        # for this flag -- a persisted BundleFacts document carries no
+        # per-library "was this an executable, not a real .so" fact at all
+        # (capture_bundle_facts() only ever stores what
+        # bundle_snapshot_from_facts() can reconstruct from an AbiSnapshot),
+        # so there is no channel to apply the same selection here. Reject
+        # rather than silently compare every intersecting entry including
+        # ones a live --dso-only run would have skipped.
+        raise click.UsageError(
+            "--dso-only is not supported when both OLD_INPUT and NEW_INPUT "
+            "are stored BundleFacts documents: a persisted document carries "
+            "no per-library executable/library distinction to filter by."
+        )
     if kwargs.get("keep_extracted"):
         raise click.UsageError(
             "--keep-extracted is not supported when both OLD_INPUT and "
@@ -606,14 +622,16 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
         )
     # --depth binary/headers are genuinely supported for stored/stored
     # (Codex review, PR #1060, fresh evidence): compare_stored_bundle_
-    # facts_pair() projects both sides via policy.depth_projection.
-    # project_pair_to_depth() before diffing, the same primitive every
-    # other resolved-snapshot comparison path in this codebase already
-    # calls -- an earlier version of this check rejected --depth binary
-    # outright on the mistaken premise that no such projection primitive
-    # existed. --depth build/source are still rejected, unconditionally,
-    # above: this driver has no channel to *collect* L3-L5 evidence on
-    # either side, only to project already-resolved evidence down.
+    # facts_pair() enforces the requested depth as a floor
+    # (enforce_requested_depth) and then projects both sides via policy.
+    # depth_projection.project_snapshot_to_depth() as a ceiling before
+    # diffing, the same primitives every other resolved-snapshot
+    # comparison path in this codebase already pairs -- an earlier version
+    # of this check rejected --depth binary outright on the mistaken
+    # premise that no such projection primitive existed. --depth build/
+    # source are still rejected, unconditionally, above: this driver has
+    # no channel to *collect* L3-L5 evidence on either side, only to
+    # enforce and project already-resolved evidence.
     # Codex review, fresh evidence: compare_cmd builds a real CompileContext
     # from these before calling dispatch() (resolve_compile_context), but
     # this stored/stored branch never consumes compile_context at all --

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -590,3 +590,20 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
             "OLD_INPUT and NEW_INPUT are stored BundleFacts documents: "
             "there is no live NEW-side resolution for it to scope."
         )
+    if kwargs.get("depth") == "binary":
+        # Codex review: --depth build/source is already rejected above,
+        # unconditionally, for a stored OLD_INPUT -- but "binary" is
+        # ordinarily *accepted* (it clears the NEW side's headers before a
+        # live dump, per dispatch()'s own comment). That channel doesn't
+        # exist here: both sides are already fully-resolved AbiSnapshots
+        # with whatever evidence they were captured with baked in, and
+        # compare_stored_bundle_facts_pair() has no snapshot-projection
+        # primitive to strip header-derived facts back out after the fact.
+        # Silently accepting it would let a request for symbols-only
+        # evidence report header-only findings anyway.
+        raise click.UsageError(
+            "--depth binary is not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: both sides are "
+            "already fully-resolved snapshots with no way to project them "
+            "back down to symbols-only evidence."
+        )

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -604,23 +604,16 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
             "OLD_INPUT and NEW_INPUT are stored BundleFacts documents: "
             "there is no live NEW-side resolution for it to scope."
         )
-    if kwargs.get("depth") == "binary":
-        # Codex review: --depth build/source is already rejected above,
-        # unconditionally, for a stored OLD_INPUT -- but "binary" is
-        # ordinarily *accepted* (it clears the NEW side's headers before a
-        # live dump, per dispatch()'s own comment). That channel doesn't
-        # exist here: both sides are already fully-resolved AbiSnapshots
-        # with whatever evidence they were captured with baked in, and
-        # compare_stored_bundle_facts_pair() has no snapshot-projection
-        # primitive to strip header-derived facts back out after the fact.
-        # Silently accepting it would let a request for symbols-only
-        # evidence report header-only findings anyway.
-        raise click.UsageError(
-            "--depth binary is not supported when both OLD_INPUT and "
-            "NEW_INPUT are stored BundleFacts documents: both sides are "
-            "already fully-resolved snapshots with no way to project them "
-            "back down to symbols-only evidence."
-        )
+    # --depth binary/headers are genuinely supported for stored/stored
+    # (Codex review, PR #1060, fresh evidence): compare_stored_bundle_
+    # facts_pair() projects both sides via policy.depth_projection.
+    # project_pair_to_depth() before diffing, the same primitive every
+    # other resolved-snapshot comparison path in this codebase already
+    # calls -- an earlier version of this check rejected --depth binary
+    # outright on the mistaken premise that no such projection primitive
+    # existed. --depth build/source are still rejected, unconditionally,
+    # above: this driver has no channel to *collect* L3-L5 evidence on
+    # either side, only to project already-resolved evidence down.
     # Codex review, fresh evidence: compare_cmd builds a real CompileContext
     # from these before calling dispatch() (resolve_compile_context), but
     # this stored/stored branch never consumes compile_context at all --

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -50,10 +50,17 @@ from typing import Any
 import click
 
 
-def reject_unsupported_options(kwargs: dict[str, Any]) -> None:
+def reject_unsupported_options(kwargs: dict[str, Any], *, new_is_stored: bool = False) -> None:
     """Raise ``click.UsageError`` for any flag a stored-bundle-facts
     OLD_INPUT has no channel to honor. See this module's own docstring for
-    the design."""
+    the design.
+
+    *new_is_stored* (CLI cleanup phase two, PR I), when true, means
+    NEW_INPUT classified as a stored BundleFacts document too -- every
+    check below still applies (neither stored side has any of these
+    channels), plus the NEW-side-specific extraction options rejected at
+    the bottom of this function, which only make sense when NEW_INPUT is a
+    *live* directory/package (the default, ``False``, unchanged)."""
     fmt = kwargs.get("fmt", "json")
     if fmt not in ("json", "markdown"):
         raise click.UsageError(
@@ -503,4 +510,83 @@ def reject_unsupported_options(kwargs: dict[str, Any]) -> None:
         raise click.UsageError(
             "--demangle/--no-demangle is not supported together with "
             "a stored-bundle-facts OLD_INPUT."
+        )
+    if new_is_stored:
+        _reject_new_side_extraction_options_for_stored_pair(kwargs)
+
+
+def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) -> None:
+    """PR I stored/stored: the NEW-side-scoped mirror of every OLD-side
+    extraction-only rejection above, applied once NEW_INPUT classifies as a
+    stored BundleFacts document too -- ``compare_stored_bundle_facts_pair()``
+    reads no binaries and parses no header AST on *either* side, so every
+    flag that would only ever apply to a *live* NEW_INPUT directory/package
+    has no channel to honor here either, the identical reasoning the
+    OLD-side checks above already establish for OLD_INPUT."""
+    if (
+        kwargs.get("new_headers_only")
+        or kwargs.get("new_includes_only")
+        or kwargs.get("headers")
+        or kwargs.get("includes")
+    ):
+        raise click.UsageError(
+            "--header new=.../--include new=... (or the uniform --header/"
+            "--include) are not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: neither side has "
+            "any header re-extraction available."
+        )
+    if kwargs.get("new_header_backend") is not None or kwargs.get("header_backend") not in (
+        None,
+        "auto",
+    ):
+        # `header_backend` (the uniform/base value) defaults to the literal
+        # string "auto", never None (cli_options._split_sided_frontend) --
+        # unlike `old_header_backend`/`new_header_backend`, which really do
+        # default to None. Checking `is not None` here would reject every
+        # ordinary invocation, since the untouched default is always
+        # present; only a value that actually differs from that silent
+        # default means the flag was really given.
+        raise click.UsageError(
+            "--ast-frontend is not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: neither side has "
+            "any header re-extraction available."
+        )
+    if kwargs.get("devel_pkg2") is not None:
+        raise click.UsageError(
+            "--devel-pkg new=... is not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: there is no live "
+            "NEW-side package to extract a devel companion package's "
+            "headers into."
+        )
+    if kwargs.get("bundle_facts_library_manifest") is not None:
+        raise click.UsageError(
+            "--bundle-facts-library-manifest is not supported when both "
+            "OLD_INPUT and NEW_INPUT are stored BundleFacts documents: "
+            "there is no live NEW-side library set to apply per-library "
+            "header/include/compile overrides to."
+        )
+    if kwargs.get("include_private_dso"):
+        raise click.UsageError(
+            "--include-private-dso is not supported when both OLD_INPUT "
+            "and NEW_INPUT are stored BundleFacts documents: neither side "
+            "discovers shared libraries from a live directory/package."
+        )
+    if kwargs.get("keep_extracted"):
+        raise click.UsageError(
+            "--keep-extracted is not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: neither side is "
+            "ever extracted to a temporary directory."
+        )
+    if kwargs.get("new_version") not in (None, "", "new"):
+        raise click.UsageError(
+            "--version new=... is not supported when both OLD_INPUT and "
+            "NEW_INPUT are stored BundleFacts documents: NEW_INPUT's own "
+            "per-library snapshots already carry whatever version they "
+            "were captured with."
+        )
+    if kwargs.get("include_dependencies"):
+        raise click.UsageError(
+            "--include-system-declarations is not supported when both "
+            "OLD_INPUT and NEW_INPUT are stored BundleFacts documents: "
+            "there is no live NEW-side resolution for it to scope."
         )

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -698,3 +698,37 @@ def reject_explicit_compile_config_for_stored_pair(config_path: Path) -> None:
             "ambient project config, if any, stay harmlessly unused here "
             "instead, or use a --config that declares no compile: block."
         )
+
+
+#: (Click parameter dest, CLI flag) pairs for the expose_value=False
+#: AST-override flags reject_ast_override_flags_for_stored_pair() checks --
+#: shared so the two never drift, since neither name is derivable from the
+#: other mechanically (Click's default dest derivation is one-way).
+_AST_OVERRIDE_FLAGS: tuple[tuple[str, str], ...] = (
+    ("allow_ast_frontend_fallback", "--allow-ast-frontend-fallback"),
+    ("allow_unsupported_castxml", "--allow-unsupported-castxml"),
+)
+
+
+def reject_ast_override_flags_for_stored_pair(ctx: click.Context) -> None:
+    """Raise ``click.UsageError`` for an explicitly-given
+    ``--allow-ast-frontend-fallback``/``--allow-unsupported-castxml`` on a
+    stored/stored comparison (Codex review, PR #1060, round 11).
+
+    Both flags are ``expose_value=False`` (``cli_options.
+    _scoped_env_flag_callback`` sets a scoped env var as a side effect and
+    never adds a ``kwargs`` entry at all), so ``reject_unsupported_
+    options()`` -- which reads only ``kwargs`` -- can never see either flag
+    to reject it: neither side of a stored/stored comparison runs any
+    header-frontend AST extraction for either flag to affect, so both were
+    silently accepted and had no effect. ``ctx.get_parameter_source()``
+    still answers ``COMMANDLINE`` for an ``expose_value=False`` option --
+    Click records the source at parse time regardless of exposure -- so
+    this checks the one place that survives instead of ``kwargs``."""
+    for dest, flag in _AST_OVERRIDE_FLAGS:
+        if ctx.get_parameter_source(dest) == click.core.ParameterSource.COMMANDLINE:
+            raise click.UsageError(
+                f"{flag} is not supported when both OLD_INPUT and NEW_INPUT "
+                "are stored BundleFacts documents: neither side runs any "
+                "header-frontend AST extraction for it to affect."
+            )

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -732,3 +732,34 @@ def reject_ast_override_flags_for_stored_pair(ctx: click.Context) -> None:
                 "are stored BundleFacts documents: neither side runs any "
                 "header-frontend AST extraction for it to affect."
             )
+
+
+def exit_bundle_facts_not_comparable(exc: Exception) -> None:
+    """Translate a ``ProfileMismatchError``/``ScopeMismatchError`` raised
+    from inside a per-library ``compare_snapshots()`` call into a clean CLI
+    failure, exit 16 -- the same code native ``compare``'s own ADR-050 D2
+    comparability gate uses (``frontends.cli.runtime._EXIT_NOT_COMPARABLE``),
+    rather than the generic exit-1 ``click.ClickException`` translation the
+    sibling ``except (SnapshotError, TypeError, ValueError, OSError)``
+    clause gives every other malformed-input case (Codex review, PR #1060,
+    round 12). Neither exception type is a ``ValueError``/``TypeError``/
+    ``SnapshotError`` (both are plain ``AbicheckError``), so it previously
+    reached neither clause and surfaced as a raw traceback instead. Shared
+    by both the stored/stored and stored/live dispatch branches, which both
+    diff each matched library through the identical ``compare_snapshots()``
+    chokepoint. Deliberately narrower than native compare's own
+    ``_report_not_comparable`` (no SARIF/JUnit rendering, no schema-
+    conformant JSON envelope): this dispatcher's own JSON output is the
+    simpler ``mode: "bundle_facts"`` shape, which has no not-comparable
+    document convention of its own to fabricate one for -- a clear stderr
+    message is what every non-JSON native-compare format already gets too."""
+    import sys
+
+    click.echo(
+        f"Error: not comparable: {exc}\n"
+        "Two matched libraries were not extracted under a comparable "
+        "profile/scope contract (ADR-050 D1/D2), so no verdict was "
+        "produced for this bundle.",
+        err=True,
+    )
+    sys.exit(16)

--- a/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_facts_rejections.py
@@ -607,3 +607,31 @@ def _reject_new_side_extraction_options_for_stored_pair(kwargs: dict[str, Any]) 
             "already fully-resolved snapshots with no way to project them "
             "back down to symbols-only evidence."
         )
+    # Codex review, fresh evidence: compare_cmd builds a real CompileContext
+    # from these before calling dispatch() (resolve_compile_context), but
+    # this stored/stored branch never consumes compile_context at all --
+    # neither side does any header-frontend extraction, so every one of
+    # these was silently accepted and discarded rather than applied or
+    # rejected.
+    if (
+        kwargs.get("compiler_path") is not None
+        or kwargs.get("compiler_prefix") is not None
+        or kwargs.get("compiler_option_tokens")
+        or kwargs.get("sysroot") is not None
+        or kwargs.get("nostdinc")
+        or kwargs.get("frontend_context") not in (None, "host")
+    ):
+        raise click.UsageError(
+            "--compiler/--compiler-prefix/--compiler-option/--sysroot/"
+            "--nostdinc/--frontend-context are not supported when both "
+            "OLD_INPUT and NEW_INPUT are stored BundleFacts documents: "
+            "neither side runs any header-frontend extraction for a compile "
+            "context to configure."
+        )
+    if kwargs.get("lang_explicit"):
+        raise click.UsageError(
+            "--lang is not supported when both OLD_INPUT and NEW_INPUT are "
+            "stored BundleFacts documents: neither side's language is "
+            "re-detected or re-parsed from headers, so there is nothing "
+            "left for it to select."
+        )

--- a/abicheck/frontends/cli/commands/compare_bundle_operand_dispatch.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_operand_dispatch.py
@@ -29,8 +29,8 @@ here, at the CLI boundary.
 
 **Three of the four operand shapes now have a real execution engine**
 (``bundle_side_input.compare_release_against_bundle_facts`` for stored/live,
-``bundle_side_input.compare_stored_bundle_facts_pair`` for stored/stored,
-plain ``run_compare``/the live release fan-out for live/live -- see
+``workflows.bundle_stored_pair_compare.compare_stored_bundle_facts_pair`` for
+stored/stored, plain ``run_compare``/the live release fan-out for live/live -- see
 ``compare_bundle_facts.py``'s own ``dispatch()`` for how the two stored-
 OLD_INPUT drivers are selected). **Live/stored (a live OLD_INPUT compared
 against a stored NEW_INPUT) is the one shape still rejected outright** --

--- a/abicheck/frontends/cli/commands/compare_bundle_operand_dispatch.py
+++ b/abicheck/frontends/cli/commands/compare_bundle_operand_dispatch.py
@@ -23,34 +23,58 @@ live outside ``compare.py`` itself: that module sits at the architecture
 :func:`resolve_bundle_compare_dispatch` is ``compare_cmd``'s entire bundle-
 facts routing decision -- classify both operands
 (``workflows.bundle_compare_operand``, which is deliberately ``click``-free)
-and translate the one unsupported combination (a stored NEW_INPUT) into a
-``click.UsageError`` here, at the CLI boundary.
+and translate the one remaining unsupported combination (a stored NEW_INPUT
+paired with a *live* OLD_INPUT -- "live/stored") into a ``click.UsageError``
+here, at the CLI boundary.
+
+**Three of the four operand shapes now have a real execution engine**
+(``bundle_side_input.compare_release_against_bundle_facts`` for stored/live,
+``bundle_side_input.compare_stored_bundle_facts_pair`` for stored/stored,
+plain ``run_compare``/the live release fan-out for live/live -- see
+``compare_bundle_facts.py``'s own ``dispatch()`` for how the two stored-
+OLD_INPUT drivers are selected). **Live/stored (a live OLD_INPUT compared
+against a stored NEW_INPUT) is the one shape still rejected outright** --
+see ``bundle_side_input.py``'s own module docstring for exactly what
+implementing it would take (the mirror image of the stored/live driver, with
+every OLD-side extraction option -- ``--header old=``/``--include old=``/
+``--ast-frontend old=``/``--devel-pkg old=``/
+``--bundle-facts-library-manifest`` -- newly meaningful and every NEW-side
+one of those newly rejected, which ``compare_bundle_facts_rejections.py``
+does not yet parameterize for).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
+if TYPE_CHECKING:
+    from ....workflows.bundle_compare_operand import BundleCompareRequest
 
-def resolve_bundle_compare_dispatch(old_input: Path, new_input: Path) -> bool:
+
+def resolve_bundle_compare_dispatch(old_input: Path, new_input: Path) -> BundleCompareRequest:
     """Classify *old_input*/*new_input* for ``compare``'s bundle-facts
-    routing. Returns ``True`` when OLD_INPUT is a stored BundleFacts
-    document (the caller should dispatch to ``compare_bundle_facts.
-    dispatch()``); raises ``click.UsageError`` when NEW_INPUT is one
-    instead (live/stored and stored/stored are not yet implemented -- see
-    ``workflows/bundle_compare_operand.py``'s own docstring)."""
+    routing. Returns the
+    :class:`~abicheck.workflows.bundle_compare_operand.BundleCompareRequest`
+    classification (the caller dispatches to ``compare_bundle_facts.
+    dispatch()`` whenever ``.any_stored`` is true, forwarding ``.new_is_
+    stored`` so that module can select the stored/live vs. stored/stored
+    driver); raises ``click.UsageError`` for the one remaining unimplemented
+    shape -- a stored NEW_INPUT paired with a *live* OLD_INPUT (see this
+    module's own docstring)."""
     from ....workflows.bundle_compare_operand import classify_bundle_compare_operands
 
     operands = classify_bundle_compare_operands(old_input, new_input)
-    if operands.new_is_stored:
+    if operands.new_is_stored and not operands.old_is_stored:
         raise click.UsageError(
             f"'{new_input}' looks like a stored BundleFacts document (from "
-            "a prior --bundle-facts-out) -- comparing against a stored "
-            "NEW_INPUT is not yet supported; NEW_INPUT must be a live "
-            "library/directory/package. If you meant to compare two stored "
-            "bundle-facts documents, or swap old/new, neither combination "
-            "is implemented yet."
+            "a prior --bundle-facts-out) and "
+            f"'{old_input}' does not -- comparing a live OLD_INPUT against "
+            "a stored NEW_INPUT is not yet supported. Either swap old/new "
+            "(if you meant to compare the stored document against a live "
+            "baseline), or capture OLD_INPUT with --bundle-facts-out first "
+            "so both sides are stored."
         )
-    return operands.old_is_stored
+    return operands

--- a/abicheck/storage/bundle_facts_validation.py
+++ b/abicheck/storage/bundle_facts_validation.py
@@ -21,7 +21,7 @@ budget check, and ``load_bundle_facts``'s full dispatch body, split out of
 `storage/`'s own ADR-061 D1 remit ("serialize snapshots/baselines, own
 their schemas") and its `model`-only dependency rule: every function here
 depends on nothing first-party but ``errors`` (a `public_root_surfaces`
-exemption) and `storage.json_budget` (same package) --
+exemption) and `storage.json_budget`/`storage.guards` (same package) --
 ``load_bundle_facts_dispatch`` takes its `bundle_facts.py`/`snapshot_io.py`/
 `serialization.py` collaborators as injected callables instead of importing
 them, since `storage`'s own `may_import: [model]` forbids importing any of
@@ -264,12 +264,22 @@ def validated_variant_fingerprint(raw: object) -> str:
     valid string -- before this function ever sees it, while an explicit
     ``null`` reaches this function as ``None`` and is rejected by the
     ``isinstance`` check like any other wrong-typed value, never silently
-    defaulted."""
-    if not isinstance(raw, str):
-        raise ValueError(
-            f"bundle facts: 'variant_fingerprint' must be a string, got {raw!r}"
-        )
-    return raw
+    defaulted.
+
+    Delegates to ``guards.identity_text()`` (Codex review, PR #1060, round
+    11) rather than repeating its own ``isinstance`` check -- this module's
+    own docstring and ``storage/AGENTS.md``'s "Never coerce a value a
+    decision reads" section both name ``guards.py`` as the one place this
+    check lives, precisely because a duplicated copy is how a future
+    validation improvement (or a bug fix to the check itself) drifts
+    between sites; an earlier version of this function kept its own
+    independent copy instead. Raises ``TypeError`` (``identity_text``'s own
+    contract), not this module's usual ``ValueError`` -- already covered by
+    every caller's ``except (SnapshotError, TypeError, ValueError,
+    OSError)`` boundary."""
+    from .guards import identity_text
+
+    return identity_text(raw, "variant_fingerprint")
 
 
 def validated_filename_map(raw: object) -> dict[str, str]:

--- a/abicheck/storage/bundle_facts_validation.py
+++ b/abicheck/storage/bundle_facts_validation.py
@@ -239,7 +239,7 @@ def validated_alias_map(raw: object) -> dict[str, tuple[str, ...]]:
     return aliases
 
 
-def validated_variant_fingerprint(raw: object, *, default: str) -> str:
+def validated_variant_fingerprint(raw: object) -> str:
     """Validate a persisted top-level ``variant_fingerprint`` field.
 
     Rejects a non-string value (Codex review, PR #1060, round 8) instead of
@@ -248,16 +248,23 @@ def validated_variant_fingerprint(raw: object, *, default: str) -> str:
     "1"`` both loaded as the identical string ``"1"``, so
     ``compare_stored_bundle_facts_pair()``'s own mismatch/empty-fingerprint
     checks (which compare this field for identity) could not tell a real
-    match from a coincidental one. *raw* is ``None`` when the key was absent
-    from the document entirely (``dict.get`` with no default, as every other
-    caller here passes it) -- that case returns *default* unchanged, exactly
-    :data:`~abicheck.bundle_facts.DEFAULT_VARIANT_FINGERPRINT`'s prior
-    fallback; a present-but-wrong-typed value is rejected outright rather
-    than coerced. *default* is a parameter, not imported, so this leaf
-    module's own "no ``bundle_facts.py`` import" contract (this module's own
-    docstring) stays intact."""
-    if raw is None:
-        return default
+    match from a coincidental one.
+
+    Deliberately no ``default``/``None``-means-absent special case (Codex
+    review, PR #1060, round 9): an earlier version of this function treated
+    ``raw is None`` as "key absent, use the default", but the caller's own
+    ``d.get("variant_fingerprint")`` (no default arg) returns ``None`` for
+    an *explicit* JSON ``null`` too -- collapsing "never captured" and "a
+    malformed document naming an explicit null" onto the same fallback, the
+    same class of bug the non-string fix just above closed for an int/list/
+    dict value. The caller now passes ``d.get("variant_fingerprint",
+    default)`` instead (mirroring ``validated_alias_map``'s/
+    ``validated_filename_map``'s own identical two-arg ``.get`` call
+    immediately below): a truly absent key resolves to *default* -- a
+    valid string -- before this function ever sees it, while an explicit
+    ``null`` reaches this function as ``None`` and is rejected by the
+    ``isinstance`` check like any other wrong-typed value, never silently
+    defaulted."""
     if not isinstance(raw, str):
         raise ValueError(
             f"bundle facts: 'variant_fingerprint' must be a string, got {raw!r}"

--- a/abicheck/storage/bundle_facts_validation.py
+++ b/abicheck/storage/bundle_facts_validation.py
@@ -239,6 +239,32 @@ def validated_alias_map(raw: object) -> dict[str, tuple[str, ...]]:
     return aliases
 
 
+def validated_variant_fingerprint(raw: object, *, default: str) -> str:
+    """Validate a persisted top-level ``variant_fingerprint`` field.
+
+    Rejects a non-string value (Codex review, PR #1060, round 8) instead of
+    silently coercing it with ``str(...)`` -- the prior behavior meant a
+    malformed ``variant_fingerprint: 1`` and a genuine ``variant_fingerprint:
+    "1"`` both loaded as the identical string ``"1"``, so
+    ``compare_stored_bundle_facts_pair()``'s own mismatch/empty-fingerprint
+    checks (which compare this field for identity) could not tell a real
+    match from a coincidental one. *raw* is ``None`` when the key was absent
+    from the document entirely (``dict.get`` with no default, as every other
+    caller here passes it) -- that case returns *default* unchanged, exactly
+    :data:`~abicheck.bundle_facts.DEFAULT_VARIANT_FINGERPRINT`'s prior
+    fallback; a present-but-wrong-typed value is rejected outright rather
+    than coerced. *default* is a parameter, not imported, so this leaf
+    module's own "no ``bundle_facts.py`` import" contract (this module's own
+    docstring) stays intact."""
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        raise ValueError(
+            f"bundle facts: 'variant_fingerprint' must be a string, got {raw!r}"
+        )
+    return raw
+
+
 def validated_filename_map(raw: object) -> dict[str, str]:
     """Validate and convert a persisted ``library_filenames`` mapping --
     rejects a non-string value instead of silently coercing it

--- a/abicheck/workflows/bundle_stored_pair_compare.py
+++ b/abicheck/workflows/bundle_stored_pair_compare.py
@@ -68,7 +68,7 @@ def compare_stored_bundle_facts_pair(
     No binaries are read and no header AST is parsed on either side --
     both sides are already resolved, per-library ``AbiSnapshot``s, so this
     driver is a pure in-memory diff: matched-key intersection, then one
-    ``service.compare_snapshots()`` call per matched library, exactly the
+    ``workflows.compare_policy.compare_snapshots()`` call per matched library, exactly the
     same Tier-2 chokepoint every other comparison entry point in this
     codebase uses (never ``checker.compare`` directly). Mirrors
     :func:`~abicheck.bundle_side_input.compare_release_against_bundle_facts`'s
@@ -119,7 +119,7 @@ def compare_stored_bundle_facts_pair(
     *suppress* all mean exactly what they mean on
     ``compare_release_against_bundle_facts`` -- see that function's own
     docstring for the full account of each. *policy*/*policy_file* are
-    forwarded to every per-library ``service.compare_snapshots()`` call
+    forwarded to every per-library ``workflows.compare_policy.compare_snapshots()`` call
     *and* to the final ``compare_bundle_from_facts()`` call, so
     ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
     every per-library diff, not just the live-NEW-side driver's own case.
@@ -140,7 +140,7 @@ def compare_stored_bundle_facts_pair(
     from ..bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
     from ..bundle_manifest import load_manifest
     from ..serialization import load_bundle_facts
-    from ..service import compare_snapshots
+    from .compare_policy import compare_snapshots
 
     old_facts = load_bundle_facts(
         old_facts_path, max_json_object_nodes=old_max_json_object_nodes
@@ -149,6 +149,27 @@ def compare_stored_bundle_facts_pair(
         new_facts_path, max_json_object_nodes=new_max_json_object_nodes
     )
 
+    # Codex review, PR #1060, fresh evidence after the mismatch check just
+    # below landed: an empty variant_fingerprint carries no real identity
+    # evidence at all (bundle_multibuild.variant_fingerprint() itself never
+    # produces one -- the no-coordinates case is the DEFAULT_VARIANT_
+    # FINGERPRINT sentinel, never "" -- but the plain BundleFacts loader
+    # preserves an empty string verbatim if the document was hand-authored
+    # or otherwise malformed), so two such documents comparing "" == ""
+    # would pass the equality check below despite neither side actually
+    # attesting to being the same build. Reject rather than let an
+    # identity-free coincidence stand in for a real match, mirroring
+    # bundle_multibuild._index_by_fingerprint's own identical rejection for
+    # the multi-variant case.
+    for _facts, _path in ((old_facts, old_facts_path), (new_facts, new_facts_path)):
+        if not _facts.variant_fingerprint:
+            raise ValueError(
+                f"{_path} has an empty variant_fingerprint -- "
+                "variant_fingerprint() never produces one (the no-coordinates "
+                "case is the DEFAULT_VARIANT_FINGERPRINT sentinel, not ''), "
+                "so this document did not come from it; fix the input rather "
+                "than comparing it on an empty, non-identifying key"
+            )
     if old_facts.variant_fingerprint != new_facts.variant_fingerprint:
         raise ValueError(
             f"{old_facts_path} and {new_facts_path} were captured from "
@@ -175,7 +196,21 @@ def compare_stored_bundle_facts_pair(
         )
         per_library_results.append(diff)
 
-    manifest = load_manifest(manifest_path) if manifest_path is not None else None
+    # Codex review, PR #1060: compare_bundle_from_facts()'s own precedence
+    # (an explicit manifest, else old_facts.manifest) is the wrong contract
+    # here -- it was written for the stored/live driver, whose NEW side is
+    # never itself a BundleFacts document with its own captured manifest.
+    # Both sides genuinely can carry one here, so this mirrors
+    # compare_bundle_sides()'s own three-tier precedence instead: an
+    # explicit --manifest always wins, then OLD's own captured manifest,
+    # then NEW's -- rather than silently discarding a real NEW-only
+    # manifest (which would drop its BUNDLE_MANIFEST_INSTANTIATION_REMOVED
+    # coverage entirely).
+    manifest = (
+        load_manifest(manifest_path)
+        if manifest_path is not None
+        else (old_facts.manifest or new_facts.manifest)
+    )
     new_bundle_snapshot = bundle_snapshot_from_facts(new_facts)
     return compare_bundle_from_facts(
         old_facts,

--- a/abicheck/workflows/bundle_stored_pair_compare.py
+++ b/abicheck/workflows/bundle_stored_pair_compare.py
@@ -156,6 +156,7 @@ def compare_stored_bundle_facts_pair(
     ``enforce_requested_depth``'s/``project_snapshot_to_depth``'s own
     documented contracts.
     """
+    from ..analysis_assurance import compute_analysis_assurance
     from ..bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
     from ..bundle_manifest import load_manifest
     from ..policy.depth_projection import project_snapshot_to_depth
@@ -254,6 +255,24 @@ def compare_stored_bundle_facts_pair(
             policy=policy,
             policy_file=policy_file,
         )
+        if depth is not None:
+            # Codex review, PR #1060, round 10: service_compare_pipeline.
+            # resolve_compare_request() stamps DiffResult.requested_depth
+            # and recomputes analysis_assurance (depth_satisfied included)
+            # after its own floor/ceiling pair -- this driver enforced and
+            # projected depth (immediately above) but never did either, so
+            # every stored/stored --depth run persisted analysis_assurance.
+            # requested_depth/depth_satisfied as null despite the evidence
+            # contract this driver actually enforced. compute_analysis_
+            # assurance is pure/cheap (reads fields already on diff/the
+            # projected snapshots, no re-extraction) -- safe to call once
+            # more per matched library here, the same "safe to call
+            # unconditionally, again later once enriched" contract that
+            # function's own docstring states.
+            diff.requested_depth = depth
+            diff.analysis_assurance = compute_analysis_assurance(
+                diff, projected_old_snapshots[key], projected_new_snapshots[key]
+            )
         per_library_results.append(diff)
 
     # Codex review, PR #1060: compare_bundle_from_facts()'s own precedence

--- a/abicheck/workflows/bundle_stored_pair_compare.py
+++ b/abicheck/workflows/bundle_stored_pair_compare.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stored/stored ``BundleFacts`` pair comparison (CLI cleanup phase two,
+PR I).
+
+:func:`compare_stored_bundle_facts_pair` is the driver behind ``compare``'s
+stored/stored operand shape: both OLD_INPUT and NEW_INPUT are already
+persisted :class:`~abicheck.bundle_facts.BundleFacts` documents (each from a
+prior ``compare --bundle-facts-out``), so this is a pure in-memory diff --
+no binaries read, no header AST parsed on either side.
+
+Lives under ``abicheck/workflows/`` (ADR-061 -- "Coordinate dump, compare,
+scan, release, aggregate, project, or dependency behavior" is exactly what
+this function does) rather than alongside its stored/live sibling in
+``bundle_side_input.py`` -- that module is itself a grandfathered flat-root
+legacy file (see its own module docstring), and this is genuinely new
+compare-workflow coordination, not a resolution primitive that module's
+existing ``LiveBundleInput``/``StoredBundleFactsInput``/``resolve_bundle_
+side`` shapes already cover (Codex review, PR #1060: "put the stored-pair
+workflow in workflows" -- the same reasoning that already moved
+``known_libraries_for_new_side`` out to
+``workflows/bundle_facts_library_overrides.py`` rather than growing
+``bundle_side_input.py`` for it).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..bundle_models import BundleDiffResult
+    from ..checker_types import DiffResult
+    from ..policy_file import PolicyFile
+    from .suppression import SuppressionList
+
+
+def compare_stored_bundle_facts_pair(
+    old_facts_path: Path,
+    new_facts_path: Path,
+    *,
+    manifest_path: Path | None = None,
+    system_providers: list[str] | None = None,
+    cohorts: list[str] | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+    suppress: SuppressionList | None = None,
+    old_max_json_object_nodes: int | None = None,
+    new_max_json_object_nodes: int | None = None,
+) -> BundleDiffResult:
+    """End-to-end driver: two stored ``BundleFacts`` documents compared
+    against each other -- the stored/stored operand shape (CLI cleanup
+    phase two, PR I).
+
+    No binaries are read and no header AST is parsed on either side --
+    both sides are already resolved, per-library ``AbiSnapshot``s, so this
+    driver is a pure in-memory diff: matched-key intersection, then one
+    ``service.compare_snapshots()`` call per matched library, exactly the
+    same Tier-2 chokepoint every other comparison entry point in this
+    codebase uses (never ``checker.compare`` directly). Mirrors
+    :func:`~abicheck.bundle_side_input.compare_release_against_bundle_facts`'s
+    own final step (a direct call into
+    :func:`~abicheck.bundle_facts.compare_bundle_from_facts`, never
+    :func:`~abicheck.bundle_side_input.compare_bundle_sides`/
+    :func:`~abicheck.bundle_side_input.resolve_bundle_side`) for the
+    identical reason documented there: each stored document is already
+    loaded in memory for the per-library matching loop below, and routing
+    through ``StoredBundleFactsInput``/``resolve_bundle_side`` instead would
+    reload and re-parse both documents from disk a second time for no
+    benefit.
+
+    Refuses to diff two documents captured from different logical build
+    variants (Codex review, PR #1060): ``BundleFacts.variant_fingerprint``
+    (``bundle_multibuild.variant_fingerprint`` -- stable build-axis identity
+    only, e.g. a CPU-only build vs. a SYCL/DPC build of the same source
+    tree) must match on both sides, or this raises ``ValueError`` rather
+    than silently intersecting their library names and diffing artifacts
+    that were never the same build to begin with -- the same "never union,
+    never silently pair a mismatch" discipline
+    ``bundle_multibuild.pair_variants`` already establishes for the
+    *multi*-variant case. This function deliberately doesn't route through
+    ``pair_variants`` itself: that machinery pairs whole *mappings* of
+    labelled variants (the not-yet-wired multibuild CLI/config surface --
+    see that module's own docstring), which is the wrong shape for two
+    single, already-identified documents -- a direct fingerprint-equality
+    check is the proportionate check for exactly two inputs. An ordinary
+    document that never set a variant (``BundleFacts.variant_fingerprint``
+    defaults to ``DEFAULT_VARIANT_FINGERPRINT``) is unaffected: both sides
+    share that same default and compare equal.
+
+    A library present in only one of the two documents' own
+    ``per_library_snapshots`` is simply not diffed, the same "not itself a
+    release fan-out's ``--fail-on-removed-library``/added-library
+    accounting" narrowing ``compare_release_against_bundle_facts``'s own
+    docstring already states for its NEW-live side -- neither stored side
+    can name a *set* of on-disk libraries to fail on the absence of, both
+    are already a fixed, resolved snapshot.
+
+    *old_max_json_object_nodes*/*new_max_json_object_nodes*, each when
+    given, override ``bundle_facts.DEFAULT_MAX_JSON_OBJECT_NODES`` for that
+    side's own load -- forwarded to ``serialization.load_bundle_facts``,
+    mirroring ``StoredBundleFactsInput``'s own field of the same purpose.
+    ``None`` (the default) uses the library default for that side.
+
+    *manifest_path*/*system_providers*/*cohorts*/*policy*/*policy_file*/
+    *suppress* all mean exactly what they mean on
+    ``compare_release_against_bundle_facts`` -- see that function's own
+    docstring for the full account of each. *policy*/*policy_file* are
+    forwarded to every per-library ``service.compare_snapshots()`` call
+    *and* to the final ``compare_bundle_from_facts()`` call, so
+    ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
+    every per-library diff, not just the live-NEW-side driver's own case.
+
+    Callers requesting a limited evidence depth (``compare``'s
+    ``--depth binary``) must reject it themselves before calling this
+    function rather than relying on it to project either side down to
+    symbols-only evidence: unlike a live NEW-side dump (which
+    ``service.resolve_input`` can be asked to skip header parsing for),
+    both sides here are *already* fully-resolved ``AbiSnapshot``s with
+    whatever evidence they were captured with baked in, and this module has
+    no general snapshot-projection primitive to strip header-derived facts
+    back out after the fact (Codex review, PR #1060) --
+    ``frontends/cli/commands/compare_bundle_facts_rejections.py`` is where
+    that rejection lives, the same "reject rather than silently diverge"
+    rule every other unsupported flag in that module is held to.
+    """
+    from ..bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
+    from ..bundle_manifest import load_manifest
+    from ..serialization import load_bundle_facts
+    from ..service import compare_snapshots
+
+    old_facts = load_bundle_facts(
+        old_facts_path, max_json_object_nodes=old_max_json_object_nodes
+    )
+    new_facts = load_bundle_facts(
+        new_facts_path, max_json_object_nodes=new_max_json_object_nodes
+    )
+
+    if old_facts.variant_fingerprint != new_facts.variant_fingerprint:
+        raise ValueError(
+            f"{old_facts_path} and {new_facts_path} were captured from "
+            f"different build variants (variant_fingerprint "
+            f"{old_facts.variant_fingerprint!r} vs "
+            f"{new_facts.variant_fingerprint!r}) -- refusing to diff them "
+            "as if they were the same build. Compare two documents captured "
+            "from the same logical variant (or use "
+            "bundle_multibuild.pair_variants() for a genuine multi-variant "
+            "comparison)."
+        )
+
+    matched_keys = sorted(
+        set(old_facts.per_library_snapshots) & set(new_facts.per_library_snapshots)
+    )
+    per_library_results: list[DiffResult] = []
+    for key in matched_keys:
+        diff = compare_snapshots(
+            old_facts.per_library_snapshots[key],
+            new_facts.per_library_snapshots[key],
+            suppress,
+            policy=policy,
+            policy_file=policy_file,
+        )
+        per_library_results.append(diff)
+
+    manifest = load_manifest(manifest_path) if manifest_path is not None else None
+    new_bundle_snapshot = bundle_snapshot_from_facts(new_facts)
+    return compare_bundle_from_facts(
+        old_facts,
+        new_bundle_snapshot,
+        per_library_results,
+        manifest=manifest,
+        system_providers=system_providers,
+        cohorts=cohorts,
+        policy=policy,
+        policy_file=policy_file,
+        new_signature_evidence=dict(new_facts.per_library_snapshots),
+    )

--- a/abicheck/workflows/bundle_stored_pair_compare.py
+++ b/abicheck/workflows/bundle_stored_pair_compare.py
@@ -125,29 +125,42 @@ def compare_stored_bundle_facts_pair(
     ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
     every per-library diff, not just the live-NEW-side driver's own case.
 
-    *depth*, when given, caps both sides' evidence to what ``compare``'s
-    ``--depth`` requested before diffing (``binary``/``headers`` -- the
-    only two values reachable here at all, since ``--depth build``/
-    ``source`` are rejected unconditionally for a stored OLD_INPUT
-    elsewhere: this driver has no channel to *collect* L3-L5 evidence, only
-    to project already-resolved evidence down). Unlike a live NEW-side dump
-    (which ``service.resolve_input`` can be asked to skip header parsing
-    for), both sides here are *already* fully-resolved ``AbiSnapshot``s
-    with whatever evidence they were captured with baked in -- so this
-    calls the same ``policy.depth_projection.project_pair_to_depth()``
-    ordinary live comparisons use (``service_compare_pipeline.py``,
-    ``cli_compare_helpers.py``, ``cli_scan_baseline.py``) rather than
-    rejecting the flag outright, which an earlier version of this function
-    did on the mistaken premise that no such projection primitive existed
+    *depth*, when given, is enforced as a floor (``workflows.artifact.
+    execute.enforce_requested_depth`` -- raises ``ValueError`` when a
+    matched pair's resolved evidence falls short of what was requested)
+    and then applied as a ceiling to every stored snapshot on both sides
+    (``policy.depth_projection.project_snapshot_to_depth``) before diffing
+    -- the same floor-then-ceiling pairing ``classify_compare_pair``
+    (``service_compare_pipeline.py``) applies for every other
+    resolved-snapshot comparison path (``cli_compare_helpers.py``,
+    ``cli_scan_baseline.py``). Only ``binary``/``headers`` are reachable
+    here at all, since ``--depth build``/``source`` are rejected
+    unconditionally for a stored OLD_INPUT elsewhere: this driver has no
+    channel to *collect* L3-L5 evidence, only to enforce and project
+    already-resolved evidence. Unlike a live NEW-side dump (which
+    ``service.resolve_input`` can be asked to skip header parsing for),
+    both sides here are *already* fully-resolved ``AbiSnapshot``s with
+    whatever evidence they were captured with baked in -- rejecting the
+    flag outright, which an earlier version of this function did on the
+    mistaken premise that no such projection primitive existed, was wrong
     (Codex review, PR #1060, fresh evidence: it does, and every other
     resolved-snapshot comparison path in this codebase already calls it).
-    ``None`` (the default) is a no-op, matching
-    ``project_snapshot_to_depth``'s own documented contract.
+    Both projected maps -- not the raw, unprojected
+    ``old_facts``/``new_facts.per_library_snapshots`` -- are also what
+    reaches ``compare_bundle_from_facts()``'s own signature-evidence gate
+    below (Codex review, PR #1060, round 6): otherwise a header-complete
+    stored snapshot could still satisfy ``find_unverified_signature_
+    findings``'s type-evidence check under an explicit depth ceiling the
+    per-library diff itself was capped to. ``None`` (the default) is a
+    no-op for both the floor check and the projection, matching
+    ``enforce_requested_depth``'s/``project_snapshot_to_depth``'s own
+    documented contracts.
     """
     from ..bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
     from ..bundle_manifest import load_manifest
-    from ..policy.depth_projection import project_pair_to_depth
+    from ..policy.depth_projection import project_snapshot_to_depth
     from ..serialization import load_bundle_facts
+    from .artifact.execute import enforce_requested_depth
     from .compare_policy import compare_snapshots
 
     old_facts = load_bundle_facts(
@@ -193,14 +206,50 @@ def compare_stored_bundle_facts_pair(
     matched_keys = sorted(
         set(old_facts.per_library_snapshots) & set(new_facts.per_library_snapshots)
     )
+
+    # Codex review, PR #1060, round 6: project *every* library's stored
+    # snapshot (not just the matched pairs fed to compare_snapshots below)
+    # down to the requested depth once, up front, and reuse the same
+    # projected maps both for the per-library diff and for the bundle-level
+    # signature-evidence gate a few lines down -- previously that gate read
+    # old_facts.per_library_snapshots/new_facts.per_library_snapshots
+    # (raw, unprojected) directly, so a header-complete stored snapshot
+    # could still satisfy find_unverified_signature_findings' type-evidence
+    # check under an explicit --depth binary/headers ceiling even though the
+    # equivalent live binary-depth view would mark those exports ELF_ONLY
+    # and flag BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED. project_snapshot_to_
+    # depth is a pure per-snapshot projection (no cross-side interaction),
+    # so projecting the whole map here is equivalent to -- and replaces --
+    # the previous per-matched-pair project_pair_to_depth() call.
+    projected_old_snapshots = {
+        key: project_snapshot_to_depth(snap, depth)
+        for key, snap in old_facts.per_library_snapshots.items()
+    }
+    projected_new_snapshots = {
+        key: project_snapshot_to_depth(snap, depth)
+        for key, snap in new_facts.per_library_snapshots.items()
+    }
+
     per_library_results: list[DiffResult] = []
     for key in matched_keys:
-        old_snapshot, new_snapshot = project_pair_to_depth(
-            old_facts.per_library_snapshots[key], new_facts.per_library_snapshots[key], depth
-        )
+        raw_old = old_facts.per_library_snapshots[key]
+        raw_new = new_facts.per_library_snapshots[key]
+        # Codex review, PR #1060, round 6: the floor half of the same
+        # binary/headers/build/source contract project_snapshot_to_depth()
+        # (the ceiling half, applied above) already enforces below --
+        # classify_compare_pipeline pairs the two unconditionally
+        # (enforce_requested_depth() confirms the resolved evidence
+        # *reaches* depth, then the projection caps it back down), and this
+        # driver had only ever picked up the second half. Without this,
+        # --depth headers over two binary-only stored documents silently
+        # reported NO_CHANGE instead of failing loudly: the projection is a
+        # no-op ceiling on evidence that was already at or below the
+        # requested rung, so the comparison would proceed on binary-only
+        # facts as if headers-level evidence had genuinely backed it.
+        enforce_requested_depth(depth, ((f"old:{key}", raw_old), (f"new:{key}", raw_new)))
         diff = compare_snapshots(
-            old_snapshot,
-            new_snapshot,
+            projected_old_snapshots[key],
+            projected_new_snapshots[key],
             suppress,
             policy=policy,
             policy_file=policy_file,
@@ -232,5 +281,13 @@ def compare_stored_bundle_facts_pair(
         cohorts=cohorts,
         policy=policy,
         policy_file=policy_file,
-        new_signature_evidence=dict(new_facts.per_library_snapshots),
+        # Codex review, PR #1060, round 6: both maps must be the same
+        # depth-projected snapshots the per-library diff above just used --
+        # passing the raw, unprojected old_facts.per_library_snapshots (the
+        # old_signature_evidence default) or new_facts.per_library_snapshots
+        # here would let find_unverified_signature_findings judge type-
+        # evidence completeness against evidence richer than what --depth
+        # actually allowed the comparison to see.
+        old_signature_evidence=dict(projected_old_snapshots),
+        new_signature_evidence=dict(projected_new_snapshots),
     )

--- a/abicheck/workflows/bundle_stored_pair_compare.py
+++ b/abicheck/workflows/bundle_stored_pair_compare.py
@@ -60,6 +60,7 @@ def compare_stored_bundle_facts_pair(
     suppress: SuppressionList | None = None,
     old_max_json_object_nodes: int | None = None,
     new_max_json_object_nodes: int | None = None,
+    depth: str | None = None,
 ) -> BundleDiffResult:
     """End-to-end driver: two stored ``BundleFacts`` documents compared
     against each other -- the stored/stored operand shape (CLI cleanup
@@ -124,21 +125,28 @@ def compare_stored_bundle_facts_pair(
     ``BundleDiffResult.bundle_verdict`` is scored under the same policy as
     every per-library diff, not just the live-NEW-side driver's own case.
 
-    Callers requesting a limited evidence depth (``compare``'s
-    ``--depth binary``) must reject it themselves before calling this
-    function rather than relying on it to project either side down to
-    symbols-only evidence: unlike a live NEW-side dump (which
-    ``service.resolve_input`` can be asked to skip header parsing for),
-    both sides here are *already* fully-resolved ``AbiSnapshot``s with
-    whatever evidence they were captured with baked in, and this module has
-    no general snapshot-projection primitive to strip header-derived facts
-    back out after the fact (Codex review, PR #1060) --
-    ``frontends/cli/commands/compare_bundle_facts_rejections.py`` is where
-    that rejection lives, the same "reject rather than silently diverge"
-    rule every other unsupported flag in that module is held to.
+    *depth*, when given, caps both sides' evidence to what ``compare``'s
+    ``--depth`` requested before diffing (``binary``/``headers`` -- the
+    only two values reachable here at all, since ``--depth build``/
+    ``source`` are rejected unconditionally for a stored OLD_INPUT
+    elsewhere: this driver has no channel to *collect* L3-L5 evidence, only
+    to project already-resolved evidence down). Unlike a live NEW-side dump
+    (which ``service.resolve_input`` can be asked to skip header parsing
+    for), both sides here are *already* fully-resolved ``AbiSnapshot``s
+    with whatever evidence they were captured with baked in -- so this
+    calls the same ``policy.depth_projection.project_pair_to_depth()``
+    ordinary live comparisons use (``service_compare_pipeline.py``,
+    ``cli_compare_helpers.py``, ``cli_scan_baseline.py``) rather than
+    rejecting the flag outright, which an earlier version of this function
+    did on the mistaken premise that no such projection primitive existed
+    (Codex review, PR #1060, fresh evidence: it does, and every other
+    resolved-snapshot comparison path in this codebase already calls it).
+    ``None`` (the default) is a no-op, matching
+    ``project_snapshot_to_depth``'s own documented contract.
     """
     from ..bundle_facts import bundle_snapshot_from_facts, compare_bundle_from_facts
     from ..bundle_manifest import load_manifest
+    from ..policy.depth_projection import project_pair_to_depth
     from ..serialization import load_bundle_facts
     from .compare_policy import compare_snapshots
 
@@ -187,9 +195,12 @@ def compare_stored_bundle_facts_pair(
     )
     per_library_results: list[DiffResult] = []
     for key in matched_keys:
+        old_snapshot, new_snapshot = project_pair_to_depth(
+            old_facts.per_library_snapshots[key], new_facts.per_library_snapshots[key], depth
+        )
         diff = compare_snapshots(
-            old_facts.per_library_snapshots[key],
-            new_facts.per_library_snapshots[key],
+            old_snapshot,
+            new_snapshot,
             suppress,
             policy=policy,
             policy_file=policy_file,

--- a/changelog.d/20260904_182514_noreply_cli_bundle_compare_unification_xq4rnr.md
+++ b/changelog.d/20260904_182514_noreply_cli_bundle_compare_unification_xq4rnr.md
@@ -3,9 +3,10 @@
 - **`compare` now supports a stored/stored `BundleFacts` comparison** — when
   both OLD_INPUT and NEW_INPUT classify as persisted `BundleFacts`
   documents (from a prior `--bundle-facts-out`), `compare` diffs them
-  directly (`bundle_side_input.compare_stored_bundle_facts_pair`): a pure
-  in-memory per-library diff, reading no binaries and parsing no header AST
-  on either side. Closes one of the two operand shapes CLI cleanup phase
+  directly (`workflows.bundle_stored_pair_compare.
+  compare_stored_bundle_facts_pair`): a pure in-memory per-library diff,
+  reading no binaries and parsing no header AST on either side. Closes one
+  of the two operand shapes CLI cleanup phase
   two's PR I left without a real execution engine (`docs/contribute/plans/
   cli-cleanup-phase-two.md`); the JSON envelope's `new_dir` field keeps its
   established meaning, with a new `new_is_stored` field distinguishing the

--- a/changelog.d/20260904_182514_noreply_cli_bundle_compare_unification_xq4rnr.md
+++ b/changelog.d/20260904_182514_noreply_cli_bundle_compare_unification_xq4rnr.md
@@ -1,0 +1,13 @@
+### Added
+
+- **`compare` now supports a stored/stored `BundleFacts` comparison** — when
+  both OLD_INPUT and NEW_INPUT classify as persisted `BundleFacts`
+  documents (from a prior `--bundle-facts-out`), `compare` diffs them
+  directly (`bundle_side_input.compare_stored_bundle_facts_pair`): a pure
+  in-memory per-library diff, reading no binaries and parsing no header AST
+  on either side. Closes one of the two operand shapes CLI cleanup phase
+  two's PR I left without a real execution engine (`docs/contribute/plans/
+  cli-cleanup-phase-two.md`); the JSON envelope's `new_dir` field keeps its
+  established meaning, with a new `new_is_stored` field distinguishing the
+  two shapes. The remaining shape — a live OLD_INPUT compared against a
+  stored NEW_INPUT — is still rejected outright with a clear error.

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -196,6 +196,7 @@ topics:
       - abicheck/product_baseline.py
       - abicheck/bundle_side_input.py
       - abicheck/workflows/bundle_facts_library_overrides.py
+      - abicheck/workflows/bundle_stored_pair_compare.py
       - abicheck/frontends/cli/commands/compare_bundle_facts.py
       - abicheck/frontends/cli/options/bundle_facts.py
     reference_page: reference/cli-reference.md

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -5101,18 +5101,27 @@ PR I  one bundle compare, not two     — NEW (2026-09-01 checkpoint): an
                                        standing stance. **Stored/stored
                                        execution engine landed
                                        2026-09-04:**
-                                       bundle_side_input.
+                                       workflows.bundle_stored_pair_compare.
                                        compare_stored_bundle_facts_pair()
                                        diffs two already-persisted
                                        BundleFacts documents directly --
-                                       matched-key intersection, then one
-                                       service.compare_snapshots() call per
-                                       matched library (no binaries read, no
-                                       header AST parsed on either side),
+                                       matched-key intersection, an
+                                       enforce_requested_depth() floor check
+                                       plus a project_snapshot_to_depth()
+                                       ceiling per matched library for an
+                                       explicit --depth, then one
+                                       workflows.compare_policy.
+                                       compare_snapshots() call per matched
+                                       library (no binaries read, no header
+                                       AST parsed on either side),
                                        delegating the bundle-level call to
                                        the same bundle_facts.
                                        compare_bundle_from_facts() every
-                                       other operand shape already shares.
+                                       other operand shape already shares
+                                       (now also passed both sides'
+                                       depth-projected signature-evidence
+                                       maps, via a new old_signature_
+                                       evidence parameter on that function).
                                        compare_bundle_facts.py's dispatch()
                                        selects between the two stored-
                                        OLD_INPUT drivers on the new

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -5043,10 +5043,11 @@ PR H  artifact-set semantics          = PR 5 — provider ownership, moved and
 PR I  one bundle compare, not two     — NEW (2026-09-01 checkpoint): an
       (prerequisite DONE; operand        explicit artifact_type discriminator
        classification + flag deletion    on BundleFacts, operand classification
-       DONE 2026-09-03; full             instead of a mode flag, and one
-       BundleCompareRequest unification  BundleCompareRequest over live/live +
-       not started)                      stored/live + live/stored +
-                                       stored/stored, with the full
+       DONE 2026-09-03; stored/stored    instead of a mode flag, and one
+       execution engine DONE            BundleCompareRequest over live/live +
+       2026-09-04; live/stored and       stored/live + live/stored +
+       full evaluation/gate/report/      stored/stored, with the full
+       dry-run unification not started)
                                        evaluation/gate/report/dry-run surface
                                        answered once. Shares PR G2's own
                                        GateOptions prerequisite.
@@ -5090,21 +5091,61 @@ PR I  one bundle compare, not two     — NEW (2026-09-01 checkpoint): an
                                        marker-less legacy v1 document);
                                        `compare_bundle_operand_dispatch.py`
                                        is the frontends-boundary translation
-                                       (a stored NEW_INPUT is a
-                                       click.UsageError, live/stored and
-                                       stored/stored still having no
-                                       execution engine). `--old-bundle-facts`
+                                       (a stored NEW_INPUT paired with a
+                                       *live* OLD_INPUT is a
+                                       click.UsageError -- live/stored is
+                                       the one shape still with no execution
+                                       engine). `--old-bundle-facts`
                                        and its former help text are gone, no
                                        deprecation alias, per this plan's
-                                       standing stance. **Still not
-                                       started, and still this row's own
-                                       open design question:** the actual
-                                       BundleCompareRequest unification --
+                                       standing stance. **Stored/stored
+                                       execution engine landed
+                                       2026-09-04:**
+                                       bundle_side_input.
+                                       compare_stored_bundle_facts_pair()
+                                       diffs two already-persisted
+                                       BundleFacts documents directly --
+                                       matched-key intersection, then one
+                                       service.compare_snapshots() call per
+                                       matched library (no binaries read, no
+                                       header AST parsed on either side),
+                                       delegating the bundle-level call to
+                                       the same bundle_facts.
+                                       compare_bundle_from_facts() every
+                                       other operand shape already shares.
+                                       compare_bundle_facts.py's dispatch()
+                                       selects between the two stored-
+                                       OLD_INPUT drivers on the new
+                                       new_is_stored flag, and
+                                       compare_bundle_facts_rejections.py
+                                       gained the NEW-side-scoped mirror of
+                                       every OLD-side extraction-only
+                                       rejection (--header new=,
+                                       --ast-frontend, --devel-pkg new=,
+                                       --bundle-facts-library-manifest,
+                                       --include-private-dso,
+                                       --keep-extracted, an explicit
+                                       --version new=,
+                                       --include-system-declarations) for
+                                       when NEW_INPUT is stored too, since
+                                       neither side has anything left to
+                                       re-extract. **Still not started, and
+                                       still this row's own open design
+                                       question:** live/stored (a live
+                                       OLD_INPUT compared against a stored
+                                       NEW_INPUT) -- the mirror image of the
+                                       stored/live driver, with every
+                                       OLD-side extraction option newly
+                                       meaningful and every NEW-side one of
+                                       those newly rejected -- and, across
+                                       all four operand shapes, the actual
                                        one evaluation/gate/report/dry-run
-                                       path across all four operand
-                                       combinations, live/stored and
-                                       stored/stored gaining a real engine
-                                       instead of a clean rejection, and
+                                       path unification (today each stored
+                                       shape still renders its own narrower
+                                       `mode: "bundle_facts"` envelope
+                                       through compare_bundle_facts.py
+                                       rather than the shared ExitDecision/
+                                       report pipeline live/live uses), and
                                        whether that unification reuses
                                        GateOptions as-is or needs a broader
                                        one.

--- a/docs/use/multi-binary.md
+++ b/docs/use/multi-binary.md
@@ -553,15 +553,30 @@ abicheck compare release-1.0.bundlefacts.json release-3.0/
 `OLD_INPUT` being a stored `BundleFacts` document (from a prior
 `--bundle-facts-out` run) is detected automatically, the same way `compare`
 already classifies a directory vs. a package vs. a single binary — there is
-no separate flag to pass. `NEW_INPUT` stays a live release directory or
-package (extracted the same way the ordinary release fan-out extracts one).
-Only `--format json`/`markdown` are available in this mode, and most of the
-~44 flags the live release fan-out accepts have no channel into a
+no separate flag to pass. `NEW_INPUT` can be either a live release
+directory/package (extracted the same way the ordinary release fan-out
+extracts one) or a *second* stored `BundleFacts` document — comparing two
+previously-captured documents with no binaries reopened on either side, e.g.
+`abicheck compare release-1.0.bundlefacts.json release-2.0.bundlefacts.json`.
+Only `--format json`/`markdown` are available in either mode, and most of
+the ~44 flags the live release fan-out accepts have no channel into a
 stored-facts comparison and are rejected explicitly (exit 64) rather than
 silently ignored — see `abicheck compare --help-all` for the full, current
-list. Internally it routes through `abicheck.bundle_side_input.
-compare_release_against_bundle_facts()`, the same driver the paragraph
-below describes.
+list. When `NEW_INPUT` is also stored, every flag that would only ever
+apply to a *live* `NEW_INPUT` (`--header`/`--include`, `--ast-frontend`,
+`--compiler`/`--sysroot`, `--devel-pkg new=`,
+`--bundle-facts-library-manifest`, an explicit `--version new=`, ...) is
+rejected too, alongside a mismatched build variant between the two
+documents (`BundleFacts.variant_fingerprint`, a stable build-identity
+fingerprint each captured document carries): two documents captured from
+different logical builds (a CPU-only build vs. a SYCL/DPC build of the
+same source tree, say) are refused outright rather than silently diffed as
+if they were the same release. Internally, OLD-stored/NEW-live routes
+through
+`abicheck.bundle_side_input.compare_release_against_bundle_facts()` (the
+same driver the paragraph below describes); OLD-stored/NEW-stored routes
+through `abicheck.workflows.bundle_stored_pair_compare.
+compare_stored_bundle_facts_pair()`.
 
 `compare_bundle_from_facts()` reconstructs a live-equivalent
 `BundleSnapshot` from the stored per-library `AbiSnapshot.elf` metadata (no

--- a/tests/test_bundle_facts_archive.py
+++ b/tests/test_bundle_facts_archive.py
@@ -861,3 +861,30 @@ class TestBundleFactsArchiveArtifactTypeDiscriminator:
         # not the preserved 1 the in-memory facts object claimed.
         reloaded = load_bundle_facts(out, format="archive")
         assert reloaded.schema_version == BUNDLE_FACTS_SCHEMA_VERSION
+
+    def test_load_rejects_a_non_string_variant_fingerprint(
+        self, tmp_path: Path
+    ) -> None:
+        """The archive manifest's own ``variant_fingerprint`` field must go
+        through the same ``validated_variant_fingerprint()`` check the
+        plain-JSON loader uses, not a bare ``str(...)`` coercion -- a
+        malformed ``variant_fingerprint: 1`` and a genuine
+        ``variant_fingerprint: "1"`` must not both load as the identical
+        string ``"1"`` (Codex review, PR #1060, round 10)."""
+        from abicheck.bundle_facts import BUNDLE_FACTS_SCHEMA_VERSION
+        from abicheck.storage.bundle_archive import BundleArchiveWriter
+
+        out = tmp_path / "bad-fingerprint.bundlefacts.archive.zip"
+        with BundleArchiveWriter(out) as writer:
+            writer.write_manifest(
+                {
+                    "artifact_type": BUNDLE_ARCHIVE_ARTIFACT_TYPE,
+                    "schema_version": 1,
+                    "bundle_facts_schema_version": BUNDLE_FACTS_SCHEMA_VERSION,
+                    "variant_fingerprint": 1,
+                    "library_blobs": {},
+                }
+            )
+
+        with pytest.raises(ValueError, match="variant_fingerprint"):
+            load_bundle_facts(out, format="archive")

--- a/tests/test_bundle_facts_archive.py
+++ b/tests/test_bundle_facts_archive.py
@@ -870,7 +870,9 @@ class TestBundleFactsArchiveArtifactTypeDiscriminator:
         plain-JSON loader uses, not a bare ``str(...)`` coercion -- a
         malformed ``variant_fingerprint: 1`` and a genuine
         ``variant_fingerprint: "1"`` must not both load as the identical
-        string ``"1"`` (Codex review, PR #1060, round 10)."""
+        string ``"1"`` (Codex review, PR #1060, round 10). The check now
+        delegates to ``storage.guards.identity_text()`` (round 11), which
+        raises ``TypeError`` rather than a bare ``ValueError``."""
         from abicheck.bundle_facts import BUNDLE_FACTS_SCHEMA_VERSION
         from abicheck.storage.bundle_archive import BundleArchiveWriter
 
@@ -886,5 +888,5 @@ class TestBundleFactsArchiveArtifactTypeDiscriminator:
                 }
             )
 
-        with pytest.raises(ValueError, match="variant_fingerprint"):
+        with pytest.raises(TypeError, match="variant_fingerprint"):
             load_bundle_facts(out, format="archive")

--- a/tests/test_bundle_facts_signature_evidence.py
+++ b/tests/test_bundle_facts_signature_evidence.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for :func:`abicheck.bundle_facts.compare_bundle_from_facts`'s
+*old_signature_evidence* parameter (Codex review, PR #1060, round 6).
+
+Split out of ``test_bundle_facts.py`` -- that file sits at its architecture
+debt-no-growth line cap (CLAUDE.md "move responsibility instead of raising
+the baseline"), and this is genuinely new coverage for a new parameter, not
+a fixup to an existing test there. Mirrors that file's own
+``TestCompareBundleFromFactsPhase4Parity`` fixture style (``_meta``,
+``_snapshot``, ``_diff``) rather than importing its private test helpers
+across files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.bundle import _compute_resolution_graph
+from abicheck.bundle_facts import capture_bundle_facts, compare_bundle_from_facts
+from abicheck.bundle_models import BundleSnapshot
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.checker_types import DiffResult
+from abicheck.elf_metadata import ElfImport, ElfMetadata, ElfSymbol
+from abicheck.model import AbiSnapshot, Function, Visibility
+
+
+def _meta(
+    *,
+    soname: str,
+    exports: list[str] | None = None,
+    needed: list[str] | None = None,
+    imports: list[str] | None = None,
+) -> ElfMetadata:
+    return ElfMetadata(
+        soname=soname,
+        needed=needed or [],
+        symbols=[ElfSymbol(name=n, visibility="default") for n in exports or []],
+        imports=[ElfImport(name=n) for n in imports or []],
+    )
+
+
+def _snapshot(libraries: dict[str, ElfMetadata]) -> BundleSnapshot:
+    libs = {name: Path(f"/fake/{name}") for name in libraries}
+    graph = _compute_resolution_graph(libs, libraries)
+    return BundleSnapshot(
+        root=Path("/fake"), libraries=libs, metadata=libraries, resolution=graph
+    )
+
+
+def _diff(library: str, *, verdict: Verdict) -> DiffResult:
+    return DiffResult(
+        old_version="old", new_version="new", library=library, changes=[], verdict=verdict
+    )
+
+
+def _typed_function(version_marker: str) -> Function:
+    # A fully typed (non-elf_only) declaration: real type evidence, with
+    # both tri-state fields (is_variadic/contract_attributes) positively
+    # determined rather than left at their "not captured" None default --
+    # bundle_signature_evidence._symbol_evidence_sufficient() treats either
+    # field left at None as insufficient evidence, the same as an ELF-only
+    # declaration with no corroboration at all.
+    return Function(
+        name="core_fn",
+        mangled="core_fn",
+        return_type="int",
+        visibility=Visibility.PUBLIC,
+        is_variadic=False,
+        contract_attributes=[],
+    )
+
+
+def _elf_only_evidence(version: str) -> dict[str, AbiSnapshot]:
+    # elf_only_mode=True, ELF_ONLY visibility -- no header evidence at all
+    # for this symbol, so find_unverified_signature_findings() cannot
+    # confirm or deny the signature actually agrees between old and new.
+    fn = Function(
+        name="core_fn", mangled="core_fn", return_type="?", visibility=Visibility.ELF_ONLY
+    )
+    return {
+        "libcore.so": AbiSnapshot(
+            library="libcore.so", version=version, functions=[fn], elf_only_mode=True
+        )
+    }
+
+
+def _typed_evidence(version: str) -> dict[str, AbiSnapshot]:
+    return {
+        "libcore.so": AbiSnapshot(
+            library="libcore.so", version=version, functions=[_typed_function(version)]
+        )
+    }
+
+
+def test_old_signature_evidence_override_reaches_the_gate() -> None:
+    """*old_signature_evidence*, when given, must override the default
+    (*old_facts.per_library_snapshots*), the same way *new_signature_
+    evidence* already overrides its own default (no evidence at all).
+    Without a real override parameter, a caller that already
+    depth-projected its own old-side evidence
+    (``workflows.bundle_stored_pair_compare.compare_stored_bundle_facts_
+    pair``) had no way to make the gate see anything but the raw,
+    unprojected facts."""
+    metadata = {
+        "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+        "libconsumer.so": _meta(
+            soname="libconsumer.so", needed=["libcore.so"], imports=["core_fn"]
+        ),
+    }
+    new_snapshot = _snapshot(metadata)
+    per_lib_results = [
+        _diff("libcore.so", verdict=Verdict.NO_CHANGE),
+        _diff("libconsumer.so", verdict=Verdict.NO_CHANGE),
+    ]
+    new_evidence = _typed_evidence("new")
+
+    # The facts document's own per_library_snapshots also carries a fully
+    # typed (non-elf_only) libcore.so, matching new_evidence -- the default
+    # old-side evidence lets the gate confirm the signature agrees, so no
+    # finding.
+    facts_snapshots = {
+        "libcore.so": AbiSnapshot(
+            library="libcore.so",
+            version="old",
+            elf=metadata["libcore.so"],
+            functions=[_typed_function("old")],
+        ),
+        "libconsumer.so": AbiSnapshot(
+            library="libconsumer.so", version="old", elf=metadata["libconsumer.so"]
+        ),
+    }
+    facts = capture_bundle_facts(facts_snapshots)
+
+    baseline = compare_bundle_from_facts(
+        facts, new_snapshot, per_lib_results, new_signature_evidence=new_evidence
+    )
+    assert not any(
+        f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED
+        for f in baseline.bundle_findings
+    )
+
+    # An explicit old_signature_evidence override -- elf_only, no header
+    # evidence -- must reach the gate and change the outcome even though
+    # facts.per_library_snapshots itself (still fully typed) is untouched.
+    overridden = compare_bundle_from_facts(
+        facts,
+        new_snapshot,
+        per_lib_results,
+        new_signature_evidence=new_evidence,
+        old_signature_evidence=_elf_only_evidence("old"),
+    )
+    assert any(
+        f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED
+        for f in overridden.bundle_findings
+    )

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -388,6 +388,62 @@ class TestCompareReleaseAgainstBundleFactsResolutionUnit:
         )
         assert captured_kwargs["include_dependencies"] is True
 
+    def test_scope_mismatch_error_propagates_uncaught(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``compare_snapshots()`` raises ``ScopeMismatchError`` when a
+        matched pair's ``dependency_scope`` disagrees (both sides
+        header-derived) -- this function must let it propagate uncaught,
+        not swallow or translate it, since ``workflows/AGENTS.md``'s own
+        rule is that error types are the contract and the *CLI* layer is
+        the one place that translates them (Codex review, PR #1060, round
+        12 -- found on this function's stored/stored sibling, but this
+        function shares the identical ``service.compare_snapshots()``
+        chokepoint and so the identical failure mode)."""
+        import abicheck.package as package_mod
+        import abicheck.service as service_mod
+        from abicheck.errors import ScopeMismatchError
+
+        facts_path = self._old_facts(tmp_path)
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        new_so = new_dir / "libcore.so"
+        new_so.write_bytes(b"")
+
+        monkeypatch.setattr(
+            package_mod,
+            "discover_shared_libraries",
+            lambda d, include_private=False: [new_so],
+        )
+        monkeypatch.setattr(
+            service_mod,
+            "resolve_input",
+            lambda path, **kwargs: AbiSnapshot(
+                library="libcore.so",
+                version="new",
+                elf=_meta(soname="libcore.so", exports=["core_fn"]),
+                from_headers=True,
+                dependency_scope="full",
+            ),
+        )
+
+        # service.compare_snapshots() is deliberately left real here -- it's
+        # the function under test for this scenario, not a collaborator to
+        # stub out.
+
+        # The OLD side's own facts were captured from a plain-ELF fixture
+        # (no from_headers/dependency_scope at all) -- reload and mutate it
+        # so both sides carry an explicit, disagreeing dependency_scope.
+        from abicheck.serialization import load_bundle_facts, save_bundle_facts
+
+        facts = load_bundle_facts(facts_path)
+        facts.per_library_snapshots["libcore.so"].from_headers = True
+        facts.per_library_snapshots["libcore.so"].dependency_scope = "filtered"
+        save_bundle_facts(facts, facts_path)
+
+        with pytest.raises(ScopeMismatchError):
+            compare_release_against_bundle_facts(facts_path, new_dir)
+
     def test_policy_file_is_forwarded_to_per_library_compare(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -40,7 +40,6 @@ from abicheck.bundle_side_input import (
     StoredBundleFactsInput,
     compare_bundle_sides,
     compare_release_against_bundle_facts,
-    compare_stored_bundle_facts_pair,
     resolve_bundle_side,
 )
 from abicheck.checker_policy import ChangeKind, Verdict
@@ -301,113 +300,10 @@ class TestCompareBundleSidesManifestPrecedence:
         )
 
 
-# ---------------------------------------------------------------------------
-# compare_stored_bundle_facts_pair -- the stored/stored driver (CLI cleanup
-# phase two, PR I). No binaries, no header AST, no live extraction on
-# either side -- so unlike compare_release_against_bundle_facts's own
-# end-to-end class below (@pytest.mark.integration, needs gcc), this class
-# needs no compiler at all: both sides are already plain, hand-built
-# AbiSnapshots.
-# ---------------------------------------------------------------------------
-
-
-class TestCompareStoredBundleFactsPair:
-    def _facts_path(
-        self, tmp_path: Path, name: str, version: str, visibility: Visibility
-    ) -> Path:
-        fn = Function(
-            name="core_fn", mangled="core_fn", return_type="int", visibility=visibility
-        )
-        snapshot = AbiSnapshot(
-            library="libcore.so",
-            version=version,
-            elf=_meta(soname="libcore.so", exports=["core_fn"]),
-            functions=[fn],
-        )
-        facts = capture_bundle_facts({"libcore.so": snapshot})
-        path = tmp_path / name
-        save_bundle_facts(facts, path)
-        return path
-
-    def test_visibility_change_is_detected_with_no_binaries_read(
-        self, tmp_path: Path
-    ) -> None:
-        old_path = self._facts_path(
-            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
-        )
-        new_path = self._facts_path(
-            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
-        )
-
-        result = compare_stored_bundle_facts_pair(old_path, new_path)
-
-        assert [d.library for d in result.per_library] == ["libcore.so"]
-        assert result.per_library[0].changes
-        assert result.verdict != Verdict.NO_CHANGE
-
-    def test_unchanged_pair_is_no_change(self, tmp_path: Path) -> None:
-        old_path = self._facts_path(
-            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
-        )
-        new_path = self._facts_path(
-            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
-        )
-
-        result = compare_stored_bundle_facts_pair(old_path, new_path)
-
-        assert [d.library for d in result.per_library] == ["libcore.so"]
-        assert result.verdict == Verdict.NO_CHANGE
-
-    def test_library_present_on_only_one_side_is_not_diffed(
-        self, tmp_path: Path
-    ) -> None:
-        old_metadata = {
-            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
-            "libonly_old.so": _meta(soname="libonly_old.so", exports=["only_old_fn"]),
-        }
-        new_metadata = {
-            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
-            "libonly_new.so": _meta(soname="libonly_new.so", exports=["only_new_fn"]),
-        }
-        old_path = tmp_path / "old.bundlefacts.json"
-        new_path = tmp_path / "new.bundlefacts.json"
-        save_bundle_facts(
-            capture_bundle_facts(_per_library_snapshots(old_metadata)), old_path
-        )
-        save_bundle_facts(
-            capture_bundle_facts(_per_library_snapshots(new_metadata)), new_path
-        )
-
-        result = compare_stored_bundle_facts_pair(old_path, new_path)
-
-        assert [d.library for d in result.per_library] == ["libcore.so"]
-
-    def test_policy_file_override_reaches_the_per_library_diff(
-        self, tmp_path: Path
-    ) -> None:
-        """Mirrors ``TestCompareReleaseAgainstBundleFactsResolutionUnit.
-        test_policy_file_override_genuinely_demotes_a_real_verdict`` below,
-        for the stored/stored driver: a real ``overrides`` rule must reach
-        each per-library ``service.compare_snapshots()`` call, not just a
-        bare *policy* string."""
-        from abicheck.policy_file import PolicyFile
-
-        old_path = self._facts_path(
-            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
-        )
-        new_path = self._facts_path(
-            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
-        )
-        baseline = compare_stored_bundle_facts_pair(old_path, new_path)
-        assert baseline.verdict != Verdict.NO_CHANGE
-        demoted_kind = baseline.per_library[0].changes[0].kind
-
-        policy_file = PolicyFile(overrides={demoted_kind: Verdict.NO_CHANGE})
-        result = compare_stored_bundle_facts_pair(
-            old_path, new_path, policy_file=policy_file
-        )
-        assert result.verdict != baseline.verdict
-        assert result.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
+# compare_stored_bundle_facts_pair (the stored/stored driver, CLI cleanup
+# phase two, PR I) moved to abicheck/workflows/bundle_stored_pair_compare.py
+# (Codex review, PR #1060) -- its own tests now live in
+# tests/test_bundle_stored_pair_compare.py.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bundle_side_input.py
+++ b/tests/test_bundle_side_input.py
@@ -40,6 +40,7 @@ from abicheck.bundle_side_input import (
     StoredBundleFactsInput,
     compare_bundle_sides,
     compare_release_against_bundle_facts,
+    compare_stored_bundle_facts_pair,
     resolve_bundle_side,
 )
 from abicheck.checker_policy import ChangeKind, Verdict
@@ -298,6 +299,115 @@ class TestCompareBundleSidesManifestPrecedence:
             f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
             for f in result.bundle_findings
         )
+
+
+# ---------------------------------------------------------------------------
+# compare_stored_bundle_facts_pair -- the stored/stored driver (CLI cleanup
+# phase two, PR I). No binaries, no header AST, no live extraction on
+# either side -- so unlike compare_release_against_bundle_facts's own
+# end-to-end class below (@pytest.mark.integration, needs gcc), this class
+# needs no compiler at all: both sides are already plain, hand-built
+# AbiSnapshots.
+# ---------------------------------------------------------------------------
+
+
+class TestCompareStoredBundleFactsPair:
+    def _facts_path(
+        self, tmp_path: Path, name: str, version: str, visibility: Visibility
+    ) -> Path:
+        fn = Function(
+            name="core_fn", mangled="core_fn", return_type="int", visibility=visibility
+        )
+        snapshot = AbiSnapshot(
+            library="libcore.so",
+            version=version,
+            elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            functions=[fn],
+        )
+        facts = capture_bundle_facts({"libcore.so": snapshot})
+        path = tmp_path / name
+        save_bundle_facts(facts, path)
+        return path
+
+    def test_visibility_change_is_detected_with_no_binaries_read(
+        self, tmp_path: Path
+    ) -> None:
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+        assert result.per_library[0].changes
+        assert result.verdict != Verdict.NO_CHANGE
+
+    def test_unchanged_pair_is_no_change(self, tmp_path: Path) -> None:
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_library_present_on_only_one_side_is_not_diffed(
+        self, tmp_path: Path
+    ) -> None:
+        old_metadata = {
+            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+            "libonly_old.so": _meta(soname="libonly_old.so", exports=["only_old_fn"]),
+        }
+        new_metadata = {
+            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+            "libonly_new.so": _meta(soname="libonly_new.so", exports=["only_new_fn"]),
+        }
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(
+            capture_bundle_facts(_per_library_snapshots(old_metadata)), old_path
+        )
+        save_bundle_facts(
+            capture_bundle_facts(_per_library_snapshots(new_metadata)), new_path
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+
+    def test_policy_file_override_reaches_the_per_library_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """Mirrors ``TestCompareReleaseAgainstBundleFactsResolutionUnit.
+        test_policy_file_override_genuinely_demotes_a_real_verdict`` below,
+        for the stored/stored driver: a real ``overrides`` rule must reach
+        each per-library ``service.compare_snapshots()`` call, not just a
+        bare *policy* string."""
+        from abicheck.policy_file import PolicyFile
+
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+        baseline = compare_stored_bundle_facts_pair(old_path, new_path)
+        assert baseline.verdict != Verdict.NO_CHANGE
+        demoted_kind = baseline.per_library[0].changes[0].kind
+
+        policy_file = PolicyFile(overrides={demoted_kind: Verdict.NO_CHANGE})
+        result = compare_stored_bundle_facts_pair(
+            old_path, new_path, policy_file=policy_file
+        )
+        assert result.verdict != baseline.verdict
+        assert result.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -265,6 +265,37 @@ class TestCompareStoredBundleFactsPair:
         with pytest.raises(ValueError, match="variant_fingerprint"):
             compare_stored_bundle_facts_pair(old_path, new_path)
 
+    def test_explicit_null_variant_fingerprint_is_refused_not_defaulted(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit ``\"variant_fingerprint\": null`` must be rejected,
+        not silently treated as an absent key and defaulted -- prior to
+        this fix the loader's ``d.get(\"variant_fingerprint\")`` call (no
+        default arg) returned ``None`` for both cases alike, so a malformed
+        document naming an explicit null could compare as the default
+        variant against a genuinely coordinate-less document, bypassing
+        the stored-pair identity check entirely (Codex review, PR #1060,
+        round 9)."""
+        import json
+
+        old_path = tmp_path / "old.bundlefacts.json"
+        old_path.write_text(
+            json.dumps(
+                {
+                    "artifact_type": "abicheck.bundle-facts",
+                    "schema_version": 2,
+                    "per_library_snapshots": {},
+                    "variant_fingerprint": None,
+                }
+            )
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        with pytest.raises(ValueError, match="variant_fingerprint"):
+            compare_stored_bundle_facts_pair(old_path, new_path)
+
     def test_new_only_manifest_is_not_silently_discarded(self, tmp_path: Path) -> None:
         """When no explicit --manifest is given and only the NEW document
         captured one, it must still be consulted -- compare_bundle_from_

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -376,6 +376,35 @@ class TestCompareStoredBundleFactsPair:
         assert {c[1] for c in calls} == {"binary"}
         assert {c[0].library for c in calls} == {"libcore.so"}
 
+    def test_explicit_depth_is_stamped_onto_each_per_library_result(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit ``depth`` must reach each per-library ``DiffResult``'s
+        own ``requested_depth``/``analysis_assurance.depth_satisfied`` --
+        ``service_compare_pipeline.resolve_compare_request()`` stamps both
+        after its own floor/ceiling pair, and this driver enforces and
+        projects depth the identical way but previously never stamped
+        either, so every stored/stored ``--depth`` run persisted them as
+        ``None`` despite the evidence contract this driver actually
+        enforced (Codex review, PR #1060, round 10). ``None`` (the default,
+        no explicit depth) must leave both unset, matching every other
+        comparison path's identical "no request, nothing to stamp"
+        contract."""
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+
+        unrequested = compare_stored_bundle_facts_pair(old_path, new_path)
+        assert unrequested.per_library[0].requested_depth is None
+        assert unrequested.per_library[0].analysis_assurance.depth_satisfied is None
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path, depth="binary")
+        assert result.per_library[0].requested_depth == "binary"
+        assert result.per_library[0].analysis_assurance.depth_satisfied is True
+
     def test_depth_headers_strips_build_mode_before_diffing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -269,3 +269,98 @@ class TestCompareStoredBundleFactsPair:
             f.kind.name == "BUNDLE_MANIFEST_INSTANTIATION_REMOVED"
             for f in result.bundle_findings
         )
+
+    def test_depth_is_forwarded_to_project_pair_to_depth(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit *depth* must reach ``policy.depth_projection.
+        project_pair_to_depth()`` for every matched library, and its
+        *projected* return value -- not the raw stored snapshot -- must be
+        what actually reaches ``compare_snapshots()`` (Codex review, PR
+        #1060, fresh evidence: an earlier version of this function rejected
+        --depth binary outright on the mistaken premise that no projection
+        primitive existed; this pins the real wiring instead of only
+        exercising the ``None``/no-op default every other test here uses)."""
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+
+        import abicheck.policy.depth_projection as depth_projection_module
+
+        real_project_pair_to_depth = depth_projection_module.project_pair_to_depth
+        calls: list[tuple[object, object, str | None]] = []
+
+        def _fake_project_pair_to_depth(old, new, depth):
+            calls.append((old, new, depth))
+            return real_project_pair_to_depth(old, new, depth)
+
+        monkeypatch.setattr(
+            depth_projection_module, "project_pair_to_depth", _fake_project_pair_to_depth
+        )
+
+        compare_stored_bundle_facts_pair(old_path, new_path, depth="binary")
+
+        assert len(calls) == 1
+        called_old, called_new, called_depth = calls[0]
+        assert called_depth == "binary"
+        assert called_old.library == "libcore.so"
+        assert called_new.library == "libcore.so"
+
+    def test_depth_headers_strips_build_mode_before_diffing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact scenario Codex's round-5 review named: a stored
+        document captured with build-mode evidence must reach
+        ``compare_snapshots`` with it stripped under an explicit ``--depth
+        headers`` (``policy.depth_projection.project_snapshot_to_depth``
+        nulls ``build_mode`` below the ``build`` rung), not sent through
+        unprojected -- otherwise a build-mode finding could still surface
+        and change the reported verdict despite the explicit ``headers``
+        ceiling."""
+        from abicheck.model.build_mode_facts import BuildMode, CompilerFamily
+
+        old_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="old",
+            elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            functions=[
+                Function(
+                    name="core_fn",
+                    mangled="core_fn",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            build_mode=BuildMode(compiler_family=CompilerFamily.GCC),
+        )
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(capture_bundle_facts({"libcore.so": old_snapshot}), old_path)
+        save_bundle_facts(capture_bundle_facts({"libcore.so": old_snapshot}), new_path)
+
+        import abicheck.workflows.compare_policy as compare_policy_module
+
+        seen: list[object] = []
+        real_compare_snapshots = compare_policy_module.compare_snapshots
+
+        def _spy_compare_snapshots(old, new, *args, **kwargs):
+            seen.append(old.build_mode)
+            seen.append(new.build_mode)
+            return real_compare_snapshots(old, new, *args, **kwargs)
+
+        monkeypatch.setattr(
+            compare_policy_module, "compare_snapshots", _spy_compare_snapshots
+        )
+
+        compare_stored_bundle_facts_pair(old_path, new_path)
+        assert seen == [
+            BuildMode(compiler_family=CompilerFamily.GCC),
+            BuildMode(compiler_family=CompilerFamily.GCC),
+        ]
+
+        seen.clear()
+        compare_stored_bundle_facts_pair(old_path, new_path, depth="headers")
+        assert seen == [None, None]

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -233,6 +233,38 @@ class TestCompareStoredBundleFactsPair:
         with pytest.raises(ValueError, match="empty variant_fingerprint"):
             compare_stored_bundle_facts_pair(old_path, new_path)
 
+    def test_non_string_variant_fingerprint_is_refused(self, tmp_path: Path) -> None:
+        """A malformed ``variant_fingerprint: 1`` must not silently load as
+        the string ``"1"`` and then compare equal to a genuine
+        ``variant_fingerprint: "1"`` on the other side -- prior to this fix
+        the loader (``bundle_facts_serialization.bundle_facts_from_dict``)
+        applied a blind ``str(...)`` coercion, so the two were
+        indistinguishable by the time they reached this function's own
+        mismatch/empty checks (Codex review, PR #1060, round 8)."""
+        import json
+
+        old_path = tmp_path / "old.bundlefacts.json"
+        old_path.write_text(
+            json.dumps(
+                {
+                    "artifact_type": "abicheck.bundle-facts",
+                    "schema_version": 2,
+                    "per_library_snapshots": {},
+                    "variant_fingerprint": 1,
+                }
+            )
+        )
+        new_path = self._facts_path(
+            tmp_path,
+            "new.bundlefacts.json",
+            "new",
+            Visibility.PUBLIC,
+            variant_fingerprint="1",
+        )
+
+        with pytest.raises(ValueError, match="variant_fingerprint"):
+            compare_stored_bundle_facts_pair(old_path, new_path)
+
     def test_new_only_manifest_is_not_silently_discarded(self, tmp_path: Path) -> None:
         """When no explicit --manifest is given and only the NEW document
         captured one, it must still be consulted -- compare_bundle_from_

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`abicheck.workflows.bundle_stored_pair_compare` (CLI
+cleanup phase two, PR I's stored/stored driver).
+
+No binaries, no header AST, no live extraction on either side -- both sides
+are already plain, hand-built ``AbiSnapshot``s, so unlike
+``TestCompareReleaseAgainstBundleFacts`` in ``test_bundle_side_input.py``
+(``@pytest.mark.integration``, needs gcc), this file needs no compiler at
+all. Mirrors that file's own fixture style.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.bundle_facts import capture_bundle_facts
+from abicheck.checker_policy import Verdict
+from abicheck.elf_metadata import ElfImport, ElfMetadata, ElfSymbol
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import save_bundle_facts
+from abicheck.workflows.bundle_stored_pair_compare import (
+    compare_stored_bundle_facts_pair,
+)
+
+
+def _meta(
+    *,
+    soname: str = "",
+    needed: list[str] | None = None,
+    exports: list[str] | None = None,
+    imports: list[str] | None = None,
+) -> ElfMetadata:
+    syms = [ElfSymbol(name=name, visibility="default") for name in exports or []]
+    imps = [ElfImport(name=name) for name in imports or []]
+    return ElfMetadata(soname=soname or "", needed=needed or [], symbols=syms, imports=imps)
+
+
+def _per_library_snapshots(metadata: dict[str, ElfMetadata]) -> dict[str, AbiSnapshot]:
+    return {
+        name: AbiSnapshot(library=name, version="old", elf=meta)
+        for name, meta in metadata.items()
+    }
+
+
+class TestCompareStoredBundleFactsPair:
+    def _facts_path(
+        self,
+        tmp_path: Path,
+        name: str,
+        version: str,
+        visibility: Visibility,
+        *,
+        variant_fingerprint: str | None = None,
+    ) -> Path:
+        fn = Function(
+            name="core_fn", mangled="core_fn", return_type="int", visibility=visibility
+        )
+        snapshot = AbiSnapshot(
+            library="libcore.so",
+            version=version,
+            elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            functions=[fn],
+        )
+        kwargs = {} if variant_fingerprint is None else {"variant_fingerprint": variant_fingerprint}
+        facts = capture_bundle_facts({"libcore.so": snapshot}, **kwargs)
+        path = tmp_path / name
+        save_bundle_facts(facts, path)
+        return path
+
+    def test_visibility_change_is_detected_with_no_binaries_read(
+        self, tmp_path: Path
+    ) -> None:
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+        assert result.per_library[0].changes
+        assert result.verdict != Verdict.NO_CHANGE
+
+    def test_unchanged_pair_is_no_change(self, tmp_path: Path) -> None:
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_library_present_on_only_one_side_is_not_diffed(
+        self, tmp_path: Path
+    ) -> None:
+        old_metadata = {
+            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+            "libonly_old.so": _meta(soname="libonly_old.so", exports=["only_old_fn"]),
+        }
+        new_metadata = {
+            "libcore.so": _meta(soname="libcore.so", exports=["core_fn"]),
+            "libonly_new.so": _meta(soname="libonly_new.so", exports=["only_new_fn"]),
+        }
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(
+            capture_bundle_facts(_per_library_snapshots(old_metadata)), old_path
+        )
+        save_bundle_facts(
+            capture_bundle_facts(_per_library_snapshots(new_metadata)), new_path
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+
+    def test_policy_file_override_reaches_the_per_library_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """A real ``overrides`` rule must reach each per-library
+        ``service.compare_snapshots()`` call, not just a bare *policy*
+        string."""
+        from abicheck.policy_file import PolicyFile
+
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = self._facts_path(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+        baseline = compare_stored_bundle_facts_pair(old_path, new_path)
+        assert baseline.verdict != Verdict.NO_CHANGE
+        demoted_kind = baseline.per_library[0].changes[0].kind
+
+        policy_file = PolicyFile(overrides={demoted_kind: Verdict.NO_CHANGE})
+        result = compare_stored_bundle_facts_pair(
+            old_path, new_path, policy_file=policy_file
+        )
+        assert result.verdict != baseline.verdict
+        assert result.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
+
+    def test_mismatched_variant_fingerprint_is_refused(self, tmp_path: Path) -> None:
+        """Two documents captured from different logical build variants
+        (e.g. a CPU-only build vs. a SYCL/DPC build) must never be silently
+        diffed as if they were the same build -- Codex review, PR #1060."""
+        old_path = self._facts_path(
+            tmp_path,
+            "old.bundlefacts.json",
+            "old",
+            Visibility.PUBLIC,
+            variant_fingerprint="cpu",
+        )
+        new_path = self._facts_path(
+            tmp_path,
+            "new.bundlefacts.json",
+            "new",
+            Visibility.PUBLIC,
+            variant_fingerprint="sycl",
+        )
+
+        with pytest.raises(ValueError, match="different build variants"):
+            compare_stored_bundle_facts_pair(old_path, new_path)
+
+    def test_matching_explicit_variant_fingerprint_is_accepted(
+        self, tmp_path: Path
+    ) -> None:
+        """The mismatch check above must not reject two documents that
+        genuinely share the same explicit, non-default variant."""
+        old_path = self._facts_path(
+            tmp_path,
+            "old.bundlefacts.json",
+            "old",
+            Visibility.PUBLIC,
+            variant_fingerprint="cpu",
+        )
+        new_path = self._facts_path(
+            tmp_path,
+            "new.bundlefacts.json",
+            "new",
+            Visibility.PUBLIC,
+            variant_fingerprint="cpu",
+        )
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert [d.library for d in result.per_library] == ["libcore.so"]
+        assert result.verdict == Verdict.NO_CHANGE

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -240,7 +240,10 @@ class TestCompareStoredBundleFactsPair:
         the loader (``bundle_facts_serialization.bundle_facts_from_dict``)
         applied a blind ``str(...)`` coercion, so the two were
         indistinguishable by the time they reached this function's own
-        mismatch/empty checks (Codex review, PR #1060, round 8)."""
+        mismatch/empty checks (Codex review, PR #1060, round 8). The
+        loader now delegates to ``storage.guards.identity_text()`` (round
+        11), which raises ``TypeError`` rather than this module's usual
+        ``ValueError``."""
         import json
 
         old_path = tmp_path / "old.bundlefacts.json"
@@ -262,7 +265,7 @@ class TestCompareStoredBundleFactsPair:
             variant_fingerprint="1",
         )
 
-        with pytest.raises(ValueError, match="variant_fingerprint"):
+        with pytest.raises(TypeError, match="variant_fingerprint"):
             compare_stored_bundle_facts_pair(old_path, new_path)
 
     def test_explicit_null_variant_fingerprint_is_refused_not_defaulted(
@@ -293,7 +296,7 @@ class TestCompareStoredBundleFactsPair:
             tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
         )
 
-        with pytest.raises(ValueError, match="variant_fingerprint"):
+        with pytest.raises(TypeError, match="variant_fingerprint"):
             compare_stored_bundle_facts_pair(old_path, new_path)
 
     def test_new_only_manifest_is_not_silently_discarded(self, tmp_path: Path) -> None:

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -207,3 +207,65 @@ class TestCompareStoredBundleFactsPair:
 
         assert [d.library for d in result.per_library] == ["libcore.so"]
         assert result.verdict == Verdict.NO_CHANGE
+
+    def test_empty_variant_fingerprint_is_refused_even_when_both_sides_match(
+        self, tmp_path: Path
+    ) -> None:
+        """An empty fingerprint carries no real identity evidence --
+        ``variant_fingerprint()`` itself never produces one -- so two
+        documents both carrying "" must not be treated as a match just
+        because they're equal (Codex review, PR #1060, fresh evidence)."""
+        old_path = self._facts_path(
+            tmp_path,
+            "old.bundlefacts.json",
+            "old",
+            Visibility.PUBLIC,
+            variant_fingerprint="",
+        )
+        new_path = self._facts_path(
+            tmp_path,
+            "new.bundlefacts.json",
+            "new",
+            Visibility.PUBLIC,
+            variant_fingerprint="",
+        )
+
+        with pytest.raises(ValueError, match="empty variant_fingerprint"):
+            compare_stored_bundle_facts_pair(old_path, new_path)
+
+    def test_new_only_manifest_is_not_silently_discarded(self, tmp_path: Path) -> None:
+        """When no explicit --manifest is given and only the NEW document
+        captured one, it must still be consulted -- compare_bundle_from_
+        facts()'s own precedence (explicit, else OLD's manifest) silently
+        drops a NEW-only manifest, which would hide a real missing-symbol
+        regression (Codex review, PR #1060)."""
+        from abicheck.bundle_manifest import InstantiationManifest, ManifestEntry
+        from abicheck.serialization import save_bundle_facts
+
+        old_path = self._facts_path(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        fn = Function(
+            name="core_fn", mangled="core_fn", return_type="int", visibility=Visibility.PUBLIC
+        )
+        new_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="new",
+            elf=_meta(soname="libcore.so", exports=["core_fn"]),
+            functions=[fn],
+        )
+        new_facts = capture_bundle_facts(
+            {"libcore.so": new_snapshot},
+            manifest=InstantiationManifest(
+                entries=(ManifestEntry(symbol="promised_but_missing"),)
+            ),
+        )
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(new_facts, new_path)
+
+        result = compare_stored_bundle_facts_pair(old_path, new_path)
+
+        assert any(
+            f.kind.name == "BUNDLE_MANIFEST_INSTANTIATION_REMOVED"
+            for f in result.bundle_findings
+        )

--- a/tests/test_bundle_stored_pair_compare.py
+++ b/tests/test_bundle_stored_pair_compare.py
@@ -270,17 +270,21 @@ class TestCompareStoredBundleFactsPair:
             for f in result.bundle_findings
         )
 
-    def test_depth_is_forwarded_to_project_pair_to_depth(
+    def test_depth_is_forwarded_to_project_snapshot_to_depth(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An explicit *depth* must reach ``policy.depth_projection.
-        project_pair_to_depth()`` for every matched library, and its
-        *projected* return value -- not the raw stored snapshot -- must be
-        what actually reaches ``compare_snapshots()`` (Codex review, PR
-        #1060, fresh evidence: an earlier version of this function rejected
-        --depth binary outright on the mistaken premise that no projection
-        primitive existed; this pins the real wiring instead of only
-        exercising the ``None``/no-op default every other test here uses)."""
+        project_snapshot_to_depth()`` for both sides of every matched
+        library, and its *projected* return value -- not the raw stored
+        snapshot -- must be what actually reaches ``compare_snapshots()``
+        (Codex review, PR #1060, fresh evidence: an earlier version of this
+        function rejected --depth binary outright on the mistaken premise
+        that no projection primitive existed; this pins the real wiring
+        instead of only exercising the ``None``/no-op default every other
+        test here uses). Both fixtures carry no header evidence
+        (``from_headers`` unset), so ``binary`` is the rung both sides
+        genuinely reach -- the floor check ``enforce_requested_depth`` now
+        also runs (round 6) does not reject it."""
         old_path = self._facts_path(
             tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
         )
@@ -290,24 +294,24 @@ class TestCompareStoredBundleFactsPair:
 
         import abicheck.policy.depth_projection as depth_projection_module
 
-        real_project_pair_to_depth = depth_projection_module.project_pair_to_depth
-        calls: list[tuple[object, object, str | None]] = []
+        real_project_snapshot_to_depth = depth_projection_module.project_snapshot_to_depth
+        calls: list[tuple[object, str | None]] = []
 
-        def _fake_project_pair_to_depth(old, new, depth):
-            calls.append((old, new, depth))
-            return real_project_pair_to_depth(old, new, depth)
+        def _fake_project_snapshot_to_depth(snap, depth):
+            calls.append((snap, depth))
+            return real_project_snapshot_to_depth(snap, depth)
 
         monkeypatch.setattr(
-            depth_projection_module, "project_pair_to_depth", _fake_project_pair_to_depth
+            depth_projection_module,
+            "project_snapshot_to_depth",
+            _fake_project_snapshot_to_depth,
         )
 
         compare_stored_bundle_facts_pair(old_path, new_path, depth="binary")
 
-        assert len(calls) == 1
-        called_old, called_new, called_depth = calls[0]
-        assert called_depth == "binary"
-        assert called_old.library == "libcore.so"
-        assert called_new.library == "libcore.so"
+        assert len(calls) == 2
+        assert {c[1] for c in calls} == {"binary"}
+        assert {c[0].library for c in calls} == {"libcore.so"}
 
     def test_depth_headers_strips_build_mode_before_diffing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -319,7 +323,10 @@ class TestCompareStoredBundleFactsPair:
         nulls ``build_mode`` below the ``build`` rung), not sent through
         unprojected -- otherwise a build-mode finding could still surface
         and change the reported verdict despite the explicit ``headers``
-        ceiling."""
+        ceiling. ``from_headers=True`` so the round-6 floor check
+        (``enforce_requested_depth``) accepts ``--depth headers`` -- the
+        fixture genuinely reached that rung, it's the *build_mode* ceiling
+        this test is pinning, not the floor."""
         from abicheck.model.build_mode_facts import BuildMode, CompilerFamily
 
         old_snapshot = AbiSnapshot(
@@ -335,6 +342,7 @@ class TestCompareStoredBundleFactsPair:
                 )
             ],
             build_mode=BuildMode(compiler_family=CompilerFamily.GCC),
+            from_headers=True,
         )
         old_path = tmp_path / "old.bundlefacts.json"
         new_path = tmp_path / "new.bundlefacts.json"

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -254,17 +254,31 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--include-system-declarations" in out
 
-    def test_depth_binary_is_rejected(self, tmp_path: Path) -> None:
-        """Unlike the stored/live shape (where --depth binary is a
-        legitimate, supported combination), neither side here has any way
-        to be projected down to symbols-only evidence -- both are already
-        fully-resolved snapshots."""
+    def test_depth_binary_is_not_rejected(self, tmp_path: Path) -> None:
+        """--depth binary is genuinely supported for stored/stored (both
+        sides are projected via policy.depth_projection.
+        project_pair_to_depth() before diffing) -- see
+        TestStoredPairEndToEnd for the actual projection behavior."""
         old_path, new_path = self._both_stored(tmp_path)
 
         code, out = _invoke("compare", str(old_path), str(new_path), "--depth", "binary")
 
-        assert code == 64
-        assert "--depth binary" in out
+        assert code != 64
+        assert "nothing was compared" in out
+
+    def test_depth_headers_is_not_rejected(self, tmp_path: Path) -> None:
+        """--depth headers is the other value reachable for stored/stored
+        (Codex review, PR #1060, round 5: fresh evidence that this specific
+        value still slipped past the earlier --depth binary-only rejection
+        fix) -- both sides are projected via policy.depth_projection.
+        project_pair_to_depth() before diffing, same as --depth binary
+        above."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--depth", "headers")
+
+        assert code != 64
+        assert "nothing was compared" in out
 
     def test_compiler_is_rejected(self, tmp_path: Path) -> None:
         old_path, new_path = self._both_stored(tmp_path)

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -308,6 +308,33 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--lang" in out
 
+    def test_allow_ast_frontend_fallback_is_rejected(self, tmp_path: Path) -> None:
+        """--allow-ast-frontend-fallback is expose_value=False (Codex
+        review, PR #1060, round 11) -- it never reaches kwargs at all, so
+        reject_unsupported_options() (kwargs-only) can never see it. Must
+        still be rejected via ctx.get_parameter_source(), not silently
+        accepted with no effect."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--allow-ast-frontend-fallback"
+        )
+
+        assert code == 64
+        assert "--allow-ast-frontend-fallback" in out
+
+    def test_allow_unsupported_castxml_is_rejected(self, tmp_path: Path) -> None:
+        """The expose_value=False sibling of the above (Codex review, PR
+        #1060, round 11)."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--allow-unsupported-castxml"
+        )
+
+        assert code == 64
+        assert "--allow-unsupported-castxml" in out
+
     def test_default_invocation_is_not_rejected_by_any_new_side_check(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -578,3 +578,67 @@ class TestStoredPairEndToEnd:
 
         assert code == 16
         assert "not comparable" in out
+
+    def test_incomparable_dependency_scope_emits_json_when_requested(
+        self, tmp_path: Path
+    ) -> None:
+        """The JSON half of the same refusal (Codex review, PR #1060, round
+        14): ``exit_bundle_facts_not_comparable`` previously wrote only the
+        stderr message and exited, even under ``--format json`` -- unlike
+        native ``compare``'s own ``_report_not_comparable``, which still
+        emits the requested JSON envelope. A stored-pair refusal must do the
+        same instead of silently dropping the requested report format."""
+        old_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="old",
+            elf=ElfMetadata(
+                soname="libcore.so",
+                symbols=[ElfSymbol(name="core_fn", visibility="default")],
+            ),
+            functions=[
+                Function(
+                    name="core_fn",
+                    mangled="core_fn",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            from_headers=True,
+            dependency_scope="filtered",
+        )
+        new_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="new",
+            elf=ElfMetadata(
+                soname="libcore.so",
+                symbols=[ElfSymbol(name="core_fn", visibility="default")],
+            ),
+            functions=[
+                Function(
+                    name="core_fn",
+                    mangled="core_fn",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            from_headers=True,
+            dependency_scope="full",
+        )
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(capture_bundle_facts({"libcore.so": old_snapshot}), old_path)
+        save_bundle_facts(capture_bundle_facts({"libcore.so": new_snapshot}), new_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--format", "json"
+        )
+
+        assert code == 16
+        assert "not comparable" in out
+        start = out.index("{")
+        document = json.loads(out[start:])
+        assert document["mode"] == "bundle_facts"
+        assert document["verdict"] is None
+        assert document["not_comparable"] is True
+        assert document["reason"]["kind"] == "scope_mismatch"
+        assert "message" in document["reason"]

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -234,6 +234,16 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--version" in out
 
+    def test_explicit_old_version_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--version", "old=1.0"
+        )
+
+        assert code == 64
+        assert "--version" in out
+
     def test_include_system_declarations_is_rejected(self, tmp_path: Path) -> None:
         old_path, new_path = self._both_stored(tmp_path)
 
@@ -301,6 +311,39 @@ class TestStoredPairEarlyRejections:
         monkeypatch.chdir(tmp_path)
 
         code, out = _invoke("compare", str(old_path), str(new_path))
+
+        assert code != 64
+        assert "nothing was compared" in out
+
+    def test_explicit_config_with_compile_block_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """Unlike an ambient, auto-discovered config (silently unused,
+        above), an *explicitly* given ``--config`` whose compile: block
+        would have no effect on a stored/stored comparison must be
+        rejected, not silently ignored -- the user asked for it by name
+        (Codex review, PR #1060, fresh evidence)."""
+        old_path, new_path = self._both_stored(tmp_path)
+        config_path = tmp_path / "custom.yml"
+        config_path.write_text("compile:\n  include_dirs: [include]\n")
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--config", str(config_path)
+        )
+
+        assert code == 64
+        assert "compile:" in out
+
+    def test_explicit_config_with_no_compile_block_is_not_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+        config_path = tmp_path / "custom.yml"
+        config_path.write_text("{}\n")
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--config", str(config_path)
+        )
 
         assert code != 64
         assert "nothing was compared" in out

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -436,3 +436,48 @@ class TestStoredPairEndToEnd:
         assert code != 0
         assert code != 64  # a real ValueError, not a usage error
         assert "different build variants" in out
+
+    def test_depth_binary_over_binary_only_evidence_is_a_clean_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """The floor half of the depth contract (Codex review, PR #1060,
+        round 6): --depth binary over two stored documents that genuinely
+        only carry binary-level evidence must succeed, not be rejected by
+        the new ``enforce_requested_depth`` floor check -- that check must
+        only reject a depth the resolved evidence falls *short* of, never
+        one it already meets."""
+        old_path = _write_facts(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = _write_facts(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--depth", "binary", "--format", "json"
+        )
+
+        assert code == 0
+        assert json.loads(out)["verdict"] == "NO_CHANGE"
+
+    def test_depth_headers_over_binary_only_evidence_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """The floor half of the depth contract (Codex review, PR #1060,
+        round 6): --depth headers over two stored documents that only
+        reached binary-level evidence (no ``from_headers``) must fail
+        loudly -- ``enforce_requested_depth`` -- rather than silently
+        report ``NO_CHANGE`` as if headers-level evidence had genuinely
+        backed the comparison."""
+        old_path = _write_facts(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = _write_facts(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--depth", "headers")
+
+        assert code != 0
+        assert code != 64  # a real ValidationError, not a Click usage error
+        assert "evidence depth" in out

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -25,9 +25,11 @@ NEW-side-specific rejections (``compare_bundle_facts_rejections.
 _reject_new_side_extraction_options_for_stored_pair``), and one real
 end-to-end comparison through the actual CLI entry point. No gcc/castxml
 needed anywhere here: both sides are already resolved, stored documents, so
-``compare_stored_bundle_facts_pair`` (``bundle_side_input.py``) reads no
-binaries and parses no header AST on either side -- see that function's own
-docstring.
+``compare_stored_bundle_facts_pair``
+(``workflows/bundle_stored_pair_compare.py``) reads no binaries and parses
+no header AST on either side -- see that function's own docstring. Its own
+direct-call unit tests (including the variant-fingerprint mismatch check)
+live in ``tests/test_bundle_stored_pair_compare.py``.
 """
 
 from __future__ import annotations
@@ -64,7 +66,12 @@ def _write_stub(tmp_path: Path, name: str) -> Path:
 
 
 def _write_facts(
-    tmp_path: Path, name: str, version: str, visibility: Visibility
+    tmp_path: Path,
+    name: str,
+    version: str,
+    visibility: Visibility,
+    *,
+    variant_fingerprint: str | None = None,
 ) -> Path:
     fn = Function(
         name="core_fn", mangled="core_fn", return_type="int", visibility=visibility
@@ -78,7 +85,8 @@ def _write_facts(
         ),
         functions=[fn],
     )
-    facts = capture_bundle_facts({"libcore.so": snapshot})
+    kwargs = {} if variant_fingerprint is None else {"variant_fingerprint": variant_fingerprint}
+    facts = capture_bundle_facts({"libcore.so": snapshot}, **kwargs)
     path = tmp_path / name
     save_bundle_facts(facts, path)
     return path
@@ -235,6 +243,18 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--include-system-declarations" in out
 
+    def test_depth_binary_is_rejected(self, tmp_path: Path) -> None:
+        """Unlike the stored/live shape (where --depth binary is a
+        legitimate, supported combination), neither side here has any way
+        to be projected down to symbols-only evidence -- both are already
+        fully-resolved snapshots."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--depth", "binary")
+
+        assert code == 64
+        assert "--depth binary" in out
+
     def test_default_invocation_is_not_rejected_by_any_new_side_check(
         self, tmp_path: Path
     ) -> None:
@@ -300,3 +320,27 @@ class TestStoredPairEndToEnd:
         )
 
         assert "NEW (stored facts)" in out
+
+    def test_mismatched_variant_is_refused_through_the_real_cli(
+        self, tmp_path: Path
+    ) -> None:
+        old_path = _write_facts(
+            tmp_path,
+            "old.bundlefacts.json",
+            "old",
+            Visibility.PUBLIC,
+            variant_fingerprint="cpu",
+        )
+        new_path = _write_facts(
+            tmp_path,
+            "new.bundlefacts.json",
+            "new",
+            Visibility.PUBLIC,
+            variant_fingerprint="sycl",
+        )
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--format", "json")
+
+        assert code != 0
+        assert code != 64  # a real ValueError, not a usage error
+        assert "different build variants" in out

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -255,6 +255,22 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--depth binary" in out
 
+    def test_compiler_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--compiler", "clang++")
+
+        assert code == 64
+        assert "--compiler" in out
+
+    def test_explicit_lang_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--lang", "c")
+
+        assert code == 64
+        assert "--lang" in out
+
     def test_default_invocation_is_not_rejected_by_any_new_side_check(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -216,6 +216,18 @@ class TestStoredPairEarlyRejections:
         assert code == 64
         assert "--include-private-dso" in out
 
+    def test_dso_only_is_rejected(self, tmp_path: Path) -> None:
+        """A persisted BundleFacts document carries no per-library
+        executable/library distinction to filter by, unlike the live
+        release fan-out's own old/new map filtering for this flag (Codex
+        review, PR #1060, round 7)."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--dso-only")
+
+        assert code == 64
+        assert "--dso-only" in out
+
     def test_keep_extracted_is_rejected(self, tmp_path: Path) -> None:
         old_path, new_path = self._both_stored(tmp_path)
 

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from abicheck.bundle_facts import capture_bundle_facts
@@ -280,6 +281,24 @@ class TestStoredPairEarlyRejections:
         the routing test: reaching the "nothing was compared" failure, not
         a click.UsageError."""
         old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path))
+
+        assert code != 64
+        assert "nothing was compared" in out
+
+    def test_ambient_project_config_include_dirs_is_not_treated_as_explicit_include(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An ordinary project's own ``.abicheck.yml`` `compile:
+        include_dirs:` must not be folded into ``kwargs["includes"]`` and
+        then rejected as if the user had passed an explicit ``--include``
+        -- Codex review, PR #1060: resolve_compile_context's own config
+        merge ran unconditionally, so any project with a compile config
+        block could never run a stored/stored comparison at all."""
+        old_path, new_path = self._both_stored(tmp_path)
+        (tmp_path / ".abicheck.yml").write_text("compile:\n  include_dirs: [include]\n")
+        monkeypatch.chdir(tmp_path)
 
         code, out = _invoke("compare", str(old_path), str(new_path))
 

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the stored/stored ``compare`` operand shape (CLI cleanup phase
+two, PR I): both OLD_INPUT and NEW_INPUT classify as stored ``BundleFacts``
+documents.
+
+Companion to ``test_cli_compare_bundle_facts.py`` (stored OLD_INPUT / live
+NEW_INPUT) and ``test_cli_compare_bundle_facts_rejections*.py`` (that
+shape's own early-rejection tests) -- this file covers the newer shape
+those predate: routing (``compare_bundle_operand_dispatch.py``), the
+NEW-side-specific rejections (``compare_bundle_facts_rejections.
+_reject_new_side_extraction_options_for_stored_pair``), and one real
+end-to-end comparison through the actual CLI entry point. No gcc/castxml
+needed anywhere here: both sides are already resolved, stored documents, so
+``compare_stored_bundle_facts_pair`` (``bundle_side_input.py``) reads no
+binaries and parses no header AST on either side -- see that function's own
+docstring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.bundle_facts import capture_bundle_facts
+from abicheck.cli import main
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import save_bundle_facts
+
+#: Carries the marker so operand classification routes it to
+#: compare_bundle_facts.dispatch() -- see test_cli_compare_bundle_facts_
+#: rejections_more.py's identical constant docstring.
+_STUB_BUNDLE_FACTS_JSON = (
+    '{"artifact_type": "abicheck.bundle-facts", "schema_version": 2, '
+    '"per_library_snapshots": {}}'
+)
+
+
+def _invoke(*args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(main, list(args))
+    return result.exit_code, result.output
+
+
+def _write_stub(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / name
+    path.write_text(_STUB_BUNDLE_FACTS_JSON)
+    return path
+
+
+def _write_facts(
+    tmp_path: Path, name: str, version: str, visibility: Visibility
+) -> Path:
+    fn = Function(
+        name="core_fn", mangled="core_fn", return_type="int", visibility=visibility
+    )
+    snapshot = AbiSnapshot(
+        library="libcore.so",
+        version=version,
+        elf=ElfMetadata(
+            soname="libcore.so",
+            symbols=[ElfSymbol(name="core_fn", visibility="default")],
+        ),
+        functions=[fn],
+    )
+    facts = capture_bundle_facts({"libcore.so": snapshot})
+    path = tmp_path / name
+    save_bundle_facts(facts, path)
+    return path
+
+
+class TestBundleCompareOperandRouting:
+    def test_stored_stored_pair_with_no_matching_library_fails_loudly(
+        self, tmp_path: Path
+    ) -> None:
+        """Both sides classify as stored and reach the driver (no early
+        rejection) -- proven by getting past every option check straight to
+        the "nothing was compared" failure, not a click.UsageError about an
+        unsupported flag."""
+        old_path = _write_stub(tmp_path, "old.bundlefacts.json")
+        new_path = _write_stub(tmp_path, "new.bundlefacts.json")
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--format", "json")
+
+        assert code != 64
+        assert "nothing was compared" in out
+
+    def test_live_old_input_against_stored_new_input_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """The one operand shape with no driver yet (live/stored) --
+        compare_bundle_operand_dispatch.resolve_bundle_compare_dispatch's
+        own remaining UsageError."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_path = _write_stub(tmp_path, "new.bundlefacts.json")
+
+        code, out = _invoke("compare", str(old_dir), str(new_path), "--format", "json")
+
+        assert code == 64
+        assert "not yet supported" in out
+
+
+class TestStoredPairEarlyRejections:
+    """The NEW-side mirror of the OLD-side extraction-only rejections
+    already covered by test_cli_compare_bundle_facts_rejections*.py --
+    each below proves the flag is rejected *before* any real facts loading,
+    the same "reject rather than silently diverge" bar every check in
+    compare_bundle_facts_rejections.py is held to."""
+
+    def _both_stored(self, tmp_path: Path) -> tuple[Path, Path]:
+        return (
+            _write_stub(tmp_path, "old.bundlefacts.json"),
+            _write_stub(tmp_path, "new.bundlefacts.json"),
+        )
+
+    def test_new_side_header_operand_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+        header_dir = tmp_path / "headers"
+        header_dir.mkdir()
+
+        code, out = _invoke(
+            "compare",
+            str(old_path),
+            str(new_path),
+            "--header",
+            f"new={header_dir}",
+            "--format",
+            "json",
+        )
+
+        assert code == 64
+        assert "--header" in out
+
+    def test_uniform_include_operand_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+        include_dir = tmp_path / "includes"
+        include_dir.mkdir()
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--include", str(include_dir)
+        )
+
+        assert code == 64
+        assert "--include" in out
+
+    def test_explicit_ast_frontend_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--ast-frontend", "clang"
+        )
+
+        assert code == 64
+        assert "--ast-frontend" in out
+
+    def test_devel_pkg_new_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+        devel_dir = tmp_path / "devel"
+        devel_dir.mkdir()
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--devel-pkg", f"new={devel_dir}"
+        )
+
+        assert code == 64
+        assert "--devel-pkg" in out
+
+    def test_bundle_facts_library_manifest_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("libraries: {}\n")
+
+        code, out = _invoke(
+            "compare",
+            str(old_path),
+            str(new_path),
+            "--bundle-facts-library-manifest",
+            str(manifest_path),
+        )
+
+        assert code == 64
+        assert "--bundle-facts-library-manifest" in out
+
+    def test_include_private_dso_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--include-private-dso"
+        )
+
+        assert code == 64
+        assert "--include-private-dso" in out
+
+    def test_keep_extracted_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--keep-extracted")
+
+        assert code == 64
+        assert "--keep-extracted" in out
+
+    def test_explicit_new_version_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--version", "new=2.0"
+        )
+
+        assert code == 64
+        assert "--version" in out
+
+    def test_include_system_declarations_is_rejected(self, tmp_path: Path) -> None:
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--include-system-declarations"
+        )
+
+        assert code == 64
+        assert "--include-system-declarations" in out
+
+    def test_default_invocation_is_not_rejected_by_any_new_side_check(
+        self, tmp_path: Path
+    ) -> None:
+        """The untouched Click defaults (header_backend="auto",
+        new_version="new", include_dependencies=False, ...) must not
+        themselves trip any of the checks above -- proven the same way as
+        the routing test: reaching the "nothing was compared" failure, not
+        a click.UsageError."""
+        old_path, new_path = self._both_stored(tmp_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path))
+
+        assert code != 64
+        assert "nothing was compared" in out
+
+
+class TestStoredPairEndToEnd:
+    def test_visibility_change_is_detected_through_the_real_cli(
+        self, tmp_path: Path
+    ) -> None:
+        old_path = _write_facts(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = _write_facts(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.HIDDEN
+        )
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--format", "json")
+
+        data = json.loads(out)
+        assert data["mode"] == "bundle_facts"
+        assert data["new_is_stored"] is True
+        assert data["new_dir"] == str(new_path)
+        assert "libcore.so" in data["libraries"]
+        assert code != 0
+
+    def test_unchanged_pair_is_a_clean_exit(self, tmp_path: Path) -> None:
+        old_path = _write_facts(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = _write_facts(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        code, out = _invoke("compare", str(old_path), str(new_path), "--format", "json")
+
+        data = json.loads(out)
+        assert data["verdict"] == "NO_CHANGE"
+        assert code == 0
+
+    def test_markdown_output_labels_new_side_as_stored_facts(
+        self, tmp_path: Path
+    ) -> None:
+        old_path = _write_facts(
+            tmp_path, "old.bundlefacts.json", "old", Visibility.PUBLIC
+        )
+        new_path = _write_facts(
+            tmp_path, "new.bundlefacts.json", "new", Visibility.PUBLIC
+        )
+
+        _code, out = _invoke(
+            "compare", str(old_path), str(new_path), "--format", "markdown"
+        )
+
+        assert "NEW (stored facts)" in out

--- a/tests/test_cli_compare_bundle_facts_stored_pair.py
+++ b/tests/test_cli_compare_bundle_facts_stored_pair.py
@@ -520,3 +520,61 @@ class TestStoredPairEndToEnd:
         assert code != 0
         assert code != 64  # a real ValidationError, not a Click usage error
         assert "evidence depth" in out
+
+    def test_incomparable_dependency_scope_exits_16_not_a_traceback(
+        self, tmp_path: Path
+    ) -> None:
+        """A matched pair whose extraction contracts disagree
+        (``dependency_scope`` "filtered" vs "full") makes
+        ``compare_snapshots()`` raise ``ScopeMismatchError`` from inside
+        ``compare_stored_bundle_facts_pair()``'s per-library loop -- neither
+        a ``ValueError``/``TypeError``/``SnapshotError``, so the dispatcher's
+        generic exception clause previously never saw it and let it surface
+        as an unhandled traceback (exit 1, no output) instead of native
+        ``compare``'s own established not-comparable response (exit 16)
+        (Codex review, PR #1060, round 12)."""
+        old_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="old",
+            elf=ElfMetadata(
+                soname="libcore.so",
+                symbols=[ElfSymbol(name="core_fn", visibility="default")],
+            ),
+            functions=[
+                Function(
+                    name="core_fn",
+                    mangled="core_fn",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            from_headers=True,
+            dependency_scope="filtered",
+        )
+        new_snapshot = AbiSnapshot(
+            library="libcore.so",
+            version="new",
+            elf=ElfMetadata(
+                soname="libcore.so",
+                symbols=[ElfSymbol(name="core_fn", visibility="default")],
+            ),
+            functions=[
+                Function(
+                    name="core_fn",
+                    mangled="core_fn",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            from_headers=True,
+            dependency_scope="full",
+        )
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(capture_bundle_facts({"libcore.so": old_snapshot}), old_path)
+        save_bundle_facts(capture_bundle_facts({"libcore.so": new_snapshot}), new_path)
+
+        code, out = _invoke("compare", str(old_path), str(new_path))
+
+        assert code == 16
+        assert "not comparable" in out

--- a/tests/test_compare_profiles.py
+++ b/tests/test_compare_profiles.py
@@ -205,3 +205,48 @@ class TestProfileOperandClassification:
 
     def test_a_missing_operand_key_is_skipped_without_classifying(self) -> None:
         assert _profile_targets_set_input({"old_input": None}) is False
+
+    def test_a_stored_bundle_facts_operand_is_recognised_as_a_set_input(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #1060, round 13: a stored ``BundleFacts``
+        document is not a directory/package operand
+        (``classify_compare_operand`` reports it as an ordinary ``"file"``),
+        but it represents a whole multi-library bundle the same way a
+        directory/package does, and dispatches to the identical multi-
+        library engine -- ``--profile`` must reject it too, not silently
+        inject e.g. ``depth="binary"`` into every library's evidence depth."""
+        from abicheck.bundle_facts import capture_bundle_facts
+        from abicheck.elf_metadata import ElfMetadata
+        from abicheck.serialization import save_bundle_facts
+
+        snapshot = AbiSnapshot(library="libcore.so", version="old", elf=ElfMetadata(soname="libcore.so"))
+        facts = capture_bundle_facts({"libcore.so": snapshot})
+        facts_path = tmp_path / "old.bundlefacts.json"
+        save_bundle_facts(facts, facts_path)
+
+        assert _profile_targets_set_input({"old_input": str(facts_path)}) is True
+
+    def test_stored_bundle_facts_pair_rejects_profile_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        """`compare old.bundlefacts.json new.bundlefacts.json --profile
+        ci-gate` exits as a usage error (64), the identical response a
+        directory/package pair already gets."""
+        from abicheck.bundle_facts import capture_bundle_facts
+        from abicheck.elf_metadata import ElfMetadata
+        from abicheck.serialization import save_bundle_facts
+
+        snapshot = AbiSnapshot(library="libcore.so", version="old", elf=ElfMetadata(soname="libcore.so"))
+        facts = capture_bundle_facts({"libcore.so": snapshot})
+        old_path = tmp_path / "old.bundlefacts.json"
+        new_path = tmp_path / "new.bundlefacts.json"
+        save_bundle_facts(facts, old_path)
+        save_bundle_facts(facts, new_path)
+
+        result = CliRunner().invoke(
+            main, ["compare", str(old_path), str(new_path), "--profile", "ci-gate"]
+        )
+
+        assert result.exit_code == 64, result.output
+        assert "single-pair" in result.output


### PR DESCRIPTION
## Summary

Gives the stored/stored `compare` operand shape a real execution engine, closing one of the two gaps CLI cleanup phase two's PR I left open (`docs/contribute/plans/cli-cleanup-phase-two.md`).

## Motivation

PR I (#1042) landed automatic operand classification for `compare`'s bundle-facts routing and deleted `--old-bundle-facts`, but left two of the four live/stored operand combinations without an execution engine: a stored NEW_INPUT (paired with either a stored or a live OLD_INPUT) was rejected outright with `click.UsageError`. This PR closes the stored/stored combination — comparing two documents previously captured with `--bundle-facts-out`.

## Changes

- `bundle_side_input.compare_stored_bundle_facts_pair()`: a new driver that diffs two already-persisted `BundleFacts` documents directly — matched-key intersection, then one `service.compare_snapshots()` call per matched library. No binaries are read and no header AST is parsed on either side. Delegates the bundle-level call to the same `bundle_facts.compare_bundle_from_facts()` every other operand shape already shares, so the detector suite can't independently drift between shapes.
- `compare_bundle_operand_dispatch.resolve_bundle_compare_dispatch()` now returns the full `BundleCompareRequest` classification instead of a bare `bool`, and only rejects the one remaining unimplemented shape: a stored NEW_INPUT paired with a *live* OLD_INPUT.
- `compare_bundle_facts.dispatch()` gains a `new_is_stored` flag selecting between the stored/live driver (existing) and the new stored/stored driver. The JSON envelope keeps its established `new_dir` field (still the NEW-side path either way) and adds an additive `new_is_stored` boolean; markdown labels the NEW side as "stored facts" instead of "release directory".
- `compare_bundle_facts_rejections.py` gained the NEW-side-scoped mirror of every OLD-side extraction-only rejection (`--header new=`, `--ast-frontend`, `--devel-pkg new=`, `--bundle-facts-library-manifest`, `--include-private-dso`, `--keep-extracted`, an explicit `--version new=`, `--include-system-declarations`) for when NEW_INPUT is stored too — neither side has anything left to re-extract.
- Updated `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR I entry to record what's landed and what's still open: live/stored (a live OLD_INPUT against a stored NEW_INPUT), and the broader one-evaluation/gate/report/dry-run-path unification across all four operand shapes (today each stored shape still renders its own narrower `mode: "bundle_facts"` envelope rather than the shared `ExitDecision`/report pipeline live/live uses).

## Bug-fix test contract

N/A — this is a `feat:` PR, not a bug fix.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_bundle_side_input.py::TestCompareStoredBundleFactsPair`, new `tests/test_cli_compare_bundle_facts_stored_pair.py` covering routing, the new NEW-side rejections, and end-to-end CLI behavior)
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (plan doc)
- [x] `ruff check`/`mypy abicheck/`/`scripts/check_architecture.py`/`scripts/check_ai_readiness.py` all pass with no new findings
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014U5x8D3ggNzUSTxPpu9CmP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for comparing two stored BundleFacts documents directly, without reopening binaries.
  * Added depth projection, variant validation, manifest handling, and stored-input labeling for these comparisons.
  * Added configurable old-side signature evidence for bundle analysis.

* **Bug Fixes**
  * Improved validation and rejection of unsupported options and mismatched build variants.

* **Documentation**
  * Documented stored/stored comparisons, supported operand combinations, and applicable command-line restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->