### PR TITLE
fix: dedupe shared objects in stored-release materialization, validate library_filenames shape

### DIFF
--- a/abicheck/cli_compare_release_matrix.py
+++ b/abicheck/cli_compare_release_matrix.py
@@ -615,12 +615,13 @@ def _resolve_release_package_side(
         return resolve_release_package_map(
             side_dir, variant_id=variant_id, dest_root=dest_root
         )
-    except (KeyError, ValueError, OSError, SnapshotError) as exc:
+    except (KeyError, ValueError, TypeError, OSError, SnapshotError) as exc:
         # Ambiguous variant, a same-key collision (ValueError), a missing/
         # unreadable ref (OSError), an object absent from objects/ entirely
         # (KeyError, DirectoryObjectStore.get's own error on a truncated
-        # package; CodeRabbit review), or a corrupt document (SnapshotError)
-        # are all usage errors, translated like `_build_match_map`'s own
+        # package; CodeRabbit review), a corrupt document (SnapshotError), or
+        # a wrong-shaped composition field (TypeError, storage.guards' own
+        # convention) are all usage errors, like `_build_match_map`'s own
         # `AmbiguousLibraryMatchError` (Codex review).
         raise click.UsageError(str(exc)) from exc
 

--- a/abicheck/project_snapshot_legacy.py
+++ b/abicheck/project_snapshot_legacy.py
@@ -29,6 +29,8 @@ out, don't trim the file to fit.
 
 from __future__ import annotations
 
+import os
+import shutil
 from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from pathlib import Path
@@ -299,6 +301,8 @@ def _materialize_referenced_objects(
     dest_dir: Path,
     source_store: DirectoryObjectStore,
     refs: Iterable[ObjectRef],
+    *,
+    materialized_cache: dict[str, Path] | None = None,
 ) -> None:
     """Copy exactly the objects *refs* names -- not *root*'s entire
     `objects/` tree -- into a fresh `DirectoryObjectStore` rooted at
@@ -321,9 +325,43 @@ def _materialize_referenced_objects(
     tampered or substituted object fails there, not silently), and no
     directory-level symlink -- the one thing a malicious package's own
     `objects/` layout could otherwise influence -- is ever created.
+
+    *materialized_cache*, when given, is shared across every sub-package
+    this same `materialize_release_variant_artifacts()` call materializes:
+    a variant- or project-level section is identical for every artifact in
+    the variant (Codex review, fresh evidence -- a large shared composition
+    or manifest was otherwise re-read from *source_store* and re-written
+    once per artifact, an N-fold disk blow-up for a many-artifact package).
+    The *first* artifact to need a given digest still goes through the
+    verified `get()`/`put()` round trip above; every later artifact
+    hard-links that already-verified destination file instead of touching
+    *source_store* again, falling back to a real copy only if hard-linking
+    itself fails (e.g. `dest_dir` spans a different filesystem/device from
+    the cached path) -- never linking to anything in *source_store* itself,
+    so the "no directory-level symlink into the untrusted source" invariant
+    above is preserved; only two already-verified destination copies ever
+    share an inode.
     """
     dest_store = DirectoryObjectStore(dest_dir)
     for ref in refs:
+        cached_path = (
+            materialized_cache.get(ref.digest)
+            if materialized_cache is not None
+            else None
+        )
+        if cached_path is not None:
+            dest_path = (
+                dest_store._json_path(ref.digest)
+                if cached_path.name.endswith(".json.zst")
+                else dest_store._raw_path(ref.digest)
+            )
+            if not dest_path.exists():
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    os.link(cached_path, dest_path)
+                except OSError:
+                    shutil.copyfile(cached_path, dest_path)
+            continue
         materialized_digest = dest_store.put(source_store.get(ref.digest))
         if materialized_digest != ref.digest:
             # Can only happen if the source store's own content no longer
@@ -334,6 +372,11 @@ def _materialize_referenced_objects(
                 "after being read back from the source package -- the "
                 "source package's object store is corrupted or was "
                 "hand-edited"
+            )
+        if materialized_cache is not None:
+            json_path = dest_store._json_path(ref.digest)
+            materialized_cache[ref.digest] = (
+                json_path if json_path.exists() else dest_store._raw_path(ref.digest)
             )
 
 
@@ -432,6 +475,11 @@ def materialize_release_variant_artifacts(
     source_store = DirectoryObjectStore(root_path)
 
     result: dict[str, tuple[Path, ArtifactRef]] = {}
+    # Shared across every artifact below -- a variant-/project-level
+    # section's own object is identical for all of them, so only the first
+    # artifact that needs it pays the real get()/put() cost (see
+    # `_materialize_referenced_objects`'s own docstring).
+    materialized_cache: dict[str, Path] = {}
     for artifact_id in variant.artifact_ids:
         full_variant, artifact = read_variant_artifact_pair(
             root_path, variant_id, artifact_id
@@ -488,6 +536,7 @@ def materialize_release_variant_artifacts(
                 *full_variant.sections.values(),
                 *summary.project_sections.values(),
             ],
+            materialized_cache=materialized_cache,
         )
         sub_manifest = PackageManifest(
             versions=trimmed_versions,

--- a/abicheck/storage/variant_composition.py
+++ b/abicheck/storage/variant_composition.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from . import guards
 from .dto import (
     BUNDLE_COMPOSITION_SECTION_KIND,
     SectionDTO,
@@ -116,18 +117,22 @@ def read_variant_composition_library_filenames(
     `dict(...)`'s own permissive construction unrejected, silently
     normalizing it (with a duplicate key becoming last-wins) instead of
     failing as malformed input `_release_match_key` then trusts for a real
-    matching decision (Codex review, fresh evidence).
+    matching decision. Validated through the shared `storage.guards`
+    primitives rather than a bespoke check here (`guards.mapping` for the
+    container, `guards.decision_key` for each bundle key -- exactly what
+    `_release_match_key` looks this mapping up by -- `guards.identity_text`
+    for each real filename), per `storage/AGENTS.md`'s "new guard goes in
+    guards.py" rule: a storage reader restating this rule ad hoc is the
+    drift that rule exists to stop (Codex review, fresh evidence).
     """
     composition = _read_variant_composition(root, variant_id)
     if composition is None:
         return {}
     raw = composition.get("library_filenames", {})
-    if not isinstance(raw, dict) or not all(
-        isinstance(k, str) and isinstance(v, str) for k, v in raw.items()
-    ):
-        raise ValueError(
-            f"{root}: variant {variant_id!r}'s bundle_composition "
-            "library_filenames must be an object of string -> string, got "
-            f"{raw!r}"
+    guards.mapping(raw, "library_filenames")
+    return {
+        guards.decision_key(k, "library_filenames key"): guards.identity_text(
+            v, f"library_filenames[{k!r}]"
         )
-    return dict(raw)
+        for k, v in raw.items()
+    }

--- a/abicheck/storage/variant_composition.py
+++ b/abicheck/storage/variant_composition.py
@@ -108,8 +108,26 @@ def read_variant_composition_library_filenames(
     `native_identity` carries only the bundle key, which can differ from a
     live directory operand's own filename-derived key; `workflows.
     release_package._release_match_key` uses this to recover it.
+
+    `bundle_composition_from_dto` only asserts its own top-level payload is
+    a dict -- it does not validate `library_filenames`'s own shape, so a
+    hand-produced or malformed composition storing it as an iterable of
+    pairs (rather than a JSON object) would otherwise pass through
+    `dict(...)`'s own permissive construction unrejected, silently
+    normalizing it (with a duplicate key becoming last-wins) instead of
+    failing as malformed input `_release_match_key` then trusts for a real
+    matching decision (Codex review, fresh evidence).
     """
     composition = _read_variant_composition(root, variant_id)
     if composition is None:
         return {}
-    return dict(composition.get("library_filenames", {}))
+    raw = composition.get("library_filenames", {})
+    if not isinstance(raw, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in raw.items()
+    ):
+        raise ValueError(
+            f"{root}: variant {variant_id!r}'s bundle_composition "
+            "library_filenames must be an object of string -> string, got "
+            f"{raw!r}"
+        )
+    return dict(raw)

--- a/changelog.d/20260904_224152_noreply_dedupe_shared_release_objects.md
+++ b/changelog.d/20260904_224152_noreply_dedupe_shared_release_objects.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Stored-release materialization no longer duplicates shared objects per
+  artifact** — `materialize_release_variant_artifacts` now hard-links a
+  variant-/project-level object (composition, manifest) into every
+  single-artifact sub-package after the first materializes it, instead of
+  re-reading and re-writing it from the source package once per artifact —
+  closing an N-fold temporary-disk blow-up for a many-artifact release
+  (e.g. 100 artifacts sharing a 100 MB section previously consumed ~10 GB).
+- **Reject a malformed `library_filenames` composition table** —
+  `storage.variant_composition.read_variant_composition_library_filenames`
+  now validates that a stored `library_filenames` payload is an object of
+  string to string, instead of silently normalizing a malformed shape
+  (e.g. an iterable of pairs) through `dict(...)`, which could pair a
+  stored snapshot with the wrong library or mask a real ABI comparison.

--- a/tests/test_cli_compare_release_evidence_preservation.py
+++ b/tests/test_cli_compare_release_evidence_preservation.py
@@ -111,9 +111,29 @@ class TestMaterializationObjectScoping:
         many artifacts (e.g. 100 artifacts sharing a 100 MB section
         consuming ~10 GB of temporary disk). The second (and later)
         artifact's copy of a shared object must now share an inode with
-        the first's, not merely have identical bytes."""
+        the first's, not merely have identical bytes.
+
+        Skipped when the filesystem under *tmp_path* itself rejects
+        `os.link` (a network/FAT volume, a restricted sandbox): the
+        production code deliberately catches exactly that `OSError` and
+        falls back to a real copy, so the inode-sharing assertion below
+        would fail against its own documented, supported fallback path
+        rather than a real regression (Codex review, fresh evidence)."""
+        import os
+
         from abicheck.project_snapshot_store import read_project_manifest
         from abicheck.workflows.release_package import resolve_release_package_map
+
+        probe_a = tmp_path / ".hardlink_probe_a"
+        probe_b = tmp_path / ".hardlink_probe_b"
+        probe_a.write_bytes(b"x")
+        try:
+            os.link(probe_a, probe_b)
+        except OSError:
+            pytest.skip(f"{tmp_path} does not support hard links (os.link)")
+        finally:
+            probe_a.unlink(missing_ok=True)
+            probe_b.unlink(missing_ok=True)
 
         old_libs, _ = _old_new_libraries()
         pkg = tmp_path / "pkg"

--- a/tests/test_cli_compare_release_evidence_preservation.py
+++ b/tests/test_cli_compare_release_evidence_preservation.py
@@ -101,6 +101,57 @@ class TestMaterializationObjectScoping:
             assert expected_digests
             assert len(_object_files(sub_dir)) == len(expected_digests)
 
+    def test_shared_objects_are_hard_linked_not_re_copied(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, fresh evidence: a variant-/project-level object is
+        identical for every artifact in the variant, but each sub-package
+        used to re-fetch it from the source package and re-write it under
+        its own destination store -- an N-fold *physical* disk cost across
+        many artifacts (e.g. 100 artifacts sharing a 100 MB section
+        consuming ~10 GB of temporary disk). The second (and later)
+        artifact's copy of a shared object must now share an inode with
+        the first's, not merely have identical bytes."""
+        from abicheck.project_snapshot_store import read_project_manifest
+        from abicheck.workflows.release_package import resolve_release_package_map
+
+        old_libs, _ = _old_new_libraries()
+        pkg = tmp_path / "pkg"
+        _write_package(pkg, old_libs, variant_id="v1")
+
+        resolved = resolve_release_package_map(
+            pkg, variant_id=None, dest_root=tmp_path / "resolved"
+        )
+        assert len(resolved) == 3
+
+        def _object_path_for_digest(sub_dir: Path, digest: str) -> Path | None:
+            objects_dir = sub_dir / "objects"
+            if not objects_dir.is_dir():
+                return None
+            for p in objects_dir.rglob("*"):
+                if p.is_file() and digest.split(":", 1)[-1] in p.name:
+                    return p
+            return None
+
+        # Every sub-package shares the identical variant-level composition
+        # section (they were all cut from the same one variant).
+        sub_dirs = list(resolved.values())
+        (variant,) = read_project_manifest(sub_dirs[0]).variant_refs
+        shared_digest = next(iter(variant.sections.values())).digest
+
+        paths = [
+            _object_path_for_digest(sub_dir, shared_digest) for sub_dir in sub_dirs
+        ]
+        assert all(p is not None for p in paths), paths
+        inodes = {p.stat().st_ino for p in paths if p is not None}  # type: ignore[union-attr]
+        assert len(inodes) == 1, (
+            "expected every sub-package's copy of the shared variant-level "
+            f"object to share one inode (hard-linked), got {len(inodes)} "
+            f"distinct inodes across {len(paths)} sub-packages"
+        )
+        for p in paths:
+            assert p is not None and p.stat().st_nlink >= len(sub_dirs)
+
 
 class TestEmbeddedInstantiationManifest:
     """Codex review, eighth round: nothing in the ordinary

--- a/tests/test_cli_compare_release_package_resolution.py
+++ b/tests/test_cli_compare_release_package_resolution.py
@@ -544,6 +544,43 @@ class TestMalformedCompositionShapeRaises:
             bundle._stored_library_identity(sub_dir, 0)
 
 
+class TestVariantCompositionRejectsNonMappingLibraryFilenames:
+    """Codex review, fresh evidence: `bundle_composition_from_dto` only
+    asserts its own top-level payload is a dict -- it does not validate
+    `library_filenames`'s own shape. A hand-produced or malformed
+    composition storing it as an iterable of pairs instead of a JSON
+    object previously passed through `dict(...)`'s permissive construction
+    unrejected (silently normalizing it, a duplicate key becoming
+    last-wins) instead of failing as malformed input -- `_release_match_key`
+    then trusts that mapping for a real matching decision."""
+
+    def test_non_mapping_library_filenames_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from abicheck.storage.variant_composition import (
+            read_variant_composition_library_filenames,
+        )
+
+        libs = {
+            "liba.so": _snap("liba.so", "1.0", [_fn("foo", "_Z3foov")]),
+        }
+        facts = capture_bundle_facts(libs, variant_fingerprint="gcc13-avx2")
+        pkg = tmp_path / "pkg"
+        store = DirectoryObjectStore(pkg)
+        manifest = write_bundle_facts_package(facts, store=store, variant_id="v1")
+        write_project_manifest(pkg, manifest)
+
+        def _bad_shape(raw: object) -> dict[str, object]:
+            return {"library_filenames": [["liba.so", "liba.so.1"]]}
+
+        monkeypatch.setattr(
+            "abicheck.storage.variant_composition.bundle_composition_from_dto",
+            _bad_shape,
+        )
+        with pytest.raises(ValueError):
+            read_variant_composition_library_filenames(pkg, "v1")
+
+
 class TestWriteBundleFactsOutUsesMatchedReleaseKey:
     """Codex review, fresh evidence: a stored snapshot's logical library
     label (e.g. ``"provider"``) can differ from its real filename's own

--- a/tests/test_cli_compare_release_package_resolution.py
+++ b/tests/test_cli_compare_release_package_resolution.py
@@ -577,7 +577,7 @@ class TestVariantCompositionRejectsNonMappingLibraryFilenames:
             "abicheck.storage.variant_composition.bundle_composition_from_dto",
             _bad_shape,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             read_variant_composition_library_filenames(pkg, "v1")
 
 


### PR DESCRIPTION
## Summary

Follow-up to two fresh Codex P1 findings that landed on [PR #1058](https://github.com/abicheck/abicheck/pull/1058) after its merge commit — deferred out of that already-large PR rather than folded in.

## Motivation

Two independent P1 findings surfaced on `materialize_release_variant_artifacts` and `storage.variant_composition.read_variant_composition_library_filenames`:

1. Every artifact in a variant re-fetches and re-writes the identical variant-/project-level shared object (composition, manifest) into its own single-artifact sub-package — an N-fold temporary-disk cost (100 artifacts sharing a 100 MB section previously consumed ~10 GB) that can exhaust a CI worker before comparison even begins.
2. `read_variant_composition_library_filenames` coerced `library_filenames` through `dict(...)` without validating its shape — a malformed composition (e.g. an iterable of pairs instead of a JSON object) would silently normalize instead of failing, and `_release_match_key` then trusts that mapping for a real matching decision, so a corrupted package could pair a stored snapshot with the wrong live library.

## Changes

- `materialize_release_variant_artifacts`/`_materialize_referenced_objects`: a shared `materialized_cache: dict[digest -> Path]` is threaded across every artifact in one call. The first artifact that needs a given digest still goes through the verified `get()`/`put()` round trip; every later artifact hard-links that already-verified destination file instead of touching the source store again (falling back to a real copy only if hard-linking itself fails, e.g. a cross-device `dest_root`).
- `storage.variant_composition.read_variant_composition_library_filenames`: validates that the decoded `library_filenames` payload is an object of `str -> str` before returning it, raising `ValueError` (already caught and translated to a CLI usage error by `_resolve_release_package_side`) otherwise.

## Bug-fix test contract

- Bug class: Stored-release materialization/composition-reading trusting adversarial or accidentally-malformed package content without validation, and re-copying already-verified content unnecessarily.
- Publicly observable failure: (1) `abicheck compare` on a many-artifact stored release package consumes disk proportional to `artifacts × shared-section-size` instead of `shared-section-size` once; (2) a stored package with a malformed `library_filenames` shape silently matches libraries by the wrong key instead of failing.
- Regression test fails on base: Yes — `TestMaterializationObjectScoping::test_shared_objects_are_hard_linked_not_re_copied` (asserts every sub-package's copy of the shared object shares one inode) and `TestVariantCompositionRejectsNonMappingLibraryFilenames::test_non_mapping_library_filenames_raises` both verified to fail against the pre-fix code (temporarily reverted each fix locally, confirmed the exact failure, then restored).
- Negative control: The existing `TestMaterializationObjectScoping::test_only_this_artifacts_own_objects_are_materialized` (per-directory object count) and the full `read_variant_composition_library_filenames` happy-path tests still pass unchanged.
- Public-surface test: Both new tests exercise the real public entry points (`resolve_release_package_map`, `read_variant_composition_library_filenames`) rather than internal arithmetic.
- Axes covered: disk-cost (hard-link sharing) and input-shape validation (non-mapping payload) — two independent P1 findings, one regression test each.
- General invariant: (1) a variant-/project-level shared object is materialized at most once per `materialize_release_variant_artifacts()` call, regardless of artifact count; (2) `library_filenames` is either a genuine `str -> str` mapping or the read raises, never silently coerced.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — n/a, internal storage-layer behavior
- [x] `pre-commit run --all-files` passes locally (ruff, mypy, architecture gate all clean)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECpZ23jinVpakvhsKCubFQ)_