### PR TITLE
fix(release): zero-comparison releases exit nonzero; mark stranded snapshots

### DIFF
--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -357,31 +357,18 @@ def _neutralize_gate(report: dict[str, Any]) -> None:
         ):
             node["analysis_assurance_exit_contribution"] = 0
         # CLI cleanup phase two, PR G1/PR E: the canonical `exit` block
-        # (`exit_decision.ExitDecision`) lives at exactly the same
-        # locations as the two contributions above -- the document root for
-        # a `compare` report, `diff`/`report.diff` for a scan one -- so the
-        # same `contract_coverage_block_paths` traversal already finds it;
-        # no separate path-finder is needed (Codex review, fresh evidence:
-        # an earlier revision neutralized every axis this block summarizes
-        # except the block itself, so an advisory report could still
-        # publish a nonzero `exit.code` -- and nonzero contributions -- that
-        # a consumer adopting the new canonical field would read as
-        # blocking). Replaced wholesale with the "clean" decision, the same
-        # way the `severity` gate above is replaced rather than
-        # conditionally rewritten: advisory mode means every *deferrable*
-        # axis gates nothing, so the persisted explanation has to say so
-        # outright rather than being left to disagree with the axes it
-        # summarizes. The four "comparison never completed" axes --
-        # operational_error/evidence_contract_error/budget_overflow/
-        # not_comparable_contribution (`_classify_verdict` treats those
-        # verdicts identically to an operational error; mutually exclusive
-        # per `resolve_scan_exit_decision`'s own docstring, so at most one
-        # is ever nonzero) -- are carried over, not zeroed with the rest
-        # (Codex review, fresh evidence, two rounds: round one only kept
-        # `operational_error_contribution`, leaving the same "exit.code: 0
-        # but the job still fails" gap for `NOT_COMPARABLE`). Every one of
-        # these fails every gate mode per `final_exit_code`, so zeroing any
-        # would make `exit.code` claim a clean pass the job doesn't give.
+        # (`exit_decision.ExitDecision`) lives at the same locations as the
+        # two contributions above, so the same traversal finds it too (Codex
+        # review: an earlier revision left it unneutralized, so an advisory
+        # report could still publish a nonzero `exit.code`). Replaced
+        # wholesale with the "clean" decision, same as `severity` above. The
+        # five "comparison never completed" axes -- operational_error/
+        # evidence_contract_error/budget_overflow/not_comparable/
+        # no_comparison_completed_contribution (mutually exclusive per
+        # `resolve_scan_exit_decision`'s docstring) -- are carried over, not
+        # zeroed: each fails every gate mode per `final_exit_code`, so
+        # zeroing any would claim a clean pass the job doesn't give (Codex
+        # review, fresh evidence, two rounds).
         old_exit = node.get("exit")
         if isinstance(old_exit, Mapping):
             from ..exit_decision import resolve_exit_decision
@@ -396,6 +383,7 @@ def _neutralize_gate(report: dict[str, Any]) -> None:
                 evidence_contract_error_contribution=_int_or_zero("evidence_contract_error_contribution"),
                 budget_overflow_contribution=_int_or_zero("budget_overflow_contribution"),
                 not_comparable_contribution=_int_or_zero("not_comparable_contribution"),
+                no_comparison_completed_contribution=_int_or_zero("no_comparison_completed_contribution"),  # ADR-065 D7
             ).to_dict()
 
 
@@ -522,16 +510,23 @@ def _classify_verdict(
 ) -> None:
     """Split *raw_verdict* into a compatibility verdict or an operational error.
 
-    Any verdict string a scan run can produce that is neither a legacy
-    compatibility verdict nor the explicit operational-error sentinel (e.g.
-    ``"BUDGET_OVERFLOW"``/``"EVIDENCE_CONTRACT_ERROR"`` -- ``service_scan.py``'s
-    guard sentinels) is not a compatibility finding either: it is the scan
-    never completing its comparison at all, the same class of problem as an
-    analysis CLI error, not something ADR-047 §7's "deferred only defers the
-    *compatibility* verdict" rule was meant to cover. Treated as operational so
-    ``gate-mode: deferred``/``advisory`` cannot turn a guard failure into a
-    quiet pass (Codex review).
+    A verdict a scan run can produce that is neither a legacy compatibility
+    verdict nor the operational-error sentinel is the scan never completing
+    its comparison at all -- treated as operational so ``gate-mode: deferred``/
+    ``advisory`` cannot turn a guard failure into a quiet pass (Codex review).
+
+    ADR-065 D7's release ``no_comparison_completed`` outcome keeps a legacy
+    ``verdict`` too, so it's checked via ``run_outcome.operational`` instead,
+    mirroring ``aggregate.declares_null_compatibility()``.
     """
