### PR TITLE
refactor: close ADR-063 Track T4 (backend selection/fallback split + source-only dump execution)

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import shutil as shutil  # noqa: F401  # legacy test patch target
 import subprocess
 import tempfile
@@ -162,39 +161,16 @@ from .extract.export_symbol_identity import (
     itanium_export_variable as _itanium_export_variable,
     msvc_export_function as _msvc_export_function,
 )
+from .extract.header_ast_backend import (
+    HEADER_BACKENDS as HEADER_BACKENDS,
+    _resolve_effective_ast_backend as _resolve_effective_ast_backend,
+    _resolve_header_backend as _resolve_header_backend,
+    _resolve_single_ast_backend as _resolve_single_ast_backend,
+)
 from .extract.header_ast_fields import parse_header_ast_fields
 from .model import AbiSnapshot, RecordType
 
 log = logging.getLogger(__name__)
-
-
-# L2 producers; hybrid is explicit because it runs both tools (~2x cost).
-HEADER_BACKENDS = ("auto", "castxml", "clang", "hybrid")
-
-
-def _resolve_header_backend(backend: str | None) -> str:
-    """Resolve an L2 header-AST frontend request to a concrete ``castxml``/
-    ``clang``/``hybrid``.
-
-    Precedence: an explicit ``castxml``/``clang``/``hybrid`` is honored
-    verbatim (and the caller gets a clear error later if a needed tool is
-    missing). ``auto``/``None`` consults the ``ABICHECK_AST_FRONTEND`` env
-    var first, then resolves to castxml (the schema reference). Never
-    auto-falls-back to clang, and never auto-resolves to ``hybrid``: clang
-    JSON AST snapshots lack computed layout, and running both backends
-    unasked would silently double dump cost (see ``dumper_hybrid.py``).
-    """
-    choice = (backend or "auto").lower()
-    if choice in ("castxml", "clang", "hybrid"):
-        return choice
-    if choice != "auto":
-        raise ValidationError(
-            f"Unknown AST frontend {backend!r}; expected one of {HEADER_BACKENDS}."
-        )
-    env = os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower()
-    if env in ("castxml", "clang", "hybrid"):
-        return env
-    return "castxml"
 
 
 def _resolve_clang_langmode(
@@ -470,41 +446,6 @@ def _clang_header_dump(
             _p.unlink(missing_ok=True)
 
 
-def _resolve_single_ast_backend(backend: str, frontend_context: str) -> str:
-    """Resolve *backend* to the one L2 frontend that will actually run.
-
-    Rejects the two requests no single parser can satisfy: ``"hybrid"`` (which
-    only :func:`abicheck.dumper_hybrid.run_hybrid_dump` can resolve) and a
-    non-``"host"`` *frontend_context* under a deliberately-chosen castxml, which
-    has no SYCL/DPC++ host/device context concept. Split out of
-    :func:`_header_ast_parser` so that function reads as the three-way backend
-    dispatch it is.
-    """
-    resolved = _resolve_header_backend(backend)
-    if resolved == "hybrid":
-        # No single parser exists for "hybrid" — must be resolved by
-        # dumper_hybrid.run_hybrid_dump, not silently treated as castxml.
-        raise ValidationError(
-            '"hybrid" AST frontend has no single parser here '
-            "(see dumper_hybrid.run_hybrid_dump)."
-        )
-    # `resolved` alone can't tell explicit/env-pinned/defaulted castxml apart; an env pin counts as explicit (environment.md: "honoured verbatim").
-    _env_pinned_castxml = (backend or "auto").lower() == "auto" and (
-        os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower() == "castxml"
-    )
-    if (
-        resolved == "castxml"
-        and frontend_context != "host"
-        and ((backend or "auto").lower() == "castxml" or _env_pinned_castxml)
-    ):
-        raise AstContextMissingError(
-            f"--frontend-context {frontend_context!r} requires the clang "
-            "header backend (--ast-frontend clang); castxml has no SYCL/"
-            "DPC++ host/device context concept."
-        )
-    return resolved
-
-
 def _castxml_fallback_reason(
     exc: SnapshotError,
     *,
@@ -606,7 +547,12 @@ def _header_ast_parser(
     fails immediately rather than silently returning an ordinary castxml
     dump; under ``"auto"`` a non-``"host"`` request skips castxml entirely.
     """
-    resolved = _resolve_single_ast_backend(backend, frontend_context)
+    # `_resolve_effective_ast_backend` both validates (raising for a request
+    # no single parser can satisfy) and predicts the dispatch below in one
+    # call — the same "selection" function `resolve_dump_request` now calls
+    # for its own reporting-only preview, so the two can never disagree
+    # about what this function is about to do.
+    effective = _resolve_effective_ast_backend(backend, frontend_context)
 
     def _stamp_parser(
         parser: _CastxmlParser | _ClangAstParser,
@@ -676,7 +622,7 @@ def _header_ast_parser(
         setattr(stamped, "_abicheck_frontend_context_kind", resolved_kind)
         return stamped
 
-    if resolved == "clang" or frontend_context != "host":
+    if effective == "clang":
         return _run_clang()
 
     # Auto mode may use the explicit opt-in fallback for known toolchain or

--- a/abicheck/extract/header_ast_backend.py
+++ b/abicheck/extract/header_ast_backend.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""L2 header-AST backend **selection** -- deciding which castxml/clang/hybrid
+frontend a request nominally resolves to, before any tool ever runs.
+
+ADR-063 Track T4 ("Dump request contract"), item 1's first still-open
+clause: splitting backend *selection* from *fallback policy*. Selection
+answers "which backend does this request nominally resolve to" and is pure
+-- no subprocess, no filesystem, no attempt at running anything. Fallback
+policy (:func:`abicheck.dumper._castxml_fallback_reason`) is the opposite:
+it is only discoverable by actually attempting castxml and observing a
+specific failure signature, and stays in :mod:`abicheck.dumper` where the
+attempt itself happens.
+
+Before this split, :func:`abicheck.dumper._header_ast_parser` computed its
+own dispatch inline, and
+:func:`abicheck.service_dump_pipeline.resolve_dump_request` independently
+re-derived the identical prediction a second time for its own
+reporting-only ``effective_header_backend`` field -- duplicating both the
+override-precedence rule and the "any non-host context forces clang" rule.
+Two Codex-review-caught regressions in that exact spot (a missing
+case-insensitivity check, and conflating an explicit pinned castxml with an
+auto request) are why :func:`_resolve_effective_ast_backend`'s own
+docstring is as precise as it is about what it delegates to.
+
+Lives here (a real ADR-061 ``extract`` responsibility-package module, not a
+flat ``abicheck/dumper_*.py`` sibling) because ``architecture/modules.yaml``'s
+``frozen_root_families`` closes that flat namespace to new members and
+:mod:`abicheck.dumper`/:mod:`abicheck.dumper_toolchain` were both already
+at their own no-growth debt-ledger line-count baseline with no room for a
+new function. Both re-export every name here
+(``abicheck.dumper._resolve_header_backend`` and siblings keep resolving
+unchanged) via the same explicit ``X as X`` re-export
+:mod:`abicheck.dumper` already uses for its other split-out sibling
+modules, so every existing call site, monkeypatch target, and cross-module
+``from .dumper import _resolve_header_backend`` import is unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..errors import AstContextMissingError, ValidationError
+
+__all__ = [
+    "HEADER_BACKENDS",
+    "_resolve_effective_ast_backend",
+    "_resolve_header_backend",
+    "_resolve_single_ast_backend",
+]
+
+# L2 producers; hybrid is explicit because it runs both tools (~2x cost).
+HEADER_BACKENDS = ("auto", "castxml", "clang", "hybrid")
+
+
+def _resolve_header_backend(backend: str | None) -> str:
+    """Resolve an L2 header-AST frontend request to a concrete ``castxml``/
+    ``clang``/``hybrid``.
+
+    Precedence: an explicit ``castxml``/``clang``/``hybrid`` is honored
+    verbatim (and the caller gets a clear error later if a needed tool is
+    missing). ``auto``/``None`` consults the ``ABICHECK_AST_FRONTEND`` env
+    var first, then resolves to castxml (the schema reference). Never
+    auto-falls-back to clang, and never auto-resolves to ``hybrid``: clang
+    JSON AST snapshots lack computed layout, and running both backends
+    unasked would silently double dump cost (see ``dumper_hybrid.py``).
+    """
+    choice = (backend or "auto").lower()
+    if choice in ("castxml", "clang", "hybrid"):
+        return choice
+    if choice != "auto":
+        raise ValidationError(
+            f"Unknown AST frontend {backend!r}; expected one of {HEADER_BACKENDS}."
+        )
+    env = os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower()
+    if env in ("castxml", "clang", "hybrid"):
+        return env
+    return "castxml"
+
+
+def _resolve_single_ast_backend(backend: str, frontend_context: str) -> str:
+    """Resolve *backend* to the one L2 frontend that will actually run.
+
+    Rejects the two requests no single parser can satisfy: ``"hybrid"``
+    (which only :func:`abicheck.dumper_hybrid.run_hybrid_dump` can resolve)
+    and a non-``"host"`` *frontend_context* under a deliberately-chosen
+    castxml, which has no SYCL/DPC++ host/device context concept. Split out
+    of :func:`abicheck.dumper._header_ast_parser` so that function reads as
+    the three-way backend dispatch it is.
+    """
+    resolved = _resolve_header_backend(backend)
+    if resolved == "hybrid":
+        # No single parser exists for "hybrid" — must be resolved by
+        # dumper_hybrid.run_hybrid_dump, not silently treated as castxml.
+        raise ValidationError(
+            '"hybrid" AST frontend has no single parser here '
+            "(see dumper_hybrid.run_hybrid_dump)."
+        )
+    # `resolved` alone can't tell explicit/env-pinned/defaulted castxml apart; an env pin counts as explicit (environment.md: "honoured verbatim").
+    _env_pinned_castxml = (backend or "auto").lower() == "auto" and (
+        os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower() == "castxml"
+    )
+    if (
+        resolved == "castxml"
+        and frontend_context != "host"
+        and ((backend or "auto").lower() == "castxml" or _env_pinned_castxml)
+    ):
+        raise AstContextMissingError(
+            f"--frontend-context {frontend_context!r} requires the clang "
+            "header backend (--ast-frontend clang); castxml has no SYCL/"
+            "DPC++ host/device context concept."
+        )
+    return resolved
+
+
+def _resolve_effective_ast_backend(
+    requested_frontend: str, frontend_context: str
+) -> str:
+    """Predict the concrete L2 backend :func:`abicheck.dumper._header_ast_parser`
+    will run, with no execution and no runtime fallback-eligibility consulted.
+
+    This is the "selection" half of backend resolution (see this module's
+    own docstring for the selection/fallback-policy split). Delegates to
+    :func:`_resolve_single_ast_backend` for the actual resolution and its
+    validation (raises for a ``"hybrid"`` request, or an explicit/env-pinned
+    ``castxml`` under a non-``"host"`` context — neither is satisfiable by
+    any single parser, so there is no backend to predict). Then mirrors
+    ``_header_ast_parser``'s own post-resolution dispatch rule exactly:
+    ``if resolved == "clang" or frontend_context != "host": return
+    _run_clang()`` — any surviving non-``"host"`` context always predicts
+    clang, regardless of what `_resolve_single_ast_backend` itself named,
+    because castxml has no SYCL/DPC++ host/device context concept and every
+    code path already reaching this point past the raise above must
+    therefore be clang-bound.
+    """
+    resolved = _resolve_single_ast_backend(requested_frontend, frontend_context)
+    if frontend_context != "host":
+        return "clang"
+    return resolved

--- a/abicheck/service_compare_evidence.py
+++ b/abicheck/service_compare_evidence.py
@@ -63,7 +63,9 @@ __all__ = [
     "dump_collect_mode_for",
     "L4_SOURCE_EXTRACTORS",
     "effective_frontend",
+    "effective_frontend_for_context",
     "explicit_source_extractor",
+    "requested_frontend_override",
     "normalized_debug_format",
     "reject_compile_db_filter_scope_mismatch",
     "reject_debug_format_for_binaries",
@@ -72,6 +74,26 @@ __all__ = [
     "resolve_dump_request_evidence",
     "resolve_side_evidence",
 ]
+
+
+def requested_frontend_override(
+    compile: CompileContext | None, header_backend: str
+) -> str:
+    """The *unresolved* frontend name an explicit `compile.frontend` or the
+    bare `header_backend` default names -- the override-precedence half of
+    :func:`effective_frontend`, split out so a caller that needs the raw
+    request (not yet resolved to a concrete backend) doesn't reimplement
+    this precedence rule a second time. An explicit `compile.frontend` wins
+    over `header_backend` unless it is itself the case-insensitive no-op
+    spelling `"auto"` (`compile.frontend="AUTO"` is an accepted spelling --
+    `frontend_value_errors` validates case-insensitively -- and must mean
+    "no override", not a literal request for whatever `_resolve_header_
+    backend` does with the string `"AUTO"`)."""
+    return (
+        compile.frontend
+        if (compile is not None and compile.frontend.lower() != "auto")
+        else header_backend
+    )
 
 
 def effective_frontend(compile: CompileContext | None, header_backend: str) -> str:
@@ -86,15 +108,51 @@ def effective_frontend(compile: CompileContext | None, header_backend: str) -> s
     "is this actually 'auto'" check itself was still case-sensitive in the
     third -- `compile.frontend="AUTO"` is an accepted spelling
     (`frontend_value_errors` validates case-insensitively) that used to be
-    treated as an *explicit* override instead of the no-op it means)."""
+    treated as an *explicit* override instead of the no-op it means).
+
+    This is the "host" projection only -- it ignores `compile.frontend_
+    context` entirely, which is correct for its own callers (source-ABI
+    replay has no host/device concept) but under-reports the backend a
+    non-"host" `frontend_context` would actually select (dumper.
+    _header_ast_parser routes ANY such context to clang unconditionally).
+    See :func:`effective_frontend_for_context` for the context-aware
+    prediction `service_dump_pipeline.resolve_dump_request` needs."""
     from .dumper import _resolve_header_backend
 
-    requested = (
-        compile.frontend
-        if (compile is not None and compile.frontend.lower() != "auto")
-        else header_backend
-    )
-    return _resolve_header_backend(requested)
+    return _resolve_header_backend(requested_frontend_override(compile, header_backend))
+
+
+def effective_frontend_for_context(
+    compile: CompileContext | None, header_backend: str
+) -> str | None:
+    """Predict the L2 backend a non-``"host"`` `compile.frontend_context`
+    would select, or ``None`` when `compile` is absent, names ``"host"``, or
+    the resulting request is one no single parser could satisfy (e.g. an
+    explicit ``castxml`` under a non-``"host"`` context, or ``"hybrid"``) --
+    a `None` here means the caller should keep whatever host-only value
+    :func:`effective_frontend` already produced, exactly mirroring how
+    `dumper._header_ast_parser` itself would raise rather than silently
+    substitute a different backend for those same requests.
+
+    Delegates the actual selection to `dumper._resolve_effective_ast_
+    backend` -- the one place `_header_ast_parser`'s own dispatch is
+    predicted -- rather than re-deriving that dispatch rule here a second
+    time (the gap this function closes: `resolve_dump_request` used to
+    inline both `requested_frontend_override`'s precedence rule and the
+    context-forces-clang rule directly, so a future change to either could
+    silently diverge between the two functions predicting the same thing)."""
+    if compile is None or compile.frontend_context.lower() == "host":
+        return None
+    from .dumper import _resolve_effective_ast_backend
+    from .errors import AstContextMissingError, ValidationError
+
+    requested = requested_frontend_override(compile, header_backend)
+    try:
+        return _resolve_effective_ast_backend(
+            requested, compile.frontend_context.lower()
+        )
+    except (AstContextMissingError, ValidationError):
+        return None
 
 
 #: The backends an ``--ast-frontend`` request can actually select for L4

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -45,16 +45,22 @@ import cycle.
 from __future__ import annotations
 
 import dataclasses
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from .errors import AstContextMissingError, ValidationError
+from .errors import ValidationError
 from .workflows.artifact import ResolvedArtifactPlan
 from .workflows.artifact.compile_context_gate import side_effective_compile_context
+from .workflows.artifact.dump_execution_options import (
+    DumpExecutionOptions as DumpExecutionOptions,
+    _DumpAssuranceView as _DumpAssuranceView,
+)
+from .workflows.artifact.dump_request import ResolvedDumpRequest as ResolvedDumpRequest
 from .workflows.artifact.execute import (
     _resolve_side_snapshot_impl,
     enforce_requested_depth,
 )
+from .workflows.artifact.execute_source_only import execute_source_only_dump_request
 from .workflows.artifact.resolve import (
     is_raw_source_tree,
     reject_hybrid_source_frontend,
@@ -78,152 +84,6 @@ __all__ = [
     "resolve_dump_request",
     "run_dump_request",
 ]
-
-
-@dataclass(frozen=True)
-class ResolvedDumpRequest:
-    """A :class:`DumpRequest` after resolution, before execution.
-
-    CLI cleanup phase two, PR C / PR 3A (see
-    ``docs/contribute/plans/cli-cleanup-phase-two.md``): the object
-    ``dump --dry-run`` is meant to render, once its rendering path
-    (``cli_dump_helpers.render_dump_dry_run``, currently a hand-written
-    second implementation) is migrated to build from this instead of
-    re-deriving the same facts independently.
-
-    Carries only what :func:`resolve_dump_request` can determine without
-    invoking castxml/clang or writing anything: the normalized language, the
-    requested header-AST backend, the detected binary format, the requested
-    ``depth`` (an input, known up front) and the effective *collect mode*
-    (the build/source evidence level ``depth`` resolves to). Deliberately
-    does **not** carry an *achieved* depth — that can only be read off the
-    completed snapshot (``cli_dump_helpers.fold_dump_provenance_into_dict``
-    derives it via ``_gated_source_label(snap.build_source, snap)``), so a
-    resolve-only object reporting it would have to guess, and a guess that
-    disagrees with the real run defeats the point of rendering ``--dry-run``
-    from a real resolved object (Codex review, fresh evidence). See
-    :class:`DumpResult` for the achieved depth.
-
-    Also deliberately excludes the P0.3 L3→L2 compile-context fold's result:
-    that fold (``buildsource.l2_seed.seed_includes_and_fold_compile_context``)
-    can raise ``HeaderCompileContextAmbiguousError`` on genuinely ambiguous
-    build evidence, and ``--dry-run``'s existing contract
-    (``render_dump_dry_run``'s own docstring) is to never raise on anything
-    but a usage error. Folding it in here would be a real behavior change to
-    that contract, not merely an additive one — it stays inside
-    :func:`execute_dump_request`, unchanged from where :func:`run_dump_request`
-    already runs it today (via :func:`~abicheck.service_input_resolution.resolve_side_snapshot`).
-
-    ``artifact_plan`` (dedup-and-convergence plan, Phase 1 item 1
-    "Milestone B"): the same facts this object already carries, also
-    attached to a :class:`~abicheck.workflows.artifact.ResolvedArtifactPlan`
-    -- the general, cross-consumer shape the plan's target architecture
-    names. Built with an empty ``pending_cleanups`` (this function allocates
-    no resource -- see :mod:`abicheck.workflows.artifact.contracts`'s own
-    module docstring for why the two fields that *would* require one,
-    effective include search and effective compile context, stay excluded
-    here too), so it is
-    additive, inert data today: nothing yet reads it. It exists so a future
-    consumer of the general shape (e.g. a migrated ``render_dump_dry_run``)
-    has one object to build from instead of this dump-specific one, without
-    this dataclass's own field surface changing again when that lands.
-
-    Excluded from this dataclass's generated ``__eq__``/``__hash__``
-    (``compare=False``, Codex review): ``ResolvedArtifactPlan`` is a plain
-    class, not a dataclass, so it compares by identity. Two structurally
-    identical ``DumpRequest``s resolved independently would otherwise
-    produce two ``ResolvedDumpRequest``s that compare unequal purely
-    because each carries its own, distinct ``ResolvedArtifactPlan``
-    instance -- silently breaking equality-based comparison or caching for
-    every existing and future caller of this frozen dataclass, over a field
-    that is itself inert today.
-
-    ``resolved_execution_context`` (One Semantic Pipeline plan, sub-phase 4B
-    -- ``dump``'s own slice of the gap
-    :class:`~abicheck.service_compare_pipeline.ResolvedComparePair`'s
-    identically-named field already closed for ``compare``): the
-    :class:`~abicheck.workflows.resolved_execution_context.
-    ResolvedExecutionContext` built from this same call's own, otherwise-
-    discarded :class:`~abicheck.workflows.plan.AnalysisPlan`
-    (:func:`resolve_dump_request` already calls ``AnalysisPlanner.resolve``
-    for its ADR-063 Phase 4 pre-flight check -- this is not a second
-    resolution). ``operation`` reads ``"dump"`` off the plan; ``evidence``
-    carries only ``requested_depth``/``available_depths`` at this point --
-    the pre-execution view, via :meth:`~abicheck.workflows.
-    resolved_execution_context.ResolvedExecutionContext.from_plan` with no
-    *assurance*. Optional and additive: excluded from ``compare=False`` for
-    the same reason ``artifact_plan`` is -- a fresh, distinct
-    ``ResolvedExecutionContext`` instance must not make two structurally
-    identical resolutions compare unequal. Carries no ``evaluation_config``/
-    ``compile_contexts`` yet, for the identical reason
-    ``ResolvedComparePair.resolved_execution_context`` does not: neither
-    resolves at this seam. See :func:`execute_dump_request` for the
-    post-execution counterpart, attached via
-    :meth:`~abicheck.workflows.resolved_execution_context.
-    ResolvedExecutionContext.with_assurance`.
-    """
-
-    request: DumpRequest
-    lang: str
-    lang_explicit: bool
-    header_backend: str
-    # A *reporting-only* projection of the concrete header-AST backend
-    # resolution currently favors -- what a future `--dry-run` render would
-    # show. `header_backend` alone under-reports this: service.py's own
-    # eff_backend computation gives an explicit `evidence.compile.frontend`
-    # precedence over the bare `header_backend` arg, and resolves "auto" to
-    # a concrete backend either way, so a naive render of `header_backend`
-    # can name a different frontend than what would currently be chosen.
-    #
-    # Deliberately NOT what execute_dump_request passes to execution
-    # (Codex review, two rounds -- the first attempt did pass this value
-    # through, which is a real regression, not a pin: `dumper.
-    # _header_ast_parser`'s own `_auto_ast_fallback_eligible(backend)`
-    # checks whether `backend` is *literally* the string "auto" to decide
-    # whether a CastXML failure may gracefully fall back to Clang, and a
-    # non-"host" `frontend_context` has its own "auto"-specific routing --
-    # pre-resolving "auto" to a concrete choice before it reaches that
-    # function silently strips those behaviors). Execution therefore keeps
-    # passing the bare `header_backend` through unchanged, and this field
-    # is accepted as a best-effort preview that can, in principle, disagree
-    # with what execution ends up doing if the environment changes between
-    # resolve and execute, or if the genuinely-unpinned-"auto" fallback
-    # path fires -- the same class of accepted imprecision every other
-    # resolve-time preview in this object already carries.
-    effective_header_backend: str
-    fmt: str | None
-    debug_format: str | None
-    requested_depth: str | None
-    evidence: SideEvidence
-    public_headers: tuple[Path, ...]
-    public_header_dirs: tuple[Path, ...]
-    artifact_plan: ResolvedArtifactPlan | None = field(default=None, compare=False)
-    resolved_execution_context: ResolvedExecutionContext | None = field(
-        default=None, compare=False
-    )
-    # ADR-063 Track T4 ("Dump request contract"): the `DumpExecutionOptions`
-    # a real execution would pass to `execute_dump_request`, when a caller
-    # has resolved one -- so `dump --dry-run`
-    # (`cli_dump_helpers.render_dump_dry_run`) can show these nine values.
-    # `resolve_dump_request` never populates this itself (`build_config`/
-    # `legacy_compile_db_tokens`/`legacy_compile_db_matched` are CLI-only
-    # values with no `DumpRequest` equivalent); the `dump` CLI attaches its
-    # own via `dataclasses.replace(resolved, execution_options=...)`.
-    # `execute_dump_request` reads this as its default when its own
-    # `options` is `None` -- an explicit `options=` argument still wins.
-    # Comparable like any plain value (unlike `artifact_plan`/
-    # `resolved_execution_context` above, which compare by identity).
-    execution_options: DumpExecutionOptions | None = None
-
-    @property
-    def collect_mode(self) -> str:
-        """The effective build/source evidence level ``depth`` resolved to."""
-        return self.evidence.collect_mode
-
-    @property
-    def headers(self) -> tuple[Path, ...]:
-        """The resolved public-header set (files only; see ``public_header_dirs``)."""
-        return tuple(self.evidence.headers)
 
 
 @dataclass(frozen=True)
@@ -444,38 +304,31 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     # ResolvedDumpRequest.effective_header_backend's own comment).
     effective_header_backend = _sce.effective_frontend(evidence.compile, header_backend)
     # dumper._header_ast_parser routes ANY non-"host" frontend_context to
-    # clang unconditionally (`if resolved == "clang" or frontend_context !=
-    # "host": return _run_clang()`), regardless of what the backend itself
-    # resolved to -- mirror that here so this reporting field doesn't claim
-    # castxml for a request that will always run clang. But an *explicit*
+    # clang unconditionally, regardless of what the backend itself resolved
+    # to -- so the host-only `effective_frontend` above can under-report a
+    # request that will always run clang. But an *explicit*
     # `--ast-frontend castxml` (or an env-pinned one) combined with a
     # non-host context doesn't route to clang at all -- it raises
     # AstContextMissingError at execution, so claiming "clang" there would
     # be equally wrong in the other direction (Codex review, two rounds:
     # the first fix applied the clang override unconditionally, missing
-    # this pinned-castxml case entirely). Reuse dumper's own resolver to
-    # tell the two apart without duplicating its pin/env logic; on the
-    # raising path, leave whatever `_resolve_header_backend` already
-    # produced above -- this best-effort preview never raises.
-    if (
-        evidence.compile is not None
-        and evidence.compile.frontend_context.lower() != "host"
-    ):
-        from .dumper import _resolve_single_ast_backend
-
-        requested = (
-            evidence.compile.frontend
-            if evidence.compile.frontend.lower() != "auto"
-            else header_backend
-        )
-        try:
-            _resolve_single_ast_backend(
-                requested, evidence.compile.frontend_context.lower()
-            )
-        except (AstContextMissingError, ValidationError):
-            pass
-        else:
-            effective_header_backend = "clang"
+    # this pinned-castxml case entirely).
+    #
+    # `effective_frontend_for_context` is the one shared "selection"
+    # function this and `dumper._header_ast_parser` both call for that
+    # prediction (`dumper._resolve_effective_ast_backend`, ADR-063 T4) --
+    # this used to inline the same override-precedence and
+    # context-forces-clang rules a second time, which is exactly the
+    # duplicated reimplementation that made those two Codex-review rounds
+    # necessary in the first place. `None` means "leave `effective_frontend`
+    # above unchanged" -- either the context is "host" (nothing to predict),
+    # or the request is one no single parser could satisfy, and this is a
+    # best-effort preview that must never raise.
+    context_backend = _sce.effective_frontend_for_context(
+        evidence.compile, header_backend
+    )
+    if context_backend is not None:
+        effective_header_backend = context_backend
 
     # `headers` doubles as the public-header set for provenance tagging and
     # must be split into files and directories before tagging (an unsplit
@@ -517,117 +370,6 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     )
 
 
-@dataclass(frozen=True)
-class _DumpAssuranceView:
-    """The minimal shape :meth:`~abicheck.workflows.resolved_execution_context.
-    EvidenceView.from_assurance` reads via ``getattr`` -- ``requested_depth``/
-    ``effective_depth``/``depth_satisfied`` -- built from a completed
-    :class:`DumpResult`'s own facts rather than a real
-    :class:`~abicheck.analysis_assurance.AnalysisAssurance`.
-
-    ``AnalysisAssurance`` is comparison-shaped: pair symmetry (L0/header/DWARF
-    context drift between two sides), target/TU/export accounting, fact-set
-    comparability -- none of it meaningful for a single ``dump`` with no other
-    side to compare against. But the one axis ``AnalysisAssurance`` and a
-    single dump genuinely share -- "did the requested ``--depth`` get
-    reached" -- *is* knowable here, from :func:`execute_dump_request`'s own
-    already-computed ``effective_depth`` (a real post-execution fact, the
-    identical value :class:`DumpResult` itself carries), so this class states
-    exactly that axis rather than leaving :meth:`~abicheck.workflows.
-    resolved_execution_context.ResolvedExecutionContext.with_assurance`
-    fully unwired for ``dump``.
-    """
-
-    requested_depth: str | None
-    effective_depth: str | None
-    depth_satisfied: bool | None
-
-
-@dataclass(frozen=True)
-class DumpExecutionOptions:
-    """The out-of-band execution semantics :func:`execute_dump_request`
-    needs beyond *resolved* itself and *notify*, folded into one typed value
-    -- ADR-063 ``duplication-and-convergence-assessment.md`` Track T4 ("Dump
-    request contract"). Before this, the nine fields below were nine
-    separate keyword parameters on :func:`execute_dump_request`: reaching
-    the same function did not mean a caller stated a coherent, nameable
-    execution plan, only that it happened to pass the same nine positional
-    names. Grouping them is additive, not a new decision point -- every
-    field keeps the exact default :func:`execute_dump_request` already gave
-    it, so ``DumpExecutionOptions()`` (the parameter's own default) is
-    bit-for-bit equivalent to omitting all nine kwargs before this change.
-
-    Since this track's follow-up, an instance is also attachable to the
-    *resolved* request (see :attr:`ResolvedDumpRequest.execution_options`)
-    rather than only assembled fresh at :func:`execute_dump_request`'s own
-    call boundary -- so ``dump --dry-run`` can render what a real run would
-    pass, instead of the ``dump`` CLI threading the nine values through
-    :func:`~abicheck.frontends.cli.dump_execute.execute_dump_cli_run` as
-    separate parameters.
-
-    *build_config*/*build_query*/*build_compile_db*/*changed_paths*/
-    *allow_build_query* (PR 3A, dump/scan resolver convergence): optional
-    pass-throughs to
-    :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`.
-    These exist only for the ELF ``dump`` CLI path's ``--config`` flag --
-    and, for a programmatic caller, its own ``build_query``/
-    ``build_compile_db`` arguments (PR 3C removed the CLI flags of those
-    names; these fields stay because a Python API caller is the operator,
-    exactly as an explicit ``--config`` is) -- to route through this one
-    shared primitive instead of a second, independent call to the same
-    underlying fold.
-
-    *legacy_compile_db_tokens* (ADR-063 Phase 1): the castxml flags the CLI's
-    own legacy ``-p``/``--compile-db`` auto-match
-    (``cli_helpers_compare._resolve_build_context_flags``) already derived,
-    forwarded verbatim to :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`
-    -- see that function's own docstring for the precedence rule (the P0.3
-    fold's own result wins whenever it applies) and
-    ``docs/contribute/known-gaps.md``'s "ADR-063 Phase 1" entry for exactly
-    what this closes and what still doesn't. *legacy_compile_db_matched*
-    (Codex review, fresh evidence) is a separate signal from whether any
-    tokens were actually derived -- see the resolve-layer function's own
-    docstring for why a real match with zero derived flags still must set
-    it. Both are passed by the migrated ``dump`` CLI's real run for either
-    binary format (``frontends.cli.dump_execute.execute_dump_cli_run``) --
-    ADR-063 Phase 1 migrated PE/Mach-O onto this same function after ELF, so
-    ``cli_dump_non_elf.handle_non_elf_dump`` stopped being called from
-    ``dump_cmd`` for either format; ADR-063 Track 1 then deleted it, and
-    ``cli_dump_helpers.perform_elf_dump`` with it, once the only thing left
-    holding either alive was its own unit tests.
-
-    *seed_collect_mode*/*source_frontend_from_folded_context* (Codex review
-    on the initial ELF migration -- two real regressions it introduced):
-    forwarded verbatim to
-    :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`,
-    whose own docstring documents each. Both default to the pre-typed-object
-    behavior (``seed_collect_mode=None`` pins the L2 seed's collect mode to
-    ``"off"``; ``source_frontend_from_folded_context=False`` keeps L4 replay
-    pointed at the pre-fold compiler). The retired ``perform_elf_dump``
-    always forwarded its own resolved ``collect_mode`` to the identical L2
-    seed call (unconditionally running a zero-config inferred build query
-    for a ``--sources`` tree with no compile database) and always
-    reassigned ``gcc_path``/``gcc_prefix``/``effective_gcc_options`` from
-    the L3 fold's context once it applied (so an L4 source replay used the
-    compiler the L3 fold actually matched, not the caller's pre-fold
-    default) -- the migrated ELF run builds
-    ``DumpExecutionOptions(seed_collect_mode=resolved.collect_mode,
-    source_frontend_from_folded_context=True, ...)`` to preserve both,
-    exactly as ``scan``'s own candidate resolution already does for the
-    identical reasons (see that call site's comments).
-    """
-
-    build_config: Path | None = None
-    build_query: str | None = None
-    build_compile_db: str | None = None
-    changed_paths: tuple[str, ...] = ()
-    allow_build_query: bool | None = None
-    legacy_compile_db_tokens: tuple[str, ...] = ()
-    legacy_compile_db_matched: bool = False
-    seed_collect_mode: str | None = None
-    source_frontend_from_folded_context: bool = False
-
-
 def execute_dump_request(
     resolved: ResolvedDumpRequest,
     *,
@@ -654,11 +396,14 @@ def execute_dump_request(
     one, or ``DumpExecutionOptions()`` when neither is set -- every
     pre-existing caller is unaffected.
 
+    A binary-less (``InputSpec.path is None``) *resolved* is dispatched to
+    :func:`~abicheck.workflows.artifact.execute_source_only.
+    execute_source_only_dump_request` instead (ADR-063 Track T4) -- see
+    that function's own docstring.
+
     Raises:
         ValidationError: If *resolved* requests a ``depth`` the resolved
-            snapshot did not reach, or if its input carries no ``path`` (a
-            source-only request — see
-            :func:`~abicheck.cli_buildsource.dump_source_only`).
+            snapshot did not reach.
         SnapshotError: If the input cannot be loaded.
     """
     from .dependency_info import populate_side_dependency_info
@@ -669,22 +414,21 @@ def execute_dump_request(
     request = resolved.request
     side = request.input
     if side.path is None:
-        # PR 3A blocker 5: `InputSpec.path` was widened to `Path | None` so a
-        # source-only dump is *expressible* as a typed request (which is what
-        # lets `dump_cmd` build one `DumpRequest` covering both of its
-        # branches, and lets `--dry-run` resolve one). Executing that shape is
-        # a genuinely different pipeline -- `cli_buildsource.dump_source_only`
-        # collects L3-L5 into an otherwise empty snapshot with no
-        # `resolve_input` call at all -- and routing it through here is its own
-        # slice, not part of making the model able to say it. Fail loudly and
-        # specifically rather than with an `AttributeError` from deep inside
-        # extraction.
-        raise ValidationError(
-            "executing a binary-less (source-only) DumpRequest is not wired "
-            "into execute_dump_request yet -- resolve_dump_request() supports "
-            "it (that is what `dump --dry-run` needs), but producing the "
-            "snapshot is still cli_buildsource.dump_source_only's own "
-            "pipeline. Supply InputSpec.path, or use the `dump` CLI."
+        # A source-only dump (ADR-063 Track T4's own tracked gap, now
+        # closed): a sibling module's function rather than a branch
+        # continuing below, since nearly every remaining line here reads
+        # `side.path` or a value `_resolve_side_snapshot_impl` only
+        # produces from a real artifact -- see that function's own
+        # docstring for why it lives in its own module. It returns a plain
+        # `SourceOnlyDumpOutcome`, not a `DumpResult`, so this is the one
+        # place that constructs the latter for this shape (see that
+        # module's own docstring for why -- avoiding a real import cycle).
+        outcome = execute_source_only_dump_request(resolved, options)
+        return DumpResult(
+            resolved=resolved,
+            snapshot=outcome.snapshot,
+            effective_depth=outcome.effective_depth,
+            resolved_execution_context=outcome.resolved_execution_context,
         )
 
     resolution = _resolve_side_snapshot_impl(
@@ -778,7 +522,7 @@ def execute_dump_request(
         # answers whether `resolution.effective_compile_context` is safe to
         # record, including its own format detection (following a GNU ld
         # linker script to its real target). `side.path` is guaranteed
-        # non-None here -- the `is None` branch above already raised.
+        # non-None here -- the `is None` branch above already returned.
         side_ctx = side_effective_compile_context(
             resolution.effective_compile_context,
             snap,

--- a/abicheck/workflows/artifact/dump_execution_options.py
+++ b/abicheck/workflows/artifact/dump_execution_options.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``execute_dump_request``'s own execution-options value object.
+
+Split out of :mod:`abicheck.service_dump_pipeline` purely to keep that
+module under the architecture gate's 800-line new-file cap once ADR-063
+Track T4's second item (a real source-only dump execution variant) needed
+more room there -- both classes here are plain, dependency-free value
+objects with no reference to :class:`~abicheck.model.AbiSnapshot` or
+anything else that would make ``workflows`` importing them a layering
+problem, so moving them (rather than the execution logic that *constructs*
+:class:`~abicheck.service_dump_pipeline.DumpResult`, which cannot move here
+without ``workflows`` importing back up into the flat ``service_`` family)
+is the safe half of this split. Mirrors the precedent set when
+``service_scan.py`` split ``_descendant_pgids``/``_kill_process_tree`` out
+to ``workflows/scan_subprocess.py`` for the identical reason (see
+``docs/contribute/plans/one-semantic-pipeline.md``'s "Closed in a later
+session" note on that split) -- a genuine one-directional move, since
+neither class here calls back into ``service_dump_pipeline``.
+``service_dump_pipeline.py`` re-exports both names
+(``DumpExecutionOptions as DumpExecutionOptions`` /
+``_DumpAssuranceView as _DumpAssuranceView``) so every existing import site
+and monkeypatch target is unaffected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["DumpExecutionOptions", "_DumpAssuranceView"]
+
+
+@dataclass(frozen=True)
+class _DumpAssuranceView:
+    """The minimal shape :meth:`~abicheck.workflows.resolved_execution_context.
+    EvidenceView.from_assurance` reads via ``getattr`` -- ``requested_depth``/
+    ``effective_depth``/``depth_satisfied`` -- built from a completed
+    :class:`~abicheck.service_dump_pipeline.DumpResult`'s own facts rather
+    than a real :class:`~abicheck.analysis_assurance.AnalysisAssurance`.
+
+    ``AnalysisAssurance`` is comparison-shaped: pair symmetry (L0/header/DWARF
+    context drift between two sides), target/TU/export accounting, fact-set
+    comparability -- none of it meaningful for a single ``dump`` with no other
+    side to compare against. But the one axis ``AnalysisAssurance`` and a
+    single dump genuinely share -- "did the requested ``--depth`` get
+    reached" -- *is* knowable here, from
+    :func:`~abicheck.service_dump_pipeline.execute_dump_request`'s own
+    already-computed ``effective_depth`` (a real post-execution fact, the
+    identical value :class:`~abicheck.service_dump_pipeline.DumpResult`
+    itself carries), so this class states exactly that axis rather than
+    leaving :meth:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext.with_assurance` fully unwired for ``dump``.
+    """
+
+    requested_depth: str | None
+    effective_depth: str | None
+    depth_satisfied: bool | None
+
+
+@dataclass(frozen=True)
+class DumpExecutionOptions:
+    """The out-of-band execution semantics
+    :func:`~abicheck.service_dump_pipeline.execute_dump_request` needs beyond
+    *resolved* itself and *notify*, folded into one typed value -- ADR-063
+    ``duplication-and-convergence-assessment.md`` Track T4 ("Dump request
+    contract"). Before this, the nine fields below were nine separate
+    keyword parameters on :func:`~abicheck.service_dump_pipeline.
+    execute_dump_request`: reaching the same function did not mean a caller
+    stated a coherent, nameable execution plan, only that it happened to
+    pass the same nine positional names. Grouping them is additive, not a
+    new decision point -- every field keeps the exact default
+    :func:`~abicheck.service_dump_pipeline.execute_dump_request` already gave
+    it, so ``DumpExecutionOptions()`` (the parameter's own default) is
+    bit-for-bit equivalent to omitting all nine kwargs before this change.
+
+    Since this track's follow-up, an instance is also attachable to the
+    *resolved* request (see :attr:`~abicheck.service_dump_pipeline.
+    ResolvedDumpRequest.execution_options`) rather than only assembled fresh
+    at :func:`~abicheck.service_dump_pipeline.execute_dump_request`'s own
+    call boundary -- so ``dump --dry-run`` can render what a real run would
+    pass, instead of the ``dump`` CLI threading the nine values through
+    :func:`~abicheck.frontends.cli.dump_execute.execute_dump_cli_run` as
+    separate parameters.
+
+    *build_config*/*build_query*/*build_compile_db*/*changed_paths*/
+    *allow_build_query* (PR 3A, dump/scan resolver convergence): optional
+    pass-throughs to
+    :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`.
+    These exist only for the ELF ``dump`` CLI path's ``--config`` flag --
+    and, for a programmatic caller, its own ``build_query``/
+    ``build_compile_db`` arguments (PR 3C removed the CLI flags of those
+    names; these fields stay because a Python API caller is the operator,
+    exactly as an explicit ``--config`` is) -- to route through this one
+    shared primitive instead of a second, independent call to the same
+    underlying fold.
+
+    *legacy_compile_db_tokens* (ADR-063 Phase 1): the castxml flags the CLI's
+    own legacy ``-p``/``--compile-db`` auto-match
+    (``cli_helpers_compare._resolve_build_context_flags``) already derived,
+    forwarded verbatim to :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`
+    -- see that function's own docstring for the precedence rule (the P0.3
+    fold's own result wins whenever it applies) and
+    ``docs/contribute/known-gaps.md``'s "ADR-063 Phase 1" entry for exactly
+    what this closes and what still doesn't. *legacy_compile_db_matched*
+    (Codex review, fresh evidence) is a separate signal from whether any
+    tokens were actually derived -- see the resolve-layer function's own
+    docstring for why a real match with zero derived flags still must set
+    it. Both are passed by the migrated ``dump`` CLI's real run for either
+    binary format (``frontends.cli.dump_execute.execute_dump_cli_run``) --
+    ADR-063 Phase 1 migrated PE/Mach-O onto this same function after ELF, so
+    ``cli_dump_non_elf.handle_non_elf_dump`` stopped being called from
+    ``dump_cmd`` for either format; ADR-063 Track 1 then deleted it, and
+    ``cli_dump_helpers.perform_elf_dump`` with it, once the only thing left
+    holding either alive was its own unit tests.
+
+    *seed_collect_mode*/*source_frontend_from_folded_context* (Codex review
+    on the initial ELF migration -- two real regressions it introduced):
+    forwarded verbatim to
+    :func:`~abicheck.workflows.artifact.execute._resolve_side_snapshot_impl`,
+    whose own docstring documents each. Both default to the pre-typed-object
+    behavior (``seed_collect_mode=None`` pins the L2 seed's collect mode to
+    ``"off"``; ``source_frontend_from_folded_context=False`` keeps L4 replay
+    pointed at the pre-fold compiler). The retired ``perform_elf_dump``
+    always forwarded its own resolved ``collect_mode`` to the identical L2
+    seed call (unconditionally running a zero-config inferred build query
+    for a ``--sources`` tree with no compile database) and always
+    reassigned ``gcc_path``/``gcc_prefix``/``effective_gcc_options`` from
+    the L3 fold's context once it applied (so an L4 source replay used the
+    compiler the L3 fold actually matched, not the caller's pre-fold
+    default) -- the migrated ELF run builds
+    ``DumpExecutionOptions(seed_collect_mode=resolved.collect_mode,
+    source_frontend_from_folded_context=True, ...)`` to preserve both,
+    exactly as ``scan``'s own candidate resolution already does for the
+    identical reasons (see that call site's comments).
+    """
+
+    build_config: Path | None = None
+    build_query: str | None = None
+    build_compile_db: str | None = None
+    changed_paths: tuple[str, ...] = ()
+    allow_build_query: bool | None = None
+    legacy_compile_db_tokens: tuple[str, ...] = ()
+    legacy_compile_db_matched: bool = False
+    seed_collect_mode: str | None = None
+    source_frontend_from_folded_context: bool = False

--- a/abicheck/workflows/artifact/dump_request.py
+++ b/abicheck/workflows/artifact/dump_request.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``ResolvedDumpRequest`` -- split out of :mod:`abicheck.service_dump_pipeline`.
+
+ADR-063 Track T4 ("Dump request contract"): this dataclass carries zero
+dependency on :class:`~abicheck.service_dump_pipeline.DumpResult` or
+anything else in that module, so it can live in a real ADR-061
+responsibility-package leaf (``workflows/artifact/``, the same layer
+``service_dump_pipeline.py`` is itself classified into via
+``architecture/modules.yaml``'s ``layers.workflows.legacy_paths``) instead
+of growing that flat module further.
+
+The direct motivation: :mod:`abicheck.workflows.artifact.execute_source_only`
+needs this type for its own function signature, and
+:mod:`abicheck.service_dump_pipeline` needs to call that function -- a type
+importable only from ``service_dump_pipeline.py`` itself would force a
+module-level import back into it, which the AI-readiness
+``import-cycle-growth`` gate's cycle scan (an AST walk that does not
+special-case ``TYPE_CHECKING`` blocks or function-local imports) flags as a
+new two-module cycle regardless of how the import is spelled. Both modules
+importing this type from one shared, one-directional leaf avoids the cycle
+outright. ``service_dump_pipeline.py`` re-exports the name
+(``ResolvedDumpRequest as ResolvedDumpRequest``) so every existing
+``from abicheck.service_dump_pipeline import ResolvedDumpRequest`` import,
+``isinstance`` check, and ``dataclasses.replace(...)`` call site is
+unaffected -- it is the identical class object, not a copy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from . import ResolvedArtifactPlan
+from .dump_execution_options import DumpExecutionOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ...api_types import DumpRequest
+    from ...service_compare_evidence import SideEvidence
+    from ...workflows.resolved_execution_context import ResolvedExecutionContext
+
+__all__ = ["ResolvedDumpRequest"]
+
+
+@dataclass(frozen=True)
+class ResolvedDumpRequest:
+    """A ``DumpRequest`` after resolution, before execution.
+
+    CLI cleanup phase two, PR C / PR 3A (see
+    ``docs/contribute/plans/cli-cleanup-phase-two.md``): the object
+    ``dump --dry-run`` is meant to render, once its rendering path
+    (``cli_dump_helpers.render_dump_dry_run``, currently a hand-written
+    second implementation) is migrated to build from this instead of
+    re-deriving the same facts independently.
+
+    Carries only what ``resolve_dump_request`` can determine without
+    invoking castxml/clang or writing anything: the normalized language, the
+    requested header-AST backend, the detected binary format, the requested
+    ``depth`` (an input, known up front) and the effective *collect mode*
+    (the build/source evidence level ``depth`` resolves to). Deliberately
+    does **not** carry an *achieved* depth — that can only be read off the
+    completed snapshot (``cli_dump_helpers.fold_dump_provenance_into_dict``
+    derives it via ``_gated_source_label(snap.build_source, snap)``), so a
+    resolve-only object reporting it would have to guess, and a guess that
+    disagrees with the real run defeats the point of rendering ``--dry-run``
+    from a real resolved object (Codex review, fresh evidence). See
+    ``DumpResult`` for the achieved depth.
+
+    Also deliberately excludes the P0.3 L3→L2 compile-context fold's result:
+    that fold (``buildsource.l2_seed.seed_includes_and_fold_compile_context``)
+    can raise ``HeaderCompileContextAmbiguousError`` on genuinely ambiguous
+    build evidence, and ``--dry-run``'s existing contract
+    (``render_dump_dry_run``'s own docstring) is to never raise on anything
+    but a usage error. Folding it in here would be a real behavior change to
+    that contract, not merely an additive one — it stays inside
+    ``execute_dump_request``, unchanged from where ``run_dump_request``
+    already runs it today (via ``service_input_resolution.resolve_side_snapshot``).
+
+    ``artifact_plan`` (dedup-and-convergence plan, Phase 1 item 1
+    "Milestone B"): the same facts this object already carries, also
+    attached to a :class:`~abicheck.workflows.artifact.ResolvedArtifactPlan`
+    -- the general, cross-consumer shape the plan's target architecture
+    names. Built with an empty ``pending_cleanups`` (this function allocates
+    no resource -- see :mod:`abicheck.workflows.artifact.contracts`'s own
+    module docstring for why the two fields that *would* require one,
+    effective include search and effective compile context, stay excluded
+    here too), so it is
+    additive, inert data today: nothing yet reads it. It exists so a future
+    consumer of the general shape (e.g. a migrated ``render_dump_dry_run``)
+    has one object to build from instead of this dump-specific one, without
+    this dataclass's own field surface changing again when that lands.
+
+    Excluded from this dataclass's generated ``__eq__``/``__hash__``
+    (``compare=False``, Codex review): ``ResolvedArtifactPlan`` is a plain
+    class, not a dataclass, so it compares by identity. Two structurally
+    identical ``DumpRequest``s resolved independently would otherwise
+    produce two ``ResolvedDumpRequest``s that compare unequal purely
+    because each carries its own, distinct ``ResolvedArtifactPlan``
+    instance -- silently breaking equality-based comparison or caching for
+    every existing and future caller of this frozen dataclass, over a field
+    that is itself inert today.
+
+    ``resolved_execution_context`` (One Semantic Pipeline plan, sub-phase 4B
+    -- ``dump``'s own slice of the gap
+    :class:`~abicheck.service_compare_pipeline.ResolvedComparePair`'s
+    identically-named field already closed for ``compare``): the
+    :class:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext` built from this same call's own, otherwise-
+    discarded :class:`~abicheck.workflows.plan.AnalysisPlan`
+    (``resolve_dump_request`` already calls ``AnalysisPlanner.resolve``
+    for its ADR-063 Phase 4 pre-flight check -- this is not a second
+    resolution). ``operation`` reads ``"dump"`` off the plan; ``evidence``
+    carries only ``requested_depth``/``available_depths`` at this point --
+    the pre-execution view, via :meth:`~abicheck.workflows.
+    resolved_execution_context.ResolvedExecutionContext.from_plan` with no
+    *assurance*. Optional and additive: excluded from ``compare=False`` for
+    the same reason ``artifact_plan`` is -- a fresh, distinct
+    ``ResolvedExecutionContext`` instance must not make two structurally
+    identical resolutions compare unequal. Carries no ``evaluation_config``/
+    ``compile_contexts`` yet, for the identical reason
+    ``ResolvedComparePair.resolved_execution_context`` does not: neither
+    resolves at this seam. See ``execute_dump_request`` for the
+    post-execution counterpart, attached via
+    :meth:`~abicheck.workflows.resolved_execution_context.
+    ResolvedExecutionContext.with_assurance`.
+    """
+
+    request: DumpRequest
+    lang: str
+    lang_explicit: bool
+    header_backend: str
+    # A *reporting-only* projection of the concrete header-AST backend
+    # resolution currently favors -- what a future `--dry-run` render would
+    # show. `header_backend` alone under-reports this: service.py's own
+    # eff_backend computation gives an explicit `evidence.compile.frontend`
+    # precedence over the bare `header_backend` arg, and resolves "auto" to
+    # a concrete backend either way, so a naive render of `header_backend`
+    # can name a different frontend than what would currently be chosen.
+    #
+    # Deliberately NOT what execute_dump_request passes to execution
+    # (Codex review, two rounds -- the first attempt did pass this value
+    # through, which is a real regression, not a pin: `dumper.
+    # _header_ast_parser`'s own `_auto_ast_fallback_eligible(backend)`
+    # checks whether `backend` is *literally* the string "auto" to decide
+    # whether a CastXML failure may gracefully fall back to Clang, and a
+    # non-"host" `frontend_context` has its own "auto"-specific routing --
+    # pre-resolving "auto" to a concrete choice before it reaches that
+    # function silently strips those behaviors). Execution therefore keeps
+    # passing the bare `header_backend` through unchanged, and this field
+    # is accepted as a best-effort preview that can, in principle, disagree
+    # with what execution ends up doing if the environment changes between
+    # resolve and execute, or if the genuinely-unpinned-"auto" fallback
+    # path fires -- the same class of accepted imprecision every other
+    # resolve-time preview in this object already carries.
+    effective_header_backend: str
+    fmt: str | None
+    debug_format: str | None
+    requested_depth: str | None
+    evidence: SideEvidence
+    public_headers: tuple[Path, ...]
+    public_header_dirs: tuple[Path, ...]
+    artifact_plan: ResolvedArtifactPlan | None = field(default=None, compare=False)
+    resolved_execution_context: ResolvedExecutionContext | None = field(
+        default=None, compare=False
+    )
+    # ADR-063 Track T4 ("Dump request contract"): the `DumpExecutionOptions`
+    # a real execution would pass to `execute_dump_request`, when a caller
+    # has resolved one -- so `dump --dry-run`
+    # (`cli_dump_helpers.render_dump_dry_run`) can show these nine values.
+    # `resolve_dump_request` never populates this itself (`build_config`/
+    # `legacy_compile_db_tokens`/`legacy_compile_db_matched` are CLI-only
+    # values with no `DumpRequest` equivalent); the `dump` CLI attaches its
+    # own via `dataclasses.replace(resolved, execution_options=...)`.
+    # `execute_dump_request` reads this as its default when its own
+    # `options` is `None` -- an explicit `options=` argument still wins.
+    # Comparable like any plain value (unlike `artifact_plan`/
+    # `resolved_execution_context` above, which compare by identity).
+    execution_options: DumpExecutionOptions | None = None
+
+    @property
+    def collect_mode(self) -> str:
+        """The effective build/source evidence level ``depth`` resolved to."""
+        return self.evidence.collect_mode
+
+    @property
+    def headers(self) -> tuple[Path, ...]:
+        """The resolved public-header set (files only; see ``public_header_dirs``)."""
+        return tuple(self.evidence.headers)

--- a/abicheck/workflows/artifact/execute_source_only.py
+++ b/abicheck/workflows/artifact/execute_source_only.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execute a binary-less (``InputSpec.path is None``) ``ResolvedDumpRequest``.
+
+ADR-063 Track T4 ("Dump request contract"), item 1's second still-open
+clause: :func:`abicheck.service_dump_pipeline.execute_dump_request` used to
+raise unconditionally for this shape even though
+:func:`abicheck.service_dump_pipeline.resolve_dump_request` has always fully
+resolved it (that resolution is what ``dump --dry-run`` needs). The only
+real ``dump --sources``/``--build-info`` (no ``SO_PATH``) pipeline was,
+until now, :func:`~abicheck.cli_buildsource.dump_source_only`'s own -- a
+CLI-only function collecting L3-L5 evidence inline into an otherwise-empty
+snapshot with no typed request or ``resolve_input`` call at all. This
+module is that same pipeline, reduced to its engine primitives so a non-CLI
+(typed API) caller can reach it too.
+
+Split into its own module (rather than living in
+:mod:`abicheck.service_dump_pipeline` alongside
+:func:`~abicheck.service_dump_pipeline.execute_dump_request`) purely to keep
+that module under the architecture gate's 800-line new-file cap -- it has
+no debt-ledger baseline of its own and was already at the cap. It lives
+under ``workflows/artifact/`` (a real ADR-061 responsibility-package
+directory, not a new flat ``abicheck/service_*.py``/``dumper_*.py``
+sibling: ``architecture/modules.yaml``'s ``frozen_root_families`` closes
+both of those flat namespaces to new members, per ADR-061's own migration
+direction and the precedent recorded in
+``docs/contribute/adr/061-responsibility-package-architecture.md``'s
+"`abicheck/service_render_compat.py` ... was itself rejected" note) --
+``service_dump_pipeline.py`` is itself classified into the ``workflows``
+layer (``architecture/modules.yaml``'s ``layers.workflows.legacy_paths``),
+so this is a same-layer sibling, not a new cross-layer dependency.
+
+:func:`execute_source_only_dump_request` returns a plain
+:class:`SourceOnlyDumpOutcome` rather than a real
+:class:`~abicheck.service_dump_pipeline.DumpResult` -- deliberately, not
+merely to avoid one import. ``service_dump_pipeline.py`` imports *this*
+module (to call the function), and the AI-readiness ``import-cycle-growth``
+gate's cycle scan walks every import anywhere in a file, including inside a
+function body, so importing ``DumpResult`` back here even lazily would
+still register as a new two-module cycle. Returning the three facts
+``execute_dump_request`` needs (unpacked in that function's own source-only
+branch, which already has ``DumpResult`` in scope to construct) avoids the
+cycle entirely rather than papering over it with a deferred import that the
+gate would catch anyway.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ...errors import ValidationError
+from ..extraction import embed_build_source, resolve_source_frontend_clang_bin
+from .dump_execution_options import DumpExecutionOptions, _DumpAssuranceView
+from .dump_request import ResolvedDumpRequest
+from .execute import enforce_requested_depth
+
+if TYPE_CHECKING:
+    from ...model import AbiSnapshot
+    from ...workflows.resolved_execution_context import ResolvedExecutionContext
+
+__all__ = ["SourceOnlyDumpOutcome", "execute_source_only_dump_request"]
+
+
+@dataclass(frozen=True)
+class SourceOnlyDumpOutcome:
+    """The three facts :func:`~abicheck.service_dump_pipeline.execute_dump_request`
+    needs to build its own :class:`~abicheck.service_dump_pipeline.DumpResult`
+    from -- see this module's own docstring for why this function returns
+    this instead of a real ``DumpResult``."""
+
+    snapshot: AbiSnapshot
+    effective_depth: str
+    resolved_execution_context: ResolvedExecutionContext | None
+
+
+def execute_source_only_dump_request(
+    resolved: ResolvedDumpRequest, options: DumpExecutionOptions
+) -> SourceOnlyDumpOutcome:
+    """Execute a binary-less :class:`~abicheck.service_dump_pipeline.ResolvedDumpRequest`.
+
+    Build an empty-library :class:`~abicheck.model.AbiSnapshot` (no L0-L2
+    pass at all, named after whichever of ``sources``/``build_info`` is
+    given, matching ``dump_source_only``'s own naming rule); embed the
+    requested L3-L5 evidence via
+    :func:`~abicheck.workflows.extraction.embed_build_source` (the engine
+    primitive, not :func:`~abicheck.cli_buildsource.embed_build_source`'s
+    Click-error-translating wrapper -- both raise the identical
+    :class:`~abicheck.errors.ValidationError`/
+    :class:`~abicheck.errors.SnapshotError` pair, so nothing here weakens
+    ``execute_dump_request``'s own documented contract); then enforce the
+    requested-depth floor and derive ``effective_depth`` exactly like the
+    binary path does. ``gcc_path``/``gcc_prefix`` come from ``side.compile``
+    (the typed equivalent of ``dump_source_only``'s own ``--compiler``/
+    ``--compiler-prefix``) -- there is no L2 header AST here to have
+    resolved a ``CompileContext`` from, but the field still carries a
+    caller's explicit L4 cross-toolchain override.
+
+    **No idempotence guard needed here** (unlike ``cli_buildsource.
+    _write_snapshot_output``'s own ``build_source_already_satisfies``
+    check): that guard stops a *second* embed replaying L4 source-ABI
+    replay over a snapshot a prior embed already populated (the CLI's own
+    write step, or ``execute_dump_request``'s binary path embedding at
+    *resolve* time). This function's ``snap`` is freshly constructed and
+    gets exactly one ``embed_build_source`` call -- nothing earlier to be
+    idempotent against. A caller that passes the resulting snapshot through
+    ``_write_snapshot_output`` a second time is exactly the case that guard
+    protects, unaffected by anything here.
+
+    Deliberately narrower than the general path-less shape
+    ``DumpRequest.validate()`` accepts: a *manifest-only* (``dump_manifest``
+    set, ``sources``/``build_info`` both absent) path-less request
+    validates (a manifest counts as declared evidence too), but executing
+    one would need a full header-AST manifest dump with no binary to derive
+    an exported-symbol set from -- a materially different, unimplemented
+    pipeline. That shape reaches the same "no sources, no build_info" guard
+    below and gets the identical ``ValidationError``, preserving
+    ``dump_source_only``'s own long-standing contract rather than silently
+    embedding nothing.
+    """
+    from ...evidence_depth import depth_rank, gated_source_label
+    from ...model import AbiSnapshot
+
+    side = resolved.request.input
+    if side.sources is None and side.build_info is None:
+        raise ValidationError(
+            "a binary-less DumpRequest (InputSpec.path is None) needs "
+            "sources and/or build_info to have anything to extract -- "
+            "supply InputSpec.path for an ordinary artifact dump, or "
+            "sources/build_info for a source-only snapshot."
+        )
+
+    hint = side.sources if side.sources is not None else side.build_info
+    library = hint.name if hint is not None else "source"
+    snap = AbiSnapshot(library=library, version=side.version)
+
+    compile_ctx = side.compile
+    clang_bin = resolve_source_frontend_clang_bin(
+        compile_ctx.gcc_path if compile_ctx is not None else None,
+        compile_ctx.gcc_prefix if compile_ctx is not None else None,
+        exclude_cl_style=False,
+    )
+    embed_build_source(
+        snap,
+        side.build_info,
+        side.sources,
+        build_config=options.build_config,
+        clang_bin=clang_bin,
+        collect_mode=resolved.collect_mode,
+        build_query=options.build_query,
+        build_compile_db=options.build_compile_db,
+        build_targets=side.build_targets,
+        changed_paths=options.changed_paths,
+        extractor=resolved.header_backend,
+    )
+
+    enforce_requested_depth(resolved.requested_depth, (("input", snap),))
+    try:
+        # Defensive fallback, mirrors execute_dump_request's own.
+        effective_depth = gated_source_label(snap.build_source, snap)
+    except (TypeError, ValueError, OverflowError):
+        effective_depth = "headers" if snap.from_headers else "binary"
+
+    resolved_execution_context = None
+    if resolved.resolved_execution_context is not None:
+        requested_depth = (
+            resolved.requested_depth.lower()
+            if resolved.requested_depth is not None
+            else None
+        )
+        resolved_execution_context = resolved.resolved_execution_context.with_assurance(
+            _DumpAssuranceView(
+                requested_depth=requested_depth,
+                effective_depth=effective_depth,
+                depth_satisfied=(
+                    None
+                    if requested_depth is None
+                    else depth_rank(effective_depth) >= depth_rank(requested_depth)
+                ),
+            )
+        )
+        # No `side_effective_compile_context` call (unlike the binary path):
+        # there is no `side.path`/header-AST parse to record a compile
+        # context against, so `compile_contexts` stays empty.
+    return SourceOnlyDumpOutcome(
+        snapshot=snap,
+        effective_depth=effective_depth,
+        resolved_execution_context=resolved_execution_context,
+    )

--- a/changelog.d/20260906_035358_noreply_adr_063_t1_t10_summary_wp3ceh.md
+++ b/changelog.d/20260906_035358_noreply_adr_063_t1_t10_summary_wp3ceh.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Dump request contract (ADR-063 Track T4) fully closed** — header-AST
+  backend *selection* (`dumper._resolve_effective_ast_backend`, now shared
+  by `dumper._header_ast_parser` and
+  `service_dump_pipeline.resolve_dump_request`) is split from runtime
+  *fallback policy* (`dumper._castxml_fallback_reason`), removing a
+  previously-duplicated reimplementation of the frontend-context override
+  rule. `service_dump_pipeline.execute_dump_request` also gained a real
+  execution path for a binary-less (`--sources`/`--build-info`, no
+  `SO_PATH`) `DumpRequest` — it used to raise `ValidationError`
+  unconditionally for that shape even though `resolve_dump_request` already
+  supported resolving it. `cli_buildsource.dump_source_only` and the `dump`
+  CLI's own source-only dispatch are unchanged; see the plan doc for why.

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1849,7 +1849,7 @@ track, the steps are ordered.
 | ~~**T1 — Dead-implementation retirement**~~ ✅ **done (2026-09-05)** | Rehomed `perform_elf_dump`/`handle_non_elf_dump`'s unique assertions onto the live path; deleted both functions, `cli_dump_non_elf.py` and `cli_dump_protocols.py` | `cli_dump_helpers.py` (-661 lines), `cli_dump_non_elf.py` + `cli_dump_protocols.py` (deleted), their tests, `architecture/{modules,debt}.yaml`, `CLI_CONTRACT_ALLOWLIST` | nothing |
 | ~~**T2 — Ledger/status-model change**~~ ✅ **done (2026-09-05)** | Added the `introduced → wired → authoritative → retired` ladder and a separate `investigated_declined` disposition to `docs/_meta/one-semantic-pipeline-status.yaml` + `scripts/pipeline_status_ledger.py`'s field/enum validation; re-audited every concept row against it. Shipped as ledger `schema_version: 2` with the cross-field rules and the re-audit described under "The four-state status model" above | `scripts/pipeline_status_ledger.py`, the ledger, `tests/` | nothing |
 | ~~**T3 — Typedef/constant authority cutover**~~ ✅ **done (2026-09-05)** | Deleted the runtime dual-index construction: `typedef_index_pair`/`constant_index_pair` now decide each side of a comparison independently, reading a side's real `SemanticIR` directly whenever it has one (never both-or-neither — a Codex review round found the first both-or-neither cut would starve an IR-carrying side of its own real evidence whenever the *other* side lacked one) and falling back to the legacy adapter's projection of that side's own flat collection only when it has none; the identity half of the old fidelity gate (a real IR disagreeing with its own `typedef_entity_ids`/`constant_entity_ids` sidecar) moved to the canonical model's load boundary (`AbiSnapshot.__post_init__`, and re-run explicitly after `serialization.snapshot_from_dict` decodes a stored IR — a second Codex finding, since that decode bypasses `__post_init__`), now a hard `SemanticIrAuthorityError` rather than a silent fallback. A related fix in the same PR: `diff_constants` was silently dropping a constant addition/removal whenever its value was `Fact.unsupported()`, since only now reachable with the dual-index gate gone (Codex finding). The old gate's name/value equality half against the legacy alias/value collections is deliberately *not* preserved anywhere — requiring it would make a populated legacy collection an accidental prerequisite of `SemanticIR`-only construction, the opposite of authority transfer | `compare/typedefs.py`, `compare/constants.py`, `model/semantic_ir_legacy_adapter.py`, `model/snapshot.py`, `errors.py`, `serialization.py`, `scripts/semantic_ir_cutover.py` | nothing (T2 records it) |
-| **T4 — Dump request contract** ◐ *(partial, 2026-09-05: see note below)* | Fold `execute_dump_request`'s nine semantic kwargs into the typed request; split backend selection from fallback policy; give source-only dump an execution variant | `service_dump_pipeline.py`, `cli_dump_request.py`, `cli_buildsource.py`, `frontends/cli/dump_execute.py` | ~~T1~~ — satisfied (T1 landed 2026-09-05) |
+| ~~**T4 — Dump request contract**~~ ✅ **done (2026-09-06)** | Fold `execute_dump_request`'s nine semantic kwargs into the typed request; split backend selection from fallback policy; give source-only dump an execution variant | `dumper.py`, `dumper_toolchain.py`, `extract/header_ast_backend.py`, `service_compare_evidence.py`, `service_dump_pipeline.py`, `workflows/artifact/dump_request.py`, `workflows/artifact/dump_execution_options.py`, `workflows/artifact/execute_source_only.py` | ~~T1~~ — satisfied (T1 landed 2026-09-05) |
 | ~~**T5 — Direct-bypass migration**~~ ✅ **done (2026-09-05)** | Routed `appcompat.check_appcompat()` and `stack_checker._run_abi_diff()` through `service.run_dump`/`service.compare_snapshots` instead of calling `dumper.dump()`/`checker.compare()` directly; removed `appcompat.check_appcompat()`'s two entries from `CLI_CONTRACT_ALLOWLIST` (`stack_checker.py` was never itself in that list -- it isn't one of the front-end modules the `cli-contract` gate scans). No `cli_stack.py` change was needed: `_run_abi_diff()`'s return type and failure semantics (`DiffResult \| None`, `ProfileMismatchError`/`ScopeMismatchError` still propagate) are unchanged | `appcompat.py`, `stack_checker.py`, `scripts/check_ai_readiness.py` | T4 for the dump half; the compare half is independent |
 | **T6 — Effective gate/policy convergence** ✅ *(landed 2026-09-05; the shared fold and the derived scheme are done, the two runtime shapes remain P0's own job)* | Collapse `apply_release_gate_pack`'s raw-string mirror of `pack_application.apply_to_compare_config` onto one shared fold **without inverting the dependency direction** — `policy/release_gate_options.py` deliberately consumes a `_GatePackApplication` `Protocol` rather than importing the flat-root `pack_application`, since `policy` may not import it (ADR-061; `policy/AGENTS.md`'s "Permitted imports"), so the shared fold belongs in an inward module both may import, or an outer layer invokes both halves — never a `policy → legacy root` call. Also make `GateOptions.exit_code_scheme` derived rather than independently constructible | `policy/release_gate_options.py`, `pack_application.py`, a new inward fold owner, `tests/test_release_gate_pack_fold_parity.py` | nothing |
 | **T7 — Canonical export index** | One raw export index plus named projections (versioned ELF / default versions / Mach-O normalization / named PE / ordinal imports / missing-vs-empty); delete the five sibling implementations | `policy/depth_projection.py`, `buildsource/crosscheck_base.py`, `buildsource/snapshot_exports.py`, `post_manifest.py`, `diff_unnamed_types.py` | nothing |
@@ -1884,17 +1884,109 @@ from the preview (`cli_dump_helpers.render_dump_dry_run`) — the gap this
 note used to describe ("a caller inspecting a `ResolvedDumpRequest` has no
 way to see what a real execution would pass") no longer holds.
 
-**Still open, unstarted:** item 1's other two clauses — splitting backend
-selection from fallback policy, and a source-only dump execution variant
-(`execute_dump_request` still raises `ValidationError` for a binary-less
-`InputSpec.path is None` request; producing that snapshot is still
-`cli_buildsource.dump_source_only`'s own separate pipeline, per that
-function's own docstring reference).
+**T4 closed (2026-09-06): both of item 1's remaining clauses landed.**
+
+*Backend selection split from fallback policy.* `dumper._resolve_single_
+ast_backend`/`_resolve_header_backend`/`HEADER_BACKENDS` moved to a new
+`extract/header_ast_backend.py` module (a real ADR-061 `extract`
+responsibility-package leaf, not a new flat `dumper_*.py`/`service_*.py`
+sibling — `architecture/modules.yaml`'s `frozen_root_families` closes both
+of those flat namespaces to new members, and `dumper.py`/
+`dumper_toolchain.py` were both already at their own no-growth debt-ledger
+line-count baseline with zero room to add a function). A new function
+there, `_resolve_effective_ast_backend(requested_frontend, frontend_context)`,
+is the one pure "selection" primitive: it validates via
+`_resolve_single_ast_backend` (raising for a request no single parser can
+satisfy — `"hybrid"`, or an explicit/env-pinned `castxml` under a non-host
+context) and then mirrors `_header_ast_parser`'s own post-resolution
+dispatch rule (`if resolved == "clang" or frontend_context != "host":
+return _run_clang()`) exactly. `dumper.py`/`dumper_toolchain.py` re-export
+every name from the new module unchanged, so no existing
+`from .dumper import _resolve_header_backend`-shaped call site moved.
+`dumper._header_ast_parser`'s own dispatch now calls this same function
+instead of re-deriving the rule inline, and
+`service_compare_evidence.effective_frontend_for_context` (a new function,
+alongside `requested_frontend_override` — the override-precedence half
+`effective_frontend` already had inline, now factored out so it isn't
+re-derived a second time either) calls it too for
+`service_dump_pipeline.resolve_dump_request`'s own `effective_header_
+backend` reporting field — replacing that function's previous ~25-line
+inline reimplementation of both rules with one shared-selector call.
+Runtime fallback *policy* (`dumper._castxml_fallback_reason` — only
+discoverable by actually attempting castxml and observing a specific
+failure signature) is untouched and stays in `dumper.py`, where the
+attempt itself happens; the two were never conflated by this change.
+`tests/test_ast_backend_selection.py` states the "identical prediction
+regardless of caller" contract directly, over a range of inputs, not just
+the one case each pre-existing test already covered.
+
+*Source-only dump execution variant.* `service_dump_pipeline.
+execute_dump_request` no longer raises unconditionally for a binary-less
+(`InputSpec.path is None`) `ResolvedDumpRequest` — it dispatches to a new
+`workflows/artifact/execute_source_only.execute_source_only_dump_request`,
+which builds an empty-library `AbiSnapshot` and embeds L3-L5 evidence via
+`workflows.extraction.embed_build_source` (the engine primitive, not
+`cli_buildsource.embed_build_source`'s Click-error-translating wrapper),
+then enforces the requested-depth floor exactly like the binary path does
+— the same pipeline `cli_buildsource.dump_source_only` already ran,
+reduced to its engine primitives so a non-CLI (typed API) caller can reach
+it too. No idempotence guard was needed (unlike `_write_snapshot_output`'s
+own `build_source_already_satisfies` check): the new function's snapshot
+is freshly constructed and embedded into exactly once, so there is no
+earlier embed to be idempotent against — that guard remains relevant only
+where a CLI write step might re-embed onto an already-populated snapshot
+(the binary path's resolve-time embed), which this addition doesn't touch.
+Lives in its own `workflows/artifact/` module (a same-layer sibling of
+`service_dump_pipeline.py`, which is itself `layers.workflows`-classified)
+rather than growing `service_dump_pipeline.py` past its own 800-line
+new-file architecture cap, and returns a plain `SourceOnlyDumpOutcome`
+rather than a real `DumpResult`: `service_dump_pipeline.py` imports this
+module to call the function, so returning `DumpResult` itself would need a
+module-level import back into `service_dump_pipeline.py`, which the
+AI-readiness `import-cycle-growth` gate's whole-file AST walk (it does not
+special-case `TYPE_CHECKING` blocks or function-local imports) flags as a
+new two-module cycle regardless of how that import were spelled; the
+caller (already holding `DumpResult` in scope) builds the real object from
+the three fields `SourceOnlyDumpOutcome` carries. `ResolvedDumpRequest`
+itself also moved to a new `workflows/artifact/dump_request.py` leaf for
+the identical reason — the new module's own function signature needs the
+type, and importing it only from `service_dump_pipeline.py` would create
+the same cycle; `service_dump_pipeline.py` re-exports it unchanged.
+`tests/test_dump_source_only_execution.py` pins the general contract
+(parity with `dump_source_only` for both the `--sources` and
+`--build-info`-only shapes, the "no evidence" `ValidationError`, and the
+unreached-requested-depth-floor `ValidationError`) rather than one
+hand-picked example.
+
+**`cli_buildsource.dump_source_only`/the `dump` CLI's own source-only
+dispatch (`frontends/cli/commands/dump.py`, `so_path is None` branch) are
+deliberately left as they are — not a silent two-implementations gap, but
+a scoped decision recorded here per this file's own "Record before
+disposing" norm.** A full migration of that CLI call site to build a
+`DumpRequest` and call the new shared `execute_dump_request` path (the way
+ADR-063 Phase 1 / CLI cleanup phase two PR C did for the ELF/PE/Mach-O
+binary paths) would additionally need to preserve, byte-for-byte: provenance
+stamping via `_stamp_provenance`; `_write_snapshot_output`'s full
+sectioned-document/compression/depth-check/`--include-system-declarations`
+machinery; the G21.7 "missing requested evidence layer" warning; and the
+CLI's own `-H`/`--header`-has-no-effect warning — all of which
+`service_dump_pipeline.py`'s own module docstring explicitly excludes from
+this pipeline's scope ("the CLI's presentation and provenance layer").
+Attempting that migration in the same pass that introduces the new
+execution path itself risks exactly the kind of scope creep this plan's
+own T4 status notes have twice already had to walk back an overclaiming
+draft on (see the two notes above); it is better scoped as its own
+follow-up slice once the new path has had a release cycle to prove itself,
+mirroring how the ELF/PE/Mach-O migration itself was its own dedicated,
+multi-PR effort (ADR-063 Phase 1). Nothing about leaving it as-is
+regresses any existing behavior or test: `dump_source_only`'s own pipeline
+is unchanged, and the new `execute_dump_request` path is purely additive,
+reachable only through the typed API today.
 
 **Recommended first wave (fully parallel, no shared files):** ~~T1~~ (done),
 ~~T2~~ (done), T6 (landed with caveats — see its own row), T7, T8. **Second
-wave:** ~~T3~~ (done), T4, T9 (each large enough to be its own multi-PR
-effort). **Third wave:** ~~T5~~ (done), ~~T10~~ (done).
+wave:** ~~T3~~ (done), ~~T4~~ (done), T9 (each large enough to be its own
+multi-PR effort). **Third wave:** ~~T5~~ (done), ~~T10~~ (done).
 
 **T9's first slice (2026-09-05): the PDB `vtable` fabrication is closed;
 the rest of the item's scope is not.** `Fact[T]` gained a `producer: str |

--- a/tests/test_ast_backend_selection.py
+++ b/tests/test_ast_backend_selection.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Track T4 ("Dump request contract"), item 1's first still-open
+clause: splitting header-AST **backend selection** from **fallback policy**.
+
+Before this change, ``dumper._header_ast_parser`` computed its own dispatch
+inline (``_resolve_single_ast_backend`` then ``if resolved == "clang" or
+frontend_context != "host": ...``), and
+``service_dump_pipeline.resolve_dump_request`` independently re-derived the
+identical prediction for its own reporting-only ``effective_header_backend``
+field -- re-deriving both the override-precedence rule (an explicit
+``compile.frontend`` beats the bare ``header_backend`` default, unless it is
+itself the no-op spelling ``"auto"``) and the "any non-host context forces
+clang" rule a second time. Two Codex-review-caught regressions in this exact
+spot (the first missing case-insensitivity, the second conflating an
+explicit pinned castxml with an auto request) are why the docstrings in
+``dumper.py``/``service_dump_pipeline.py`` are as detailed as they are; both
+are preserved by tests below.
+
+The fix: ``dumper._resolve_effective_ast_backend`` is now the one "selection"
+function -- pure, callable with no execution -- both ``_header_ast_parser``'s
+own dispatch and ``service_compare_evidence.effective_frontend_for_context``
+(``resolve_dump_request``'s new call) delegate to. This file states that as
+an executable contract: the prediction is *identical* regardless of which
+caller asks, over a range of inputs, not just the one case each existing
+test file happened to already cover.
+
+Fallback *policy* (``dumper._castxml_fallback_reason`` -- only discoverable
+by actually attempting castxml and observing a specific failure signature)
+is a deliberately separate concern and is untouched by this split; it has
+its own tests elsewhere (``test_clang_castxml_origin_parity.py`` and
+siblings) and is not exercised here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.errors import AstContextMissingError, ValidationError
+
+
+class TestResolveEffectiveAstBackend:
+    """Direct contract of the new pure selection function."""
+
+    def test_hybrid_is_never_selectable_regardless_of_context(self):
+        """No single parser can satisfy "hybrid" -- selection must raise for
+        it under every context, matching ``_resolve_single_ast_backend``'s
+        own hybrid rejection (see ``dumper_hybrid.run_hybrid_dump`` for the
+        only place that combination is actually resolved)."""
+        from abicheck.dumper import _resolve_effective_ast_backend
+
+        for context in ("host", "device"):
+            with pytest.raises(ValidationError):
+                _resolve_effective_ast_backend("hybrid", context)
+
+    def test_explicit_castxml_under_non_host_context_raises(self):
+        """An explicit ``castxml`` request combined with a non-"host" context
+        is a hard error (castxml has no SYCL/DPC++ host/device concept) --
+        selection must raise, not silently predict a backend that would
+        never actually run without the same request also raising."""
+        from abicheck.dumper import _resolve_effective_ast_backend
+
+        with pytest.raises(AstContextMissingError):
+            _resolve_effective_ast_backend("castxml", "device")
+
+    @pytest.mark.parametrize("requested", ["auto", "clang"])
+    def test_non_host_context_always_predicts_clang(self, requested):
+        """Every request that is NOT an explicit/pinned castxml resolves to
+        clang under a non-"host" context -- mirrors
+        ``_header_ast_parser``'s own ``if resolved == "clang" or
+        frontend_context != "host": return _run_clang()``."""
+        from abicheck.dumper import _resolve_effective_ast_backend
+
+        assert _resolve_effective_ast_backend(requested, "device") == "clang"
+
+    @pytest.mark.parametrize(
+        "requested,expected",
+        [("auto", "castxml"), ("castxml", "castxml"), ("clang", "clang")],
+    )
+    def test_host_context_resolves_normally(self, requested, expected):
+        """Under the default "host" context, selection is just the ordinary
+        auto/explicit backend resolution -- no context override applies."""
+        from abicheck.dumper import _resolve_effective_ast_backend
+
+        assert _resolve_effective_ast_backend(requested, "host") == expected
+
+
+class TestEffectiveFrontendForContextParity:
+    """``service_compare_evidence.effective_frontend_for_context`` must never
+    diverge from ``dumper._resolve_effective_ast_backend`` -- the exact
+    "callable identically from either module" contract ADR-063 T4 asks for.
+    """
+
+    @pytest.mark.parametrize(
+        "compile_frontend,header_backend,context",
+        [
+            ("auto", "auto", "device"),
+            ("auto", "clang", "device"),
+            ("clang", "auto", "device"),
+            ("AUTO", "clang", "device"),  # case-insensitive no-op override
+            ("auto", "auto", "host"),
+        ],
+    )
+    def test_agrees_with_the_shared_selection_function(
+        self, compile_frontend, header_backend, context
+    ):
+        from abicheck.compile_context import CompileContext
+        from abicheck.dumper import _resolve_effective_ast_backend
+        from abicheck.service_compare_evidence import (
+            effective_frontend_for_context,
+            requested_frontend_override,
+        )
+
+        compile_ctx = CompileContext(
+            frontend=compile_frontend, frontend_context=context
+        )
+        requested = requested_frontend_override(compile_ctx, header_backend)
+
+        if context.lower() == "host":
+            # No context to predict -- the function must say so explicitly
+            # rather than silently reusing the host-only `effective_frontend`
+            # answer itself (that split is `effective_frontend`'s own job).
+            assert effective_frontend_for_context(compile_ctx, header_backend) is None
+        else:
+            expected = _resolve_effective_ast_backend(requested, context.lower())
+            assert (
+                effective_frontend_for_context(compile_ctx, header_backend) == expected
+            )
+
+    def test_none_compile_context_predicts_nothing(self):
+        from abicheck.service_compare_evidence import effective_frontend_for_context
+
+        assert effective_frontend_for_context(None, "auto") is None
+
+    def test_unsatisfiable_combination_predicts_nothing(self):
+        """An explicit castxml under a non-host context can't be satisfied by
+        any single parser -- the context-aware prediction must answer
+        `None` (meaning: "leave whatever `effective_frontend` already
+        reported unchanged"), not raise past its own caller
+        (`resolve_dump_request` is a best-effort preview that must never
+        raise)."""
+        from abicheck.compile_context import CompileContext
+        from abicheck.service_compare_evidence import effective_frontend_for_context
+
+        compile_ctx = CompileContext(frontend="castxml", frontend_context="device")
+        assert effective_frontend_for_context(compile_ctx, "auto") is None
+
+    def test_hybrid_under_non_host_context_predicts_nothing(self):
+        from abicheck.compile_context import CompileContext
+        from abicheck.service_compare_evidence import effective_frontend_for_context
+
+        compile_ctx = CompileContext(frontend="hybrid", frontend_context="device")
+        assert effective_frontend_for_context(compile_ctx, "auto") is None
+
+
+class TestResolveDumpRequestUsesTheSharedSelector:
+    """End-to-end: ``resolve_dump_request``'s own ``effective_header_backend``
+    for a non-host ``frontend_context`` must equal what the shared selector
+    predicts -- not a second, independently-derived answer.
+    """
+
+    def test_matches_shared_selector_for_device_context(self, tmp_path):
+        from abicheck.api_types import DumpRequest, InputSpec
+        from abicheck.dumper import _resolve_effective_ast_backend
+        from abicheck.model import AbiSnapshot
+        from abicheck.serialization import snapshot_to_json
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        snap_path = tmp_path / "lib.abi.json"
+        snap_path.write_text(
+            snapshot_to_json(AbiSnapshot(library="lib", version="1.0")),
+            encoding="utf-8",
+        )
+        request = DumpRequest(
+            input=InputSpec(path=snap_path),
+            frontend="auto",
+            frontend_context="device",
+        )
+        resolved = resolve_dump_request(request)
+        assert resolved.effective_header_backend == _resolve_effective_ast_backend(
+            "auto", "device"
+        )

--- a/tests/test_dump_source_only_execution.py
+++ b/tests/test_dump_source_only_execution.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Track T4 ("Dump request contract"), item 1's second still-open
+clause: a real *execution* variant for a binary-less
+(``InputSpec.path is None``) :class:`~abicheck.api_types.DumpRequest`.
+
+Before this change, :func:`~abicheck.service_dump_pipeline.execute_dump_request`
+raised ``ValidationError`` unconditionally for this shape even though
+:func:`~abicheck.service_dump_pipeline.resolve_dump_request` has always fully
+resolved it -- the only pipeline that could actually produce the snapshot was
+:func:`~abicheck.cli_buildsource.dump_source_only`'s own CLI-only path,
+embedding L3-L5 evidence inline with no typed request at all.
+
+These tests state the general contract (not just one hand-picked example):
+a source-only :class:`~abicheck.api_types.DumpRequest`, executed through
+:func:`~abicheck.service_dump_pipeline.execute_dump_request`, produces a
+snapshot with the same L3 evidence -- and the same "no evidence at all is a
+usage error" / "an unreached requested depth floor is a hard error"
+behavior -- that :func:`~abicheck.cli_buildsource.dump_source_only` produces
+for the equivalent CLI inputs.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.api_types import DumpRequest, InputSpec
+from abicheck.errors import ValidationError
+
+
+def _source_tree_with_compile_db(tmp_path: Path) -> Path:
+    """A minimal source tree carrying its own ``compile_commands.json`` --
+    enough for L3 (build) evidence with no compiler/castxml/clang needed
+    (mirrors ``tests/test_build_source_cli.py::test_dump_source_only_no_binary``,
+    which this file's parity test is a typed-API counterpart to)."""
+    tree = tmp_path / "src"
+    tree.mkdir()
+    cdb = [
+        {
+            "directory": str(tree),
+            "file": "foo.cpp",
+            "arguments": ["c++", "-std=c++17", "-c", "foo.cpp"],
+        }
+    ]
+    (tree / "compile_commands.json").write_text(json.dumps(cdb))
+    (tree / "foo.cpp").write_text("void foo() {}\n")
+    return tree
+
+
+class TestExecuteDumpRequestSourceOnlyMatchesDumpSourceOnly:
+    """Parity: the typed pipeline and ``dump_source_only``'s own CLI pipeline
+    must agree on the snapshot they produce for equivalent inputs."""
+
+    def test_l3_evidence_matches_across_both_pipelines(self, tmp_path):
+        from abicheck.cli_buildsource import dump_source_only
+        from abicheck.serialization import load_snapshot
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        tree = _source_tree_with_compile_db(tmp_path)
+
+        # The typed pipeline.
+        request = DumpRequest(input=InputSpec(path=None, sources=tree))
+        typed_result = execute_dump_request(resolve_dump_request(request))
+        typed_snap = typed_result.snapshot
+
+        # dump_source_only's own CLI pipeline, over the identical tree.
+        legacy_out = tmp_path / "legacy.abi.json"
+        dump_source_only(
+            sources=tree,
+            build_info=None,
+            version="",
+            output=legacy_out,
+            build_config=None,
+            git_tag=None,
+            build_id=None,
+            no_git=True,
+        )
+        legacy_snap = load_snapshot(legacy_out)
+
+        # Neither carries a native artifact.
+        assert typed_snap.elf is None
+        assert typed_snap.pe is None
+        assert typed_snap.macho is None
+        assert legacy_snap.elf is None
+
+        # Both name the snapshot after the source tree.
+        assert typed_snap.library == legacy_snap.library == tree.name
+
+        # Both embedded the identical L3 build evidence.
+        assert typed_snap.build_source is not None
+        assert legacy_snap.build_source is not None
+        typed_units = typed_snap.build_source.build_evidence.compile_units
+        legacy_units = legacy_snap.build_source.build_evidence.compile_units
+        assert len(typed_units) == len(legacy_units) == 1
+        assert typed_units[0].source == legacy_units[0].source
+
+        # Both agree on the achieved evidence depth (whatever it resolves to
+        # in this environment -- "source" when L4 replay was attempted,
+        # "build" when no clang is available for it to attempt at all --
+        # the point is that the two pipelines never disagree, not which
+        # value it happens to be here).
+        from abicheck.evidence_depth import gated_source_label
+
+        legacy_effective_depth = gated_source_label(
+            legacy_snap.build_source, legacy_snap
+        )
+        assert typed_result.effective_depth == legacy_effective_depth
+
+    def test_build_info_only_also_embeds_l3(self, tmp_path):
+        """The same parity holds for ``--build-info`` alone (no ``--sources``),
+        the other half of ``dump_source_only``'s own precondition
+        (``sources is None and build_info is None`` is the only rejected
+        combination)."""
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        tree = _source_tree_with_compile_db(tmp_path)
+        cdb_path = tree / "compile_commands.json"
+
+        request = DumpRequest(input=InputSpec(path=None, build_info=cdb_path))
+        result = execute_dump_request(resolve_dump_request(request))
+        snap = result.snapshot
+        assert snap.build_source is not None
+        assert len(snap.build_source.build_evidence.compile_units) == 1
+        # Named after build_info when sources is absent (dump_source_only's
+        # own naming rule).
+        assert snap.library == cdb_path.name
+
+
+class TestExecuteDumpRequestSourceOnlyErrorContract:
+    def test_no_sources_or_build_info_is_a_validation_error(self, tmp_path):
+        """A source-only request with neither ``sources`` nor ``build_info``
+        set is not expressible through ``DumpRequest.validate()`` (which
+        `resolve_dump_request` already calls and which rejects the path-less
+        shape with no evidence at all) -- but a caller resolving one via a
+        `dump_manifest`-only path-less request (a shape `validate()` *does*
+        allow, since a manifest counts as declared evidence too) reaches
+        `execute_dump_request` with neither `sources` nor `build_info`,
+        which is exactly the gap this guard closes: rather than silently
+        embedding nothing, it fails the same way `dump_source_only`'s own
+        "dump requires a binary ... or --sources/--build-info" precondition
+        does."""
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        tree = _source_tree_with_compile_db(tmp_path)
+        request = DumpRequest(input=InputSpec(path=None, sources=tree))
+        resolved = resolve_dump_request(request)
+        # Simulate the one path-less shape `validate()` allows through with
+        # no `sources`/`build_info` at all: strip them back off the already
+        # -resolved request (a real `dump_manifest`-only request would reach
+        # this exact state without needing this stripping step -- see this
+        # function's own docstring).
+        stripped_input = dataclasses.replace(
+            resolved.request.input, sources=None, build_info=None
+        )
+        stripped_resolved = dataclasses.replace(
+            resolved,
+            request=dataclasses.replace(resolved.request, input=stripped_input),
+        )
+
+        with pytest.raises(ValidationError, match="sources and/or build_info"):
+            execute_dump_request(stripped_resolved)
+
+    def test_unreached_requested_depth_floor_raises(self, tmp_path):
+        """An explicit ``--depth build`` that the source-only run can't
+        reach (no compile database anywhere in the tree, nothing to infer a
+        build system from) is a hard ``ValidationError`` -- the identical
+        floor `execute_dump_request`'s binary path enforces via
+        `enforce_requested_depth`, not a silent weaker snapshot."""
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        tree = tmp_path / "empty_src"
+        tree.mkdir()
+        (tree / "foo.cpp").write_text("void foo() {}\n")
+
+        request = DumpRequest(input=InputSpec(path=None, sources=tree), depth="build")
+        resolved = resolve_dump_request(request)
+        with pytest.raises(ValidationError, match="depth"):
+            execute_dump_request(resolved)


### PR DESCRIPTION
## Summary

Closes both remaining items of ADR-063 Track T4 ("Dump request contract"), as tracked in `docs/contribute/plans/duplication-and-convergence-assessment.md`.

## Motivation

T4 was previously ◐ *partial*: the nine-kwarg-to-typed-object fold was done, but two items were still open — splitting header-AST backend selection from castxml→clang fallback policy, and giving a source-only (binary-less) `DumpRequest` a real execution path instead of an unconditional `ValidationError` in `execute_dump_request`.

## Changes

1. **Backend selection vs. fallback policy.** `dumper._resolve_header_backend`/`_resolve_single_ast_backend`/`HEADER_BACKENDS` moved to a new `abicheck/extract/header_ast_backend.py` leaf (a real ADR-061 responsibility-package module — `dumper.py`/`dumper_toolchain.py` were both already at their own no-growth debt-ledger baseline). A new pure selection function, `dumper._resolve_effective_ast_backend`, is now the single place that predicts what `dumper._header_ast_parser`'s dispatch will do; both that function and `service_dump_pipeline.resolve_dump_request` (via a new `service_compare_evidence.effective_frontend_for_context`) call it instead of independently re-deriving the `frontend_context` override rule. Runtime fallback policy (`dumper._castxml_fallback_reason`) is untouched.
2. **Source-only dump execution.** `service_dump_pipeline.execute_dump_request` no longer raises unconditionally for a binary-less (`InputSpec.path is None`) request. It dispatches to a new `workflows/artifact/execute_source_only.execute_source_only_dump_request`, which embeds L3-L5 evidence into an empty-library `AbiSnapshot` the same way `cli_buildsource.dump_source_only`'s own CLI-only pipeline does, then enforces the requested-depth floor. `ResolvedDumpRequest` itself moved to `workflows/artifact/dump_request.py` (re-exported unchanged) so the new module can use the type without importing `service_dump_pipeline.py` at module level, which would otherwise register as a real import cycle under the AI-readiness import-cycle-growth gate.

`cli_buildsource.dump_source_only` and the `dump` CLI's own source-only dispatch are deliberately left unmigrated — see the plan doc's updated T4 notes for exactly why (a full CLI migration needs to preserve provenance stamping, the sectioned-document write path, and several CLI-only warnings that `service_dump_pipeline.py`'s own docstring excludes from its scope). This is recorded explicitly rather than left as a silent gap.

`docs/contribute/plans/duplication-and-convergence-assessment.md`'s T4 row is updated to ✅ **done**, with the same non-overclaiming, precisely-scoped note style the T1/T2/T3/T5/T6/T10 rows already use.

## Verification

- `ruff check abicheck/ tests/` — clean
- `ruff format --check` on every touched file — clean
- `mypy abicheck/` — `Success: no issues found in 669 source files`
- `python scripts/check_ai_readiness.py` — 0 errors (warnings pre-existing)
- `python scripts/check_architecture.py` — 0 errors
- Targeted `pytest -k "dump_source_only or DumpExecutionOptions or execute_dump_request or resolve_dump_request or header_backend or ast_frontend or ast_fallback"` — 84 passed
- Full fast suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — 39,802 passed, 38 skipped, 4 xfailed, 3 failed; confirmed via `git stash` that all 3 failures are pre-existing, environment-specific, and reproduce identically on the unmodified base commit (`test_action_run_sh_baseline_set_fallback`, `test_skill_eval_pack`, `test_verify_profiles`)

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_ast_backend_selection.py`, `tests/test_dump_source_only_execution.py`)
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/contribute/plans/duplication-and-convergence-assessment.md`)
- [x] No new `mypy` or `ruff` errors introduced

Not a `fix:`/`perf:`/`security:` PR, so the bug-fix test contract section is omitted per the template's own instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ubSvMY6eRtSh6ogkxrr2X

---
_Generated by [Claude Code](https://claude.ai/code/session_016ubSvMY6eRtSh6ogkxrr2X)_