### PR TITLE
Fold DumpExecutionOptions into ResolvedDumpRequest (ADR-063 Track T4)

### DIFF
--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -738,56 +738,6 @@ def _add_dump_depth_feasibility(
         )
 
 
-def dry_run_build_context_preview(
-    compile_db_path: Path | None,
-    headers: tuple[Path, ...],
-    compile_db_filter: str | None,
-) -> tuple[list[str], bool] | None:
-    """Silent, non-raising sibling of
-    ``cli_helpers_compare._resolve_build_context_flags`` that also returns
-    the derived castxml flags themselves -- ``dump --dry-run``'s
-    :class:`~abicheck.service_dump_pipeline.DumpExecutionOptions` preview
-    (ADR-063 Track T4, "Dump request contract").
-
-    Lives here rather than alongside its sibling in ``cli_helpers_compare.py``
-    (only its own ``_matched_build_context`` core import crosses that
-    boundary -- the same pre-existing ``cli_dump_helpers -> cli_helpers_
-    compare`` edge ``discover_project_config`` already uses below, not a new
-    one) purely to keep that file's own `no_growth` debt entry
-    (``architecture/debt.yaml``) from tripping -- this function's own home
-    is ``render_dump_dry_run``'s module regardless, since it exists only to
-    feed that renderer's own "Execution options" section.
-
-    Same relationship to ``_resolve_build_context_flags`` that
-    ``cli_helpers_compare.dry_run_compile_db_matched`` already has (loading
-    and matching a compile database is cheap, deterministic, read-only
-    resolution, so a dry run may perform it) -- extended to return ``flags``
-    too, since a dry run reporting ``legacy_compile_db_tokens`` needs the
-    actual list, not just the match verdict. Never echoes to stderr and
-    never raises: an unreadable/malformed compile database folds to
-    ``([], False)`` rather than the ``click.ClickException`` the real run
-    would raise -- the same accepted imprecision
-    ``dry_run_compile_db_matched`` already documents for the identical
-    failure shape.
-
-    Returns ``None`` when no compile database was given at all (the ``dump``
-    CLI's dry-run preview reads this as "no legacy compile-db flags to
-    show", the same as an execution that never threads any).
-    """
-    if not compile_db_path:
-        return None
-    from .cli_helpers_compare import _matched_build_context
-    from .errors import AbicheckError
-
-    try:
-        ctx, _entry_count = _matched_build_context(
-            compile_db_path, headers, compile_db_filter
-        )
-        return ctx.to_castxml_flags(), ctx.compile_db_path is not None
-    except (AbicheckError, OSError, ValueError, click.ClickException):
-        return [], False
-
-
 def render_dump_dry_run(
     resolved: ResolvedDumpRequest,
     *,
@@ -924,29 +874,6 @@ def render_dump_dry_run(
         "Configuration and value origins",
         f".abicheck.yml: {cfg_path if cfg_path else '(none found)'}",
     )
-    # ADR-063 Track T4 ("Dump request contract"): render the nine execution
-    # kwargs `execute_dump_request` would receive, when the caller resolved
-    # them (`resolved.execution_options`, a preview for `--dry-run` -- see
-    # `frontends.cli.commands.dump.dump_cmd`'s own attach step). `None`
-    # (never resolved) renders nothing, same as every other optional section
-    # here -- an older caller that built a `ResolvedDumpRequest` without this
-    # field keeps seeing the unchanged report.
-    opts = resolved.execution_options
-    if opts is not None:
-        result.add(
-            "Execution options",
-            f"build config: {opts.build_config}" if opts.build_config else None,
-            f"allow build query: {opts.allow_build_query}",
-            f"legacy compile-db flags: {len(opts.legacy_compile_db_tokens)} "
-            f"derived ({'matched' if opts.legacy_compile_db_matched else 'no match'})"
-            if opts.legacy_compile_db_tokens or opts.legacy_compile_db_matched
-            else None,
-            f"seed collect mode: {opts.seed_collect_mode}"
-            if opts.seed_collect_mode
-            else None,
-            "source frontend from folded context: "
-            f"{opts.source_frontend_from_folded_context}",
-        )
     if output is not None:
         from .errors import SnapshotError
         from .workflows.storage import SnapshotCompression, resolve_write_compression

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -738,6 +738,56 @@ def _add_dump_depth_feasibility(
         )
 
 
+def dry_run_build_context_preview(
+    compile_db_path: Path | None,
+    headers: tuple[Path, ...],
+    compile_db_filter: str | None,
+) -> tuple[list[str], bool] | None:
+    """Silent, non-raising sibling of
+    ``cli_helpers_compare._resolve_build_context_flags`` that also returns
+    the derived castxml flags themselves -- ``dump --dry-run``'s
+    :class:`~abicheck.service_dump_pipeline.DumpExecutionOptions` preview
+    (ADR-063 Track T4, "Dump request contract").
+
+    Lives here rather than alongside its sibling in ``cli_helpers_compare.py``
+    (only its own ``_matched_build_context`` core import crosses that
+    boundary -- the same pre-existing ``cli_dump_helpers -> cli_helpers_
+    compare`` edge ``discover_project_config`` already uses below, not a new
+    one) purely to keep that file's own `no_growth` debt entry
+    (``architecture/debt.yaml``) from tripping -- this function's own home
+    is ``render_dump_dry_run``'s module regardless, since it exists only to
+    feed that renderer's own "Execution options" section.
+
+    Same relationship to ``_resolve_build_context_flags`` that
+    ``cli_helpers_compare.dry_run_compile_db_matched`` already has (loading
+    and matching a compile database is cheap, deterministic, read-only
+    resolution, so a dry run may perform it) -- extended to return ``flags``
+    too, since a dry run reporting ``legacy_compile_db_tokens`` needs the
+    actual list, not just the match verdict. Never echoes to stderr and
+    never raises: an unreadable/malformed compile database folds to
+    ``([], False)`` rather than the ``click.ClickException`` the real run
+    would raise -- the same accepted imprecision
+    ``dry_run_compile_db_matched`` already documents for the identical
+    failure shape.
+
+    Returns ``None`` when no compile database was given at all (the ``dump``
+    CLI's dry-run preview reads this as "no legacy compile-db flags to
+    show", the same as an execution that never threads any).
+    """
+    if not compile_db_path:
+        return None
+    from .cli_helpers_compare import _matched_build_context
+    from .errors import AbicheckError
+
+    try:
+        ctx, _entry_count = _matched_build_context(
+            compile_db_path, headers, compile_db_filter
+        )
+        return ctx.to_castxml_flags(), ctx.compile_db_path is not None
+    except (AbicheckError, OSError, ValueError, click.ClickException):
+        return [], False
+
+
 def render_dump_dry_run(
     resolved: ResolvedDumpRequest,
     *,
@@ -874,6 +924,29 @@ def render_dump_dry_run(
         "Configuration and value origins",
         f".abicheck.yml: {cfg_path if cfg_path else '(none found)'}",
     )
+    # ADR-063 Track T4 ("Dump request contract"): render the nine execution
+    # kwargs `execute_dump_request` would receive, when the caller resolved
+    # them (`resolved.execution_options`, a preview for `--dry-run` -- see
+    # `frontends.cli.commands.dump.dump_cmd`'s own attach step). `None`
+    # (never resolved) renders nothing, same as every other optional section
+    # here -- an older caller that built a `ResolvedDumpRequest` without this
+    # field keeps seeing the unchanged report.
+    opts = resolved.execution_options
+    if opts is not None:
+        result.add(
+            "Execution options",
+            f"build config: {opts.build_config}" if opts.build_config else None,
+            f"allow build query: {opts.allow_build_query}",
+            f"legacy compile-db flags: {len(opts.legacy_compile_db_tokens)} "
+            f"derived ({'matched' if opts.legacy_compile_db_matched else 'no match'})"
+            if opts.legacy_compile_db_tokens or opts.legacy_compile_db_matched
+            else None,
+            f"seed collect mode: {opts.seed_collect_mode}"
+            if opts.seed_collect_mode
+            else None,
+            "source frontend from folded context: "
+            f"{opts.source_frontend_from_folded_context}",
+        )
     if output is not None:
         from .errors import SnapshotError
         from .workflows.storage import SnapshotCompression, resolve_write_compression

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -68,6 +68,47 @@ def _provenance_timestamp(source_date_epoch: str | None) -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
+def _matched_build_context(
+    effective_compile_db: Path,
+    headers: tuple[Path, ...],
+    compile_db_filter: str | None,
+) -> tuple[Any, int]:
+    """Load *effective_compile_db* and match it against *headers* -- the one
+    resolution core :func:`_resolve_build_context_flags`,
+    :func:`dry_run_compile_db_matched`, and :func:`dry_run_build_context_preview`
+    all build on (ADR-063 Track T4: these three used to each re-derive this
+    identical load-and-match independently).
+
+    Returns ``(ctx, entry_count)`` -- the resolved
+    :class:`~abicheck.build_context.BuildContext` and the number of compile-DB
+    entries loaded (the real-run caller's stderr announcement needs the
+    count; the dry-run siblings ignore it). Raises
+    :class:`~abicheck.errors.AbicheckError`/``OSError`` on a missing or
+    malformed compile database -- callers that must not raise (the dry-run
+    siblings) catch around this call themselves; the real-run caller
+    (:func:`_resolve_build_context_flags`) translates the same exception into
+    a ``click.ClickException``.
+    """
+    from .build_context import (
+        build_context_for_header,
+        build_context_union_fallback,
+        load_compile_db,
+    )
+    from .cli_resolve import _expand_header_inputs
+
+    db_entries = load_compile_db(effective_compile_db)
+    resolved_hdrs = _expand_header_inputs(list(headers)) if headers else []
+    if resolved_hdrs:
+        ctx = build_context_for_header(
+            db_entries,
+            resolved_hdrs[0],
+            source_filter=compile_db_filter,
+        )
+    else:
+        ctx = build_context_union_fallback(db_entries, source_filter=compile_db_filter)
+    return ctx, len(db_entries)
+
+
 def _resolve_build_context_flags(
     effective_compile_db: Path | None,
     headers: tuple[Path, ...],
@@ -89,32 +130,16 @@ def _resolve_build_context_flags(
     database (Codex review, second finding on this signal)."""
     if not effective_compile_db:
         return [], False
-    from .cli_resolve import _expand_header_inputs
     from .errors import AbicheckError
 
     try:
-        from .build_context import (
-            build_context_for_header,
-            build_context_union_fallback,
-            load_compile_db,
+        ctx, entry_count = _matched_build_context(
+            effective_compile_db, headers, compile_db_filter
         )
-
-        db_entries = load_compile_db(effective_compile_db)
-        resolved_hdrs = _expand_header_inputs(list(headers)) if headers else []
-        if resolved_hdrs:
-            ctx = build_context_for_header(
-                db_entries,
-                resolved_hdrs[0],
-                source_filter=compile_db_filter,
-            )
-        else:
-            ctx = build_context_union_fallback(
-                db_entries, source_filter=compile_db_filter
-            )
         flags = ctx.to_castxml_flags()
         if flags:
             click.echo(
-                f"Build context: {len(db_entries)} entries from "
+                f"Build context: {entry_count} entries from "
                 f"{effective_compile_db}, {len(flags)} flags derived",
                 err=True,
             )
@@ -152,7 +177,8 @@ def dry_run_compile_db_matched(
     echoes to stderr (``_resolve_build_context_flags``'s "Build context: N
     entries..." announcement belongs to the real run, not a dry run) and
     never returns the derived flags themselves (dry-run has no use for
-    them). Any load/match failure (missing file, malformed JSON, wrong
+    them -- see :func:`dry_run_build_context_preview` for the sibling that
+    does). Any load/match failure (missing file, malformed JSON, wrong
     structure) is folded into ``False`` -- the real run would fail on the
     identical input too, just via a different exception shape
     (``click.ClickException`` from a malformed compile database vs.
@@ -163,29 +189,12 @@ def dry_run_compile_db_matched(
     effective_compile_db = compile_db_path or compile_db_path_alt
     if not effective_compile_db:
         return None
-    from .cli_resolve import _expand_header_inputs
     from .errors import AbicheckError
 
     try:
-        from .build_context import (
-            build_context_for_header,
-            build_context_union_fallback,
-            load_compile_db,
+        ctx, _entry_count = _matched_build_context(
+            effective_compile_db, headers, compile_db_filter
         )
-
-        db_entries = load_compile_db(effective_compile_db)
-        resolved_hdrs = _expand_header_inputs(list(headers)) if headers else []
-        if resolved_hdrs:
-            ctx = build_context_for_header(
-                db_entries,
-                resolved_hdrs[0],
-                source_filter=compile_db_filter,
-            )
-        else:
-            ctx = build_context_union_fallback(
-                db_entries,
-                source_filter=compile_db_filter,
-            )
         return ctx.compile_db_path is not None
     except (AbicheckError, OSError, ValueError, click.ClickException):
         # click.ClickException also covers _expand_header_inputs's own

--- a/abicheck/dry_run.py
+++ b/abicheck/dry_run.py
@@ -56,6 +56,10 @@ SECTION_ORDER: tuple[str, ...] = (
     "Build query (trust)",
     "Tools and frontends",
     "Configuration and value origins",
+    # ADR-063 Track T4 ("Dump request contract"): `dump --dry-run`'s own
+    # execution-options preview (`cli_dump_helpers.render_dump_dry_run`).
+    # No other command populates this section today.
+    "Execution options",
     "Consumer/contract scoping",
     "Output and exit-code behavior",
 )

--- a/abicheck/frontends/cli/commands/dump.py
+++ b/abicheck/frontends/cli/commands/dump.py
@@ -555,6 +555,35 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # not already raise -- it raises the same ones from one place.
     _resolved = resolve_dump_request_for_cli(_dump_request)
 
+    # ADR-063 Track T4 ("Dump request contract"): attach a dry-run-safe
+    # *preview* of the nine execution-option values onto the resolved
+    # request, so `dump --dry-run` can render what the real run below would
+    # pass to `execute_dump_request`. `dry_run_build_context_preview` is the
+    # silent, non-raising sibling of `_resolve_build_context_flags` used
+    # below for the real run -- same inputs, so the preview agrees with the
+    # real run except for one accepted imprecision (a malformed compile
+    # database folds to `([], False)` here rather than raising -- see that
+    # function's own docstring). Every other field mirrors a CLI-invariant
+    # value the real run always attaches too (see `execute_dump_cli_run`'s
+    # own docstring), or a value already resolved above.
+    from ....cli_dump_helpers import dry_run_build_context_preview
+    from ....service_dump_pipeline import DumpExecutionOptions
+
+    _preview_flags, _preview_matched = dry_run_build_context_preview(
+        compile_db_path, headers, compile_db_filter
+    ) or ([], False)
+    _resolved = dataclasses.replace(
+        _resolved,
+        execution_options=DumpExecutionOptions(
+            build_config=build_config,
+            allow_build_query=True,
+            legacy_compile_db_tokens=tuple(_preview_flags),
+            legacy_compile_db_matched=_preview_matched,
+            seed_collect_mode=_resolved.collect_mode,
+            source_frontend_from_folded_context=True,
+        ),
+    )
+
     if dry_run:
         from ....cli_buildsource_helpers import _is_inputs_pack_dir
         from ....cli_dump_dry_run_build_query import add_build_query_dry_run_section
@@ -704,8 +733,32 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         _dump_request,
         input=dataclasses.replace(_dump_request.input, path=so_path),
     )
+    # ADR-063 Track T4: the real (raise/echo-capable) `DumpExecutionOptions`
+    # -- unlike `_resolved`'s own dry-run-safe preview above -- attached
+    # directly onto the request this run actually executes, so
+    # `execute_dump_cli_run` picks it up as `execute_dump_request`'s default
+    # `options` rather than this call site threading the nine values through
+    # as separate keyword parameters.
     _exec_resolved = dataclasses.replace(
-        resolve_dump_request_for_cli(_exec_request), requested_depth=None,
+        resolve_dump_request_for_cli(_exec_request),
+        requested_depth=None,
+        execution_options=DumpExecutionOptions(
+            build_config=build_config,
+            allow_build_query=True,
+            legacy_compile_db_tokens=tuple(build_context_flags),
+            legacy_compile_db_matched=compile_db_matched,
+            # Codex review, two real regressions on the original ELF
+            # migration: `perform_elf_dump` always forwarded its own
+            # resolved collect mode to the L2 seed (running a zero-config
+            # inferred build query for a `--sources` tree with no compile
+            # database) and always replayed L4 source through the L3
+            # fold's own compiler once it applied -- both must be
+            # preserved here, exactly as `scan`'s own candidate resolution
+            # already does. Applies identically to PE/Mach-O, which shares
+            # this same tail.
+            seed_collect_mode=_resolved.collect_mode,
+            source_frontend_from_folded_context=True,
+        ),
     )
     from ....workflows.extraction import (
         dump_manifest_header_roots,
@@ -717,17 +770,6 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         _exec_resolved,
         notify=_click_notify,
         build_config=build_config,
-        legacy_compile_db_tokens=tuple(build_context_flags),
-        legacy_compile_db_matched=compile_db_matched,
-        # Codex review, two real regressions on the original ELF migration:
-        # `perform_elf_dump` always forwarded its own resolved collect mode
-        # to the L2 seed (running a zero-config inferred build query for a
-        # `--sources` tree with no compile database) and always replayed L4
-        # source through the L3 fold's own compiler once it applied -- both
-        # must be preserved here, exactly as `scan`'s own candidate
-        # resolution already does. Applies identically to PE/Mach-O, which
-        # shares this same tail.
-        seed_collect_mode=_resolved.collect_mode,
         stamp_provenance=_stamp_provenance,
         write_snapshot_output=_write_snapshot_output_fn,
         git_tag=git_tag, build_id=build_id, no_git=no_git,

--- a/abicheck/frontends/cli/commands/dump.py
+++ b/abicheck/frontends/cli/commands/dump.py
@@ -555,19 +555,16 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # not already raise -- it raises the same ones from one place.
     _resolved = resolve_dump_request_for_cli(_dump_request)
 
-    # ADR-063 Track T4 ("Dump request contract"): attach a dry-run-safe
-    # *preview* of the nine execution-option values onto the resolved
-    # request, so `dump --dry-run` can render what the real run below would
-    # pass to `execute_dump_request`. `dry_run_build_context_preview` is the
-    # silent, non-raising sibling of `_resolve_build_context_flags` used
-    # below for the real run -- same inputs, so the preview agrees with the
-    # real run except for one accepted imprecision (a malformed compile
-    # database folds to `([], False)` here rather than raising -- see that
-    # function's own docstring). Every other field mirrors a CLI-invariant
-    # value the real run always attaches too (see `execute_dump_cli_run`'s
-    # own docstring), or a value already resolved above.
-    from ....cli_dump_helpers import dry_run_build_context_preview
+    # ADR-063 Track T4: attach a dry-run-safe *preview* of the execution
+    # options onto the resolved request, so `--dry-run` can render what the
+    # real run below would pass to `execute_dump_request` -- see
+    # `dry_run_build_context_preview`'s own docstring for the one accepted
+    # imprecision vs. the real run's `_resolve_build_context_flags`.
     from ....service_dump_pipeline import DumpExecutionOptions
+    from ..dump_build_context_preview import (
+        add_execution_options_dry_run_section,
+        dry_run_build_context_preview,
+    )
 
     _preview_flags, _preview_matched = dry_run_build_context_preview(
         compile_db_path, headers, compile_db_filter
@@ -623,6 +620,9 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
             collect_mode=collect_mode, build_info=build_info,
             build_config=build_config,
         )
+        # ADR-063 Track T4: the execution-options preview attached onto
+        # `_resolved` above, rendered as its own section.
+        add_execution_options_dry_run_section(_dry_result, _resolved)
         emit_dry_run(_dry_result)
 
     # Source-only dump (no binary) for the parallel-baseline flow.

--- a/abicheck/frontends/cli/dump_build_context_preview.py
+++ b/abicheck/frontends/cli/dump_build_context_preview.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``dump --dry-run``'s legacy compile-db flags preview and its own
+"Execution options" report section.
+
+ADR-063 Track T4 ("Dump request contract") follow-up. A genuinely new
+module rather than an addition to ``cli_helpers_compare.py`` (its own
+``no_growth`` debt entry, ``architecture/debt.yaml``) or ``cli_dump_helpers.py``
+(same) -- both are already at or over their adoption baseline, with zero
+headroom for either this preview function or the report section it feeds.
+Per ``abicheck/CLAUDE.md``'s "New code goes to its ADR-061 target owner,
+not the flat legacy namespace", a new module belongs in ``frontends/cli/``
+rather than a new flat ``cli_*.py`` root module (``ADR-061``'s
+``architecture/modules.yaml`` freezes that root family's member list) --
+see ``frontends/cli/dump_execute.py``'s own docstring for the identical
+reasoning. :func:`add_execution_options_dry_run_section` mirrors
+``cli_dump_dry_run_build_query.add_build_query_dry_run_section``'s shape
+(a plain function appending its own section onto an already-built
+:class:`~abicheck.dry_run.DryRunResult`) for the identical reason: the
+section it renders belongs next to ``render_dump_dry_run``'s own report
+construction, but that module has no line budget left to build it inline.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ...dry_run import DryRunResult
+    from ...service_dump_pipeline import ResolvedDumpRequest
+
+__all__ = [
+    "add_execution_options_dry_run_section",
+    "dry_run_build_context_preview",
+]
+
+
+def dry_run_build_context_preview(
+    compile_db_path: Path | None,
+    headers: tuple[Path, ...],
+    compile_db_filter: str | None,
+) -> tuple[list[str], bool] | None:
+    """Silent, non-raising sibling of
+    ``cli_helpers_compare._resolve_build_context_flags`` that also returns
+    the derived castxml flags themselves -- ``dump --dry-run``'s
+    :class:`~abicheck.service_dump_pipeline.DumpExecutionOptions` preview.
+
+    Same relationship to ``_resolve_build_context_flags`` that
+    ``cli_helpers_compare.dry_run_compile_db_matched`` already has (loading
+    and matching a compile database is cheap, deterministic, read-only
+    resolution, so a dry run may perform it) -- extended to return ``flags``
+    too, since a dry run reporting ``legacy_compile_db_tokens`` needs the
+    actual list, not just the match verdict. Never echoes to stderr and
+    never raises: an unreadable/malformed compile database folds to
+    ``([], False)`` rather than the ``click.ClickException`` the real run
+    would raise -- the same accepted imprecision
+    ``dry_run_compile_db_matched`` already documents for the identical
+    failure shape.
+
+    Returns ``None`` when no compile database was given at all (the ``dump``
+    CLI's dry-run preview reads this as "no legacy compile-db flags to
+    show", the same as an execution that never threads any).
+    """
+    if not compile_db_path:
+        return None
+    from ...cli_helpers_compare import _matched_build_context
+    from ...errors import AbicheckError
+
+    try:
+        ctx, _entry_count = _matched_build_context(
+            compile_db_path, headers, compile_db_filter
+        )
+        return ctx.to_castxml_flags(), ctx.compile_db_path is not None
+    except (AbicheckError, OSError, ValueError, click.ClickException):
+        return [], False
+
+
+def add_execution_options_dry_run_section(
+    result: DryRunResult, resolved: ResolvedDumpRequest
+) -> None:
+    """Append the nine execution-option values `execute_dump_request` would
+    receive to *result*, when the caller resolved them
+    (``resolved.execution_options`` -- see
+    ``frontends.cli.commands.dump.dump_cmd``'s own attach step). A no-op
+    when unset, same as every other optional section
+    ``render_dump_dry_run`` builds -- an older caller that resolved no
+    ``execution_options`` sees the unchanged report.
+    """
+    opts = resolved.execution_options
+    if opts is None:
+        return
+    result.add(
+        "Execution options",
+        f"build config: {opts.build_config}" if opts.build_config else None,
+        f"allow build query: {opts.allow_build_query}",
+        f"legacy compile-db flags: {len(opts.legacy_compile_db_tokens)} "
+        f"derived ({'matched' if opts.legacy_compile_db_matched else 'no match'})"
+        if opts.legacy_compile_db_tokens or opts.legacy_compile_db_matched
+        else None,
+        f"seed collect mode: {opts.seed_collect_mode}"
+        if opts.seed_collect_mode
+        else None,
+        f"source frontend from folded context: "
+        f"{opts.source_frontend_from_folded_context}",
+    )

--- a/abicheck/frontends/cli/dump_execute.py
+++ b/abicheck/frontends/cli/dump_execute.py
@@ -82,12 +82,6 @@ def execute_dump_cli_run(
     exec_resolved: ResolvedDumpRequest,
     *,
     notify: Callable[[str], None],
-    build_config: Path | None,
-    allow_build_query: bool,
-    legacy_compile_db_tokens: tuple[str, ...],
-    legacy_compile_db_matched: bool,
-    seed_collect_mode: str | None,
-    source_frontend_from_folded_context: bool,
 ) -> AbiSnapshot:
     """Run the real ``dump`` extraction (ELF, PE, or Mach-O) and return its
     snapshot.
@@ -100,8 +94,20 @@ def execute_dump_cli_run(
     linker script / dev symlink: ``resolve_dump_request``'s own
     ``detect_binary_format(side.path)`` call runs before any such
     following, so feeding it the pre-follow path risks a wrong ``fmt`` for
-    a symlink-to-linker-script input) and with ``requested_depth`` nulled
-    out.
+    a symlink-to-linker-script input), with ``requested_depth`` nulled
+    out, and its own :attr:`~abicheck.service_dump_pipeline.
+    ResolvedDumpRequest.execution_options` already attached -- the nine
+    out-of-band execution kwargs this function used to accept as its own
+    separate parameters (ADR-063 Track T4, "Dump request contract";
+    :class:`~abicheck.service_dump_pipeline.DumpExecutionOptions` documents
+    each field). Folded onto *exec_resolved* itself, not threaded through
+    here, so the object the caller resolved is the one thing describing the
+    run -- the same reasoning that already governs every other value this
+    function reads off *exec_resolved* rather than taking as its own
+    parameter. :func:`~abicheck.service_dump_pipeline.execute_dump_request`
+    reads ``exec_resolved.execution_options`` itself whenever its own
+    ``options`` keyword is left unset, which is what this function relies on
+    below.
 
     That null-out matters here too, not just at the call site that does
     it: the shared pipeline's own depth gate
@@ -118,13 +124,14 @@ def execute_dump_cli_run(
     own ``_write_snapshot_output`` call stays the sole enforcement point,
     exactly as it already is today.
 
-    *legacy_compile_db_tokens*/*legacy_compile_db_matched* (ADR-063 Phase
-    1): the legacy ``-p``/``--compile-db`` auto-match's own derived
-    signal, which has no equivalent inside the shared pipeline's typed
-    ``InputSpec`` -- threaded through as an explicit pass-through
-    (``execute_dump_request``'s own docstring states the precedence rule:
-    the P0.3 fold's own result wins whenever it applies) rather than a new
-    typed field, so the migrated real run keeps seeing it exactly like
+    *exec_resolved.execution_options*'s own ``legacy_compile_db_tokens``/
+    ``legacy_compile_db_matched`` fields (ADR-063 Phase 1): the legacy
+    ``-p``/``--compile-db`` auto-match's own derived signal, which has no
+    equivalent inside the shared pipeline's typed ``InputSpec`` -- threaded
+    through as an explicit pass-through (``execute_dump_request``'s own
+    docstring states the precedence rule: the P0.3 fold's own result wins
+    whenever it applies) rather than a new typed field on ``InputSpec``
+    itself, so the migrated real run keeps seeing it exactly like
     ``perform_elf_dump`` did via its own ``legacy_build_context_flags``
     parameter.
 
@@ -138,26 +145,27 @@ def execute_dump_cli_run(
     ``cli_resolve._click_notify``, ``compare``'s own CLI convention for the
     identical pipeline, reused verbatim rather than invented a second time.
 
-    *seed_collect_mode*/*source_frontend_from_folded_context* (Codex review,
-    two real regressions the initial migration introduced): forwarded
-    verbatim to :func:`~abicheck.service_dump_pipeline.execute_dump_request`,
-    whose own docstring documents each and states the precedence/behavior
-    ``perform_elf_dump`` had that these preserve. The caller passes
+    *exec_resolved.execution_options*'s own ``seed_collect_mode``/
+    ``source_frontend_from_folded_context`` fields (Codex review, two real
+    regressions the initial migration introduced): forwarded verbatim to
+    :func:`~abicheck.service_dump_pipeline.execute_dump_request`, whose own
+    docstring documents each and states the precedence/behavior
+    ``perform_elf_dump`` had that these preserve. The caller attaches
     ``seed_collect_mode=resolved.collect_mode`` (the same collect mode
     ``--dry-run`` already projects and ``_write_snapshot_output`` already
     consumes) and ``source_frontend_from_folded_context=True`` unconditionally
     -- matching ``scan``'s own candidate resolution, which passes the
     identical value for the identical reason.
 
-    *allow_build_query* -- the caller passes ``True`` unconditionally here.
-    ``dump``'s CLI is itself the trust boundary an explicit ``--config``
-    already crossed by being typed here at all -- unlike ``scan``'s
-    config-file-sourced ``build.query``, which needs its own
-    ``resolve_effective_allow_query`` "level-implies-query" decision
-    (ADR-037 D4) precisely because it is not operator-typed. (The CLI used
-    to also carry its own always-``False`` ``--allow-build-query``/
-    ``--build-query`` no-op flags; both are gone now -- an explicit
-    ``--config`` is the only authorizer left.)
+    *exec_resolved.execution_options.allow_build_query* -- the caller
+    attaches ``True`` unconditionally here. ``dump``'s CLI is itself the
+    trust boundary an explicit ``--config`` already crossed by being typed
+    here at all -- unlike ``scan``'s config-file-sourced ``build.query``,
+    which needs its own ``resolve_effective_allow_query``
+    "level-implies-query" decision (ADR-037 D4) precisely because it is not
+    operator-typed. (The CLI used to also carry its own always-``False``
+    ``--allow-build-query``/``--build-query`` no-op flags; both are gone now
+    -- an explicit ``--config`` is the only authorizer left.)
 
     Raises:
         click.UsageError: If *exec_resolved* (or the input it resolves) is
@@ -173,21 +181,18 @@ def execute_dump_cli_run(
         click.ClickException: For any other extraction failure (exit 1).
     """
     from ...errors import ValidationError
-    from ...service_dump_pipeline import DumpExecutionOptions, execute_dump_request
+    from ...service_dump_pipeline import execute_dump_request
 
     try:
-        result = execute_dump_request(
-            exec_resolved,
-            notify=notify,
-            options=DumpExecutionOptions(
-                build_config=build_config,
-                allow_build_query=allow_build_query,
-                legacy_compile_db_tokens=legacy_compile_db_tokens,
-                legacy_compile_db_matched=legacy_compile_db_matched,
-                seed_collect_mode=seed_collect_mode,
-                source_frontend_from_folded_context=source_frontend_from_folded_context,
-            ),
-        )
+        # `options` is left unset: `execute_dump_request` itself falls back
+        # to `exec_resolved.execution_options` (or `DumpExecutionOptions()`
+        # if that is also unset) whenever its own `options` keyword is
+        # `None` -- see that function's own docstring. The caller
+        # (`dump_cmd`) is responsible for attaching the real
+        # `DumpExecutionOptions` onto `exec_resolved` before calling this
+        # function; this module deliberately does not assemble a second one
+        # of its own (ADR-063 Track T4).
+        result = execute_dump_request(exec_resolved, notify=notify)
     except ValidationError as exc:
         raise click.UsageError(str(exc)) from exc
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
@@ -203,9 +208,6 @@ def execute_and_write_dump_cli_run(
     *,
     notify: Callable[[str], None],
     build_config: Path | None,
-    legacy_compile_db_tokens: tuple[str, ...],
-    legacy_compile_db_matched: bool,
-    seed_collect_mode: str | None,
     stamp_provenance: Callable[..., None],
     write_snapshot_output: Callable[..., None],
     git_tag: str | None,
@@ -244,17 +246,17 @@ def execute_and_write_dump_cli_run(
     family (``cli_resolve``/``cli_buildsource``, ...) that supplies both --
     see this module's own docstring for why a *new* member of that already-
     accepted import cycle needs a maintainer decision, not a routine split.
+
+    *build_config* is still its own parameter here (unlike
+    :func:`execute_dump_cli_run`'s nine execution-option kwargs, which moved
+    onto ``exec_resolved.execution_options`` -- ADR-063 Track T4): it is also
+    needed below by ``write_snapshot_output``, a genuinely separate
+    provenance/write-step concern from execution, so it stays a parameter of
+    this function rather than being read a second time off
+    ``exec_resolved.execution_options.build_config`` (the caller already
+    attached the identical value there for execution's own use).
     """
-    snap = execute_dump_cli_run(
-        exec_resolved,
-        notify=notify,
-        build_config=build_config,
-        allow_build_query=True,
-        legacy_compile_db_tokens=legacy_compile_db_tokens,
-        legacy_compile_db_matched=legacy_compile_db_matched,
-        seed_collect_mode=seed_collect_mode,
-        source_frontend_from_folded_context=True,
-    )
+    snap = execute_dump_cli_run(exec_resolved, notify=notify)
 
     stamp_provenance(snap, git_tag=git_tag, build_id=build_id, no_git=no_git)
     write_snapshot_output(

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -201,6 +201,19 @@ class ResolvedDumpRequest:
     resolved_execution_context: ResolvedExecutionContext | None = field(
         default=None, compare=False
     )
+    # ADR-063 Track T4 ("Dump request contract"): the `DumpExecutionOptions`
+    # a real execution would pass to `execute_dump_request`, when a caller
+    # has resolved one -- so `dump --dry-run`
+    # (`cli_dump_helpers.render_dump_dry_run`) can show these nine values.
+    # `resolve_dump_request` never populates this itself (`build_config`/
+    # `legacy_compile_db_tokens`/`legacy_compile_db_matched` are CLI-only
+    # values with no `DumpRequest` equivalent); the `dump` CLI attaches its
+    # own via `dataclasses.replace(resolved, execution_options=...)`.
+    # `execute_dump_request` reads this as its default when its own
+    # `options` is `None` -- an explicit `options=` argument still wins.
+    # Comparable like any plain value (unlike `artifact_plan`/
+    # `resolved_execution_context` above, which compare by identity).
+    execution_options: DumpExecutionOptions | None = None
 
     @property
     def collect_mode(self) -> str:
@@ -544,6 +557,14 @@ class DumpExecutionOptions:
     it, so ``DumpExecutionOptions()`` (the parameter's own default) is
     bit-for-bit equivalent to omitting all nine kwargs before this change.
 
+    Since this track's follow-up, an instance is also attachable to the
+    *resolved* request (see :attr:`ResolvedDumpRequest.execution_options`)
+    rather than only assembled fresh at :func:`execute_dump_request`'s own
+    call boundary -- so ``dump --dry-run`` can render what a real run would
+    pass, instead of the ``dump`` CLI threading the nine values through
+    :func:`~abicheck.frontends.cli.dump_execute.execute_dump_cli_run` as
+    separate parameters.
+
     *build_config*/*build_query*/*build_compile_db*/*changed_paths*/
     *allow_build_query* (PR 3A, dump/scan resolver convergence): optional
     pass-throughs to
@@ -626,11 +647,12 @@ def execute_dump_request(
     already takes ``notify`` the same way.
 
     *options* (ADR-063 Track T4, "Dump request contract"; see
-    :class:`DumpExecutionOptions` for the full field-by-field rationale)
-    folds the nine out-of-band execution kwargs this function used to accept
-    directly into one typed value. ``None`` (the default) is equivalent to
-    ``DumpExecutionOptions()`` -- every pre-existing caller that passed none
-    of the nine is unaffected.
+    :class:`DumpExecutionOptions`) folds the nine out-of-band execution
+    kwargs this function used to accept directly into one typed value.
+    ``None`` (the default) falls back to *resolved*'s own
+    :attr:`~ResolvedDumpRequest.execution_options` when the caller resolved
+    one, or ``DumpExecutionOptions()`` when neither is set -- every
+    pre-existing caller is unaffected.
 
     Raises:
         ValidationError: If *resolved* requests a ``depth`` the resolved
@@ -643,7 +665,7 @@ def execute_dump_request(
     from .evidence_depth import depth_rank, gated_source_label
 
     if options is None:
-        options = DumpExecutionOptions()
+        options = resolved.execution_options or DumpExecutionOptions()
     request = resolved.request
     side = request.input
     if side.path is None:

--- a/changelog.d/20260905_160047_noreply_adr063_t4_dump_contract_1h8anb.md
+++ b/changelog.d/20260905_160047_noreply_adr063_t4_dump_contract_1h8anb.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **`dump --dry-run` now previews its resolved execution options.** ADR-063
+  Track T4 ("Dump request contract") folds `execute_dump_request`'s nine
+  out-of-band execution kwargs (`build_config`, `allow_build_query`, the
+  legacy `-p`/`--compile-db` auto-match's derived flags, `seed_collect_mode`,
+  `source_frontend_from_folded_context`, ...) onto
+  `ResolvedDumpRequest.execution_options` itself, instead of only ever being
+  assembled fresh at `execute_dump_request`'s own call boundary. A new
+  "Execution options" section on `dump --dry-run`'s report shows what a real
+  run would pass. `frontends.cli.dump_execute.execute_dump_cli_run` no
+  longer takes these nine values as separate parameters — it reads them off
+  the resolved request it is handed.

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1875,7 +1875,7 @@ assembling one fresh at `execute_dump_request`'s own call boundary;
 `execute_dump_cli_run`/`execute_and_write_dump_cli_run` no longer take the
 nine values as separate parameters at all — the `dump` CLI
 (`frontends/cli/commands/dump.py`) attaches a dry-run-safe *preview*
-(`cli_dump_helpers.dry_run_build_context_preview`, a new silent/
+(`frontends.cli.dump_build_context_preview.dry_run_build_context_preview`, a new silent/
 non-raising sibling of `_resolve_build_context_flags` that also returns
 the derived legacy compile-db flags) onto its `--dry-run` resolution, and
 the real (raise/echo-capable) values onto the request it actually

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1863,19 +1863,33 @@ the PR that landed this slice, correctly, caught an earlier draft of this
 row overclaiming):** `execute_dump_request`'s own nine keyword parameters
 are folded into one typed `service_dump_pipeline.DumpExecutionOptions`,
 passed as a single `options=` argument — that part of item 1 is done.
-**Not done**, and still fully open: `DumpExecutionOptions` is not a field
-on `DumpRequest` or `ResolvedDumpRequest` — it is assembled at the
-`execute_dump_request` call boundary itself
-(`frontends/cli/dump_execute.py`'s `execute_dump_cli_run`, which still
-takes the nine values as its own separate parameters and only builds the
-typed object immediately before calling `execute_dump_request`). So the
-*resolved plan* `dump --dry-run` renders from still cannot represent any of
-these nine values — a caller inspecting a `ResolvedDumpRequest` has no way
-to see what a real execution would pass. Closing that gap (folding the
-values into the typed request/resolved-request model itself, not just into
-one options value at the final call) is unstarted, as are item 1's other
-two clauses (splitting backend selection from fallback policy; a
-source-only dump execution variant).
+
+**Follow-up (2026-09-05): item 1's remaining gap is now closed too.**
+`ResolvedDumpRequest` gained its own `execution_options:
+DumpExecutionOptions | None` field, so a caller resolves and *attaches*
+its `DumpExecutionOptions` onto the request itself rather than only ever
+assembling one fresh at `execute_dump_request`'s own call boundary;
+`execute_dump_request`'s own `options=None` now falls back to
+`resolved.execution_options` before falling back to a bare
+`DumpExecutionOptions()`. `frontends/cli/dump_execute.py`'s
+`execute_dump_cli_run`/`execute_and_write_dump_cli_run` no longer take the
+nine values as separate parameters at all — the `dump` CLI
+(`frontends/cli/commands/dump.py`) attaches a dry-run-safe *preview*
+(`cli_helpers_compare.dry_run_build_context_preview`, a new silent/
+non-raising sibling of `_resolve_build_context_flags` that also returns
+the derived legacy compile-db flags) onto its `--dry-run` resolution, and
+the real (raise/echo-capable) values onto the request it actually
+executes. `dump --dry-run` now renders an "Execution options" section
+from the preview (`cli_dump_helpers.render_dump_dry_run`) — the gap this
+note used to describe ("a caller inspecting a `ResolvedDumpRequest` has no
+way to see what a real execution would pass") no longer holds.
+
+**Still open, unstarted:** item 1's other two clauses — splitting backend
+selection from fallback policy, and a source-only dump execution variant
+(`execute_dump_request` still raises `ValidationError` for a binary-less
+`InputSpec.path is None` request; producing that snapshot is still
+`cli_buildsource.dump_source_only`'s own separate pipeline, per that
+function's own docstring reference).
 
 **Recommended first wave (fully parallel, no shared files):** ~~T1~~ (done),
 ~~T2~~ (done), T6, T7, T8. **Second wave:** ~~T3~~ (done), T4, T9 (each large

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1875,7 +1875,7 @@ assembling one fresh at `execute_dump_request`'s own call boundary;
 `execute_dump_cli_run`/`execute_and_write_dump_cli_run` no longer take the
 nine values as separate parameters at all — the `dump` CLI
 (`frontends/cli/commands/dump.py`) attaches a dry-run-safe *preview*
-(`cli_helpers_compare.dry_run_build_context_preview`, a new silent/
+(`cli_dump_helpers.dry_run_build_context_preview`, a new silent/
 non-raising sibling of `_resolve_build_context_flags` that also returns
 the derived legacy compile-db flags) onto its `--dry-run` resolution, and
 the real (raise/echo-capable) values onto the request it actually

--- a/tests/test_dump_execution_options_contract.py
+++ b/tests/test_dump_execution_options_contract.py
@@ -1,0 +1,293 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Track T4 ("Dump request contract") follow-up: ``DumpExecutionOptions``
+attached to ``ResolvedDumpRequest`` itself, so ``dump --dry-run`` can render
+what a real run would pass to ``execute_dump_request`` instead of that value
+only ever existing at the executor's own call boundary.
+
+Companion to ``tests/test_legacy_compile_db_typed_threading.py`` (which pins
+the *typed-pipeline* behavior of threading ``legacy_compile_db_tokens``
+through an explicit ``options=`` argument -- unaffected by this slice) and
+``tests/test_dump_request_from_cli.py`` (which pins that the real CLI run
+reads its execution plan off the resolved request, not a parallel local).
+This file is the new field/wiring itself: default behavior is unchanged when
+nobody resolves an ``execution_options``, the resolved value is used as
+``execute_dump_request``'s own default, and ``render_dump_dry_run`` shows it
+when present.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _minimal_resolved(tmp_path: Path):
+    from abicheck.api_types import DumpRequest, InputSpec
+    from abicheck.service_dump_pipeline import resolve_dump_request
+
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"\x7fELF" + b"\x00" * 200)
+    request = DumpRequest(input=InputSpec(path=so_path))
+    return resolve_dump_request(request)
+
+
+class TestResolvedDumpRequestExecutionOptionsField:
+    def test_defaults_to_none(self, tmp_path: Path) -> None:
+        resolved = _minimal_resolved(tmp_path)
+        assert resolved.execution_options is None
+
+    def test_attachable_via_replace_without_disturbing_other_fields(
+        self, tmp_path: Path
+    ) -> None:
+        import dataclasses
+
+        from abicheck.service_dump_pipeline import DumpExecutionOptions
+
+        resolved = _minimal_resolved(tmp_path)
+        opts = DumpExecutionOptions(seed_collect_mode="off")
+        updated = dataclasses.replace(resolved, execution_options=opts)
+        assert updated.execution_options is opts
+        assert updated.lang == resolved.lang
+        assert updated.header_backend == resolved.header_backend
+        assert updated.evidence == resolved.evidence
+
+
+class TestExecuteDumpRequestDefaultsToResolvedExecutionOptions:
+    """``execute_dump_request``'s own ``options=None`` now falls back to
+    ``resolved.execution_options`` before falling back to a bare
+    ``DumpExecutionOptions()`` -- the mechanism that lets a caller (the
+    ``dump`` CLI) attach its execution plan onto the request once, instead
+    of also passing an explicit ``options=`` kwarg."""
+
+    @staticmethod
+    def _spy(monkeypatch):
+        """Patch ``_resolve_side_snapshot_impl`` and record the
+        ``seed_collect_mode``/``allow_build_query`` kwargs
+        ``execute_dump_request`` unpacks its resolved ``options`` into --
+        that function has no ``options=``-shaped parameter itself, so the
+        individual fields are what actually reach it."""
+        from abicheck import service_dump_pipeline
+
+        seen: dict[str, object] = {}
+
+        def _fake_impl(*_args, **kwargs):
+            seen["seed_collect_mode"] = kwargs.get("seed_collect_mode")
+            seen["allow_build_query"] = kwargs.get("allow_build_query")
+            from abicheck.model import AbiSnapshot
+            from abicheck.workflows.artifact.execute import SideResolution
+
+            return SideResolution(
+                snapshot=AbiSnapshot(library="lib", version="1.0"),
+                effective_includes=(),
+                effective_compile_context=None,
+            )
+
+        monkeypatch.setattr(
+            service_dump_pipeline, "_resolve_side_snapshot_impl", _fake_impl
+        )
+        return seen
+
+    def test_explicit_options_still_wins_over_resolved(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import dataclasses
+
+        from abicheck import service_dump_pipeline
+        from abicheck.service_dump_pipeline import DumpExecutionOptions
+
+        resolved = _minimal_resolved(tmp_path)
+        resolved = dataclasses.replace(
+            resolved,
+            execution_options=DumpExecutionOptions(seed_collect_mode="resolved-value"),
+        )
+        seen = self._spy(monkeypatch)
+
+        service_dump_pipeline.execute_dump_request(
+            resolved,
+            options=DumpExecutionOptions(seed_collect_mode="explicit-value"),
+        )
+        assert seen["seed_collect_mode"] == "explicit-value"
+
+    def test_falls_back_to_resolved_execution_options_when_none_passed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import dataclasses
+
+        from abicheck import service_dump_pipeline
+        from abicheck.service_dump_pipeline import DumpExecutionOptions
+
+        resolved = _minimal_resolved(tmp_path)
+        resolved = dataclasses.replace(
+            resolved,
+            execution_options=DumpExecutionOptions(seed_collect_mode="resolved-value"),
+        )
+        seen = self._spy(monkeypatch)
+
+        service_dump_pipeline.execute_dump_request(resolved)
+        assert seen["seed_collect_mode"] == "resolved-value"
+
+    def test_bare_default_when_neither_is_set(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Every pre-existing caller (no ``options=``, no resolved
+        ``execution_options``) is unaffected -- the same
+        ``DumpExecutionOptions()`` bare defaults as before this slice."""
+        from abicheck import service_dump_pipeline
+
+        resolved = _minimal_resolved(tmp_path)
+        assert resolved.execution_options is None
+        seen = self._spy(monkeypatch)
+
+        service_dump_pipeline.execute_dump_request(resolved)
+        assert seen["seed_collect_mode"] is None
+        assert seen["allow_build_query"] is None
+
+
+class TestDryRunBuildContextPreview:
+    """``cli_dump_helpers.dry_run_build_context_preview`` -- the
+    silent/non-raising sibling of ``_resolve_build_context_flags`` that also
+    returns the derived flags, used only for ``dump --dry-run``'s
+    ``execution_options`` preview."""
+
+    def test_none_when_no_compile_db_given(self) -> None:
+        from abicheck.cli_dump_helpers import dry_run_build_context_preview
+
+        assert dry_run_build_context_preview(None, (), None) is None
+
+    def test_malformed_compile_db_folds_to_empty_rather_than_raising(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.cli_dump_helpers import dry_run_build_context_preview
+
+        bad_db = tmp_path / "compile_commands.json"
+        bad_db.write_text("not json{{{", encoding="utf-8")
+        assert dry_run_build_context_preview(bad_db, (), None) == ([], False)
+
+    def test_matches_real_resolver_for_a_flagless_but_matched_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """A real compile-DB entry with no ABI-relevant flags still counts
+        as ``matched`` -- mirrors ``_resolve_build_context_flags``'s own
+        documented "matched, flagless" case, without needing g++/castxml:
+        loading and matching a compile database is pure JSON/path
+        resolution, no compiler invocation."""
+        from abicheck.cli_dump_helpers import dry_run_build_context_preview
+        from abicheck.cli_helpers_compare import _resolve_build_context_flags
+
+        src = tmp_path / "a.cpp"
+        src.write_text("int f() { return 1; }\n", encoding="utf-8")
+        compile_db = tmp_path / "compile_commands.json"
+        compile_db.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "arguments": ["c++", "-c", str(src), "-o", "a.o"],
+                        "file": str(src),
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        preview = dry_run_build_context_preview(compile_db, (), None)
+        real_flags, real_matched = _resolve_build_context_flags(compile_db, (), None)
+        assert preview == (real_flags, real_matched)
+        assert preview == ([], True)
+
+
+class TestRenderDumpDryRunExecutionOptionsSection:
+    def test_omitted_when_execution_options_not_resolved(self, tmp_path: Path) -> None:
+        from abicheck.cli_dump_helpers import render_dump_dry_run
+
+        resolved = _minimal_resolved(tmp_path)
+        assert resolved.execution_options is None
+        result = render_dump_dry_run(resolved, output=None)
+        assert "Execution options" not in result.sections
+
+    def test_shown_when_execution_options_resolved(self, tmp_path: Path) -> None:
+        import dataclasses
+
+        from abicheck.cli_dump_helpers import render_dump_dry_run
+        from abicheck.service_dump_pipeline import DumpExecutionOptions
+
+        resolved = _minimal_resolved(tmp_path)
+        resolved = dataclasses.replace(
+            resolved,
+            execution_options=DumpExecutionOptions(
+                build_config=tmp_path / ".abicheck.yml",
+                allow_build_query=True,
+                legacy_compile_db_tokens=("-DFOO=1",),
+                legacy_compile_db_matched=True,
+                seed_collect_mode="off",
+                source_frontend_from_folded_context=True,
+            ),
+        )
+        result = render_dump_dry_run(resolved, output=None)
+        lines = result.sections["Execution options"]
+        rendered = "\n".join(lines)
+        assert "allow build query: True" in rendered
+        assert "1 derived" in rendered and "matched" in rendered
+        assert "seed collect mode: off" in rendered
+        assert "source frontend from folded context: True" in rendered
+        assert str(tmp_path / ".abicheck.yml") in rendered
+
+
+@pytest.mark.parametrize("has_compile_db", [False, True])
+def test_dump_dry_run_cli_reports_execution_options(
+    tmp_path: Path, has_compile_db: bool
+) -> None:
+    """End-to-end: ``dump SO_PATH --dry-run`` renders an "Execution options"
+    section, agreeing with what the real run (mocked here, no toolchain
+    needed) would receive -- pure CLI/resolution wiring, no compiler
+    invocation on either side of this test."""
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"\x7fELF" + b"\x00" * 200)
+    header = tmp_path / "api.h"
+    header.write_text("struct S { int a; };\n", encoding="utf-8")
+
+    args = [str(so_path), "-H", str(header), "--dry-run"]
+    if has_compile_db:
+        src = tmp_path / "a.cpp"
+        src.write_text("int f() { return 1; }\n", encoding="utf-8")
+        compile_db = tmp_path / "compile_commands.json"
+        compile_db.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "arguments": ["c++", "-c", str(src), "-o", "a.o"],
+                        "file": str(src),
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        args += ["--build-info", str(compile_db)]
+
+    result = CliRunner().invoke(main, ["dump", *args])
+    assert result.exit_code == 0, result.output
+    assert "Execution options:" in result.output
+    assert "allow build query: True" in result.output
+    assert "source frontend from folded context: True" in result.output
+    if has_compile_db:
+        assert "legacy compile-db flags:" in result.output

--- a/tests/test_dump_execution_options_contract.py
+++ b/tests/test_dump_execution_options_contract.py
@@ -160,20 +160,24 @@ class TestExecuteDumpRequestDefaultsToResolvedExecutionOptions:
 
 
 class TestDryRunBuildContextPreview:
-    """``cli_dump_helpers.dry_run_build_context_preview`` -- the
-    silent/non-raising sibling of ``_resolve_build_context_flags`` that also
-    returns the derived flags, used only for ``dump --dry-run``'s
+    """``frontends.cli.dump_build_context_preview.dry_run_build_context_preview``
+    -- the silent/non-raising sibling of ``_resolve_build_context_flags``
+    that also returns the derived flags, used only for ``dump --dry-run``'s
     ``execution_options`` preview."""
 
     def test_none_when_no_compile_db_given(self) -> None:
-        from abicheck.cli_dump_helpers import dry_run_build_context_preview
+        from abicheck.frontends.cli.dump_build_context_preview import (
+            dry_run_build_context_preview,
+        )
 
         assert dry_run_build_context_preview(None, (), None) is None
 
     def test_malformed_compile_db_folds_to_empty_rather_than_raising(
         self, tmp_path: Path
     ) -> None:
-        from abicheck.cli_dump_helpers import dry_run_build_context_preview
+        from abicheck.frontends.cli.dump_build_context_preview import (
+            dry_run_build_context_preview,
+        )
 
         bad_db = tmp_path / "compile_commands.json"
         bad_db.write_text("not json{{{", encoding="utf-8")
@@ -187,8 +191,10 @@ class TestDryRunBuildContextPreview:
         documented "matched, flagless" case, without needing g++/castxml:
         loading and matching a compile database is pure JSON/path
         resolution, no compiler invocation."""
-        from abicheck.cli_dump_helpers import dry_run_build_context_preview
         from abicheck.cli_helpers_compare import _resolve_build_context_flags
+        from abicheck.frontends.cli.dump_build_context_preview import (
+            dry_run_build_context_preview,
+        )
 
         src = tmp_path / "a.cpp"
         src.write_text("int f() { return 1; }\n", encoding="utf-8")
@@ -211,19 +217,32 @@ class TestDryRunBuildContextPreview:
         assert preview == ([], True)
 
 
-class TestRenderDumpDryRunExecutionOptionsSection:
+class TestExecutionOptionsDryRunSection:
+    """``add_execution_options_dry_run_section`` -- the "Execution options"
+    section, appended onto a ``render_dump_dry_run`` result by the caller
+    (``frontends.cli.commands.dump.dump_cmd``) rather than built inline by
+    ``render_dump_dry_run`` itself, since ``cli_dump_helpers.py`` has no
+    line budget left for a new section (``architecture/debt.yaml``)."""
+
     def test_omitted_when_execution_options_not_resolved(self, tmp_path: Path) -> None:
         from abicheck.cli_dump_helpers import render_dump_dry_run
+        from abicheck.frontends.cli.dump_build_context_preview import (
+            add_execution_options_dry_run_section,
+        )
 
         resolved = _minimal_resolved(tmp_path)
         assert resolved.execution_options is None
         result = render_dump_dry_run(resolved, output=None)
+        add_execution_options_dry_run_section(result, resolved)
         assert "Execution options" not in result.sections
 
     def test_shown_when_execution_options_resolved(self, tmp_path: Path) -> None:
         import dataclasses
 
         from abicheck.cli_dump_helpers import render_dump_dry_run
+        from abicheck.frontends.cli.dump_build_context_preview import (
+            add_execution_options_dry_run_section,
+        )
         from abicheck.service_dump_pipeline import DumpExecutionOptions
 
         resolved = _minimal_resolved(tmp_path)
@@ -239,6 +258,7 @@ class TestRenderDumpDryRunExecutionOptionsSection:
             ),
         )
         result = render_dump_dry_run(resolved, output=None)
+        add_execution_options_dry_run_section(result, resolved)
         lines = result.sections["Execution options"]
         rendered = "\n".join(lines)
         assert "allow build query: True" in rendered

--- a/tests/test_dump_request_from_cli.py
+++ b/tests/test_dump_request_from_cli.py
@@ -353,8 +353,15 @@ class TestExecutionConsumesTheResolvedPlan:
             # kwargs are folded into one `DumpExecutionOptions`, so the
             # individual fields the assertions below check are flattened
             # back out here rather than making every call site below reach
-            # into `seen["options"]` itself.
-            options = kwargs.get("options")
+            # into `seen["options"]` itself. Since Track T4's follow-up,
+            # `execute_dump_cli_run` no longer passes an explicit `options=`
+            # kwarg at all -- it relies on `execute_dump_request`'s own
+            # fallback to `resolved.execution_options` -- so this reads
+            # `kwargs["options"]` when a caller did pass one explicitly
+            # (other callers/tests still do) and falls back to
+            # `resolved.execution_options` otherwise, which is exactly what
+            # a real invocation now populates.
+            options = kwargs.get("options") or resolved.execution_options
             if options is not None:
                 seen["build_config"] = options.build_config
                 seen["allow_build_query"] = options.allow_build_query


### PR DESCRIPTION
## Summary

Closes the specifically-flagged "not done" gap in ADR-063 Track T4 ("Dump request contract"): `dump --dry-run` can now render the nine execution-option values a real run would pass to `execute_dump_request`, instead of that value only ever existing at the executor's own call boundary.

## Motivation

The plan doc's T4 status note (`docs/contribute/plans/duplication-and-convergence-assessment.md`) explicitly recorded, after a Codex review caught an earlier draft overclaiming, that `DumpExecutionOptions` was assembled fresh at `execute_dump_request`'s own call boundary and was **not** a field on `DumpRequest`/`ResolvedDumpRequest` — so a caller inspecting a resolved request (in particular `dump --dry-run`'s own rendering path) had no way to see what a real execution would pass.

## Changes

- `ResolvedDumpRequest` gains an `execution_options: DumpExecutionOptions | None` field.
- `execute_dump_request`'s `options=None` now falls back to `resolved.execution_options` before falling back to a bare `DumpExecutionOptions()` — every pre-existing caller that passes neither is unaffected.
- `frontends/cli/dump_execute.py`'s `execute_dump_cli_run`/`execute_and_write_dump_cli_run` no longer take the nine execution kwargs as separate parameters — they read them off the resolved request the caller already built.
- The `dump` CLI (`frontends/cli/commands/dump.py`) attaches a dry-run-safe *preview* of the nine values onto its `--dry-run` resolution, and the real (raise/echo-capable) values onto the request it actually executes.
- New `cli_dump_helpers.dry_run_build_context_preview` — a silent, non-raising sibling of `cli_helpers_compare._resolve_build_context_flags` that also returns the derived legacy compile-db flags — shares a new `_matched_build_context` core with that function and `dry_run_compile_db_matched` (previously three independent re-derivations of the same load-and-match).
- `dump --dry-run` renders a new "Execution options" section.
- Updated `docs/contribute/plans/duplication-and-convergence-assessment.md`'s T4 status note to record this closure precisely, without overclaiming the two items that remain open.
- Added `changelog.d/` fragment.

**Still open (unstarted, documented honestly rather than claimed done):** splitting backend selection from fallback policy, and a source-only dump execution variant — each is a separate, large multi-PR effort per the plan's own track sizing.

## Tests

- New `tests/test_dump_execution_options_contract.py` (12 tests): the new field's defaults/attachment, `execute_dump_request`'s fallback precedence (explicit `options=` > resolved `execution_options` > bare default), `dry_run_build_context_preview`'s behavior (no compile-db, malformed compile-db, a real flagless-but-matched entry cross-checked against the real resolver), the new dry-run render section, and an end-to-end CLI dry-run assertion.
- Updated `tests/test_dump_request_from_cli.py`'s spy to read the resolved request's `execution_options` (since the real run no longer passes an explicit `options=` kwarg).
- `mypy abicheck/`, `ruff check`, and `scripts/check_architecture.py` all pass clean.
- Targeted test run (170 tests across the affected modules) passes.
- Full fast test suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) run in progress in this environment; will report back if it surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwCBmpqGXMtxkFacpwufBd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `dump --dry-run` now displays the resolved execution options that would be used during a real run.
  - Dry-run reports include a dedicated **Execution options** section when those values are available.
  - Build-context previews now handle missing, unreadable, or malformed compile databases without failing the preview.

- **Bug Fixes**
  - Improved consistency between dry-run previews and actual dump execution, including compile-database matching and resolved options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->