+    run_outcome = out.get("run_outcome")
+    run_outcome = run_outcome if isinstance(run_outcome, Mapping) else {}
+    if run_outcome.get("operational") == OperationalStatus.NO_COMPARISON_COMPLETED.value:
+        if run_outcome.get("compatibility") is not None:
+            out["compatibility_verdict"] = run_outcome["compatibility"]
+        msg = report.get("error") or "no comparison completed: zero library-name pairs matched between OLD and NEW"
+        out["operational_errors"] = [{"kind": "no_comparison_completed", "message": str(msg)}]
+        return
     if raw_verdict in LEGACY_VERDICT_VALUES:
         out["compatibility_verdict"] = raw_verdict
         out.setdefault("operational_errors", [])

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -834,6 +834,16 @@ def compare_release_cmd(
                                 library=old_path.name,
                                 version="",
                                 elf=extraction.parse_elf_metadata(old_path),
+                                # ADR-065 D8: this snapshot carries no header/
+                                # DWARF evidence at all -- every downstream
+                                # detector that special-cases elf_only_mode
+                                # (diff_symbols.py, diff_types.py, diff_vtable_
+                                # layout.py, bundle_signature_evidence.py,
+                                # confidence.py) must see the same reduced
+                                # evidence tier every other ELF-only snapshot
+                                # declares, not silently read as a fully-dumped
+                                # one on a later comparison against it.
+                                elf_only_mode=True,
                             ),
                             failure=f"ELF-only degraded capture: {exc}",
                         )

