### PR TITLE
Route scan --baseline resolution through resolve_side_snapshot

### DIFF
--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -1070,9 +1070,12 @@ def _run_baseline_compare(
     *diff* is stamped and ``analysis_assurance`` recomputed below so the
     requested-vs-effective gate has something real to check.
     """
+    from .api_types import InputSpec
     from .cli_buildsource import prepare_embedded_build_source
     from .errors import AbicheckError
-    from .service import collect_metadata, compare_snapshots, resolve_input
+    from .service import collect_metadata, compare_snapshots
+    from .service_compare_evidence import SideEvidence
+    from .service_input_resolution import resolve_side_snapshot
 
     # note_if_same_binary_compared lives in workflows.gate, not workflows.extraction (Codex review) -- see that module's own docstring for why a post-comparison coverage warning belongs there.
     from .workflows.gate import note_if_same_binary_compared
@@ -1089,23 +1092,46 @@ def _run_baseline_compare(
         )
     )
     try:
-        old_snap = resolve_input(
-            baseline,
-            bl_headers,
-            bl_includes,
-            version="",
+        # Routed through the shared `resolve_side_snapshot` primitive
+        # (P0 item 4 of the duplication-and-convergence-assessment plan)
+        # rather than calling `service.resolve_input()` directly. `sources`/
+        # `build_info` are left `None` -- this side's own embedded L3-L5
+        # evidence is diffed separately below via
+        # `prepare_embedded_build_source`, the same split `compare`'s
+        # implicit-dump operand keeps -- so no build/source evidence is
+        # embedded here and `_seeded_includes_and_compile_context`'s L2
+        # include/compile-context fold is a no-op, leaving `bl_includes`/
+        # `compile_context` exactly as given (unchanged behavior). The
+        # ADR-039 build-context collector this primitive also runs is
+        # likewise a no-op with no compile database resolvable
+        # (`compile_db`/`build_info` both unset here).
+        old_snap = resolve_side_snapshot(
+            InputSpec(
+                path=baseline,
+                headers=tuple(bl_headers),
+                includes=tuple(bl_includes),
+                version="",
+                compile=compile_context,
+                # Matches the candidate's own resolve_input() default in
+                # scan_engine.py's run_scan_core -- a no-op for a JSON
+                # snapshot baseline (already-serialized, no dumping
+                # happens), but keeps a *native* --baseline library filtered
+                # consistently with the candidate (Codex review).
+                include_dependencies=False,
+            ),
+            SideEvidence(
+                headers=bl_headers,
+                compile=compile_context,
+                collect_mode="off",
+                dump_manifest=None,
+            ),
             lang=lang,
+            header_backend="auto",
+            fmt=None,
             public_headers=bl_public_headers,
             public_header_dirs=bl_public_dirs,
-            compile=compile_context,
             symbols_only=symbols_only,
             debug_presence_only=debug_presence_only,
-            # Matches the candidate's own resolve_input() default in
-            # scan_engine.py's run_scan_core -- a no-op for a JSON snapshot
-            # baseline (already-serialized, no dumping happens), but keeps a
-            # *native* --baseline library filtered consistently with the
-            # candidate (Codex review).
-            include_dependencies=False,
         )
     except AbicheckError as exc:
         raise click.ClickException(

--- a/changelog.d/1787100000_claude_scan-baseline-resolver-convergence.md
+++ b/changelog.d/1787100000_claude_scan-baseline-resolver-convergence.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **`scan --baseline`'s old-side resolution now routes through the shared `service_input_resolution.resolve_side_snapshot` primitive** instead of calling `service.resolve_input()` directly — the same convergence `compare`'s implicit-dump operand, `dump`'s typed pipeline, and `scan`'s candidate resolution already went through. Closes the last `CLI_CONTRACT_ALLOWLIST` entry for `cli_scan_baseline.py`. No observable behavior change: no build/source evidence is embedded through this path (it's still diffed separately via `prepare_embedded_build_source`) and no compile database is resolvable here, so the shared primitive's L2 include/compile-context fold and ADR-039 build-context collector are both no-ops.

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -2636,23 +2636,22 @@ _RESOLVE_INPUT_WRAPPER_MODULES: frozenset[str] = frozenset({"cli_resolve"})
 # call is still there, not just that *some* finding exists at that site.
 # Pre-populated with the pre-existing, already-documented
 # `dumper.dump`/`service.resolve_input` direct-call sites Phase 1 of the
-# same plan names as duplication to converge (`appcompat.check_appcompat`,
-# `cli_scan_baseline`'s baseline resolution) — a new entry beyond these
-# needs the same reviewed sign-off (mirrors the INTENTIONAL_SUBSET
-# philosophy of D10.2). `cli_dump_helpers.perform_elf_dump`'s own entry was
-# the first to leave this list, and it left the way the plan intends one
-# to: not by rerouting the call, but by deleting the dead function that
-# made it (ADR-063 Track 1) once `dump_cmd` had already migrated onto the
-# shared typed executor.
+# same plan names as duplication to converge (`appcompat.check_appcompat`)
+# — a new entry beyond these needs the same reviewed sign-off (mirrors the
+# INTENTIONAL_SUBSET philosophy of D10.2). `cli_dump_helpers.
+# perform_elf_dump`'s own entry was the first to leave this list, and it
+# left the way the plan intends one to: not by rerouting the call, but by
+# deleting the dead function that made it (ADR-063 Track 1) once `dump_cmd`
+# had already migrated onto the shared typed executor.
+# `cli_scan_baseline`'s baseline resolution (P0 item 4's baseline half) was
+# the second to leave this list: its `service.resolve_input()` call now
+# routes through `service_input_resolution.resolve_side_snapshot`, same as
+# every other resolver P0 item 4 converged.
 CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         # `appcompat.check_appcompat`'s two `dumper.dump()` call sites left
         # this list in T5 (direct-bypass migration): both now route through
         # `service.run_dump` instead.
-        # Scan baseline resolution (P0 item 4's baseline half): calls
-        # `service.resolve_input()` directly rather than through
-        # `service_input_resolution.resolve_side_snapshot`.
-        "abicheck/cli_scan_baseline.py:1092:19:service.resolve_input",
         # ABICC compatibility wrapper (P1 "ABICC compatibility is a parallel
         # frontend and engine path"): its own parallel engine path calls
         # both `dumper.dump()` and `checker.compare()` directly.

--- a/tests/test_pr494_scan_regressions.py
+++ b/tests/test_pr494_scan_regressions.py
@@ -19,7 +19,7 @@ def test_scan_baseline_compare_preserves_hard_l0_elf_removal(monkeypatch) -> Non
     remains authoritative and must be folded into the final scan verdict.
     """
 
-    old_snap = SimpleNamespace(build_source=None)
+    old_snap = SimpleNamespace(build_source=None, elf=None)
     new_snap = SimpleNamespace(build_source=None)
     hard_l0 = SimpleNamespace(kind=SimpleNamespace(value="func_removed_elf_only"))
     calls: list[dict[str, object]] = []
@@ -126,7 +126,7 @@ def test_scan_baseline_compare_does_not_promote_advisory_l0_findings(
 ) -> None:
     """Only explicit hard L0 removals are preserved; crosschecks stay advisory."""
 
-    old_snap = SimpleNamespace(build_source=None)
+    old_snap = SimpleNamespace(build_source=None, elf=None)
     new_snap = SimpleNamespace(build_source=None)
     advisory = SimpleNamespace(
         kind=SimpleNamespace(value="header_build_context_mismatch")
@@ -242,7 +242,7 @@ def test_scan_baseline_compare_truncates_large_finding_lists(monkeypatch) -> Non
     """A large baseline diff caps embedded findings and flags the truncation."""
     from abicheck.cli_scan_baseline import _MAX_BASELINE_FINDINGS
 
-    old_snap = SimpleNamespace(build_source=None)
+    old_snap = SimpleNamespace(build_source=None, elf=None)
     new_snap = SimpleNamespace(build_source=None)
     many_breaks = [
         SimpleNamespace(
@@ -320,7 +320,7 @@ def test_scan_baseline_compare_truncates_large_suppressed_lists(monkeypatch) -> 
     """A large *suppressed* list caps independently and flags its own truncation."""
     from abicheck.cli_scan_baseline import _MAX_BASELINE_FINDINGS
 
-    old_snap = SimpleNamespace(build_source=None)
+    old_snap = SimpleNamespace(build_source=None, elf=None)
     new_snap = SimpleNamespace(build_source=None)
     many_suppressed = [
         SimpleNamespace(
@@ -409,7 +409,7 @@ def test_scan_baseline_compare_filters_dependency_scope_by_default(monkeypatch) 
     dump'd baseline" workflow with ScopeMismatchError. Assert the baseline
     resolve_input() call now matches the candidate's own default."""
 
-    old_snap = SimpleNamespace(build_source=None)
+    old_snap = SimpleNamespace(build_source=None, elf=None)
     new_snap = SimpleNamespace(build_source=None)
     calls: list[dict[str, object]] = []
 

--- a/tests/test_scan_baseline_headers.py
+++ b/tests/test_scan_baseline_headers.py
@@ -127,6 +127,7 @@ class _FakeDiff:
 
 class _FakeSnap:
     build_source = None
+    elf = None
 
 
 @pytest.fixture
@@ -137,7 +138,7 @@ def _patched(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
 
     captured: dict[str, object] = {}
 
-    def fake_resolve_input(path, headers, includes, **kw):  # type: ignore[no-untyped-def]
+    def fake_resolve_input(path, headers, includes, version, lang, **kw):  # type: ignore[no-untyped-def]
         if "headers" not in captured:
             captured["headers"] = list(headers)
             captured["includes"] = list(includes)
@@ -263,7 +264,7 @@ def test_run_baseline_compare_threads_policy_and_scope_to_compare_snapshots(
 
     captured: dict[str, object] = {}
 
-    def fake_resolve_input(path, headers, includes, **kw):  # type: ignore[no-untyped-def]
+    def fake_resolve_input(path, headers, includes, version, lang, **kw):  # type: ignore[no-untyped-def]
         return _FakeSnap()
 
     def fake_compare_snapshots(
@@ -345,7 +346,7 @@ def test_run_baseline_compare_forwards_policy_file_to_embedded_build_source(
 
     captured: dict[str, object] = {}
 
-    def fake_resolve_input(path, headers, includes, **kw):  # type: ignore[no-untyped-def]
+    def fake_resolve_input(path, headers, includes, version, lang, **kw):  # type: ignore[no-untyped-def]
         return _FakeSnap()
 
     def fake_prepare_embedded_build_source(old, new, cm, extra, *rest, **kw):  # type: ignore[no-untyped-def]

--- a/tests/test_scan_compare_parity.py
+++ b/tests/test_scan_compare_parity.py
@@ -424,6 +424,7 @@ def test_run_baseline_compare_forwards_collapse_versioned_symbols(
 
     class _FakeSnap:
         build_source = None
+        elf = None
 
     class _FakeVerdict:
         value = "NO_CHANGE"
@@ -435,7 +436,7 @@ def test_run_baseline_compare_forwards_collapse_versioned_symbols(
         risk: list[object] = []
         compatible: list[object] = []
 
-    def fake_resolve_input(path, headers, includes, **kw):  # type: ignore[no-untyped-def]
+    def fake_resolve_input(path, headers, includes, version, lang, **kw):  # type: ignore[no-untyped-def]
         return _FakeSnap()
 
     def fake_compare_snapshots(old, new, suppression=None, *, extra_changes, **kw):


### PR DESCRIPTION
## Summary

Closes the last `CLI_CONTRACT_ALLOWLIST` entry naming `cli_scan_baseline.py`: `scan --baseline`'s old-side resolution now routes through the shared `service_input_resolution.resolve_side_snapshot` primitive instead of calling `service.resolve_input()` directly.

## Motivation

ADR-063 (T1-T10) is closed; the one remaining item was `cli_scan_baseline.py:1092` calling `service.resolve_input()` directly, bypassing `service_input_resolution.resolve_side_snapshot` — the primitive `compare`'s implicit-dump operand, `dump`'s typed pipeline, and `scan`'s own candidate-side resolution already converged onto (P0 item 4 of the duplication-and-convergence-assessment plan).

## Changes

- `cli_scan_baseline._run_baseline_compare` now builds an `InputSpec`/`SideEvidence` pair for the `--baseline` old side and resolves it via `resolve_side_snapshot`, matching every other resolver.
- `sources`/`build_info` are left `None` on the `InputSpec` — this side's embedded L3-L5 evidence is still diffed separately via `prepare_embedded_build_source` (unchanged) — so the shared primitive's L2 include/compile-context fold and ADR-039 build-context collector are both no-ops here. No observable behavior change.
- Removed the now-stale `CLI_CONTRACT_ALLOWLIST` entry and updated its surrounding comments in `scripts/check_ai_readiness.py`.
- Updated test doubles in `test_pr494_scan_regressions.py`, `test_scan_baseline_headers.py`, and `test_scan_compare_parity.py` whose fake snapshots/`fake_resolve_input` signatures didn't match the shared primitive's calling convention (it checks `snap.elf` and calls `resolve_input` with `version`/`lang` positionally).
- Added a changelog fragment.

This is an internal architecture-contract cleanup with no observable behavior change (verified below), not a behavioral bug fix — hence `refactor:`.

## Verification

- `python scripts/check_ai_readiness.py` — 0 errors (no new warnings; `cli-contract` clean).
- `mypy abicheck/` — clean, 674 source files.
- `ruff check`/`ruff format --check` on touched files — no new violations.
- `pytest tests/ -k "baseline and scan" -m "not integration and not libabigail and not abicc and not slow and not golden"` — 183 passed.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — n/a, no user-visible behavior change
- [x] `pre-commit run --all-files` equivalent checks (ruff/mypy/ai-readiness) pass locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AhJF9x3HdXjQULq2XZ5zQX)_