### PR TITLE
fix: close ADR-063 T9's legacy-hybrid backfill blocker

### DIFF
--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -1088,6 +1088,11 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         clang_deprecation_facts_reliable_value=clang_deprecation_facts_reliable_value,
         clang_restrict_facts_reliable_value=clang_restrict_facts_reliable_value,
         castxml_var_access_facts_reliable_value=castxml_var_access_facts_reliable_value,
+        # T9 / ADR-063 Phase 6 item 4 (legacy-hybrid backfill blocker): the
+        # raw per-declaration provenance map, same source as the
+        # `AbiSnapshot.fact_provenance` field constructed further below --
+        # read here too since this call happens before that field exists.
+        fact_provenance=dict(d.get("fact_provenance", {})),
     )
 
     # ADR-050 D1 (schema v12) — profile/scope fingerprints. Missing key (every

--- a/abicheck/storage/fact_backfill.py
+++ b/abicheck/storage/fact_backfill.py
@@ -29,11 +29,44 @@ module holding the per-field thresholds both this module and ``fact_codec``
 need. Importing them back from ``fact_codec`` instead would be a real import
 cycle (``fact_codec`` re-exports this module's three public names for
 compatibility), which the ``import-cycle-growth`` gate rejects.
+
+**T9 / ADR-063 Phase 6 item 4 (the "legacy-hybrid backfill blocker"):** the
+whole-snapshot ``reliable``/``evidenced`` framework above cannot see the one
+ambiguity that only exists on a ``--ast-frontend hybrid`` snapshot: seven
+fields (``RecordType.deprecated``, ``EnumType.deprecated``/``is_scoped``,
+``Function.deprecated``, ``Variable.deprecated``, ``TypeField.deprecated``/
+``default``) are gated, at COMPARE time, by ``fact_provenance.py``'s
+per-declaration ``AbiSnapshot.fact_provenance`` map rather than by a
+snapshot-level flag -- because a hybrid merge's own two backends can
+disagree on which of them actually populated any one declaration's fact,
+which no whole-snapshot boolean can express. ``clang_deprecation_facts_
+reliable`` reads ``True`` for a hybrid producer unconditionally (an
+ordinary, fresh hybrid dump states this fact explicitly per declaration, so
+the flag has no reason to distrust it), so the ``unreliable``/
+``unproduceable`` checks above both pass for a legacy (pre-``min_schema_
+version``) hybrid document, and the pre-existing ``__post_init__`` bridge's
+``Fact.present(raw_value)`` is left standing -- even for a declaration
+neither backend actually confirmed on that document, since the legacy JSON
+format always serializes SOME value (there is no "omitted" concept once a
+dict round-trips through a dataclass constructor). ``fact_provenance_kind``
+on :class:`CaseAFactRule`, consulted only when the
+document's ``ast_producer`` is exactly ``"hybrid"`` and only for a rule
+that names one, resolves this the same way ``fact_provenance.
+resolved_fact_producer`` already does at compare time: probe the
+declaration's namespace-qualified provenance key first, falling back to the
+bare pre-qualification key only when no OTHER declaration on this same
+snapshot shares that bare name (an ambiguous bare fallback would misattribute
+one declaration's real provenance to an unrelated sibling). No entry under
+either key means neither backend's merge recorded ever having looked --
+which downgrades the *claim* exactly like an ``evidenced``-only miss above
+(never the value, and only when the value is already the field's own
+resting default -- the existing "downgrade the claim, never the value"
+convention this module's own callers already rely on).
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -71,6 +104,19 @@ class CaseAFactRule:
     ``ast_producer`` note); ``normalized_default`` is the value the legacy
     field is reset to when the fact is downgraded, so the pair cannot be
     left holding a placeholder beside a NOT_COLLECTED status.
+
+    ``fact_provenance_kind`` (see this module's own "legacy-hybrid backfill
+    blocker" docstring section) names which per-declaration
+    ``fact_provenance`` key shape this field's provenance is recorded under
+    on a hybrid merge — ``"type"``/``"enum"``/``"field"`` (namespace-
+    qualified with a bare-name fallback, keyed by the owning
+    ``RecordType``/``EnumType``'s own identity) or ``"func"``/``"var"``
+    (keyed by the declaration's own mangled name, already unique — no
+    bare/qualified split to resolve). ``None`` (the default) means this
+    field carries no such per-declaration mechanism, so the check is never
+    consulted for it — every rule converted before this one, and
+    ``is_va_list``/``is_restrict``/``access``, which have their own
+    independent reliability signals instead.
     """
 
     owner: str
@@ -78,43 +124,78 @@ class CaseAFactRule:
     min_schema_version: int
     reliable: bool
     normalized_default: Any
+    fact_provenance_kind: str | None = None
+
+
+#: ``(qualified key, bare key)`` for the entity a rule's per-declaration
+#: ``fact_provenance`` lookup is scoped by -- the object itself for a
+#: ``RecordType``/``EnumType`` rule, its OWNING record for a ``TypeField``
+#: rule (a field's provenance key is scoped by its type, not the field's own
+#: name -- see ``dumper_hybrid._merge_field``), and the declaration's own
+#: mangled name twice over for ``Function``/``Variable`` (already unique, so
+#: there is no bare/qualified split to fall back through). ``(None, None)``
+#: for ``Param``, which carries no per-declaration provenance mechanism at
+#: all -- its one case-(a) field (``is_va_list``) is gated by a snapshot-level
+#: producer check instead (``apply_legacy_fact_backfill``'s own
+#: ``ast_producer_value == "clang"`` gate), so no rule ever sets
+#: ``fact_provenance_kind`` for it and this value is never consulted.
+_OwnerKey = tuple[str, str] | tuple[None, None]
 
 
 def _owner_pairs(
     d: dict[str, Any],
     owner: str,
     decoded: dict[str, list[Any]],
-) -> Iterator[tuple[dict[str, Any], Any]]:
-    """Every ``(raw dict, decoded object)`` pair for one *owner* dataclass.
+) -> Iterator[tuple[dict[str, Any], Any, _OwnerKey]]:
+    """Every ``(raw dict, decoded object, owner_key)`` triple for one *owner*
+    dataclass.
 
     The one place this module knows how a given owner's instances are
     reached from the raw snapshot document — two owners (``TypeField``,
     ``Param``) live one level below a collection rather than in one, and a
     per-field ``zip`` open-coded at each call site is exactly the kind of
     duplication a later owner's conversion would get subtly wrong.
+
+    ``owner_key`` (added for the module docstring's "legacy-hybrid backfill
+    blocker" section) is threaded through unconditionally rather than
+    computed only when a rule needs it — every owner already has it for
+    free from the same objects this generator already walks, and computing
+    it lazily per-rule would mean re-deriving the same TypeField-owning
+    RecordType walk a second time.
     """
     if owner == "RecordType":
-        yield from zip(d.get("types", []), decoded.get("types", []), strict=False)
+        for raw, obj in zip(d.get("types", []), decoded.get("types", []), strict=False):
+            yield raw, obj, (obj.qualified_name or obj.name, obj.name)
     elif owner == "EnumType":
-        yield from zip(d.get("enums", []), decoded.get("enums", []), strict=False)
+        for raw, obj in zip(d.get("enums", []), decoded.get("enums", []), strict=False):
+            yield raw, obj, (obj.qualified_name or obj.name, obj.name)
     elif owner == "Variable":
-        yield from zip(
+        for raw, obj in zip(
             d.get("variables", []), decoded.get("variables", []), strict=False
-        )
+        ):
+            yield raw, obj, (obj.mangled, obj.mangled)
     elif owner == "Function":
-        yield from zip(
+        for raw, obj in zip(
             d.get("functions", []), decoded.get("functions", []), strict=False
-        )
+        ):
+            yield raw, obj, (obj.mangled, obj.mangled)
     elif owner == "TypeField":
         for type_dict, record in zip(
             d.get("types", []), decoded.get("types", []), strict=False
         ):
-            yield from zip(type_dict.get("fields", []), record.fields, strict=False)
+            owner_key: _OwnerKey = (record.qualified_name or record.name, record.name)
+            for raw, field in zip(
+                type_dict.get("fields", []), record.fields, strict=False
+            ):
+                yield raw, field, owner_key
     elif owner == "Param":
         for func_dict, func in zip(
             d.get("functions", []), decoded.get("functions", []), strict=False
         ):
-            yield from zip(func_dict.get("params", []), func.params, strict=False)
+            for raw, param in zip(
+                func_dict.get("params", []), func.params, strict=False
+            ):
+                yield raw, param, (None, None)
     else:  # pragma: no cover - guarded by the caller's own closed rule set
         raise ValueError(f"no raw-document navigation known for owner {owner!r}")
 
@@ -249,6 +330,82 @@ def _unproduceable(owner: str, field: str, evidenced: frozenset[str]) -> bool:
     return not (set(entry.producing_backends) & evidenced)
 
 
+def _bare_name_ambiguous(entities: list[Any]) -> dict[str, bool]:
+    """Per bare ``.name``, whether more than one DISTINCT qualified identity
+    on this document's side shares it.
+
+    The per-snapshot-side counterpart of
+    ``fact_provenance.resolved_fact_producer``'s own ``bare_unambiguous``
+    guard, computed once here instead of once per rule/declaration:
+    :func:`_hybrid_provenance_confirms` must not fall back from a
+    qualified-but-absent provenance key to the bare one when two distinct
+    types/enums on this same side happen to share a leaf name, since the
+    fallback would then attribute one declaration's real provenance entry
+    to an unrelated sibling.
+    """
+    qualified_by_bare: dict[str, set[str]] = {}
+    for e in entities:
+        qualified_by_bare.setdefault(e.name, set()).add(e.qualified_name or e.name)
+    return {bare: len(qualified) > 1 for bare, qualified in qualified_by_bare.items()}
+
+
+def _hybrid_provenance_confirms(
+    rule: CaseAFactRule,
+    obj: Any,
+    owner_key: _OwnerKey,
+    fact_provenance: Mapping[str, str],
+    bare_ambiguous: bool,
+) -> bool:
+    """Whether *this declaration's* ``fact_provenance`` entry (module
+    docstring's "legacy-hybrid backfill blocker" section) confirms that some
+    backend's merge actually recorded looking at *rule.field* here.
+
+    Key formats are inlined rather than imported from ``fact_provenance.py``
+    (a flat-root, ``model``-only-adjacent module): ``storage`` may depend on
+    ``model`` only (``architecture/modules.yaml``), and the scheme itself is
+    small, public, and stable across a serialize/deserialize round-trip
+    (``fact_provenance.py``'s own module docstring) -- a second literal
+    formatting of the same three-token scheme, not a duplicated algorithm.
+
+    Probes the namespace-qualified key first, falling back to the former
+    bare key only when *bare_ambiguous* says no OTHER declaration on this
+    side shares that bare name -- the same qualified-then-bare-with-
+    ambiguity-guard shape ``fact_provenance.resolved_fact_producer`` already
+    applies at compare time, so a hybrid baseline persisted before the
+    provenance-key qualification fix (real data recorded under the bare key
+    alone) is not wrongly treated as unconfirmed.
+    """
+    qualified, bare = owner_key
+    kind = rule.fact_provenance_kind
+    if kind == "func":
+        return f"func:{qualified}:{rule.field}" in fact_provenance
+    if kind == "var":
+        return f"var:{qualified}:{rule.field}" in fact_provenance
+    if kind == "type":
+        prefix = "type"
+    elif kind == "enum":
+        prefix = "enum"
+    elif kind == "field":
+        prefix = "type"
+        # A field's own key names both the owning type and the field itself
+        # (`fact_provenance.field_fact_key`) -- the field's bare NAME is not
+        # part of the ambiguity question above (only the owning type's is).
+        suffix = f":field:{obj.name}:{rule.field}"
+        if f"{prefix}:{qualified}{suffix}" in fact_provenance:
+            return True
+        if bare != qualified and not bare_ambiguous:
+            return f"{prefix}:{bare}{suffix}" in fact_provenance
+        return False
+    else:  # pragma: no cover - guarded by the caller's own closed rule set
+        raise ValueError(f"unknown fact_provenance_kind {kind!r}")
+    suffix = f":{rule.field}"
+    if f"{prefix}:{qualified}{suffix}" in fact_provenance:
+        return True
+    if bare != qualified and not bare_ambiguous:
+        return f"{prefix}:{bare}{suffix}" in fact_provenance
+    return False
+
+
 def apply_case_a_fact_backfill(
     d: dict[str, Any],
     *,
@@ -261,6 +418,13 @@ def apply_case_a_fact_backfill(
     # document with no header provenance at all (CodeRabbit review, PR #995).
     # A caller with nothing to report passes `frozenset()`.
     evidenced: frozenset[str],
+    # Both optional and both `None` by default -- a caller that never heard
+    # of the legacy-hybrid provenance check (every pre-existing call site)
+    # gets exactly the old behavior, since no rule it passes can carry a
+    # `fact_provenance_kind` it doesn't already set. See the module
+    # docstring's "legacy-hybrid backfill blocker" section.
+    fact_provenance: Mapping[str, str] | None = None,
+    ast_producer: str | None = None,
     **decoded: list[Any],
 ) -> None:
     """Downgrade every case-(a) fact a legacy document cannot vouch for.
@@ -283,7 +447,28 @@ def apply_case_a_fact_backfill(
     :func:`evidenced_producers`): a producer this document shows no trace of
     cannot have observed a fact only it produces, which no reliability flag
     expresses.
+
+    ``fact_provenance``/``ast_producer`` carry the third downgrade reason
+    (module docstring, "legacy-hybrid backfill blocker"): for a rule whose
+    ``fact_provenance_kind`` is set, on a document whose ``ast_producer`` is
+    exactly ``"hybrid"``, the whole-snapshot ``reliable``/``evidenced``
+    checks above both pass unconditionally, but the per-DECLARATION question
+    they cannot ask -- did either backend's merge actually record having
+    looked at this one declaration's fact -- is exactly what
+    ``fact_provenance`` answers. Absent on both callers, this check is
+    inert, matching every pre-existing rule and call site exactly.
     """
+    # Bare-name ambiguity, precomputed once per document rather than
+    # per-rule: whether a given bare `RecordType`/`EnumType` name is shared
+    # by more than one distinct qualified identity on THIS side (needed only
+    # by the hybrid-provenance check below, mirroring
+    # `fact_provenance.resolved_fact_producer`'s own `bare_unambiguous`
+    # guard -- an ambiguous bare fallback would misattribute one
+    # declaration's real provenance to an unrelated sibling sharing its leaf
+    # name). Harmless (and unused) when no rule sets `fact_provenance_kind`.
+    type_bare_ambiguous = _bare_name_ambiguous(decoded.get("types", []))
+    enum_bare_ambiguous = _bare_name_ambiguous(decoded.get("enums", []))
+
     for rule in rules:
         if schema_version >= rule.min_schema_version:
             continue
@@ -306,10 +491,28 @@ def apply_case_a_fact_backfill(
         # block, the document's own platform.
         unreliable = not rule.reliable
         unproduceable = _unproduceable(rule.owner, rule.field, evidenced)
-        if not (unreliable or unproduceable):
+        # Third reason, hybrid-only (module docstring, "legacy-hybrid
+        # backfill blocker"): a rule naming a `fact_provenance_kind`, on a
+        # document whose merge recorded per-declaration provenance at all,
+        # needs every declaration probed even when `unreliable`/
+        # `unproduceable` are both False -- so this must join the rule-level
+        # skip below, not just gate what happens inside the loop.
+        provenance_gated = (
+            rule.fact_provenance_kind is not None
+            and ast_producer == "hybrid"
+            and fact_provenance is not None
+        )
+        if not (unreliable or unproduceable or provenance_gated):
             continue
         fact_key = f"{rule.field}_fact"
-        for raw, obj in _owner_pairs(d, rule.owner, decoded):
+        bare_ambiguous: dict[str, bool]
+        if rule.owner in ("RecordType", "TypeField"):
+            bare_ambiguous = type_bare_ambiguous
+        elif rule.owner == "EnumType":
+            bare_ambiguous = enum_bare_ambiguous
+        else:
+            bare_ambiguous = {}
+        for raw, obj, owner_key in _owner_pairs(d, rule.owner, decoded):
             # Skip only an entry carrying a *usable* fact, not merely the
             # key. A `"<field>_fact": {}` or `: null` decodes to nothing
             # (`decode_fact`'s own `if not raw`), so the owning dataclass's
@@ -324,13 +527,36 @@ def apply_case_a_fact_backfill(
             if unreliable:
                 setattr(obj, rule.field, rule.normalized_default)
                 setattr(obj, fact_key, Fact.not_collected())
-            elif getattr(obj, rule.field) == rule.normalized_default:
-                # Unproduceable-only: downgrade the *claim*, never the
-                # value. A non-header document carrying a non-resting value
-                # for one of these fields got it from somewhere this
-                # registry doesn't model, and discarding it would lose real
-                # data -- unlike the unreliable case, where the value is
-                # known to be a placeholder.
+                continue
+            downgrade_claim_only = unproduceable
+            bare_name = owner_key[1]
+            if (
+                not downgrade_claim_only
+                and provenance_gated
+                and fact_provenance is not None  # narrows for mypy
+                and not _hybrid_provenance_confirms(
+                    rule,
+                    obj,
+                    owner_key,
+                    fact_provenance,
+                    bare_ambiguous.get(bare_name, False)
+                    if bare_name is not None
+                    else False,
+                )
+            ):
+                downgrade_claim_only = True
+            if (
+                downgrade_claim_only
+                and getattr(obj, rule.field) == rule.normalized_default
+            ):
+                # Downgrade the *claim*, never the value, in either
+                # remaining case: a non-header document (unproduceable) or a
+                # hybrid document whose merge never recorded provenance for
+                # this declaration (provenance_gated) carrying a non-resting
+                # value for one of these fields got it from somewhere this
+                # correction doesn't model, and discarding it would lose
+                # real data -- unlike the unreliable case above, where the
+                # value is known to be a placeholder.
                 setattr(obj, fact_key, Fact.not_collected())
 
 
@@ -357,6 +583,12 @@ def apply_legacy_fact_backfill(
     castxml_var_access_facts_reliable_value: bool = True,
     clang_field_initializer_facts_reliable_value: bool = True,
     clang_deprecation_facts_reliable_value: bool = True,
+    # T9 / ADR-063 Phase 6 item 4: the raw `AbiSnapshot.fact_provenance` map,
+    # threaded through so the seven rules below carrying a
+    # `fact_provenance_kind` can resolve the legacy-hybrid backfill blocker
+    # (see `apply_case_a_fact_backfill`'s own docstring). `None` (the
+    # default) leaves every rule's existing behavior exactly unchanged.
+    fact_provenance: Mapping[str, str] | None = None,
 ) -> None:
     """Correct the legacy backfill for every case-(a) fact a document predates.
 
@@ -466,6 +698,7 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_TYPEFIELD_VALUE_FACTS,
                 clang_field_initializer_facts_reliable_value,
                 None,
+                fact_provenance_kind="field",
             ),
             CaseAFactRule(
                 "TypeField",
@@ -473,17 +706,32 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_TYPEFIELD_VALUE_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="field",
             ),
             # ADR-063 Phase 5 (ninth batch, schema v40): the other four
             # `deprecated` surfaces plus EnumType.is_scoped, all guarded by
             # the same flag TypeField.deprecated is -- one rule each, which
             # is the whole point of the rule table.
+            #
+            # T9 / ADR-063 Phase 6 item 4: all seven rules in this batch
+            # (including the two TypeField ones above) also carry a
+            # `fact_provenance_kind` -- the whole-snapshot
+            # `clang_deprecation_facts_reliable`/`clang_field_initializer_
+            # facts_reliable` flags above both read True unconditionally for
+            # a hybrid producer (an ordinary fresh hybrid dump states these
+            # facts explicitly per declaration), so on a document that
+            # predates this fact family's own schema version, only a real
+            # per-declaration `fact_provenance` lookup -- not either flag --
+            # can tell "neither backend's merge ever recorded looking here"
+            # apart from "confirmed, genuinely resting-default". See
+            # `apply_case_a_fact_backfill`'s own docstring.
             CaseAFactRule(
                 "Function",
                 "deprecated",
                 _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="func",
             ),
             CaseAFactRule(
                 "Variable",
@@ -491,6 +739,7 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="var",
             ),
             CaseAFactRule(
                 "RecordType",
@@ -498,6 +747,7 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="type",
             ),
             CaseAFactRule(
                 "EnumType",
@@ -505,6 +755,7 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="enum",
             ),
             CaseAFactRule(
                 "EnumType",
@@ -512,6 +763,7 @@ def apply_legacy_fact_backfill(
                 _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
                 clang_deprecation_facts_reliable_value,
                 None,
+                fact_provenance_kind="enum",
             ),
             # ADR-063 Phase 5 (tenth batch, schema v41): the last two
             # case-(a) fields, each with its own guarding flag.
@@ -531,6 +783,8 @@ def apply_legacy_fact_backfill(
             ),
         ),
         evidenced=evidenced,
+        fact_provenance=fact_provenance,
+        ast_producer=ast_producer_value,
         types=types,
         functions=funcs,
         variables=variables or [],

--- a/changelog.d/1788700000_claude_adr063-t9-legacy-hybrid-provenance-backfill.md
+++ b/changelog.d/1788700000_claude_adr063-t9-legacy-hybrid-provenance-backfill.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **ADR-063 T9's "legacy-hybrid backfill blocker" is closed.** Seven case-(a)
+  facts (`RecordType.deprecated`, `EnumType.deprecated`/`is_scoped`,
+  `Function.deprecated`, `Variable.deprecated`, `TypeField.deprecated`/
+  `default`) are gated at compare time by `AbiSnapshot.fact_provenance`
+  rather than a snapshot-level flag, because a hybrid (`--ast-frontend
+  hybrid`) merge's two backends can disagree on which of them actually
+  populated any one declaration's fact. `clang_deprecation_facts_reliable`
+  reads `True` unconditionally for a hybrid producer, so loading a document
+  that predates this fact family's own schema version previously
+  reconstructed every one of these facts as a confirmed `PRESENT` —
+  including for a declaration neither backend's merge ever actually
+  recorded looking at, since the legacy JSON format always serializes some
+  value. `storage/fact_backfill.py`'s legacy-load correction now consults
+  the document's own per-declaration `fact_provenance` map on a hybrid
+  document, downgrading a declaration with no recorded provenance entry to
+  `NOT_COLLECTED` (namespace-qualified key first, falling back to a legacy
+  bare key only when unambiguous) while leaving a real, non-resting legacy
+  value untouched either way.

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1854,7 +1854,7 @@ track, the steps are ordered.
 | **T6 — Effective gate/policy convergence** ✅ *(landed 2026-09-05; the shared fold and the derived scheme are done, the two runtime shapes remain P0's own job)* | Collapse `apply_release_gate_pack`'s raw-string mirror of `pack_application.apply_to_compare_config` onto one shared fold **without inverting the dependency direction** — `policy/release_gate_options.py` deliberately consumes a `_GatePackApplication` `Protocol` rather than importing the flat-root `pack_application`, since `policy` may not import it (ADR-061; `policy/AGENTS.md`'s "Permitted imports"), so the shared fold belongs in an inward module both may import, or an outer layer invokes both halves — never a `policy → legacy root` call. Also make `GateOptions.exit_code_scheme` derived rather than independently constructible | `policy/release_gate_options.py`, `pack_application.py`, a new inward fold owner, `tests/test_release_gate_pack_fold_parity.py` | nothing |
 | **T7 — Canonical export index** | One raw export index plus named projections (versioned ELF / default versions / Mach-O normalization / named PE / ordinal imports / missing-vs-empty); delete the five sibling implementations | `policy/depth_projection.py`, `buildsource/crosscheck_base.py`, `buildsource/snapshot_exports.py`, `post_manifest.py`, `diff_unnamed_types.py` | nothing |
 | **T8 — Action boundary** | Remove the residual raw-exit/stderr verdict reconstruction; keep only a transport-level no-result fallback; keep `fail-on-*` as step policy that never rewrites the verdict | `action/run.sh`, `action/` tests | nothing |
-| **T9 — Fact provenance and scope** (first slice landed 2026-09-05 — see note below the table) | Extend the fact model with observation-vs-inference, producer/scope, and positive-observation-vs-completeness; fix the PDB `vtable` and legacy-hybrid backfill blockers at the model/import boundary; add shared analysis accounting for declined comparisons | `model/fact*.py`, `diff_types_vtable.py`, `diff_cxx_rules.py`, the import adapter | ~~T2~~ — satisfied (T2 landed 2026-09-05, so the ladder and `investigated_declined` are available to record this work's status); otherwise independent |
+| **T9 — Fact provenance and scope** (first and second slices landed 2026-09-05 — see notes below the table) | Extend the fact model with observation-vs-inference, producer/scope, and positive-observation-vs-completeness; fix the PDB `vtable` and legacy-hybrid backfill blockers at the model/import boundary; add shared analysis accounting for declined comparisons | `model/fact*.py`, `diff_types_vtable.py`, `diff_cxx_rules.py`, `storage/fact_backfill.py`, the import adapter | ~~T2~~ — satisfied (T2 landed 2026-09-05, so the ladder and `investigated_declined` are available to record this work's status); otherwise independent |
 | **T10 — Shared report preparation** | Compute evaluated findings/outcomes once ahead of format-specific construction; remove **both** runtime cycle escape hatches, which are distinct sites with distinct fixes: `render_markdown_document._reporter_markdown()`'s `..reporter_markdown` load (the Markdown cycle) and `report/scoped_gate.py`'s `..reporter` load (scoped-JSON construction, whose cycle exists only because `apply_scoped_gate` mutates an already-built payload); give consumer scoping an explicit finalization boundary instead of mutating shared changes | `report/render_markdown_document.py`, `report/render_markdown_alternate.py`, `report/scoped_gate.py`, `reporter_markdown.py`, `appcompat.py`'s `scope_diff_to_app` | T5's appcompat half for the scoping item |
 
 **T4 status note (2026-09-05, stated precisely rather than as a blanket
@@ -1914,14 +1914,51 @@ genuinely `PRESENT`, for a class whose virtuals live in a TU only the
 `producer`/`UNSUPPORTED` cannot express this, since DWARF genuinely can
 capture the family; the gap is per-TU *scope*, which is the
 observed-vs-inferred / positive-observation-vs-completeness half of this
-item's own stated scope, still unimplemented. Also untouched: the
-legacy-hybrid backfill blocker holding the seven `fact_provenance`-gated
-case-(a) fields (5B's own fourth-through-seventh-slice finding), and the
-shared analysis accounting for declined comparisons (`observed changes` /
+item's own stated scope, still unimplemented. Also untouched: the shared
+analysis accounting for declined comparisons (`observed changes` /
 `evaluated requirements` / `unresolved requirements` / `unsupported
 requirements`) this item's own text calls for. Each remains real,
 scoped, separately-actionable work — recorded here rather than implied
 closed by the row above.
+
+**T9's second slice (2026-09-05): the legacy-hybrid backfill blocker is
+closed too.** `storage/fact_backfill.py`'s `CaseAFactRule` gained a fifth,
+optional field, `fact_provenance_kind` (`"type"`/`"enum"`/`"field"`/
+`"func"`/`"var"`) — additive, defaulting to `None`, so every pre-existing
+rule and call site is unaffected. Set on the seven rules the "legacy-hybrid
+backfill blocker" note above named (`RecordType.deprecated`,
+`EnumType.deprecated`/`is_scoped`, `Function.deprecated`,
+`Variable.deprecated`, `TypeField.deprecated`/`default`), it makes
+`apply_case_a_fact_backfill` consult the document's own per-declaration
+`AbiSnapshot.fact_provenance` map — passed through from `serialization.py`'s
+existing `d.get("fact_provenance", {})` — whenever the document's
+`ast_producer` is exactly `"hybrid"`: a declaration with no recorded
+provenance entry (probed namespace-qualified first, falling back to the
+former bare key only when this document's own side has no other declaration
+sharing that bare name — the same shape `fact_provenance.
+resolved_fact_producer` already applies at compare time) downgrades the
+claim to `NOT_COLLECTED`, following the module's own pre-existing
+"downgrade the claim, never the value" rule (a real non-resting legacy
+value is left untouched either way). This is exactly the correction the
+5B investigation described as blocked: `clang_deprecation_facts_reliable`
+reads `True` unconditionally for a hybrid producer, so only a real
+per-declaration provenance lookup — not that flag — can tell "neither
+backend's merge ever recorded looking here" apart from "confirmed,
+genuinely resting-default" on a document predating this fact family's own
+schema version. Verified against the full fast unit suite (no regressions,
+including the exact end-to-end scenario the original investigation's
+attempted fix broke,
+`test_dumper_hybrid.py::TestNamespaceQualifiedMerging::
+test_legacy_bare_keyed_hybrid_baseline_still_detects_transition` — which,
+on inspection, never exercises this JSON-load-time code path at all, since
+it constructs its snapshot in-memory rather than through
+`snapshot_from_dict`) plus a new, dedicated test class,
+`tests/test_deprecation_family_facts.py::TestLegacyHybridProvenanceBackfill`,
+covering the qualified-key, bare-key-fallback (both unambiguous and
+ambiguous), mangled-name-keyed, value-preserving, and non-hybrid-producer-
+unaffected shapes directly. Still open, unchanged by this slice: the DWARF
+per-TU completeness gap and the shared declined-comparison accounting
+named above.
 
 ## Acceptance tests
 

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -1068,6 +1068,44 @@ BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="storage.legacy_availability_collapse",
+        invariant=(
+            "A legacy document's per-declaration fact must never be read "
+            "as a confirmed, positively-observed value on the strength of "
+            "a whole-snapshot/producer-level reliability flag alone when a "
+            "finer-grained availability signal already recorded on that "
+            "same document (e.g. per-declaration provenance) is silent "
+            "about that exact declaration -- the coarser signal may "
+            "confirm, but may never override, the absence the finer one "
+            "reports."
+        ),
+        fixed_by=(1091,),
+        seed_tests=("tests/test_deprecation_family_facts.py",),
+        axes={"ast_producer": ("hybrid", "castxml")},
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Closes the gap only for the seven fields gated by "
+                    "`AbiSnapshot.fact_provenance` (the legacy-hybrid "
+                    "backfill blocker, ADR-063 T9 / duplication-and-"
+                    "convergence-assessment Phase 6 item 4). The sibling "
+                    "gap for DWARF's own per-translation-unit vtable "
+                    "coverage (`RecordType.vtable_fact` reading a genuine "
+                    "`PRESENT` for a class whose virtuals live in a TU "
+                    "only the other side's debug info covers) is a "
+                    "different evidentiary shape -- no per-declaration "
+                    "signal exists to consult at all, DWARF's own extractor "
+                    "cannot see the gap either -- and remains open, "
+                    "tracked in that same plan document rather than here."
+                ),
+                reference=(
+                    "docs/contribute/plans/"
+                    "duplication-and-convergence-assessment.md -- T9"
+                ),
+            ),
+        ),
+    ),
 )
 
 

--- a/tests/test_deprecation_family_facts.py
+++ b/tests/test_deprecation_family_facts.py
@@ -41,7 +41,10 @@ from abicheck.model import (
     Variable,
 )
 from abicheck.serialization import SCHEMA_VERSION, snapshot_from_dict, snapshot_to_dict
-from abicheck.storage.fact_codec import _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS
+from abicheck.storage.fact_codec import (
+    _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS,
+    _MIN_SCHEMA_VERSION_FOR_TYPEFIELD_VALUE_FACTS,
+)
 
 _LEGACY = _MIN_SCHEMA_VERSION_FOR_DEPRECATION_FACTS - 1
 
@@ -198,6 +201,246 @@ class TestDeprecatedFamilyRoundTrip:
         )
         f = snapshot_from_dict(d).types[0].fields[0]
         assert f.deprecated_fact.status is FactStatus.NOT_COLLECTED
+
+
+#: A well-formed ``qualified_name_fact``/``enum``-sibling encoding -- needed
+#: whenever a fixture below sets a real ``qualified_name`` differing from its
+#: bare ``name`` at ``_LEGACY`` (which already sits above both
+#: ``RecordType``/``EnumType``'s own case-(b) qualified-name schema
+#: thresholds): without it, the missing sibling key reads as a
+#: malformed/hand-authored document (`decode_fact`'s own documented
+#: contract) and the explicit ``Fact.not_collected()`` that produces
+#: overwrites the legacy ``qualified_name`` value back to ``None`` --
+#: unrelated to, and a confound for, the mechanism these tests target.
+def _present(value: object) -> dict[str, object]:
+    return {"status": "present", "value": value}
+
+
+class TestLegacyHybridProvenanceBackfill:
+    """T9 / ADR-063 Phase 6 item 4 ("legacy-hybrid backfill blocker").
+
+    ``clang_deprecation_facts_reliable`` reads True unconditionally for a
+    hybrid producer (an ordinary, fresh hybrid dump states this fact
+    explicitly per declaration, so the flag has no reason to distrust it),
+    so on a document that predates this fact family's own schema version the
+    whole-snapshot ``reliable``/``evidenced`` checks both pass regardless —
+    only a real per-declaration ``fact_provenance`` lookup can tell "neither
+    backend's merge ever recorded looking here" apart from "confirmed,
+    genuinely resting-default". See ``storage/fact_backfill.py``'s own
+    module docstring for the full account.
+
+    Every fixture spells its ambiguous fact as an EXPLICIT resting value
+    (``"deprecated": None``), never an omitted key: an omitted legacy key is
+    a *different*, already-covered shape (`decode_fact_with_legacy_presence`
+    resolves it to ``Fact.not_collected()`` outright, before this module's
+    correction pass ever runs) -- the shape this module's own docstring
+    describes is the legacy JSON format's inability to omit a value at all.
+    """
+
+    def test_confirmed_by_qualified_provenance_key_stays_present(self) -> None:
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                }
+            ],
+            fact_provenance={"type:ns::Foo:deprecated": "castxml"},
+        )
+        rec = snapshot_from_dict(d).types[0]
+        assert rec.deprecated_fact.status is FactStatus.PRESENT
+
+    def test_no_provenance_entry_downgrades_a_resting_default(self) -> None:
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                }
+            ],
+            fact_provenance={},
+        )
+        rec = snapshot_from_dict(d).types[0]
+        assert rec.deprecated is None
+        assert rec.deprecated_fact.status is FactStatus.NOT_COLLECTED
+
+    def test_no_provenance_entry_preserves_a_real_non_default_value(self) -> None:
+        # "Downgrade the claim, never the value" -- a document carrying a
+        # non-resting value for this field got it from somewhere this
+        # correction doesn't model, and discarding it would lose real data.
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": "use Bar",
+                }
+            ],
+            fact_provenance={},
+        )
+        rec = snapshot_from_dict(d).types[0]
+        assert rec.deprecated == "use Bar"
+        assert rec.deprecated_fact.status is FactStatus.PRESENT
+
+    def test_bare_key_fallback_when_unambiguous(self) -> None:
+        # A hybrid baseline persisted before the provenance-key
+        # qualification fix has real provenance recorded under the former
+        # bare key alone -- must still resolve, not read as unconfirmed.
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                }
+            ],
+            fact_provenance={"type:Foo:deprecated": "castxml"},
+        )
+        rec = snapshot_from_dict(d).types[0]
+        assert rec.deprecated_fact.status is FactStatus.PRESENT
+
+    def test_bare_key_fallback_declined_when_ambiguous(self) -> None:
+        # Two distinct qualified types share the bare name "Foo" -- the
+        # bare-keyed provenance entry cannot be safely attributed to either
+        # one, so neither may fall back to it.
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                },
+                {
+                    "name": "Foo",
+                    "qualified_name": "other::Foo",
+                    "qualified_name_fact": _present("other::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                },
+            ],
+            fact_provenance={"type:Foo:deprecated": "castxml"},
+        )
+        recs = snapshot_from_dict(d).types
+        assert {r.deprecated_fact.status for r in recs} == {FactStatus.NOT_COLLECTED}
+
+    def test_typefield_deprecated_uses_owning_type_provenance_key(self) -> None:
+        # TypeField.deprecated converted one batch earlier (v39) than the
+        # other six fields in this table (v40) -- needs its OWN, one-lower
+        # legacy threshold to actually reach the backfill rule at all
+        # (schema_version == 39 is already >= TypeField's own min_schema_
+        # version, so at 39 this rule's own decode-time
+        # `decode_fact_with_legacy_presence` resolves it directly, never
+        # reaching this correction pass -- see
+        # `test_typefield_deprecated_answers_to_the_same_flag` above for
+        # that already-covered, ordinary v39 shape).
+        d = _minimal_dict(
+            schema_version=_MIN_SCHEMA_VERSION_FOR_TYPEFIELD_VALUE_FACTS - 1,
+            ast_producer="hybrid",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "fields": [{"name": "m", "type": "int", "deprecated": None}],
+                }
+            ],
+            fact_provenance={"type:ns::Foo:field:m:deprecated": "clang"},
+        )
+        field = snapshot_from_dict(d).types[0].fields[0]
+        assert field.deprecated_fact.status is FactStatus.PRESENT
+
+    def test_function_and_variable_use_mangled_name_key(self) -> None:
+        # Mangled names are already unique -- no bare/qualified split, and
+        # no provenance entry at all means neither backend ever looked.
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            functions=[
+                {
+                    "name": "f",
+                    "mangled": "_Z1fv",
+                    "return_type": "void",
+                    "deprecated": None,
+                }
+            ],
+            variables=[
+                {"name": "g", "mangled": "g", "type": "int", "deprecated": None}
+            ],
+            fact_provenance={},
+        )
+        snap = snapshot_from_dict(d)
+        assert snap.functions[0].deprecated_fact.status is FactStatus.NOT_COLLECTED
+        assert snap.variables[0].deprecated_fact.status is FactStatus.NOT_COLLECTED
+
+    def test_enum_is_scoped_uses_the_enum_provenance_key(self) -> None:
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="hybrid",
+            from_headers=True,
+            enums=[
+                {
+                    "name": "Color",
+                    "qualified_name": "ns::Color",
+                    "qualified_name_fact": _present("ns::Color"),
+                    "is_scoped": False,
+                }
+            ],
+            fact_provenance={"enum:ns::Color:is_scoped": "clang"},
+        )
+        e = snapshot_from_dict(d).enums[0]
+        assert e.is_scoped_fact.status is FactStatus.PRESENT
+
+    def test_non_hybrid_producer_is_unaffected(self) -> None:
+        # The provenance check only ever applies to ast_producer == "hybrid"
+        # -- a plain clang/castxml legacy document keeps its pre-existing
+        # (unrelated) reliability-flag-only behavior exactly.
+        d = _minimal_dict(
+            schema_version=_LEGACY,
+            ast_producer="castxml",
+            from_headers=True,
+            types=[
+                {
+                    "name": "Foo",
+                    "qualified_name": "ns::Foo",
+                    "qualified_name_fact": _present("ns::Foo"),
+                    "kind": "class",
+                    "deprecated": None,
+                }
+            ],
+            fact_provenance={},
+        )
+        rec = snapshot_from_dict(d).types[0]
+        assert rec.deprecated_fact.status is FactStatus.PRESENT
 
 
 class TestEnumIsScopedFact:


### PR DESCRIPTION
## Summary

ADR-063 T9 ("Fact provenance and scope") landed its first slice on
2026-09-05 (`Fact[T]` gained a `producer` field, closing the PDB `vtable`
fabrication). This PR closes the item's second named blocker: **the
legacy-hybrid backfill blocker** holding seven `fact_provenance`-gated
case-(a) fields (`RecordType.deprecated`, `EnumType.deprecated`/`is_scoped`,
`Function.deprecated`, `Variable.deprecated`, `TypeField.deprecated`/
`default`).

### The bug

These seven fields are gated at compare time by
`AbiSnapshot.fact_provenance` (a per-declaration map) rather than a
snapshot-level flag, because a `--ast-frontend hybrid` merge's two backends
can disagree on which of them actually populated any one declaration's
fact. `clang_deprecation_facts_reliable` reads `True` unconditionally for a
hybrid producer (an ordinary, fresh hybrid dump states these facts
explicitly per declaration, so the flag has no reason to distrust it) — so
loading a document that predates this fact family's own schema version
previously reconstructed every one of these facts as a confirmed `PRESENT`,
including for a declaration neither backend's merge ever actually recorded
looking at, since the legacy JSON format always serializes some value
(there is no "omitted" concept once a dict round-trips through a dataclass
constructor).

### The fix

`storage/fact_backfill.py`'s legacy-load correction (`CaseAFactRule`)
gains a fifth, optional field, `fact_provenance_kind` — additive and
`None` by default, so every pre-existing rule and call site is
unaffected. Set on the seven affected rules, it makes
`apply_case_a_fact_backfill` consult the document's own per-declaration
`fact_provenance` map whenever `ast_producer == "hybrid"`: a declaration
with no recorded provenance entry (probed namespace-qualified first,
falling back to the former bare key only when this document's own side has
no other declaration sharing that bare name — the same shape
`fact_provenance.resolved_fact_producer` already applies at compare time)
downgrades the claim to `NOT_COLLECTED`, following the module's
pre-existing "downgrade the claim, never the value" convention (a real
non-resting legacy value is left untouched either way).

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `storage.legacy_availability_collapse` (new entry added to `tests/regressions/manifest.py`, since no existing class matched this shape — a legacy document's per-declaration fact must never be read as a confirmed, positively-observed value on a whole-snapshot reliability flag alone when a finer-grained availability signal recorded on that same document is silent about that exact declaration).
- Publicly observable failure: Loading a `--ast-frontend hybrid` snapshot from a pre-v40 (or pre-v39 for `TypeField`) JSON document reports `deprecated`/`is_scoped`/`default` as a confirmed `PRESENT` fact (e.g. "confirmed not deprecated") for a declaration neither backend's merge ever recorded looking at, so a `compare` run can silently treat an unconfirmed absence as a real observation instead of `NOT_COLLECTED`.
- Regression test fails on base: Yes — `tests/test_deprecation_family_facts.py::TestLegacyHybridProvenanceBackfill::test_no_provenance_entry_downgrades_a_resting_default` and its `RecordType`/`EnumType`/`Function`/`Variable`/`TypeField` siblings assert `NOT_COLLECTED`; on `main` (pre-fix) `CaseAFactRule` has no `fact_provenance_kind`, and `clang_deprecation_facts_reliable`/`clang_field_initializer_facts_reliable` read `True` unconditionally for a hybrid producer, so every one of these resolves to `PRESENT` instead.
- Negative control: `test_confirmed_by_qualified_provenance_key_stays_present`, `test_bare_key_fallback_when_unambiguous`, `test_no_provenance_entry_preserves_a_real_non_default_value`, and `test_non_hybrid_producer_is_unaffected` assert the fact stays `PRESENT` (or the real legacy value is preserved) whenever provenance genuinely confirms it, the producer isn't hybrid, or the value is a real non-resting one — the fix narrows exactly the ambiguous case, not the whole fact family.
- Public-surface test: Every new test goes through `abicheck.serialization.snapshot_from_dict` — the real, public JSON-load chokepoint every CLI/typed-API caller uses to read a stored/cached snapshot — not a hand-rolled shortcut directly into `apply_case_a_fact_backfill`/`_hybrid_provenance_confirms`.
- Axes covered: `ast_producer` (hybrid vs. castxml/clang single-backend); owner kind (`RecordType`/`EnumType`/`TypeField`/`Function`/`Variable`); provenance-key shape (namespace-qualified, bare-fallback unambiguous, bare-fallback declined-as-ambiguous, mangled-name-keyed).
- General invariant: `storage.legacy_availability_collapse` (`tests/regressions/manifest.py`) — backed by `TestLegacyHybridProvenanceBackfill`'s independently-chosen sibling cases across all five owner kinds plus all four provenance-key shapes, checked against the qualified-then-bare-with-ambiguity-guard shape `fact_provenance.resolved_fact_producer` already applies at compare time as the oracle (this fix's lookup logic mirrors that algorithm independently rather than calling it, since `storage/` may not import the flat-root `fact_provenance.py`).

Real-dependency test: every new test drives the real `snapshot_from_dict` JSON-decode chokepoint (the format boundary this fix corrects) end to end — building a raw legacy-shaped dict and reading it back through the actual decoder, not a hand-constructed shortcut into the correction function directly — the same pattern this file's own pre-existing `TestDeprecatedFamilyRoundTrip`/`TestEnumIsScopedFact` classes use.

## Testing

- New test class: `tests/test_deprecation_family_facts.py::TestLegacyHybridProvenanceBackfill`
  — covers the qualified-key, bare-key-fallback (unambiguous and
  ambiguous), mangled-name-keyed, value-preserving, and
  non-hybrid-producer-unaffected shapes.
- New bug-class registry entry: `tests/regressions/manifest.py`'s
  `storage.legacy_availability_collapse`.
- `ruff check`, `ruff format --check`, `mypy abicheck/`: clean.
- `python scripts/check_architecture.py`: 0 errors.
- `python scripts/check_ai_readiness.py`: no new errors (4 pre-existing,
  unrelated ADR-verification-receipt errors, confirmed present at the
  PR's base commit too).
- `python scripts/check_fp_rate.py`: 0 FP / 0 FN, unchanged.
- `python scripts/check_tier_accuracy.py`: unchanged.
- Verified the original investigation's own regression scenario still
  passes: `tests/test_dumper_hybrid.py::TestNamespaceQualifiedMerging::test_legacy_bare_keyed_hybrid_baseline_still_detects_transition`
  (which, on inspection, never exercises this JSON-load-time code path at
  all, since it constructs its snapshot in-memory rather than through
  `snapshot_from_dict`).
- Full fast unit-test suite (`pytest tests/ -m "not integration and not
  libabigail and not abicc and not slow and not golden"`): 39741 passed, 4
  failed. Confirmed all 4 failures pre-exist at this PR's base commit
  (`d1a486bb`), unrelated to this diff — `test_action_run_sh_baseline_set_fallback.py`,
  `test_ai_readiness.py::test_adr_status_sync_holds`/`test_main_returns_zero_on_clean_tree`
  (the same pre-existing ADR-verification-receipt issue noted above), and
  `test_verify_profiles.py::test_isolated_module_runner_preserves_user_site_without_root_shadowing`
  (an environment/venv isolation issue in this sandbox).

## Documentation

Records this slice in
`docs/contribute/plans/duplication-and-convergence-assessment.md`'s T9
tracking row/note, and adds a `changelog.d/` fragment.

Still open, unchanged by this PR: the DWARF per-translation-unit
completeness gap (needs new evidence infrastructure the model doesn't
carry yet) and the shared analysis accounting for declined comparisons —
both recorded as T9's remaining scope in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV4ZWN7nVotQukVwtURg8S


---
_Generated by [Claude Code](https://claude.ai/code/session_01PV4ZWN7nVotQukVwtURg8S)_