--- a/changelog.d/20260905_155404_noreply_cli_cleanup_release_fanout_iv2b68.md
+++ b/changelog.d/20260905_155404_noreply_cli_cleanup_release_fanout_iv2b68.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Release fan-out gap-fills on top of ADR-065 S2.** A directory/package
+  `compare`'s stranded-library resolver (`--bundle-facts-out`'s degrade-on-
+  failure fallback) now marks its snapshot `elf_only_mode=True`, so a later
+  comparison against it sees the same reduced evidence tier every other
+  ELF-only snapshot declares instead of silently reading it as fully-dumped.
+  `actions/check-target`'s `_classify_verdict` now also recognizes a
+  release/bundle fan-out's `run_outcome.operational ==
+  "no_comparison_completed"` outcome (ADR-065 D7), so `gate-mode:
+  advisory`/`deferred` no longer misreads a release that completed zero
+  comparisons as an ordinary clean compatibility pass.
+

--- a/tests/test_check_report_no_comparison_completed.py
+++ b/tests/test_check_report_no_comparison_completed.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``actions/check-target``'s handling of a release/bundle fan-out's
+``no_comparison_completed`` outcome (ADR-065 D7).
+
+Split out of ``tests/test_check_report.py`` rather than added there -- that
+file sits at its own ``architecture/debt.yaml`` adoption baseline and has no
+headroom left, mirroring this repo's own established split-for-size
+precedent (e.g. ``tests/test_check_report_run_outcome_backfill.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.buildsource.check_report import augment_report, final_exit_code
+
+
+class TestAugmentReportNoComparisonCompleted:
+    """A release/bundle fan-out's ``no_comparison_completed`` outcome
+    (ADR-065 D7) keeps an ordinary legacy top-level ``verdict`` (typically
+    ``"NO_CHANGE"``, from the vacuous bundle/matrix pass over disjoint
+    library sets) so older readers still parse it. Before this fix,
+    ``_classify_verdict`` read only that raw ``verdict`` string, so
+    ``gate-mode: advisory``/``deferred`` classified it as an ordinary clean
+    compatibility pass instead of an operational failure -- `final_exit_code`
+    silently returned 0 for a release that completed zero comparisons.
+    ``gate-mode: local`` was unaffected (it reads the real ``exit_code``,
+    which already carries the contribution)."""
+
+    @staticmethod
+    def _no_comparison_report(
+        *, release_global_verdict: str | None = None
+    ) -> dict[str, object]:
+        return {
+            "verdict": "NO_CHANGE",
+            "old_dir": "/old",
+            "new_dir": "/new",
+            "libraries": [],
+            "no_comparison_completed": True,
+            "run_outcome": {
+                "schema_version": "1.1",
+                "compatibility": release_global_verdict,
+                "assurance": None,
+                "gate": "none",
+                "operational": "no_comparison_completed",
+                "lifecycle": "existing",
+                "scope": "complete",
+            },
+            "exit": {
+                "code": 1,
+                "reasons": ["no_comparison_completed"],
+                "compatibility_contribution": 0,
+                "contract_coverage_contribution": 0,
+                "analysis_assurance_contribution": 0,
+                "crosscheck_promotion_contribution": 0,
+                "operational_error_contribution": 0,
+                "evidence_contract_error_contribution": 0,
+                "budget_overflow_contribution": 0,
+                "not_comparable_contribution": 0,
+                "removed_required_library_contribution": 0,
+                "incomplete_scope_contribution": 0,
+                "no_comparison_completed_contribution": 1,
+            },
+        }
+
+    @pytest.mark.parametrize("gate_mode", ["local", "deferred", "advisory"])
+    def test_classified_as_an_operational_error_under_every_gate_mode(self, gate_mode):
+        out = augment_report(
+            self._no_comparison_report(),
+            name="libfoo",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode=gate_mode,
+        )
+        assert out["operational_errors"] == [
+            {
+                "kind": "no_comparison_completed",
+                "message": "no comparison completed: zero library-name "
+                "pairs matched between OLD and NEW",
+            }
+        ]
+        assert (
+            final_exit_code(
+                gate_mode,
+                real_exit_code=0,
+                operational_error=bool(out["operational_errors"]),
+            )
+            == 1
+        )
+
+    def test_compatibility_verdict_stays_unset_not_the_vacuous_raw_verdict(self):
+        """``run_outcome.compatibility`` is correctly ``None`` here (no
+        release-global pass observed a real result) -- ``compatibility_
+        verdict`` must not be backfilled from the vacuous raw ``"NO_CHANGE"``
+        verdict, which would make this envelope simultaneously claim no
+        comparison completed and a clean compatibility result."""
+        out = augment_report(
+            self._no_comparison_report(),
+            name="libfoo",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert "compatibility_verdict" not in out
+
+    def test_compatibility_verdict_preserves_a_real_mixed_axis_result(self):
+        """A release-global bundle/probe-matrix break can dominate the exit
+        code while zero per-library pairs matched -- `run_outcome.
+        compatibility` carries that real result, and it must not be lost
+        just because the independent no_comparison_completed axis also
+        fired."""
+        out = augment_report(
+            self._no_comparison_report(release_global_verdict="BREAKING"),
+            name="libfoo",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["compatibility_verdict"] == "BREAKING"
+        assert out["operational_errors"] == [
+            {
+                "kind": "no_comparison_completed",
+                "message": "no comparison completed: zero library-name "
+                "pairs matched between OLD and NEW",
+            }
+        ]
+
+    def test_advisory_preserves_the_contribution_others_are_zeroed(self):
+        """`_neutralize_gate`'s advisory rewrite must carry
+        `no_comparison_completed_contribution` through unchanged -- unlike
+        `compatibility_contribution`/`incomplete_scope_contribution`, this
+        axis is policy-independent (always 1, never a deferrable finding)."""
+        out = augment_report(
+            self._no_comparison_report(),
+            name="libfoo",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="advisory",
+        )
+        assert out["exit"]["no_comparison_completed_contribution"] == 1
+        assert out["exit"]["compatibility_contribution"] == 0
+        assert out["exit"]["incomplete_scope_contribution"] == 0
+
+    def test_a_real_compatibility_verdict_is_not_reclassified(self):
+        """Negative control: an ordinary completed release (no
+        no_comparison_completed operational status) is unaffected."""
+        out = augment_report(
+            {
+                "verdict": "BREAKING",
+                "old_dir": "/old",
+                "new_dir": "/new",
+                "libraries": [{"library": "libfoo.so", "verdict": "BREAKING"}],
+                "run_outcome": {
+                    "schema_version": "1.1",
+                    "compatibility": "BREAKING",
+                    "assurance": None,
+                    "gate": "abi_breaking",
+                    "operational": "none",
+                    "lifecycle": "existing",
+                    "scope": "complete",
+                },
+            },
+            name="libfoo",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["compatibility_verdict"] == "BREAKING"
+        assert out["operational_errors"] == []

--- a/tests/test_cli_compare_release_stranded_depth.py
+++ b/tests/test_cli_compare_release_stranded_depth.py
@@ -167,3 +167,65 @@ class TestBundleFactsOutStrandedLibraryHonoursDepthBinary:
 
         assert code == 0
         assert captured["headers"] == [header]
+
+
+class TestStrandedResolverFallbackIsElfOnly:
+    def test_real_stranded_resolver_marks_the_fallback_snapshot_elf_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ADR-065 D8: the real ``_resolve_stranded_library`` closure inside
+        ``compare_release_cmd`` (not a hand-built test double) must mark its
+        own degrade-on-failure fallback ``elf_only_mode=True`` -- it carries
+        no header/DWARF evidence at all (only ``extraction.
+        parse_elf_metadata``), so every downstream detector that special-
+        cases ``elf_only_mode`` (``diff_symbols.py``, ``diff_types.py``,
+        ``bundle_signature_evidence.py``, ...) must see the same reduced
+        evidence tier every other ELF-only snapshot declares on a later
+        comparison against it -- not silently read it as a fully-dumped
+        snapshot just because ``failure``/``degraded_members`` (a separate,
+        storage-layer marker) says so instead."""
+        from abicheck.serialization import load_bundle_facts
+
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap(library="libfoo.so"))
+        _write_snap(new_dir / "libfoo.json", _snap(library="libfoo.so"))
+        # Present only on OLD -- write_bundle_facts_out's resolve_stranded_
+        # library callback is what resolves this one.
+        stranded = old_dir / "libbroken.so"
+        stranded.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        def _raise_for_stranded(request: object) -> object:
+            if request.input.path == stranded:  # type: ignore[attr-defined]
+                raise RuntimeError("boom")
+            from abicheck.service_dump_pipeline import (
+                resolve_dump_request as _real,
+            )
+
+            return _real(request)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            "abicheck.service_dump_pipeline.resolve_dump_request",
+            _raise_for_stranded,
+        )
+
+        out_path = tmp_path / "old.bundlefacts.json"
+        # Exit code itself is orthogonal to this test -- an unmatched OLD-
+        # only member under the default `warn` incomplete-scope policy
+        # (ADR-065 D6) reports a clean 0; the point here is what the
+        # persisted stranded snapshot itself declares about its own
+        # evidence tier.
+        _invoke(
+            "compare",
+            str(old_dir),
+            str(new_dir),
+            "--bundle-facts-out",
+            str(out_path),
+        )
+
+        facts = load_bundle_facts(out_path)
+        assert facts.degraded_members and "libbroken.so" in facts.degraded_members
+        stranded_snap = facts.per_library_snapshots["libbroken.so"]
+        assert stranded_snap.elf_only_mode is True

--- a/tests/test_release_scope_completeness.py
+++ b/tests/test_release_scope_completeness.py
@@ -795,6 +795,11 @@ class TestDegradedStrandedCapture:
             "libcore.so" in msg and "degraded" in msg for msg in result.analysis_errors
         )
 
+    # `test_real_stranded_resolver_marks_the_fallback_snapshot_elf_only`
+    # lives in tests/test_cli_compare_release_stranded_depth.py -- the
+    # existing home for real-`_resolve_stranded_library`-closure tests --
+    # this file has no adoption-debt headroom left for a new CLI-level test.
+
 
 # ---------------------------------------------------------------------------
 # PR comment


### PR DESCRIPTION
## Summary

Two small gap-fills on top of main's already-landed ADR-065 S2 workstream
(`OperationalStatus.NO_COMPARISON_COMPLETED` plus the broader
`ScopeAcquisitionRecord`/`AcquisitionState`/inventory-completeness model).

**This PR was rebuilt from scratch on top of `main`** after a merge conflict
revealed that main had independently landed a much broader implementation of
the same "release fan-out completed zero comparisons" concept this PR
originally introduced end-to-end (including its own `exit` code 17,
`ExitDecision`/`OperationalStatus` wiring, and schema bumps). Per the user's
direction, the original PR content was discarded in favor of main's
already-merged S2 work, and this PR now implements only the two concrete
gaps a thorough investigation found main's implementation still leaves open.

## Changes

1. **`abicheck/cli_compare_release.py`** — the release fan-out's stranded-
   library resolver (`_resolve_stranded_library`, used by
   `--bundle-facts-out` to resolve an OLD-only library absent from NEW) now
   marks its degrade-on-failure fallback snapshot `elf_only_mode=True`.
   Previously that fallback (built from ELF metadata alone via
   `extraction.parse_elf_metadata`, on any resolution failure) carried no
   evidence-tier marker at all, so a later comparison against it could be
   silently read as a fully-dumped snapshot by every downstream detector
   that special-cases `elf_only_mode` (`diff_symbols.py`, `diff_types.py`,
   `diff_vtable_layout.py`, `bundle_signature_evidence.py`,
   `confidence.py`, ...).

2. **`abicheck/buildsource/check_report.py`** — `_classify_verdict` now
   recognizes a release/bundle fan-out's `run_outcome.operational ==
   "no_comparison_completed"` outcome (ADR-065 D7, main's own enum member)
   *before* falling back to the raw legacy `verdict` string. Such a report
   keeps an ordinary `verdict: "NO_CHANGE"` for older readers, so
   `actions/check-target`'s `gate-mode: advisory`/`deferred` previously
   classified it as an ordinary clean compatibility pass instead of an
   operational failure — `final_exit_code` silently returned `0` for a
   release that completed zero comparisons. `gate-mode: local` was
   unaffected (it reads the real, already-correct `exit_code`).
   `_neutralize_gate`'s advisory-mode exit-block rewrite now carries
   `no_comparison_completed_contribution` through unchanged, mirroring how
   it already treats the other "comparison never completed" axes
   (`operational_error`/`evidence_contract_error`/`budget_overflow`/
   `not_comparable`).

## Bug-fix test contract

- Bug class: a degraded fallback snapshot omits its own reduced-evidence marker; a composite Action's advisory/deferred gate mode silently reads a release's zero-comparisons operational failure as a clean compatibility pass.
- Publicly observable failure: `--bundle-facts-out`'s stranded-library entry persists `elf_only_mode: false` despite carrying no header/DWARF evidence; `check-target`'s `gate-mode: advisory`/`deferred` reports exit `0` for a release whose `run_outcome.operational` is `no_comparison_completed`.
- Regression test fails on base: yes, both new tests fail on `main` and pass on this branch — `TestStrandedResolverFallbackIsElfOnly::test_real_stranded_resolver_marks_the_fallback_snapshot_elf_only` asserts `elf_only_mode is True` (main gives `False`), and `TestAugmentReportNoComparisonCompleted::test_classified_as_an_operational_error_under_every_gate_mode` asserts `final_exit_code(...) == 1` under `deferred`/`advisory` (main gives `0`).
- Negative control: an ordinary, non-failing stranded-resolver path stays unaffected (sibling class in the same test file), and an ordinary completed release with `operational: "none"` still classifies its real verdict normally rather than being reclassified as an operational error (`test_a_real_compatibility_verdict_is_not_reclassified`).
- Public-surface test: yes, exercised through the real CLI (`CliRunner().invoke(main, ...)` on `compare`) for the stranded-snapshot fix, and through the real `augment_report`/`final_exit_code` entry points `actions/check-target` itself calls for the check-report fix — not a hand-built envelope in either case.
- Axes covered: all three `gate-mode` values (`local`/`deferred`/`advisory`, parametrized), a real dominating `run_outcome.compatibility` alongside the operational status, and the resolver's real degrade-on-exception fallback path (not a test double) for the stranded-snapshot fix.
- General invariant: a degraded fallback snapshot always carries its own evidence-tier marker in-band rather than only a stderr line; `actions/check-target` classifies `run_outcome.operational == "no_comparison_completed"` as an operational failure under every gate mode, never a clean pass, regardless of whatever legacy `verdict` string rides alongside it — checked against sibling cases (three gate modes, a real dominating verdict, an ordinary completed release), not only the one originally reported shape.

## Checklist

- [x] Tests added for both gaps (real-closure/real-envelope tests, not
      hand-built doubles)
- [x] Changelog fragment added (`scriv create`)
- [x] `mypy abicheck/` clean (0 errors)
- [x] `python scripts/check_architecture.py` clean (0 errors — both new
      additions fit within `architecture/debt.yaml`'s existing no-growth
      baselines, no baseline bumps needed)
- [x] `ruff check`/`ruff format --check` clean on touched files (one
      pre-existing formatting nit in `check_report.py` predates this PR)
- [x] Full fast unit suite green (39,655 passed; 4 pre-existing failures
      confirmed unrelated and present on `main` without this branch's
      changes: 2 environment-specific `verify.py`/action-script tests, 2
      `test_ai_readiness.py` ADR-verification-receipt checks referencing a
      commit not yet reachable from `origin/main`)
- [x] `scripts/check_bugfix_test_contract.py` passes locally against this
      exact PR body (verified 2026-09-05T17:43Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
