### PR TITLE
docs: fix dangling vision.md link in cli-cleanup-phase-two.md

### DIFF
--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -213,7 +213,7 @@ its own section below), PR 4 changes what a CI job's exit code means.
 
 **This plan is no longer the owner of the CLI's direction.**
 [`vision-api-abi-evolution.md`](vision-api-abi-evolution.md) is, together with
-[`vision.md`](../../../vision.md) and the Proposed
+[`vision.md`](../vision.md) and the Proposed
 [ADR-065](../adr/065-comparison-scope-selection-and-completeness.md) /
 [ADR-066](../adr/066-longitudinal-history-and-versioning-policy.md) /
 [ADR-067](../adr/067-change-intent-acknowledgment-and-disposition-audit.md).


### PR DESCRIPTION
## Summary

`docs/contribute/plans/cli-cleanup-phase-two.md` links to `../../../vision.md`, which `mkdocs build --strict` fails to resolve (found while investigating an unrelated `build-docs` CI failure on [PR #1075](https://github.com/abicheck/abicheck/pull/1075) — this same broken link is already present on `main`, and `pages.yml` runs the identical strict build on every push to `main`, so this is a genuine pre-existing failure, not introduced by that PR).

## Fix

Every sibling file in `docs/contribute/plans/` (`index.md`, `vision-api-abi-evolution.md`) already spells this link as `../vision.md`. Matched that spelling.

## Verification

- `mkdocs build --strict` — clean, 0 warnings, locally.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeViThQiJAqhiWxeyScxbF)_