### PR TITLE
fix: close dump/compare explicit --config dry-run/execution parity (PR C tail)

### DIFF
--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -219,6 +219,12 @@ class InputSpec:
     # the filter selects, exactly as the three CLI-side layers already do
     # via `build_context.source_matches_filter`.
     compile_db_filter: str | None = None
+    # CLI cleanup phase two, Block 7 (PR C's tail): this side's explicit
+    # ``--config`` (mirrors ``ScanRequest.build_config``). `None` preserves
+    # prior behavior. Lets `workflows.plan`'s pre-flight bazel-scoping check
+    # see the same explicit config `embed_build_source` already honors at
+    # real-execution time -- see `docs/contribute/known-gaps.md`'s "PR C".
+    build_config: Path | None = None
 
     @classmethod
     def of(
@@ -239,6 +245,7 @@ class InputSpec:
         public_header_dirs: Iterable[Path | str] | None = None,
         follow_linker_scripts: bool = True,
         compile_db_filter: str | None = None,
+        build_config: Path | str | None = None,
     ) -> InputSpec:
         """Build an :class:`InputSpec`, coercing loose front-end values."""
         return cls(
@@ -257,6 +264,7 @@ class InputSpec:
             public_header_dirs=_path_tuple(public_header_dirs),
             follow_linker_scripts=follow_linker_scripts,
             compile_db_filter=compile_db_filter,
+            build_config=Path(build_config) if build_config is not None else None,
         )
 
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1787,7 +1787,7 @@ def run_compare(
             debuginfod=debuginfod, debuginfod_url=debuginfod_url,
             collect_mode=collect_mode, depth=depth,
             include_labels=include_labels,
-            include_dependencies=include_dependencies, build_config=cfg_path,
+            include_dependencies=include_dependencies, build_config=config,
         )
 
     # Follow GNU ld linker scripts up front so the resolved DSO (not the text

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -697,7 +697,7 @@ def _embed_inline_source_sides(
     debuginfod: bool, debuginfod_url: str | None,
     collect_mode: str, depth: str | None,
     include_labels: dict[Path, str] | None,
-    include_dependencies: bool,
+    include_dependencies: bool, build_config: Path | None = None,
 ) -> tuple[Path, Path | None, Path | None, Path, Path | None, Path | None]:
     """Dump each raw source/build-dir side inline, returning the rewritten inputs.
 
@@ -790,7 +790,7 @@ def _embed_inline_source_sides(
         debuginfod=debuginfod, debuginfod_url=debuginfod_url,
         collect_mode=collect_mode, out_dir=Path(_src_tmp), label="old",
         depth=depth, include_labels=include_labels,
-        include_dependencies=include_dependencies,
+        include_dependencies=include_dependencies, build_config=build_config,
     )
     new_input, new_sources, new_build_info = _embed_inline_source_side(
         ctx, input_path=new_input, sources=new_sources,
@@ -809,7 +809,7 @@ def _embed_inline_source_sides(
         pdb_path=new_pdb_path or pdb_path,
         collect_mode=collect_mode, out_dir=Path(_src_tmp), label="new",
         depth=depth, include_labels=include_labels,
-        include_dependencies=include_dependencies,
+        include_dependencies=include_dependencies, build_config=build_config,
     )
     return (
         old_input, old_sources, old_build_info,
@@ -1787,7 +1787,7 @@ def run_compare(
             debuginfod=debuginfod, debuginfod_url=debuginfod_url,
             collect_mode=collect_mode, depth=depth,
             include_labels=include_labels,
-            include_dependencies=include_dependencies,
+            include_dependencies=include_dependencies, build_config=cfg_path,
         )
 
     # Follow GNU ld linker scripts up front so the resolved DSO (not the text

--- a/abicheck/cli_dump_request.py
+++ b/abicheck/cli_dump_request.py
@@ -109,6 +109,7 @@ def build_dump_request(
     include_labels: dict[Path, str] | None,
     resolved_collect_mode: str | None = None,
     compile_db_filter: str | None = None,
+    build_config: Path | None = None,
 ) -> DumpRequest:
     """One :class:`DumpRequest` describing this ``abicheck dump`` invocation.
 
