### PR TITLE
feat: give ComparabilityMismatch a real per-dimension record (E-S2)

### DIFF
--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -229,6 +229,92 @@ _PLATFORM_IDENTITY_FIELDS = frozenset({"target_triple", "pointer_width", "endian
 # surface as a RISK finding, not a reason to refuse a verdict outright.
 _BUILD_CONTEXT_FIELDS = frozenset({"language_standard", "macro_ops"})
 
+# E-S2 (docs/contribute/plans/cli-cleanup-phase-two.md, Block 5) -- the
+# per-dimension comparability vocabulary. ``ComparabilityMismatch`` used to
+# carry only a single coarse ``kind`` ("scope" | "profile" |
+# "dependency_scope"), so a GCC-vs-Clang pair with a genuinely narrow mismatch
+# (say, only ``macro_ops`` differing) was reported exactly as untrustworthy as
+# one where every axis diverged -- "wholly refused or wholly trusted", per
+# that plan's own words. ``ComparabilityMismatch.dimensions`` names which of
+# these five report-facing axes the *specific* detected mismatch leaves
+# unverified; a dimension absent from the set stays as trustworthy as it was
+# before the mismatch was found. This module only ever populates dimensions
+# ADR-050's contract can actually speak to (declaration/layout/runtime, from
+# the header-declared-surface and compile-context fingerprints) -- it never
+# claims authority over ``symbol`` (the binary's own exported-symbol-table
+# identity, L0/L1, wholly independent of header/compile-context evidence) or
+# ``source`` (L4/L5 build-source-graph evidence, a separate comparability
+# axis this module's contract does not cover at all).
+COMPARABILITY_DIMENSIONS = frozenset(
+    {"symbol", "declaration", "layout", "runtime", "source"}
+)
+
+#: Which :data:`COMPARABILITY_DIMENSIONS` a differing ``profile_fields`` key
+#: leaves unverified. A field can affect more than one dimension (e.g.
+#: ``compiler_family`` bears on both struct layout and calling-convention/
+#: runtime behavior); union across every actually-differing field is what
+#: :func:`_dimensions_for_fields` computes.
+_PROFILE_FIELD_DIMENSIONS: dict[str, frozenset[str]] = {
+    "compiler_family": frozenset({"layout", "runtime"}),
+    "compiler_version": frozenset({"layout", "runtime"}),
+    "abi_dialect": frozenset({"layout", "runtime"}),
+    # A raised/lowered language standard can gate which declarations exist
+    # at all (e.g. a C++17-only member) as well as change layout (e.g.
+    # inline variables, [[no_unique_address]]).
+    "language_standard": frozenset({"declaration", "layout"}),
+    "target_triple": frozenset({"layout", "runtime"}),
+    "pointer_width": frozenset({"layout", "runtime"}),
+    "endianness": frozenset({"runtime"}),
+    # Macro state / pass-through flags can gate declarations (macro-guarded
+    # APIs) and change layout (conditional fields, packing pragmas).
+    "macro_ops": frozenset({"declaration", "layout"}),
+    "pass_through_flags": frozenset({"declaration", "layout"}),
+    "include_sequence": frozenset({"declaration"}),
+    "header_sequence": frozenset({"declaration"}),
+    # A DPC++ device/host frontend-context split changes both which
+    # declarations the frontend sees and their runtime (device vs. host)
+    # semantics (ADR-050 D5).
+    "frontend_context_kind": frozenset({"declaration", "runtime"}),
+}
+#: Every dimension any recognized profile field can affect -- the
+#: conservative fallback for a profile mismatch this module cannot attribute
+#: to specific fields (an opaque/unauthenticated fingerprint).
+_ALL_PROFILE_DIMENSIONS: frozenset[str] = frozenset().union(
+    *_PROFILE_FIELD_DIMENSIONS.values()
+)
+
+#: :data:`_PROFILE_FIELD_DIMENSIONS`'s counterpart for ``scope_fields`` keys.
+#: The declared-header-set/public-header-directory axis only ever bears on
+#: which declarations exist to compare -- never runtime behavior, and layout
+#: only insofar as an undeclared type has no layout facts to compare at all
+#: (folded into "declaration" here, not double-counted as "layout").
+_SCOPE_FIELD_DIMENSIONS: dict[str, frozenset[str]] = {
+    "headers": frozenset({"declaration"}),
+    "public_header_dirs": frozenset({"declaration"}),
+    "translation_units": frozenset({"declaration"}),
+}
+_ALL_SCOPE_DIMENSIONS: frozenset[str] = frozenset().union(
+    *_SCOPE_FIELD_DIMENSIONS.values()
+)
+
+#: A dependency-scoping mode mismatch (filtered vs. unfiltered) changes which
+#: declarations were even parsed, which in turn removes any layout evidence
+#: for whatever was filtered out on one side.
+_DEPENDENCY_SCOPE_DIMENSIONS: frozenset[str] = frozenset({"declaration", "layout"})
+
+
+def _dimensions_for_fields(
+    fields: Sequence[str] | set[str], mapping: dict[str, frozenset[str]]
+) -> frozenset[str]:
+    """Union of ``mapping[field]`` over every *fields* entry, skipping any key
+    *mapping* doesn't recognize (an unrecognized field's own caller is
+    responsible for falling back to the conservative "affects everything"
+    set -- see ``_ALL_PROFILE_DIMENSIONS``/``_ALL_SCOPE_DIMENSIONS`` above)."""
+    result: frozenset[str] = frozenset()
+    for field in fields:
+        result |= mapping.get(field, frozenset())
+    return result
+
 
 def manifest_tu_scope_field(dump_manifest: Any) -> str:
     """JSON-serializable, order-preserving encoding of every ``--dump-manifest``
@@ -714,10 +800,28 @@ class ComparabilityMismatch:
     """Returned by :func:`check_contracts_comparable` in ``diagnostic=True``
     mode instead of raising — describes the one mismatch that would
     otherwise have raised (scope is checked first, so a scope mismatch
-    shadows a co-occurring profile one, same as the raising path)."""
+    shadows a co-occurring profile one, same as the raising path).
+
+    ``kind``/``reason`` are unchanged (ADR-050 D2's original two fields --
+    ``kind`` is what ``_MISMATCH_ERRORS`` keys the raised exception type on,
+    and every existing caller of the raising path is unaffected). ``dimensions``
+    is E-S2's addition (Block 5,
+    ``docs/contribute/plans/cli-cleanup-phase-two.md``): the subset of
+    :data:`COMPARABILITY_DIMENSIONS` this specific mismatch leaves unverified.
+    A caller in ``diagnostic=True`` mode can use it to keep trusting
+    conclusions on a dimension the mismatch never touched -- e.g. an
+    intentional GCC-vs-Clang ``macro_ops`` divergence marks only
+    ``{"declaration", "layout"}`` unverified, leaving ``symbol``-dimension
+    (exported binary identity) conclusions untouched -- rather than the
+    previous all-or-nothing ``assurance: none``. Consuming this into the diff
+    pipeline's own per-finding assurance (rather than merely exposing it on
+    the mismatch descriptor) is E-S2's own next slice, not this one -- see
+    that plan section's own status note.
+    """
 
     kind: str  # "scope" | "profile" | "dependency_scope"
     reason: str
+    dimensions: frozenset[str] = frozenset()
 
 
 def _check_dependency_scope_comparable(
@@ -782,7 +886,9 @@ def _check_dependency_scope_comparable(
         "the same declared surface. Regenerate both snapshots with the same "
         "mode: pass --include-system-declarations on both sides, or on neither."
     )
-    return ComparabilityMismatch(kind="dependency_scope", reason=reason)
+    return ComparabilityMismatch(
+        kind="dependency_scope", reason=reason, dimensions=_DEPENDENCY_SCOPE_DIMENSIONS
+    )
 
 
 #: Every key set :func:`compute_extraction_contract` may have hashed a
@@ -946,6 +1052,11 @@ def _check_scope_fingerprint_comparable(
         # scope_fingerprint, so nothing reasoned from those fields
         # explains the real mismatch (Codex review, PR #641 follow-up,
         # sixth P1) -- see _fingerprint_matches_fields's own docstring.
+        # Opaque/unauthenticated fingerprint: no specific scope_fields key
+        # can be trusted to explain the mismatch, so every dimension this
+        # axis can ever affect is reported unverified (see
+        # _ALL_SCOPE_DIMENSIONS's own docstring) -- the same fail-closed
+        # default the rest of this branch already applies to `kind`/`reason`.
         return ComparabilityMismatch(
             kind="scope",
             reason=(
@@ -955,6 +1066,7 @@ def _check_scope_fingerprint_comparable(
                 "scope_fingerprint — the comparison cannot be verified "
                 "safe."
             ),
+            dimensions=_ALL_SCOPE_DIMENSIONS,
         )
 
     # Waiving the scope mismatch must fall through to the profile check, not
@@ -965,6 +1077,22 @@ def _check_scope_fingerprint_comparable(
     # gate, is what keeps that true.
     if _scope_mismatch_is_additive(old_contract, new_contract):
         return None
+    # An unrecognized scope_fields key differing (checked first, since it can
+    # never be attributed to a specific known dimension) falls back to the
+    # same conservative "affects everything this axis can affect" set as the
+    # opaque-fingerprint branch above; otherwise dimensions are exactly the
+    # ones the actually-differing recognized fields map to.
+    if _unknown_differing_keys(
+        old_contract.scope_fields, new_contract.scope_fields, SCOPE_FIELD_KEYS
+    ):
+        scope_dimensions = _ALL_SCOPE_DIMENSIONS
+    else:
+        scope_dimensions = _dimensions_for_fields(
+            _differing_keys(
+                old_contract.scope_fields, new_contract.scope_fields, SCOPE_FIELD_KEYS
+            ),
+            _SCOPE_FIELD_DIMENSIONS,
+        )
     return ComparabilityMismatch(
         kind="scope",
         reason=(
@@ -974,6 +1102,7 @@ def _check_scope_fingerprint_comparable(
             "drift between the two extraction runs, not a real API "
             "change."
         ),
+        dimensions=scope_dimensions,
     )
 
 

--- a/abicheck/comparability_profile.py
+++ b/abicheck/comparability_profile.py
@@ -36,14 +36,17 @@ the same shape ``type_reachability.py``'s own
 from __future__ import annotations
 
 from .comparability import (
+    _ALL_PROFILE_DIMENSIONS,
     _BUILD_CONTEXT_FIELDS,
     _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS,
     _PLATFORM_IDENTITY_FIELDS,
+    _PROFILE_FIELD_DIMENSIONS,
     _PROFILE_FINGERPRINT_KEY_SETS,
     ComparabilityMismatch,
     _binary_platform_components,
     _build_context_corroborated,
     _differing_keys,
+    _dimensions_for_fields,
     _fingerprint_is_authentic,
     _scope_growth_corroborated,
     _unknown_differing_keys,
@@ -340,6 +343,9 @@ def _check_profile_fingerprint_comparable(
         # profile_fingerprint (Codex review, PR #641 follow-up, sixth
         # P1) -- see _fingerprint_matches_fields's own docstring, and
         # the scope-side equivalent check above.
+        # Opaque/unauthenticated fingerprint: same fail-closed "affects
+        # every dimension this axis can ever affect" default as
+        # comparability.py's scope-side equivalent branch.
         return ComparabilityMismatch(
             kind="profile",
             reason=(
@@ -349,6 +355,7 @@ def _check_profile_fingerprint_comparable(
                 "profile_fingerprint — the comparison cannot be verified "
                 "safe."
             ),
+            dimensions=_ALL_PROFILE_DIMENSIONS,
         )
 
     differing = _differing_keys(
@@ -370,4 +377,15 @@ def _check_profile_fingerprint_comparable(
     reason = _profile_mismatch_reason(unknown_differing, differing, unexplained)
     if reason is None:
         return None
-    return ComparabilityMismatch(kind="profile", reason=reason)
+    # Mirrors _profile_mismatch_reason's own three cases (Codex-review-style
+    # fail-closed default first): an unrecognized differing field, or an
+    # entirely empty `differing` (profile_fields absent/malformed), can never
+    # be attributed to a specific dimension, so both fall back to "every
+    # dimension this axis can affect". Only the genuinely-narrowed
+    # `unexplained` case gets a per-field dimension set.
+    dimensions = (
+        _ALL_PROFILE_DIMENSIONS
+        if (unknown_differing or not differing)
+        else _dimensions_for_fields(unexplained, _PROFILE_FIELD_DIMENSIONS)
+    )
+    return ComparabilityMismatch(kind="profile", reason=reason, dimensions=dimensions)

--- a/changelog.d/comparability-per-dimension-mismatch.md
+++ b/changelog.d/comparability-per-dimension-mismatch.md
@@ -1,0 +1,15 @@
+### Added
+
+- `ComparabilityMismatch` (`abicheck/comparability.py`, ADR-050's
+  `--diagnostic-comparison` escape hatch) now carries a `dimensions` field
+  naming which of five comparability axes — `symbol`, `declaration`,
+  `layout`, `runtime`, `source` — the detected scope/profile/
+  dependency-scope mismatch actually leaves unverified, computed from the
+  specific extraction-contract fields that differ rather than treating
+  every mismatch as equally untrustworthy. `kind`/`reason` are unchanged,
+  so every existing raising and non-diagnostic caller is unaffected. This
+  is the E-S2 (Block 5, `docs/contribute/plans/cli-cleanup-phase-two.md`)
+  data-model slice; wiring `dimensions` into the diff pipeline's own
+  per-finding assurance so a report can keep trusting an unaffected
+  dimension (rather than a single report-wide `assurance: none`) is that
+  same plan section's own next slice, deliberately not part of this change.

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -423,6 +423,29 @@ block 2 — it is the one E/C overlap, and two blocks adding it is a conflict.
 `--require-complete-analysis` keeps its spelling; only its meaning becomes
 task-relative.
 
+> **Partially landed (data model only).** `ComparabilityMismatch` now
+> carries a real `dimensions: frozenset[str]` field (`symbol`, `declaration`,
+> `layout`, `runtime`, `source`) alongside the unchanged `kind`/`reason`,
+> computed from the specific `scope_fields`/`profile_fields` that actually
+> differ for a given mismatch rather than a coarse per-`kind` guess (see
+> `abicheck/comparability.py`'s `COMPARABILITY_DIMENSIONS`/
+> `_PROFILE_FIELD_DIMENSIONS`/`_SCOPE_FIELD_DIMENSIONS`, and
+> `tests/test_comparability_dimensions.py`). This module's own contract
+> (scope/profile/dependency-scope fingerprints) only ever populates
+> `declaration`/`layout`/`runtime` — it never claims authority over `symbol`
+> (binary export-table identity, wholly independent of header/compile-context
+> evidence) or `source` (a separate, L4/L5 axis). **Still open, and
+> deliberately not attempted in this slice:** consuming `dimensions` into the
+> diff pipeline's own per-finding assurance and the report (so a report can
+> read `layout: unverified` beside a still-trusted `declaration` conclusion,
+> replacing today's single report-wide `assurance: none`) — that is a
+> `checker.py`/`DiffResult`/report-schema change, not a `comparability.py`
+> one, and needs its own report-schema bump under `report/AGENTS.md`'s
+> invariants. The failed-evidence half of this block (E-S1's `FAILED`
+> toolchain identity on a compiler-probe failure, and preserving an
+> earlier-proven change through an incomplete later stage) is untouched by
+> this slice.
+
 **Block 6 — `scan --artifact-set` member-identity manifest (PR H's last
 piece).** Syntax refinement, cost/dry-run, and audit-mode ownership all
 landed (see PR 5's own section); what remains is a manifest form that names

--- a/tests/test_comparability_dimensions.py
+++ b/tests/test_comparability_dimensions.py
@@ -1,0 +1,185 @@
+"""E-S2 (docs/contribute/plans/cli-cleanup-phase-two.md, Block 5) --
+``ComparabilityMismatch.dimensions``, the per-dimension comparability record
+that replaces the previous "carries a single ``kind``" data model.
+
+These are unit tests of the *data layer* only (what
+``check_contracts_comparable``'s ``diagnostic=True`` mode attaches to the
+returned descriptor) -- not of report/detector consumption, which is E-S2's
+own explicitly-deferred next slice (see ``ComparabilityMismatch``'s own
+docstring in ``abicheck/comparability.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.comparability import (
+    COMPARABILITY_DIMENSIONS,
+    ComparabilityMismatch,
+    IncludeDir,
+    check_contracts_comparable,
+    compute_extraction_contract,
+)
+from abicheck.model import AbiSnapshot, ExtractionContract, Function, Visibility
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _snap(contract: ExtractionContract | None, **kwargs) -> AbiSnapshot:
+    return AbiSnapshot(library="libfoo.so", version="1.0", contract=contract, **kwargs)
+
+
+def _scoped_snap(
+    version: str, from_headers: bool, dependency_scope: str | None
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version=version,
+        from_headers=from_headers,
+        functions=[
+            Function(
+                name="f",
+                mangled="_Z1fv",
+                return_type="void",
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+        dependency_scope=dependency_scope,
+    )
+
+
+def test_scope_mismatch_dimensions_are_declaration_only(tmp_path):
+    # A genuine, non-additive declared-header-set drift: only the
+    # "headers" scope field differs, so only "declaration" is affected --
+    # a scope mismatch says nothing about runtime behavior or the binary's
+    # own exported-symbol identity.
+    a = _write(tmp_path / "v1" / "a.h", "int g(void);\n")
+    old_h = _write(tmp_path / "v1" / "foo.h", "int f(void);\n")
+    new_h = _write(tmp_path / "v2" / "bar.h", "int f(void);\n")
+    old = _snap(compute_extraction_contract(declared_headers=[a, old_h]))
+    new = _snap(compute_extraction_contract(declared_headers=[a, new_h]))
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "scope"
+    assert result.dimensions == frozenset({"declaration"})
+
+
+def test_profile_mismatch_dimensions_map_to_differing_fields(tmp_path):
+    # Only include-directory content differs (a struct field added) --
+    # profile_fields "include_sequence" carve-out doesn't apply here (no
+    # additive owned-growth shape), so the mismatch is genuinely reported,
+    # and its dimensions are exactly what the differing field maps to.
+    dep_old = _write(tmp_path / "d1" / "dep.h", "struct Dep { int x; };\n")
+    dep_new = _write(tmp_path / "d2" / "dep.h", "struct Dep { int x; int y; };\n")
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            declared_includes=[IncludeDir(tmp_path / "d1")],
+            depfile_resolved_paths=[dep_old],
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            declared_includes=[IncludeDir(tmp_path / "d2")],
+            depfile_resolved_paths=[dep_new],
+        )
+    )
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "profile"
+    # include_sequence is the only PROFILE_FIELD_KEYS entry this pair
+    # actually differs on -- and it maps to "declaration" only.
+    assert result.dimensions == frozenset({"declaration"})
+
+
+def test_dependency_scope_mismatch_dimensions_are_declaration_and_layout():
+    old = _scoped_snap("1.0", from_headers=True, dependency_scope="filtered")
+    new = _scoped_snap("2.0", from_headers=True, dependency_scope="full")
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "dependency_scope"
+    assert result.dimensions == frozenset({"declaration", "layout"})
+
+
+def test_opaque_scope_mismatch_falls_back_to_every_scope_dimension():
+    # A fabricated/deserialized contract whose scope_fingerprint doesn't
+    # reproduce from its own scope_fields -- nothing here can be attributed
+    # to a specific field, so every dimension the scope axis can ever
+    # affect is reported unverified (fail-closed, same as `kind`/`reason`).
+    old_contract = ExtractionContract(
+        profile_fingerprint=None,
+        scope_fingerprint="not-a-real-hash-old",
+        profile_fields={},
+        scope_fields={"headers": '["a.h"]', "public_header_dirs": "[]"},
+    )
+    new_contract = ExtractionContract(
+        profile_fingerprint=None,
+        scope_fingerprint="not-a-real-hash-new",
+        profile_fields={},
+        scope_fields={"headers": '["a.h", "b.h"]', "public_header_dirs": "[]"},
+    )
+    old = _snap(old_contract)
+    new = _snap(new_contract)
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "scope"
+    assert result.dimensions == frozenset({"declaration"})
+
+
+def test_opaque_profile_mismatch_falls_back_to_every_profile_dimension():
+    old_contract = ExtractionContract(
+        profile_fingerprint="not-a-real-hash-old",
+        scope_fingerprint=None,
+        profile_fields={"compiler_family": "gcc"},
+        scope_fields={},
+    )
+    new_contract = ExtractionContract(
+        profile_fingerprint="not-a-real-hash-new",
+        scope_fingerprint=None,
+        profile_fields={"compiler_family": "clang"},
+        scope_fields={},
+    )
+    old = _snap(old_contract)
+    new = _snap(new_contract)
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "profile"
+    # Every dimension a recognized profile field can affect -- the
+    # unauthenticated fingerprint means no single field can be trusted.
+    assert result.dimensions == frozenset({"declaration", "layout", "runtime"})
+
+
+def test_comparable_pair_produces_no_mismatch_at_all(tmp_path):
+    old_h = _write(tmp_path / "v1" / "foo.h", "int f(void);\n")
+    new_h = _write(tmp_path / "v2" / "foo.h", "int f(void);\n")
+    old = _snap(compute_extraction_contract(declared_headers=[old_h]))
+    new = _snap(compute_extraction_contract(declared_headers=[new_h]))
+    assert check_contracts_comparable(old, new, diagnostic=True) is None
+
+
+# ---------------------------------------------------------------------------
+# Property: whatever this module attaches, it's a real subset of the
+# published dimension vocabulary, and never claims authority it doesn't have.
+# ---------------------------------------------------------------------------
+
+
+def test_every_reported_dimension_is_in_the_published_vocabulary(tmp_path):
+    a = _write(tmp_path / "v1" / "a.h", "int g(void);\n")
+    old_h = _write(tmp_path / "v1" / "foo.h", "int f(void);\n")
+    new_h = _write(tmp_path / "v2" / "bar.h", "int f(void);\n")
+    old = _snap(compute_extraction_contract(declared_headers=[a, old_h]))
+    new = _snap(compute_extraction_contract(declared_headers=[a, new_h]))
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.dimensions <= COMPARABILITY_DIMENSIONS
+    # ADR-050's contract (scope/profile/dependency-scope fingerprints) never
+    # speaks to the binary's own exported-symbol-table identity (L0/L1) or
+    # to L4/L5 build-source-graph evidence -- a mismatch here must never
+    # claim authority over either.
+    assert "symbol" not in result.dimensions
+    assert "source" not in result.dimensions


### PR DESCRIPTION
## Summary

`ComparabilityMismatch` (`abicheck/comparability.py`) now carries a real per-dimension `dimensions` field instead of only a single coarse `kind`.

## Motivation

Block 5 (E-S1/S2, `docs/contribute/plans/cli-cleanup-phase-two.md`) flagged this data model as untouched: `ComparabilityMismatch` carried only `kind: "scope" | "profile" | "dependency_scope"`, so a GCC-vs-Clang pair was reported exactly as untrustworthy whether every extraction-contract axis diverged or only one narrow field did — `--diagnostic-comparison`'s report-wide `assurance: none` was the only middle ground.

## Changes

- Added `COMPARABILITY_DIMENSIONS` — the five-axis vocabulary (`symbol`, `declaration`, `layout`, `runtime`, `source`) — plus `_PROFILE_FIELD_DIMENSIONS`/`_SCOPE_FIELD_DIMENSIONS`/`_DEPENDENCY_SCOPE_DIMENSIONS` field→dimension maps in `comparability.py`.
- `ComparabilityMismatch` gained a `dimensions: frozenset[str]` field, computed at each mismatch construction site from the specific fields that actually differ (falling back to the axis's full dimension set only when the mismatch is opaque/unauthenticated or an unrecognized field is involved — the same fail-closed default the surrounding carve-out logic already uses). `kind`/`reason` are unchanged, so every existing raising and non-diagnostic caller is unaffected.
- This module's own contract (scope/profile/dependency-scope fingerprints) never speaks to the binary's own exported-symbol-table identity or to L4/L5 source-graph evidence, so a mismatch here never reports `symbol` or `source` as affected.
- Added `tests/test_comparability_dimensions.py` covering narrow scope/profile mismatches, dependency-scope mismatches, the opaque-fingerprint fallback for both axes, and a property test that every reported dimension is a real subset of the published vocabulary and never claims `symbol`/`source`.
- Added a changelog fragment.
- Updated the plan doc (Block 5) with a status note: this slice is the data-model half only. Consuming `dimensions` into the diff pipeline's own per-finding assurance (so a report can read `layout: unverified` beside a still-trusted `declaration` conclusion, replacing today's single report-wide `assurance: none`) is explicitly deferred as this plan section's own next slice — it's a `checker.py`/`DiffResult`/report-schema change, not a `comparability.py` one. E-S1's `FAILED`-toolchain-identity / preserve-earlier-proven-change half of Block 5 is also untouched by this slice.

## Bug-fix test contract

Not applicable — this is a `feat:` PR (additive data model), not a `fix:`/`perf:`/`security:` change.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated (plan doc status note)
- [x] `mypy abicheck/` clean, `ruff check`/`ruff format --check` clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT75zbhAbP4f2fzUzSkc3K)_