### PR TITLE
docs: group examples/README.md workflows by kind, closing last split item

### DIFF
--- a/docs/contribute/plans/examples-catalog-split.md
+++ b/docs/contribute/plans/examples-catalog-split.md
@@ -576,13 +576,20 @@ what was done and how it was verified.
    layer* of evidence matters is a stronger teaching tool than two
    near-identical projects would have been, and `PHASE5_TARGET_WORKFLOWS`
    (`scripts/gen_catalog_coverage_report.py`) and this plan's Phase 5 row
-   were updated together to reflect the merged 7-workflow target set. Still
-   open, and deliberately deferred rather than done as part of this pass:
-   grouping the published set (core workflows / advanced analysis /
-   ecosystem / operational recipes) instead of presenting seven peers in one
-   flat list — a presentation change to `examples/README.md`, not a new
-   workflow, and worth doing once there's enough of the set to make the
-   grouping earn its keep.
+   were updated together to reflect the merged 7-workflow target set. The
+   presentation grouping this item originally deferred — core workflows /
+   advanced analysis / ecosystem examples / operational recipes, instead of
+   seven peers in one flat list — has since landed too: `examples/README.md`'s
+   workflow table is now four grouped tables (core: `compare-release`/
+   `audit-release`/`compare-project`; advanced analysis: `evidence-depth`;
+   ecosystem examples: `python-api`; operational recipes: `github-actions`/
+   `suppressions`), matching the external review's own recommended grouping.
+   Hand-authored, not generated — `gen_examples_docs.py` never writes
+   `examples/README.md` (only `catalog/README.md`'s generated regions), so
+   this needed no generator change, and `check_ai_readiness.py`'s
+   `examples-readme-sync` check (despite its name) pins `catalog/README.md`,
+   not this file, so the grouping is free to be presentational without a
+   drift gate to satisfy.
 2. **A by-subject view and the pattern pages that go with it — done.** All
    197 cases hand-classified into **25 subjects** (bottom-up, from what the
    catalog actually contains, not a re-derivation of `topics`/`rule_slug`/

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,17 +10,35 @@ gates run against.
 
 `workflows/<task>/` is a small, curated, task-oriented walkthrough: a tiny
 purpose-built project, the real `abicheck` command you would run, and what
-the output means.
+the output means. Grouped below by the kind of question each one answers,
+rather than as seven undifferentiated peers.
+
+**Core workflows** — the everyday release-comparison loop:
 
 | Workflow | Task |
 |---|---|
 | [`workflows/compare-release/`](workflows/compare-release/README.md) | Did my next release break anything for existing consumers? |
 | [`workflows/audit-release/`](workflows/audit-release/README.md) | Did I accidentally ship an undocumented export consumers could start depending on? |
-| [`workflows/suppressions/`](workflows/suppressions/README.md) | I renamed a function on purpose — how do I stop CI from failing on it? |
 | [`workflows/compare-project/`](workflows/compare-project/README.md) | Did removing a function from one library in my project break a sibling library that depends on it? |
+
+**Advanced analysis** — how much evidence you give abicheck changes what it can see:
+
+| Workflow | Task |
+|---|---|
 | [`workflows/evidence-depth/`](workflows/evidence-depth/README.md) | What does the evidence I give abicheck actually let it see, and what does each additional layer add? |
+
+**Ecosystem examples** — driving abicheck from something other than the CLI:
+
+| Workflow | Task |
+|---|---|
 | [`workflows/python-api/`](workflows/python-api/README.md) | How do I run this check from my own Python build script or test suite? |
+
+**Operational recipes** — wiring abicheck into CI and policy:
+
+| Workflow | Task |
+|---|---|
 | [`workflows/github-actions/`](workflows/github-actions/README.md) | How do I run this check automatically on every pull request? |
+| [`workflows/suppressions/`](workflows/suppressions/README.md) | I renamed a function on purpose — how do I stop CI from failing on it? |
 
 Each one carries a `workflow.yaml` stating the commands, the expected exit
 code, and the expected verdict; `validation/scripts/run_workflow_examples.py`


### PR DESCRIPTION
## Summary

Closes the one remaining open item from the examples/catalog-split plan (all six phases had already landed on `main`): groups the seven curated workflow examples in `examples/README.md` by kind instead of listing them as seven undifferentiated peers.

## Motivation

The plan's Phase 5 entry explicitly recorded this as deliberately deferred: "grouping the published set (core workflows / advanced analysis / ecosystem / operational recipes) instead of presenting seven peers in one flat list — a presentation change to `examples/README.md`, not a new workflow, and worth doing once there's enough of the set to make the grouping earn its keep." All 7 target workflows are now in place, and this is exactly the grouping the external review of the plan (that prompted the whole split) recommended. Closing it makes the "What is left" section's "All six items below are now closed" claim fully accurate rather than accurate-with-one-nested-exception.

## Changes

- `examples/README.md`: split the single flat workflow table into four grouped tables:
  - **Core workflows**: `compare-release`, `audit-release`, `compare-project`
  - **Advanced analysis**: `evidence-depth`
  - **Ecosystem examples**: `python-api`
  - **Operational recipes**: `github-actions`, `suppressions`
- `docs/contribute/plans/examples-catalog-split.md`: updated the Phase 5 "What is left" item to record the grouping as done, and note *why* it needed no generator or gate change (`gen_examples_docs.py` never writes this file — only `catalog/README.md`'s generated regions — and `check_ai_readiness.py`'s `examples-readme-sync` check, despite its name, pins `catalog/README.md`, not this one).

No code, schema, or generated-file changes; this is a hand-authored Markdown file with no drift gate other than link validity.

## Checklist

- [x] Docs updated (this PR is a docs-only change)
- [ ] Tests added / updated for new behaviour — N/A, no behavior change
- [ ] Changelog fragment — N/A, doesn't touch `abicheck/**/*.py`
- [x] `python scripts/check_ai_readiness.py` — 0 errors (unchanged warning baseline)
- [x] `python scripts/check_docs_contract.py` — 0 errors (unchanged, pre-existing warnings only)
- [x] `pytest tests/test_ai_readiness.py -k readme` and `tests/test_workflow_examples.py` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE9gAMQ9Pp8xNYgbgxd8Kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UE9gAMQ9Pp8xNYgbgxd8Kh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the workflow catalog into four clearly labeled sections: Core workflows, Advanced analysis, Ecosystem examples, and Operational recipes.
  * Added brief introductory text for each section to make the examples easier to browse.
  * Updated the contributor planning documentation to reflect that the workflow grouping is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->