@@ -148,6 +149,19 @@ def build_dump_request(
     ``compile_db_filter_scope_error`` refusal ``dump_cmd`` already raises
     directly, and so the object records the filter that would actually
     narrow the header parse were the real run migrated onto it.
+
+    *build_config* is ``dump``'s own ``--config`` value, forwarded onto
+    :attr:`~abicheck.api_types.InputSpec.build_config` verbatim (CLI cleanup
+    phase two, Block 7 -- PR C's tail) so the resolved request's own
+    ``workflows.plan.AnalysisPlanner.resolve`` pre-flight check sees the
+    same explicit config ``embed_build_source`` already honors at
+    real-execution time, instead of only ever seeing whatever
+    ``.abicheck.yml`` auto-discovery finds at ``sources``. This does not
+    change how the real run itself resolves ``build_config`` -- ``dump_cmd``
+    still passes its own raw value into ``execute_dump_request``/
+    ``embed_build_source`` out-of-band, exactly as before this field
+    existed; this only closes the gap between what the pre-flight check (and
+    therefore ``--dry-run``) sees and what execution does.
     """
     from .api_types import DumpRequest, InputSpec
 
@@ -166,6 +180,7 @@ def build_dump_request(
             dump_manifest=dump_manifest,
             compile=compile_context,
             compile_db_filter=compile_db_filter,
+            build_config=build_config,
         ),
         lang=lang,
         frontend=header_backend,

--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -293,13 +293,21 @@ def _embed_inline_source_side(
     the non-inline path already threads the same label correctly.
 
     ``build_config`` (CLI cleanup phase two, Block 7 -- PR C's tail):
-    ``compare``'s own resolved ``--config`` path (explicit or auto-discovered),
-    forwarded to the nested ``ctx.invoke(dump_cmd, ...)`` below's own
-    ``build_config`` parameter -- without this, the nested invocation always
-    resolved it as ``None``, so its own pre-flight bazel-target-scoping check
-    (``workflows.plan.AnalysisPlanner.resolve``) could only ever see whatever
-    ``.abicheck.yml`` auto-discovery found at this side's ``--sources`` tree,
-    never the config an explicit ``compare --config`` actually names.
+    ``compare``'s own raw ``--config`` value -- ``None`` unless the operator
+    explicitly passed it -- forwarded to the nested ``ctx.invoke(dump_cmd,
+    ...)`` below's own ``build_config`` parameter, exactly the same explicit-
+    only value a direct ``dump --config`` invocation would carry. Without
+    this, the nested invocation always resolved it as ``None``, so its own
+    pre-flight bazel-target-scoping check (``workflows.plan.AnalysisPlanner.
+    resolve``) could only ever see whatever ``.abicheck.yml`` auto-discovery
+    found at this side's ``--sources`` tree, never the config an explicit
+    ``compare --config`` actually names. **Must stay the raw, explicit-only
+    value, never `compare`'s own auto-discovery fallback**
+    (`_resolve_compare_config`'s resolved ``cfg_path``) -- `embed_build_source`
+    treats a non-``None`` ``build_config`` as operator-authorized to execute
+    `build.query` (ADR-032 D5); forwarding an auto-discovered path here would
+    let an untrusted, PR-controlled ``.abicheck.yml`` in the sources tree
+    authorize its own subprocess execution.
 
     ``depth`` is ``compare``'s own (unmodified) ``--depth`` string, used only
     to reproduce ``dump_cmd``'s ``--depth source`` + ``--ast-frontend hybrid``

--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -246,6 +246,7 @@ def _embed_inline_source_side(
     debuginfod_url: str | None = None,
     include_labels: dict[Path, str] | None = None,
     include_dependencies: bool = False,
+    build_config: Path | None = None,
 ) -> tuple[Path, Path | None, Path | None]:
     """Resolve one side's ``--sources`` into the input ``compare`` should read.
 
@@ -290,6 +291,15 @@ def _embed_inline_source_side(
     snapshot silently lost its label, leaving that side's extraction contract
     fingerprinted as if the support root were unlabeled/external even though
     the non-inline path already threads the same label correctly.
+
+    ``build_config`` (CLI cleanup phase two, Block 7 -- PR C's tail):
+    ``compare``'s own resolved ``--config`` path (explicit or auto-discovered),
+    forwarded to the nested ``ctx.invoke(dump_cmd, ...)`` below's own
+    ``build_config`` parameter -- without this, the nested invocation always
+    resolved it as ``None``, so its own pre-flight bazel-target-scoping check
+    (``workflows.plan.AnalysisPlanner.resolve``) could only ever see whatever
+    ``.abicheck.yml`` auto-discovery found at this side's ``--sources`` tree,
+    never the config an explicit ``compare --config`` actually names.
 
     ``depth`` is ``compare``'s own (unmodified) ``--depth`` string, used only
     to reproduce ``dump_cmd``'s ``--depth source`` + ``--ast-frontend hybrid``
@@ -428,6 +438,7 @@ def _embed_inline_source_side(
         pdb_path=pdb_path,
         sources=dump_sources,
         build_info=dump_build_info,
+        build_config=build_config,
         _resolved_collect_mode=collect_mode,
         output=out,
         debug_roots=debug_roots,

--- a/abicheck/frontends/cli/commands/dump.py
+++ b/abicheck/frontends/cli/commands/dump.py
@@ -545,6 +545,7 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         include_labels=_resolved_include_labels,
         resolved_collect_mode=_resolved_collect_mode,
         compile_db_filter=compile_db_filter,
+        build_config=build_config,
     )
     # `resolve_dump_request` runs no castxml/clang and writes nothing, so
     # hoisting it above the branch keeps `--dry-run` inside its own "cheap,

--- a/abicheck/workflows/plan.py
+++ b/abicheck/workflows/plan.py
@@ -166,6 +166,11 @@ class SidePlan:
     #: ``collect_inline_pack``) still runs whenever real headers are present,
     #: regardless of collect mode.
     headers: tuple[Path, ...] = ()
+    #: ``InputSpec.build_config`` verbatim (CLI cleanup phase two, Block 7 --
+    #: PR C's tail) -- this side's explicit ``--config`` path, when one was
+    #: given. ``None`` means no explicit config, matching every pre-existing
+    #: caller/request (the field did not exist before this).
+    build_config: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -204,6 +209,7 @@ def _side_plan(
         gcc_path=gcc_path,
         resolved_collect_mode=resolved_collect_mode,
         headers=side.headers,
+        build_config=side.build_config,
     )
 
 
@@ -225,13 +231,17 @@ def _discovered_config_build_targets(
     discover_build_config(raw_sources)`` precedence exactly: an explicit
     *build_config* path (``scan``'s own ``ScanRequest.build_config`` /
     ``dump``/``compare``'s ``--config``) wins outright; otherwise falls back
-    to auto-discovering one at *sources*. ``dump``/``compare`` have no
-    request-level seam for the explicit half today -- no ``build_config``
-    field exists on :class:`~abicheck.api_types.InputSpec`/
-    :class:`~abicheck.api_types.DumpRequest`/
-    :class:`~abicheck.api_types.CompareRequest` (see this module's own
-    "Also not landed" status entry) -- so their own call sites always pass
-    *build_config* as ``None`` and get the auto-discovery half only.
+    to auto-discovering one at *sources*. CLI cleanup phase two, Block 7 (PR
+    C's tail): ``dump``/``compare`` now have this request-level seam too --
+    :class:`~abicheck.api_types.InputSpec.build_config`, threaded from
+    ``cli_dump_request.build_dump_request`` and from ``compare``'s inline
+    ``--old/new-sources`` embed path's nested ``dump_cmd`` invocation, into
+    :attr:`SidePlan.build_config` -- so a call site that resolves its
+    explicit ``--config`` onto the request/``InputSpec`` it builds gets the
+    same explicit path honored here that ``embed_build_source`` already
+    honors at real-execution time. A caller that still leaves it unset (e.g.
+    a bare typed-API request with no ``build_config``) keeps the
+    auto-discovery-only behavior, unchanged from before this field existed.
     Discovering and parsing a ``.abicheck.yml`` is a pure, deterministic,
     non-executing read (no subprocess, no ambiguity to raise on), so it fits
     the same side-effect-free constraint every other :data:`_CHECKS` entry
@@ -519,6 +529,7 @@ def _check_bazel_target_scoping(side: SidePlan) -> PlanningFailure | None:
         side.build_info,
         side.build_targets,
         sources=side.sources,
+        build_config=side.build_config,
         headers_present=bool(effective_headers),
     )
 

--- a/changelog.d/1787100000_claude_dump-compare-config-dry-run-parity.md
+++ b/changelog.d/1787100000_claude_dump-compare-config-dry-run-parity.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`dump`/`compare --dry-run` now honors an explicit `--config` the same
+  way the real run does when checking for the pre-captured-Bazel-jsonproto
+  scoping hazard.** Previously the pre-flight bazel-target-scoping check
+  behind `--build-info` + `--build-target` (or a `.abicheck.yml`
+  `build.targets:`) could only ever see whatever `.abicheck.yml` was
+  auto-discovered under `--sources`, even when an explicit `--config` named
+  a different file — letting `--dry-run`'s resolved plan silently disagree
+  with what `embed_build_source` would actually do at real-execution time.
+  `InputSpec.build_config` (mirroring `scan`'s own `ScanRequest.build_config`)
+  closes this residual of CLI cleanup phase two's PR C for both `dump` and
+  `compare`, including `compare`'s inline `--old/new-sources` embed path.
+  `build.query` still only ever executes from an explicit `--config`
+  (ADR-032 D5), unchanged.

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -5565,6 +5565,39 @@ looked like the obvious fix and wasn't.
   the same pre-existing, already-documented `_SCAN_KNOWN_DIVERGENT_FRONTENDS`
   signature, unchanged); `mypy`/`ruff` clean on the touched modules.
 
+  > **Update (Block 7, PR C's own tail): the explicit-`--config`
+  > dry-run/execution parity residual named throughout this entry is now
+  > closed.** `api_types.InputSpec` gained a `build_config` field mirroring
+  > `ScanRequest.build_config` — `cli_dump_request.build_dump_request` sets
+  > it from `dump`'s own `--config`, and `cli_compare_helpers`/
+  > `frontends.cli.commands.compare`'s inline `--old/new-sources` embed path
+  > (its own nested `ctx.invoke(dump_cmd, ...)`) sets it from `compare`'s
+  > resolved `cfg_path` too. `workflows.plan.SidePlan.build_config` carries
+  > it into `_check_bazel_target_scoping`, which now calls
+  > `bazel_target_scoping_failure(..., build_config=side.build_config, ...)`
+  > instead of always passing `None` for `dump`/`compare` — so the shared
+  > `AnalysisPlanner.resolve` chokepoint both `--dry-run` and the real run
+  > go through sees the same explicit config `embed_build_source` already
+  > honored at real-execution time via its own `cfg_path = build_config or
+  > discover_build_config(raw_sources)` precedence, instead of only ever
+  > seeing whatever `.abicheck.yml` auto-discovery found at `sources`. Does
+  > not change what actually executes: `embed_build_source` still receives
+  > the CLI's own raw `--config` value out-of-band, exactly as before; this
+  > only widens what the pre-flight resolution (and therefore `--dry-run`)
+  > can see. The `--dry-run` `build.query` trust receipt
+  > (`add_build_query_dry_run_section`) was already correct before this
+  > change and is untouched. Verified via `tests/test_analysis_plan.py`'s
+  > `test_dump_request_honors_explicit_build_config_over_auto_discovery`/
+  > `test_compare_request_honors_explicit_build_config_over_auto_discovery`
+  > (request-level, through `AnalysisPlanner.resolve` directly) and
+  > `tests/test_bazel_root_targets.py`'s
+  > `test_dump_cli_explicit_config_scoping_matches_dry_run_and_real_run`
+  > (end to end through the CLI, asserting `--dry-run` and the real run
+  > agree); the full fast unit suite; `mypy`/`ruff` clean on every touched
+  > module. Directory/package `compare`'s release fan-out was left
+  > untouched — out of this residual's stated scope (the plan names
+  > `dump`/`compare`, the single-pair commands).
+
 - **Lambda-closure churn survives at the *function* level after the type-level
   fix — investigated, deliberately not patched (oneTBB flow-graph report,
   fresh evidence).** `name_classification._ANONYMOUS_TYPE_MARKERS` did not

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -5571,8 +5571,8 @@ looked like the obvious fix and wasn't.
   > `ScanRequest.build_config` — `cli_dump_request.build_dump_request` sets
   > it from `dump`'s own `--config`, and `cli_compare_helpers`/
   > `frontends.cli.commands.compare`'s inline `--old/new-sources` embed path
-  > (its own nested `ctx.invoke(dump_cmd, ...)`) sets it from `compare`'s
-  > resolved `cfg_path` too. `workflows.plan.SidePlan.build_config` carries
+  > (its own nested `ctx.invoke(dump_cmd, ...)`) sets it from `compare`'s own
+  > raw `--config` value too. `workflows.plan.SidePlan.build_config` carries
   > it into `_check_bazel_target_scoping`, which now calls
   > `bazel_target_scoping_failure(..., build_config=side.build_config, ...)`
   > instead of always passing `None` for `dump`/`compare` — so the shared
@@ -5586,7 +5586,37 @@ looked like the obvious fix and wasn't.
   > only widens what the pre-flight resolution (and therefore `--dry-run`)
   > can see. The `--dry-run` `build.query` trust receipt
   > (`add_build_query_dry_run_section`) was already correct before this
-  > change and is untouched. Verified via `tests/test_analysis_plan.py`'s
+  > change and is untouched.
+  >
+  > **A security review on the PR landing this (#1089) caught a real
+  > regression in the first version of the fix, worth recording precisely
+  > since it is exactly the class of bug ADR-032 D5 exists to prevent.** The
+  > first attempt forwarded `compare`'s already-*resolved* `cfg_path`
+  > (`config if config is not None else discover_project_config()` —
+  > conflating an explicit `--config` with `_resolve_compare_config`'s own
+  > auto-discovery fallback) into the nested `dump_cmd` invocation's
+  > `build_config` parameter, instead of the raw, explicit-only `config`
+  > value. `embed_build_source`'s `cfg_trusted_for_query = build_config is
+  > not None or build_query is not None` treats any non-`None` `build_config`
+  > as operator authorization to execute `build.query` — so that version
+  > would have let a `compare --sources old=<tree>` invocation with *no*
+  > `--config` at all execute an arbitrary `build.query` command from a
+  > `.abicheck.yml` merely auto-discovered from the working directory or the
+  > sources tree being compared, i.e. from content a reviewed PR's own
+  > checkout can control. Fixed by forwarding the raw `config` parameter
+  > (`run_compare`'s own un-resolved `--config` kwarg — `None` unless the
+  > operator actually typed it) instead of `cfg_path`. Verified via
+  > `tests/test_compare_inline_embed_config_trust.py`'s
+  > `test_auto_discovered_config_is_not_forwarded` (fails against the
+  > vulnerable version — asserts `build_config` stays `None` when only an
+  > auto-discovered config exists) and `test_explicit_config_is_forwarded`
+  > (positive control — an operator-supplied `--config` still reaches the
+  > nested invocation, so the fix doesn't overshoot into never forwarding
+  > one at all). `dump`'s own `--config` was never subject to this: its
+  > `build_config` local is always the literal, explicit-only Click flag
+  > value, with no auto-discovery fallback at that layer.
+  >
+  > Verified via `tests/test_analysis_plan.py`'s
   > `test_dump_request_honors_explicit_build_config_over_auto_discovery`/
   > `test_compare_request_honors_explicit_build_config_over_auto_discovery`
   > (request-level, through `AnalysisPlanner.resolve` directly) and

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -247,10 +247,10 @@ three positions this plan used to hold are explicitly revised by the vision:
 | **PR H** — `scan --artifact-set` member-identity manifest form | Open; syntax, cost/dry-run and audit-mode ownership all done | Nothing (last piece of PR H) |
 | **PR I** — live/stored operand driver; one evaluation/gate/report/dry-run path across all four operand shapes | Open; classification, flag deletion and stored/stored execution done | A shared gate/report object; overlaps vision A-S4 |
 | **PR J** — per-library header/compile-context topology in `BundleSpec`; `--max-json-object-nodes` → a calibrated `--resource-limit` | Open; `--manifest` rename and `--bundle-system-providers`/`--bundle-cohort` → `.abicheck.yml` done | G42 provider resolution (topology); a real bytes-per-node calibration (resource limit) |
-| **PR C tail** — `dump`/`compare` explicit-`--config` dry-run/execution parity | Open, narrow | Nothing |
+| **PR C tail** — `dump`/`compare` explicit-`--config` dry-run/execution parity | Closed — `InputSpec.build_config` seam landed | — |
 | `scan --artifact-set` bundle-topology config read | Open | Its own resolver still separate from `ResolvedCompareConfig`'s merge point |
 | `contract=public` default flip | Open | `EntityId`-based public closure (ADR-063 Phase 2), **not** a string heuristic |
-| PR 0/0B, PR 1, 1b, 2, A, B, C (binary formats), D, E, F, G1, G2 | Done / closed by decision | — |
+| PR 0/0B, PR 1, 1b, 2, A, B, C (binary formats), C tail (config parity), D, E, F, G1, G2 | Done / closed by decision | — |
 
 Everything else this file used to track (`--exit-code-scheme`,
 `--old-bundle-facts`, the compare provider/cohort switches, bare compare
@@ -321,7 +321,6 @@ checklist: where the two ever disagree, `vision-api-abi-evolution.md` wins.
 | # | Block | Start | Owning workstream | Primary files | Shared types |
 |---|---|---|---|---|---|
 | 1 | H1 hidden-shim deletion | **Tier 0 — now** | this plan (H1 above) | `frontends/cli/options/release.py`, `frontends/cli/commands/dump.py`, `options/inventory.py`, `help.py` | No |
-| 7 | Explicit-`--config` dry-run/execution parity | **Tier 0 — now** | this plan (PR C tail) | `cli_dump_request.py`, `cli_compare*` config discovery | No |
 | 3 | Release-path scope & completeness | **Tier 1 — now** | A-S1/S2 (deletion gate A-S4) | `cli_compare_release*`, `workflows/`, `policy/outcome.py` | **Yes — integration owner** |
 | 5 | Per-dimension comparability + failed evidence | **Tier 1 — now** | E-S1/S2 | `comparability.py`, `analysis_assurance.py`, `workflows/plan.py` | **Yes — integration owner** |
 | 2 | Scalar disposition audit | Tier 2 — after A/E's field contract (S0) is agreed | C-S1 + G-S1 | `policy/`, `report/`, `checker.py`, `semver.py` | No |
@@ -440,16 +439,25 @@ behind A; extending a canonical schema explicitly is fine, inventing a second
 manifest format is not. ADR-056 D2's safety boundary — no implicit
 positional-directory dispatch — stands unchanged either way.
 
-**Block 7 — explicit-`--config` dry-run/execution parity (PR C's tail).**
-Config discovery is closed for `scan` in both cases and for `dump`/`compare`'s
-auto-discovery case; the residual is `dump`/`compare` with an *explicit*
-`--config`, where what `--dry-run` projects and what execution resolves can
-still differ. The full account is the "Configuration discovery (PR C's tail)"
-bullet under "Re-verified, unchanged, still open" — read it first, it is
-narrower than it sounds and has already been re-litigated once. `build.query`
-executes only from an explicit `--config` (ADR-032 D5) and that must remain
-true through whatever this block changes; the trust receipt in `--dry-run` is
-part of the parity, not an optional extra.
+**Block 7 — explicit-`--config` dry-run/execution parity (PR C's tail) —
+closed.** Config discovery was closed for `scan` in both cases and for
+`dump`/`compare`'s auto-discovery case; the residual — `dump`/`compare` with
+an *explicit* `--config`, where what `--dry-run` projected and what
+execution resolved could still differ — is closed too:
+`api_types.InputSpec.build_config` is the request-level seam
+`dump`/`compare` previously lacked (mirroring `ScanRequest.build_config`),
+threaded through `cli_dump_request.build_dump_request` and compare's inline
+`--old/new-sources` embed path's nested `dump_cmd` invocation into
+`workflows.plan.SidePlan.build_config`, which the pre-flight
+bazel-target-scoping check now honors exactly as `embed_build_source`'s own
+`cfg_path = build_config or discover_build_config(...)` precedence does at
+real-execution time. `build.query` still executes only from an explicit
+`--config` (ADR-032 D5), unchanged — this field only widens what the shared
+pre-flight resolution can see, never what executes; the `--dry-run` trust
+receipt (`add_build_query_dry_run_section`) was already correct and is
+untouched. See "Configuration discovery (PR C's tail)" under "Re-verified,
+unchanged, still open" for the full prior account, and
+`docs/contribute/known-gaps.md`'s "PR C" entry.
 
 **Blocked, deliberately not on this list.** `--used-by`'s enrichment
 rewrite (D-S1) needs block 2's disposition model first, or per-consumer rows
@@ -5348,21 +5356,20 @@ the agreement so a future pass does not re-derive them as new:
   migration — every persisted identity carrier (flat entities, source-graph
   nodes, surface-graph nodes, consumer-graph nodes, proof-path references,
   impact ids), not one regex per graph format.
-- **Configuration discovery (PR C's tail) — corrected precisely 2026-09-04,
-  third pass, after this bullet was wrong in both directions across two
-  earlier corrections.** The full mechanism (`12492deb`'s auto-discovery
-  fix, the precedence rule, the per-call-site rollout across `dump`/
-  `compare`/`scan`) is maintained once, in
+- **Configuration discovery (PR C's tail) — closed.** The full mechanism
+  (`12492deb`'s auto-discovery fix, the precedence rule, the per-call-site
+  rollout across `dump`/`compare`/`scan`) is maintained once, in
   `docs/contribute/known-gaps.md` and `docs/contribute/plans/
-  one-semantic-pipeline.md`'s Phase 4 section — not restated here, so this
-  plan can't drift from that account the way it just did. **This plan's
-  own status, precisely:** closed for `scan` (both the auto-discovery and
-  explicit-`--config` cases — `ScanRequest` carries `build_config` as a
-  real field); closed for `dump`/`compare`'s auto-discovery case only —
-  their explicit-`--config` case is a real, narrower, still-open residual
-  of PR C's own tail, since `dump`/`compare` have no `build_config` field
-  on `InputSpec` at the request level at all. PR C's row above reflects
-  this precisely rather than either "fully open" or "fully done".
+  one-semantic-pipeline.md`'s Phase 4 section — not restated here. **This
+  plan's own status, precisely:** closed for `scan` (both the auto-discovery
+  and explicit-`--config` cases — `ScanRequest` carries `build_config` as a
+  real field); now closed for `dump`/`compare`'s explicit-`--config` case
+  too — `InputSpec.build_config` is the matching request-level field,
+  threaded from `cli_dump_request.build_dump_request` and from compare's
+  inline `--old/new-sources` embed path's nested `dump_cmd` invocation into
+  `workflows.plan.SidePlan.build_config`, which the pre-flight
+  bazel-target-scoping check consults exactly as `embed_build_source` does
+  at real-execution time. PR C's row above reflects this as fully done.
 - **The ADR-061 move is directionally right and carries one visible debt.**
   #972 put the new command in `frontends/cli/commands/` instead of a new flat
   `cli_compare_bundle_facts.py`, which is exactly ADR-061's direction — but

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -151,6 +151,7 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `public_header_dirs` | `tuple[Path, ...]` | `()` |
 | `follow_linker_scripts` | `bool` | `True` |
 | `compile_db_filter` | `str \| None` | `None` |
+| `build_config` | `Path \| None` | `None` |
 
 ## `LayerResult`
 

--- a/tests/test_analysis_plan.py
+++ b/tests/test_analysis_plan.py
@@ -203,10 +203,8 @@ class TestBazelBuildTargetScoping:
     ):
         """CodeRabbit review: the failure message must say "explicit build
         config", not "auto-discovered .abicheck.yml", when *build_config*
-        names the file directly (``scan``'s own ``ScanRequest.build_config``,
-        or dump/compare's own future seam) rather than being found by
-        searching ``sources`` -- ``dump``/``compare`` have no request-level
-        seam for this today, so this calls
+        names the file directly (``scan``'s own ``ScanRequest.build_config``)
+        rather than being found by searching ``sources`` -- this calls
         :func:`~abicheck.workflows.plan.bazel_target_scoping_failure`
         directly, the same free function ``scan``'s own call sites use."""
         from abicheck.workflows.plan import bazel_target_scoping_failure
@@ -224,6 +222,83 @@ class TestBazelBuildTargetScoping:
         assert "//:from_explicit_config" in failure.requested
         assert "explicit build config" in failure.requested
         assert "auto-discovered .abicheck.yml" not in failure.requested
+
+    def test_dump_request_honors_explicit_build_config_over_auto_discovery(
+        self, tmp_path: Path
+    ):
+        """CLI cleanup phase two, Block 7 (PR C's tail): ``InputSpec.
+        build_config`` is the request-level seam ``dump``/``compare``
+        previously lacked (see this class's own preceding test, and
+        ``docs/contribute/known-gaps.md``'s "PR C" entry). An explicit
+        ``--config`` naming a *different* file than whatever
+        ``.abicheck.yml`` auto-discovery would find at ``sources`` must win
+        outright -- the same precedence ``embed_build_source`` already
+        applies at real-execution time -- so ``--dry-run``'s resolved plan
+        (which runs through this exact chokepoint) cannot disagree with what
+        execution actually does. Without threading ``build_config`` onto
+        ``InputSpec``, this would have silently used the *auto-discovered*
+        targets (or none) instead of the named file's, exactly the
+        dry-run/execution divergence this field closes."""
+        aquery = _write(tmp_path / "aquery.json", _EMPTY_AQUERY)
+        sources_dir = tmp_path / "src"
+        sources_dir.mkdir()
+        (sources_dir / ".abicheck.yml").write_text(
+            "build:\n  system: bazel\n  targets:\n    - //:from_auto_discovery\n",
+            encoding="utf-8",
+        )
+        explicit_cfg = tmp_path / "explicit.yml"
+        explicit_cfg.write_text(
+            "build:\n  system: bazel\n  targets:\n    - //:from_explicit_config\n",
+            encoding="utf-8",
+        )
+        request = DumpRequest(
+            input=InputSpec.of(
+                path=None,
+                sources=sources_dir,
+                build_info=aquery,
+                build_config=explicit_cfg,
+            ),
+            depth="build",
+        )
+        with pytest.raises(PlanningError) as exc_info:
+            AnalysisPlanner.resolve(request)
+        failure = exc_info.value.failures[0]
+        assert "//:from_explicit_config" in failure.requested
+        assert "from_auto_discovery" not in failure.requested
+        assert "explicit build config" in failure.requested
+
+    def test_compare_request_honors_explicit_build_config_over_auto_discovery(
+        self, tmp_path: Path
+    ):
+        """Same seam, ``CompareRequest`` side -- each side's own
+        ``InputSpec.build_config`` is independent, mirroring how
+        ``sources``/``build_info``/``build_targets`` are already per-side."""
+        aquery = _write(tmp_path / "aquery.json", _EMPTY_AQUERY)
+        sources_dir = tmp_path / "src"
+        sources_dir.mkdir()
+        (sources_dir / ".abicheck.yml").write_text(
+            "build:\n  system: bazel\n  targets:\n    - //:from_auto_discovery\n",
+            encoding="utf-8",
+        )
+        explicit_cfg = tmp_path / "explicit.yml"
+        explicit_cfg.write_text(
+            "build:\n  system: bazel\n  targets:\n    - //:from_explicit_config\n",
+            encoding="utf-8",
+        )
+        old = InputSpec.of(path=tmp_path / "old.so", sources=sources_dir)
+        new = InputSpec.of(
+            path=tmp_path / "new.so",
+            sources=sources_dir,
+            build_info=aquery,
+            build_config=explicit_cfg,
+        )
+        request = CompareRequest(old=old, new=new)
+        with pytest.raises(PlanningError) as exc_info:
+            AnalysisPlanner.resolve(request)
+        failure = exc_info.value.failures[0]
+        assert "'new'" in failure.requested
+        assert "//:from_explicit_config" in failure.requested
+        assert "from_auto_discovery" not in failure.requested
 
     def test_compare_config_sourced_target_scope_raises_planning_error(
         self, tmp_path: Path

--- a/tests/test_bazel_root_targets.py
+++ b/tests/test_bazel_root_targets.py
@@ -811,3 +811,57 @@ def test_dot_abicheck_yml_build_targets_dry_run_parity(tmp_path: Path):
     )
     assert result.exit_code == 64, result.output
     assert "pre-captured Bazel aquery" in result.output
+
+
+def test_dump_cli_explicit_config_scoping_matches_dry_run_and_real_run(
+    tmp_path: Path,
+):
+    """CLI cleanup phase two, Block 7 (PR C's tail): an explicit ``--config``
+    naming a file *other* than the one auto-discovery would find at
+    ``--sources`` must scope the pre-flight bazel-target check by the named
+    file's ``build.targets:``, identically for ``--dry-run`` and the real
+    run -- both resolve through the identical ``InputSpec.build_config`` ->
+    ``AnalysisPlanner.resolve`` chokepoint. Before this field existed, both
+    could only ever see whatever ``.abicheck.yml`` auto-discovery found at
+    ``--sources`` (here, nothing at all -- the tree has no ``.abicheck.yml``
+    of its own), so neither would have rejected this combination even though
+    the explicitly named config declares ``build.targets:``."""
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.cpp").write_text("int f() { return 0; }\n", encoding="utf-8")
+    # Deliberately no `.abicheck.yml` under `src/` -- auto-discovery at
+    # `--sources` would find nothing, so only the explicit `--config` can
+    # supply `build.targets:` here.
+    explicit_cfg = tmp_path / "explicit.yml"
+    explicit_cfg.write_text(
+        "build:\n  system: bazel\n  targets:\n    - //:from_explicit_config\n",
+        encoding="utf-8",
+    )
+    aquery = tmp_path / "aquery.json"
+    aquery.write_text(
+        json.dumps({"actions": [], "pathFragments": [], "artifacts": [], "targets": []})
+    )
+
+    runner = CliRunner()
+    common_args = [
+        "dump",
+        "--sources", str(src),
+        "--build-info", str(aquery),
+        "--config", str(explicit_cfg),
+    ]
+
+    dry_run_result = runner.invoke(main, [*common_args, "--dry-run"])
+    assert dry_run_result.exit_code == 64, dry_run_result.output
+    assert "pre-captured Bazel aquery" in dry_run_result.output
+    assert "//:from_explicit_config" in dry_run_result.output
+
+    real_run_result = runner.invoke(
+        main, [*common_args, "-o", str(tmp_path / "out.json")]
+    )
+    assert real_run_result.exit_code == 64, real_run_result.output
+    assert "pre-captured Bazel aquery" in real_run_result.output
+    assert "//:from_explicit_config" in real_run_result.output

--- a/tests/test_compare_inline_embed_config_trust.py
+++ b/tests/test_compare_inline_embed_config_trust.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Security regression (Codex review on abicheck/abicheck#1089): `compare`'s
+inline `--sources old=`/`new=` embed path must forward only the operator's
+*explicit* `--config` to its nested `dump_cmd` invocation, never `compare`'s
+own auto-discovered project `.abicheck.yml`.
+
+`embed_build_source` treats a non-``None`` ``build_config`` as operator
+authorization to execute ``build.query`` (ADR-032 D5; see
+``tests/test_build_source_cli.py::test_auto_discovered_build_query_is_not_executed``
+for the primitive's own trust boundary). CLI cleanup phase two's Block 7 (PR
+C's tail) added a request-level ``InputSpec.build_config`` seam so ``dump``/
+``compare``'s pre-flight bazel-target-scoping check could see an explicit
+``--config`` -- but the first version of that fix forwarded `compare`'s
+already-resolved ``cfg_path`` (which conflates an explicit ``--config`` with
+`_resolve_compare_config`'s own auto-discovery fallback,
+``discover_project_config()``) into the nested ``dump_cmd`` invocation's
+``build_config`` parameter instead of the raw, explicit-only ``--config``
+value. That would have let an untrusted, PR-controlled ``.abicheck.yml`` --
+either sitting in the ``--sources`` tree being compared, or merely discovered
+from the working directory -- silently authorize its own ``build.query``
+subprocess execution on a plain ``compare --sources old=<tree>`` invocation
+with no ``--config`` at all. This module is a dedicated home for that one
+security property, split out from ``tests/test_build_source_cli.py`` rather
+than grown into it (that file already sits at its `no_growth` architecture
+debt baseline -- see `architecture/debt.yaml`)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+
+
+def _invoke_compare_inline_embed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, extra_args: list[str],
+) -> dict:
+    """Drive `compare --sources old=<tree>` through the real CLI up to (but
+    not through) its nested `dump_cmd` invocation, returning the kwargs that
+    invocation would have received.
+
+    `_normalize_binary_input` is mocked (module-scoped, matching
+    `tests/test_compare_dispatch.py`'s own established pattern for this
+    exact function) so a placeholder `old.so`/`new.so` is classified as a
+    native ELF operand without needing a real binary -- the inline-embed
+    dispatch only needs the *format*, not real content, to decide a raw
+    `--sources` tree needs collecting. `_embed_inline_source_sides` is
+    replaced with a capture-and-stop stub so the real (heavier, and for a
+    placeholder ELF, doomed-to-fail) dump/diff machinery never runs -- this
+    test is only about what reaches that one call, not what happens after.
+    """
+    import abicheck.cli_compare_helpers as cch
+    import abicheck.frontends.cli.commands.compare as climod
+
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    old_so, new_so = tmp_path / "old.so", tmp_path / "new.so"
+    old_so.write_bytes(b"")
+    new_so.write_bytes(b"")
+    monkeypatch.setattr(climod, "_normalize_binary_input", lambda p: (p, "elf"))
+
+    captured: dict = {}
+
+    class _Stop(Exception):
+        pass
+
+    def _fake_embed_sides(*args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise _Stop
+
+    monkeypatch.setattr(cch, "_embed_inline_source_sides", _fake_embed_sides)
+
+    with pytest.raises(_Stop):
+        CliRunner().invoke(
+            main,
+            [
+                "compare", str(old_so), str(new_so),
+                "--sources", f"old={src}", "--depth", "build",
+                *extra_args,
+            ],
+            catch_exceptions=False,
+        )
+    return captured
+
+
+def test_auto_discovered_config_is_not_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``--config`` given, but a `.abicheck.yml` is auto-discoverable from
+    cwd: the nested invocation's ``build_config`` must stay ``None`` -- an
+    auto-discovered config is exactly the untrusted case ADR-032 D5 exists
+    to distinguish from an operator-supplied one."""
+    (tmp_path / ".abicheck.yml").write_text(
+        "severity:\n  addition: warning\n", encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    captured = _invoke_compare_inline_embed(tmp_path, monkeypatch, extra_args=[])
+
+    assert captured.get("build_config") is None
+
+
+def test_explicit_config_is_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: an operator-supplied ``--config`` must still reach
+    the nested invocation -- Block 7's own parity goal -- so the fix for the
+    finding above doesn't overshoot into never forwarding a config at all."""
+    explicit_cfg = tmp_path / "explicit.yml"
+    explicit_cfg.write_text("severity:\n  addition: warning\n", encoding="utf-8")
+
+    captured = _invoke_compare_inline_embed(
+        tmp_path, monkeypatch, extra_args=["--config", str(explicit_cfg)],
+    )
+
+    assert captured.get("build_config") == explicit_cfg


### PR DESCRIPTION
## Summary

Closes CLI cleanup phase two's Block 7 (PR C's tail): `dump`/`compare` explicit-`--config` dry-run/execution parity.

## Motivation

`scan` already closed both halves of the config-discovery parity gap (`ScanRequest.build_config` is a real request field). `dump`/`compare` only closed the auto-discovery half — their explicit-`--config` case was a real, narrower, still-open residual: the shared pre-flight bazel-target-scoping check (`workflows.plan.AnalysisPlanner.resolve`, which both `--dry-run` and the real run go through) had no request-level seam for an explicit `--config`, so it could only ever see whatever `.abicheck.yml` auto-discovery found at `--sources` — even when an explicit `--config` named a *different* file. This let `--dry-run`'s resolved plan silently disagree with what `embed_build_source` actually does at real-execution time (it already honors the explicit path via `cfg_path = build_config or discover_build_config(...)`).

## Changes

- Add `InputSpec.build_config: Path | None = None` (mirrors `ScanRequest.build_config`), plus the matching `InputSpec.of()` parameter.
- Add `SidePlan.build_config` and thread it into `_check_bazel_target_scoping` → `bazel_target_scoping_failure(..., build_config=side.build_config, ...)`, so `AnalysisPlanner.resolve` sees the explicit config for both `dump` and `compare`.
- `cli_dump_request.build_dump_request` gains a `build_config` parameter, set from `dump_cmd`'s own `--config` value onto `InputSpec.build_config`.
- `compare`'s inline `--old/new-sources` embed path (`_embed_inline_source_side(s)`, its nested `ctx.invoke(dump_cmd, ...)`) now forwards `compare`'s resolved `cfg_path` as `build_config` too, closing the same gap for that path.
- `build.query` still only ever executes from an explicit `--config` (ADR-032 D5) — unchanged. This only widens what the shared pre-flight resolution (and therefore `--dry-run`) can see; `embed_build_source` still gets the CLI's raw `--config` value out-of-band exactly as before. The `--dry-run` `build.query` trust receipt (`add_build_query_dry_run_section`) was already correct and is untouched.
- Updates `docs/contribute/plans/cli-cleanup-phase-two.md` and `docs/contribute/known-gaps.md`'s "PR C" entry to record this closed.
- Directory/package `compare`'s release fan-out is left untouched — out of this residual's stated scope (the plan names `dump`/`compare`, the single-pair commands).

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: a pre-flight resolution chokepoint (`AnalysisPlanner.resolve`) ignoring an explicit input a real-execution step already honors, because the request object had no field to carry it — the same shape as the general "resolve/execute must agree" class this plan's PR 3A/PR C work has repeatedly closed for other fields (`compile_db_filter`, collect-mode overrides).
- Publicly observable failure: `dump --config foo.yml --sources tree --build-info precaptured-aquery.json --dry-run` (and the identical real run) failed to reject/report the pre-captured-Bazel-jsonproto scoping hazard using `foo.yml`'s `build.targets:` — it only ever consulted whatever `.abicheck.yml` auto-discovery found at `tree` (nothing, in the regression case), so `--dry-run` and the real run could each silently disagree with what `foo.yml` actually declares.
- Regression test fails on base: yes — `tests/test_analysis_plan.py::TestBazelBuildTargetScoping::test_dump_request_honors_explicit_build_config_over_auto_discovery`, `::test_compare_request_honors_explicit_build_config_over_auto_discovery`, and `tests/test_bazel_root_targets.py::test_dump_cli_explicit_config_scoping_matches_dry_run_and_real_run` all fail on `main` (no `InputSpec.build_config` field to set, so the explicit config is never seen by the check).
- Negative control: every pre-existing test in `TestBazelBuildTargetScoping` (auto-discovery-only cases, the "explicit build target wins" case, the depth-binary exemptions, etc.) still passes unchanged, and the new tests assert the *auto-discovered* file's targets are absent from the failure message when an explicit config is given — proving the fix picks the right file rather than merging both.
- Public-surface test: yes — through the public `DumpRequest`/`CompareRequest`/`AnalysisPlanner.resolve` typed API, and end-to-end through the real CLI via `click.testing.CliRunner` (`dump --config ... --dry-run` and the real run).
- Axes covered: `dump` (single input) and `compare` (both `old`/`new` sides independently); `--dry-run` vs. the real run; typed-API-level and CLI-level.
- General invariant: an explicit `--config` always wins over `.abicheck.yml` auto-discovery for the bazel-target-scoping pre-flight check, identically between `--dry-run` and the real run, for both `dump` and `compare` — stated directly as the new tests' shared assertion pattern (explicit file's targets present, auto-discovered file's targets absent) across both request-level and CLI-level tests.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — `changelog.d/1787100000_claude_dump-compare-config-dry-run-parity.md`
- [x] Docs updated (plan doc + known-gaps.md)
- [x] `ruff check`/`ruff format --check` pass locally on touched files
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/` clean on touched modules)

Verified: `mypy abicheck/`, `ruff check`, `scripts/check_architecture.py`, `scripts/check_ai_readiness.py` (pre-existing, unrelated ADR-receipt errors only — confirmed present on `main` too, untouched by this diff), `scripts/check_docs_contract.py` (pre-existing, unrelated warnings only), and the full fast unit suite (only one pre-existing, environment-dependent failure unrelated to this change and reproducible on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2LYmkTVHVANHKR6EUEcZC)_