### PR TITLE
test: add scan-vs-compare parity harness (Phase 0)

### DIFF
--- a/tests/parity/__init__.py
+++ b/tests/parity/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 0 of docs/contribute/plans/one-comparison-product.md.
+
+The scan-vs-compare parity harness: a fixture corpus plus a runner that
+invokes ``scan`` and ``compare`` over the same inputs with equivalent
+evidence and diffs the *finding sets* (kind, resolved identity, severity,
+evidence refs) they produce — never the rendered report text.
+
+This package exists while both ``scan`` and ``compare`` are still public
+commands (ADR-068 D9). It is the only point at which the two can be
+compared directly, and its job is to make a silent capability loss loud:
+a check that runs under ``scan`` and produces nothing under ``compare``
+must fail a test here, by name.
+
+Do not add production-code changes alongside this package (Phase 0 is
+parity-detection only, per the plan); a red entry in ``gaps.py`` records a
+known gap, it does not excuse fixing it in this PR.
+
+Distinct from ``tests/test_scan_compare_parity.py`` (ADR-049 Phase 5 §6.4):
+that module asserts field-for-field agreement on the findings both tools
+*already* produce (policy/suppression/scope config parity, on the ordinary
+compare pipeline both share). This package asserts the opposite direction
+-- which findings ``scan`` produces that ``compare`` cannot reach *at all*.
+"""
+
+from __future__ import annotations

--- a/tests/parity/_synthetic_snapshots.py
+++ b/tests/parity/_synthetic_snapshots.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compiler-free synthetic ``AbiSnapshot`` builders for the three
+cross-source checks the committed G20 example corpus doesn't happen to
+cover on its own (``examples/case14x-18x``, see ``tests/test_g20_catalog.py``):
+``compile_context_conflict``, ``source_surface_dso_mismatch``, and
+``identity_collision_detected``.
+
+Adapted from the minimal fixtures ``tests/test_crosscheck.py`` already uses
+for the same three checks (its own ``_pack_with_units``/``_cu``/
+``_surface_with_mapping``/``_pack_with_identity_collisions`` helpers) — kept
+here as a separate, smaller module rather than importing test internals
+across files, and because a parity fixture only needs the single positive
+case each check's own oracle test already proves fires under
+``run_crosschecks``.
+
+Non-``test_*`` module (a helper, not a suite) so the test collector ignores it.
+"""
+
+from __future__ import annotations
+
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+from abicheck.buildsource.pack import BuildSourcePack
+from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
+from abicheck.model import AbiSnapshot
+
+
+def compile_context_conflict_snapshot() -> AbiSnapshot:
+    """Two TUs of one target compiled with disagreeing effective -frtti mode."""
+    build_evidence = BuildEvidence(
+        compile_units=[
+            CompileUnit(
+                id="a",
+                target_id="target://libfoo.so",
+                abi_relevant_flags=["-frtti"],
+                language="CXX",
+            ),
+            CompileUnit(
+                id="b",
+                target_id="target://libfoo.so",
+                abi_relevant_flags=["-fno-rtti"],
+                language="CXX",
+            ),
+        ]
+    )
+    return AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        from_headers=True,
+        build_source=BuildSourcePack(root="", build_evidence=build_evidence),
+    )
+
+
+def source_surface_dso_mismatch_snapshot() -> AbiSnapshot:
+    """A source-ABI surface whose mapped symbols belong to a DIFFERENT DSO."""
+    surface = SourceAbiSurface(
+        library="libfoo.so",
+        reachable_declarations=[
+            SourceEntity(id="d0", kind="function", qualified_name="d0"),
+            SourceEntity(id="d1", kind="function", qualified_name="d1"),
+        ],
+    )
+    # These map to symbols that never appear in *this* binary's own export
+    # table (below) -- the exact mis-scoped-surface shape
+    # test_source_surface_dso_mismatch_flags_stale_surface_mapped_to_other_dso
+    # exercises in tests/test_crosscheck.py.
+    surface.mappings["source_decl_to_binary_symbol"] = {
+        "d0": "_Z9otherlibv",
+        "d1": "_Z9otherfn2v",
+    }
+    from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+
+    elf = ElfMetadata(symbols=[ElfSymbol(name="_Z3foov"), ElfSymbol(name="_Z3barv")])
+    return AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        from_headers=True,
+        elf=elf,
+        build_source=BuildSourcePack(root="", source_abi=surface),
+    )
+
+
+def identity_collision_snapshot() -> AbiSnapshot:
+    """One L4 source-ABI surface recording a real identity collision."""
+    surface = SourceAbiSurface(
+        identity_collisions=[
+            {
+                "identity": "f#sha256:abc",
+                "qualified_name": "f",
+                "usr_a": "c:@F@f#",
+                "usr_b": "c:@N@ns@F@f#",
+            }
+        ],
+        # Any real L4 fact makes the surface non-empty so the check runs
+        # (an empty surface reads as "no evidence", not "clean" --
+        # ADR-035 D4 coverage honesty).
+        reachable_declarations=[
+            SourceEntity(id="d1", kind="function", qualified_name="f")
+        ],
+    )
+    return AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        from_headers=True,
+        build_source=BuildSourcePack(root="", source_abi=surface),
+    )

--- a/tests/parity/gaps.py
+++ b/tests/parity/gaps.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The expected-gap registry — the migration's own definition of done.
+
+``docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md``
+identifies the capabilities ``compare`` cannot reach today: the eleven
+cross-source checks (``abicheck/buildsource/crosscheck.py``), the lexical
+pattern pre-scan (``pattern_scan.py``), the preprocessor scan
+(``preprocessor_scan.py``), changed-path localization, and the ``abi3``
+audit. Every one of those is registered here, each with the plan phase
+that is expected to close it (``docs/contribute/plans/one-comparison-product.md``
+§6) — never a bare ``xfail``, so a reader always has a name and a phase to
+check rather than a silent skip.
+
+**This registry is the red set the migration must turn empty.** A test in
+this package asserts, for each registered key, that the capability is
+present under ``scan`` and absent under ``compare`` today. When a Phase 2
+PR gives ``compare`` the capability, the corresponding parity test starts
+asserting a contradiction (``scan`` and ``compare`` now agree) and fails
+loudly until the entry below is deleted in that same PR — see
+``test_gap_registry_contract.py``.
+
+Do not add an entry here for a loss that isn't one of the sixteen listed
+capabilities (eleven checks + pattern scan + preprocessor scan +
+changed-path localization + abi3 audit) — an *unexplained* loss anywhere
+else is a real regression the harness must fail on, not something to file
+away quietly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Shorthand for the eleven cross-source checks, all closed together
+#: (docs/contribute/plans/one-comparison-product.md §3 #3-#5, #6.8 note,
+#: §6 Phase 2a): "cross-source checks, per side, evolution-stated".
+_PHASE_2A = "Phase 2a — cross-source checks become a compare pipeline stage (plan §6)"
+_PHASE_2B = "Phase 2b — pattern + preprocessor scans move onto compare (plan §6)"
+_PHASE_2C = "Phase 2c — changed-path localization (--since/--changed-path) (plan §6)"
+_PHASE_2D = "Phase 2d — abi3 candidate-side enrichment (plan §6)"
+_PHASE_1 = "Phase 1 — FindingEvolution state on the canonical finding model (plan §6)"
+
+
+@dataclass(frozen=True)
+class ExpectedGap:
+    """One capability ``compare`` cannot reach yet."""
+
+    #: Why the gap exists today (mirrors ADR-068 §1's call-site finding).
+    reason: str
+    #: The plan phase (docs/contribute/plans/one-comparison-product.md §6)
+    #: expected to close it. Not a promise of *when* — just *which* PR.
+    plan_phase: str
+    #: The table row in the plan's §3 capability map, for cross-reference.
+    plan_row: str
+
+
+#: The eleven cross-source checks (buildsource/crosscheck.py). Verified by
+#: call site (ADR-068 §1): their only production caller anywhere under
+#: abicheck/ is scan_engine.py.
+_CROSSCHECK_REASON = (
+    "cross-source check (abicheck/buildsource/crosscheck.py); its only "
+    "production caller under abicheck/ is scan_engine.py (ADR-068 §1)"
+)
+
+EXPECTED_GAPS: dict[str, ExpectedGap] = {
+    "exported_not_public": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3/#5"),
+    "public_not_exported": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3/#5"),
+    "header_build_context_mismatch": ExpectedGap(
+        _CROSSCHECK_REASON, _PHASE_2A, "§3 #3/#10"
+    ),
+    "private_header_leak": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3/#4"),
+    "odr_type_variant": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3"),
+    "public_to_internal_dependency": ExpectedGap(
+        _CROSSCHECK_REASON, _PHASE_2A, "§3 #3"
+    ),
+    "unversioned_exported_symbol": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3"),
+    "rtti_for_internal_type": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3"),
+    "identity_collision_detected": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3"),
+    "compile_context_conflict": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3/#10"),
+    "source_surface_dso_mismatch": ExpectedGap(_CROSSCHECK_REASON, _PHASE_2A, "§3 #3"),
+    "pattern_scan": ExpectedGap(
+        "lexical pattern pre-scan (abicheck/buildsource/pattern_scan.py); its "
+        "only production caller under abicheck/ is scan_engine.py (ADR-068 §1)",
+        _PHASE_2B,
+        "§3 #6",
+    ),
+    "preprocessor_scan": ExpectedGap(
+        "preprocessor scan (abicheck/buildsource/preprocessor_scan.py); its "
+        "only production caller under abicheck/ is scan_engine.py (ADR-068 §1)",
+        _PHASE_2B,
+        "§3 #8",
+    ),
+    "changed_path_localization": ExpectedGap(
+        "--since/--changed-path exist only on `scan` (cli_scan.py, "
+        "buildsource/poi.py); `compare` has no such option",
+        _PHASE_2C,
+        "§3 #12",
+    ),
+    "abi3_audit": ExpectedGap(
+        "--abi3 single-artifact stable-ABI audit exists only on `scan` "
+        "(scan_abi3_resolve.py, scan_engine._run_abi3_audit); `compare` has "
+        "no --abi3 option at all",
+        _PHASE_2D,
+        "§3 #15",
+    ),
+}
+
+#: F-8/F-9 (plan §7): the `not_evaluated`/`resolved` evolution axis for a
+#: one-sided check re-run across a baseline. This is not a scan-vs-compare
+#: gap at all — neither tool has this vocabulary today (`FindingEvolution`
+#: is *new* Phase-1 work, not a migrated capability) — so it is tracked
+#: separately from EXPECTED_GAPS, which is specifically "scan has it,
+#: compare doesn't".
+NOT_YET_IMPLEMENTED_ANYWHERE: dict[str, ExpectedGap] = {
+    "finding_evolution": ExpectedGap(
+        "no FindingEvolution state (introduced/resolved/persistent/"
+        "not_evaluated) exists on the canonical finding model under either "
+        "`scan` or `compare` today; scan's own crosscheck pass is single-"
+        "sided even with --against and does not distinguish a pre-existing "
+        "issue from a newly introduced one",
+        _PHASE_1,
+        "§5 P2 / D3",
+    ),
+}
+
+
+#: The complete red set (plan §6 Phase 0's own phrasing): every capability
+#: this harness must show `scan`-only today. `test_gap_registry_contract.py`
+#: pins this at exactly sixteen (11 checks + pattern_scan + preprocessor_scan
+#: + changed_path_localization + abi3_audit + the F-8/F-9 evolution gap).
+ALL_EXPECTED_GAPS: dict[str, ExpectedGap] = {
+    **EXPECTED_GAPS,
+    **NOT_YET_IMPLEMENTED_ANYWHERE,
+}

--- a/tests/parity/gaps.py
+++ b/tests/parity/gaps.py
@@ -19,11 +19,17 @@ asserting a contradiction (``scan`` and ``compare`` now agree) and fails
 loudly until the entry below is deleted in that same PR — see
 ``test_gap_registry_contract.py``.
 
-Do not add an entry here for a loss that isn't one of the sixteen listed
-capabilities (eleven checks + pattern scan + preprocessor scan +
+Do not add an entry here for a loss that isn't one of the fifteen listed
+scan-only capabilities (eleven checks + pattern scan + preprocessor scan +
 changed-path localization + abi3 audit) — an *unexplained* loss anywhere
 else is a real regression the harness must fail on, not something to file
-away quietly.
+away quietly. ``EXPECTED_GAPS`` (this dict) is what ``runner.py``'s
+scan-vs-compare diff checks against; ``ALL_EXPECTED_GAPS`` below folds in
+the separate ``finding_evolution`` tracking entry too, purely for
+``test_gap_registry_contract.py``'s own completeness bookkeeping — it is
+never used to decide whether a scan finding's *absence* from `compare` is
+expected, since ``finding_evolution`` is not a real ``Finding.kind`` any
+scan-side result could ever carry.
 """
 
 from __future__ import annotations
@@ -123,10 +129,12 @@ NOT_YET_IMPLEMENTED_ANYWHERE: dict[str, ExpectedGap] = {
 }
 
 
-#: The complete red set (plan §6 Phase 0's own phrasing): every capability
-#: this harness must show `scan`-only today. `test_gap_registry_contract.py`
+#: The complete *tracked* set: every scan-only capability plus the
+#: separately-tracked F-8/F-9 evolution gap. `test_gap_registry_contract.py`
 #: pins this at exactly sixteen (11 checks + pattern_scan + preprocessor_scan
-#: + changed_path_localization + abi3_audit + the F-8/F-9 evolution gap).
+#: + changed_path_localization + abi3_audit + finding_evolution). Used only
+#: for that registry-completeness bookkeeping -- `runner.py`'s scan-vs-compare
+#: diff checks against `EXPECTED_GAPS` alone (see this module's docstring).
 ALL_EXPECTED_GAPS: dict[str, ExpectedGap] = {
     **EXPECTED_GAPS,
     **NOT_YET_IMPLEMENTED_ANYWHERE,

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -24,7 +24,7 @@ from abicheck.change_registry import REGISTRY
 from abicheck.checker_policy import ChangeKind
 from abicheck.cli import main as abicheck_main
 
-from .gaps import ALL_EXPECTED_GAPS
+from .gaps import EXPECTED_GAPS
 
 
 @dataclass(frozen=True)
@@ -164,49 +164,79 @@ def write_snapshot(snapshot: Any, path: Path) -> Path:
 
 @dataclass(frozen=True)
 class ParityReport:
-    """The outcome of comparing a scan-side and a compare-side kind set."""
+    """The outcome of comparing a scan-side and a compare-side finding set.
+
+    Diffs happen over whole :class:`Finding` values (kind + identity +
+    severity + evidence), not just kinds — two findings of the same kind
+    but different resolved identity (e.g. ``func_removed`` for symbols A
+    and B) are distinguishable, so a partial gap closure (compare now
+    reaches one of the two, not both) stays visible instead of reading as
+    full parity the moment either instance shows up on both sides.
+    """
 
     #: Present under scan, absent under compare, and *not* a recorded gap —
     #: an unexplained capability loss. Must always be empty.
-    unexplained_losses: frozenset[str]
+    unexplained_losses: frozenset[Finding]
     #: Present under scan, absent under compare, matching a recorded gap —
-    #: the expected red state.
-    expected_losses: frozenset[str]
-    #: Registered as an expected gap, but scan and compare now agree on it
-    #: (compare produces it too) — the gap is closed and must be deleted
-    #: from tests/parity/gaps.py in the same PR that closed it.
+    #: the expected red state (may be a subset of that kind's scan findings
+    #: when the gap is only partially closed).
+    expected_losses: frozenset[Finding]
+    #: A gap kind is only "healed" once EVERY scan finding of that kind is
+    #: also produced by compare — not merely once any one instance is.
     healed_gaps: frozenset[str]
     #: Present under compare but not under scan — richer, always allowed.
-    compare_only: frozenset[str]
+    compare_only: frozenset[Finding]
 
 
-def diff_kind_sets(
-    *, scan_kinds: frozenset[str], compare_kinds: frozenset[str]
+def diff_findings(
+    *, scan_findings: FindingSet, compare_findings: FindingSet
 ) -> ParityReport:
-    """Classify every kind difference between a scan-side and compare-side set."""
-    lost = scan_kinds - compare_kinds
-    expected = frozenset(ALL_EXPECTED_GAPS)
+    """Classify every finding difference between a scan-side and compare-side set.
+
+    Gap membership (``EXPECTED_GAPS``, never ``ALL_EXPECTED_GAPS`` --
+    ``finding_evolution`` there is a "not implemented anywhere" tracking
+    entry, not a scan-vs-compare capability comparison, and no real
+    ``Finding.kind`` is ever spelled that way) is checked per finding by
+    its own ``kind``, but "healed" is computed over the whole kind: it only
+    fires once every scan finding of that kind also appears on the compare
+    side, so closing the gap for one identity while another of the same
+    kind is still lost does not falsely read as a completed migration.
+    """
+    lost = scan_findings - compare_findings
+    expected_kinds = frozenset(EXPECTED_GAPS)
+    lost_kinds = kinds_of(lost)
+    scan_kinds = kinds_of(scan_findings)
     return ParityReport(
-        unexplained_losses=lost - expected,
-        expected_losses=lost & expected,
-        healed_gaps=expected & scan_kinds & compare_kinds,
-        compare_only=compare_kinds - scan_kinds,
+        unexplained_losses=frozenset(f for f in lost if f.kind not in expected_kinds),
+        expected_losses=frozenset(f for f in lost if f.kind in expected_kinds),
+        healed_gaps=frozenset(
+            k for k in expected_kinds if k in scan_kinds and k not in lost_kinds
+        ),
+        compare_only=compare_findings - scan_findings,
     )
 
 
 def assert_no_capability_loss(
-    *, scan_kinds: frozenset[str], compare_kinds: frozenset[str], context: str
+    *, scan_findings: FindingSet, compare_findings: FindingSet, context: str
 ) -> ParityReport:
     """Fail loudly, naming the check, for any loss `gaps.py` doesn't explain.
 
     Also fails when a *registered* gap turns out to no longer be a gap
-    (``compare`` now produces the kind too) — the harness must not keep
-    asserting a red state the migration already turned green, or the
-    registry silently stops being "the migration's definition of done".
+    (``compare`` now produces every one of that kind's findings too) — the
+    harness must not keep asserting a red state the migration already
+    turned green, or the registry silently stops being "the migration's
+    definition of done".
     """
-    report = diff_kind_sets(scan_kinds=scan_kinds, compare_kinds=compare_kinds)
+    report = diff_findings(
+        scan_findings=scan_findings, compare_findings=compare_findings
+    )
     if report.unexplained_losses:
-        names = ", ".join(sorted(report.unexplained_losses))
+        names = ", ".join(
+            f"{f.kind}({f.identity!r})"
+            for f in sorted(
+                report.unexplained_losses, key=lambda f: (f.kind, f.identity)
+            )
+        )
         raise AssertionError(
             f"{context}: capability loss -- present under `scan`, absent under "
             f"`compare`, and NOT a recorded parity gap: {names}. Either this is "
@@ -216,8 +246,7 @@ def assert_no_capability_loss(
         )
     if report.healed_gaps:
         entries = ", ".join(
-            f"{k} ({ALL_EXPECTED_GAPS[k].plan_phase})"
-            for k in sorted(report.healed_gaps)
+            f"{k} ({EXPECTED_GAPS[k].plan_phase})" for k in sorted(report.healed_gaps)
         )
         raise AssertionError(
             f"{context}: parity gap closed but tests/parity/gaps.py still "

--- a/tests/parity/runner.py
+++ b/tests/parity/runner.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI-invocation and finding-set helpers shared by the parity test modules.
+
+Diffs happen on structured *finding sets* — kind, resolved identity,
+severity, evidence refs — never on rendered report text (Phase 0's own
+requirement, plan §6). ``compare``/``scan`` are invoked through their real
+public CLI entry point (Click's in-process ``CliRunner``, no subprocess);
+``run_crosschecks``/``scan_files``/``audit_stable_abi_imports`` are invoked
+directly for the ``scan``-only side because they are themselves the
+production functions ADR-068 §1 named as scan-only by call site — calling
+them here *is* exercising "what scan has", not a reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from abicheck.change_registry import REGISTRY
+from abicheck.checker_policy import ChangeKind
+from abicheck.cli import main as abicheck_main
+
+from .gaps import ALL_EXPECTED_GAPS
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One finding, projected to the dimensions parity is judged on."""
+
+    kind: str
+    identity: str
+    severity: str
+    evidence_refs: tuple[str, ...] = ()
+
+
+FindingSet = frozenset[Finding]
+
+
+def invoke_cli(*args: str) -> Any:
+    """Invoke the real ``abicheck`` CLI in-process (the public entry point)."""
+    return CliRunner().invoke(abicheck_main, list(args))
+
+
+def severity_for_kind(kind_value: str) -> str:
+    """The kind's registered default verdict — independent of run context.
+
+    Both ``run_crosschecks``' ``Change`` objects and a rendered ``compare``
+    JSON report's ``changes[]`` entries carry the same ``ChangeKind``
+    vocabulary, so this is a single, side-independent severity axis: it
+    doesn't depend on which tool computed the finding, only on what kind it
+    is (``abicheck/change_registry.py``'s ``ChangeKindMeta.default_verdict``).
+    """
+    try:
+        meta = REGISTRY.get(ChangeKind(kind_value))
+    except ValueError:
+        return "UNKNOWN"
+    return meta.default_verdict.value if meta else "UNKNOWN"
+
+
+def crosscheck_finding_set(snapshot: Any, config: Any = None) -> FindingSet:
+    """The finding set ``scan``'s cross-source checks produce for *snapshot*.
+
+    Calls :func:`abicheck.buildsource.crosscheck.run_crosschecks` directly —
+    the same production function ``scan_engine.py`` is the sole caller of.
+    """
+    from abicheck.buildsource.crosscheck import run_crosschecks
+
+    result = run_crosschecks(snapshot, config)
+    findings = set()
+    for c in result.findings:
+        kind = c.kind.value
+        findings.add(
+            Finding(
+                kind=kind,
+                identity=c.symbol or "",
+                severity=severity_for_kind(kind),
+                evidence_refs=tuple(result.providers.get(kind, ())),
+            )
+        )
+    return frozenset(findings)
+
+
+def compare_json(old: Path | str, new: Path | str, *extra_args: str) -> dict[str, Any]:
+    """Invoke ``compare OLD NEW --format json`` and return the parsed report."""
+    result = invoke_cli("compare", str(old), str(new), "--format", "json", *extra_args)
+    if result.exit_code not in (0, 1, 2, 4, 6):
+        raise AssertionError(
+            f"compare failed unexpectedly (exit={result.exit_code}):\n{result.output}"
+        )
+    # `--format json` still writes diagnostics (e.g. a public-surface-scoping
+    # warning) to stderr; only stdout is the machine-readable report.
+    return json.loads(result.stdout)
+
+
+def compare_finding_set(
+    old: Path | str, new: Path | str, *extra_args: str
+) -> FindingSet:
+    """The finding set the real ``compare`` CLI produces for OLD vs NEW."""
+    data = compare_json(old, new, *extra_args)
+    findings = set()
+    for c in data.get("changes", []):
+        kind = c["kind"]
+        findings.add(
+            Finding(
+                kind=kind,
+                identity=c.get("symbol") or "",
+                severity=severity_for_kind(kind),
+                evidence_refs=tuple(c.get("contract_evidence_refs") or ()),
+            )
+        )
+    return frozenset(findings)
+
+
+def scan_json(artifact: Path | str, *extra_args: str) -> dict[str, Any]:
+    """Invoke ``scan ARTIFACT --format json`` and return the parsed report."""
+    result = invoke_cli("scan", str(artifact), "--format", "json", *extra_args)
+    if result.exit_code not in (0, 1, 2, 4, 5, 6, 7):
+        raise AssertionError(
+            f"scan failed unexpectedly (exit={result.exit_code}):\n{result.output}"
+        )
+    return json.loads(result.stdout)
+
+
+def scan_finding_set(artifact: Path | str, *extra_args: str) -> FindingSet:
+    """The finding set ``scan --against`` produces for ARTIFACT.
+
+    Only populated when the run actually reaches a baseline comparison
+    (``scan``'s JSON carries the real per-finding list at ``diff.findings``
+    then, keyed the same way as ``compare``'s ``changes[]`` -- ``kind``/
+    ``symbol``; without ``--against`` there is nothing to diff and this is
+    empty by construction).
+    """
+    data = scan_json(artifact, *extra_args)
+    diff = data.get("diff") or {}
+    findings = set()
+    for c in diff.get("findings", []):
+        kind = c["kind"]
+        findings.add(
+            Finding(
+                kind=kind,
+                identity=c.get("symbol") or "",
+                severity=severity_for_kind(kind),
+                evidence_refs=(),
+            )
+        )
+    return frozenset(findings)
+
+
+def kinds_of(finding_set: FindingSet) -> frozenset[str]:
+    return frozenset(f.kind for f in finding_set)
+
+
+def write_snapshot(snapshot: Any, path: Path) -> Path:
+    """Serialize *snapshot* to *path* for a CLI invocation to consume."""
+    from abicheck.serialization import snapshot_to_json
+
+    path.write_text(snapshot_to_json(snapshot), encoding="utf-8")
+    return path
+
+
+@dataclass(frozen=True)
+class ParityReport:
+    """The outcome of comparing a scan-side and a compare-side kind set."""
+
+    #: Present under scan, absent under compare, and *not* a recorded gap —
+    #: an unexplained capability loss. Must always be empty.
+    unexplained_losses: frozenset[str]
+    #: Present under scan, absent under compare, matching a recorded gap —
+    #: the expected red state.
+    expected_losses: frozenset[str]
+    #: Registered as an expected gap, but scan and compare now agree on it
+    #: (compare produces it too) — the gap is closed and must be deleted
+    #: from tests/parity/gaps.py in the same PR that closed it.
+    healed_gaps: frozenset[str]
+    #: Present under compare but not under scan — richer, always allowed.
+    compare_only: frozenset[str]
+
+
+def diff_kind_sets(
+    *, scan_kinds: frozenset[str], compare_kinds: frozenset[str]
+) -> ParityReport:
+    """Classify every kind difference between a scan-side and compare-side set."""
+    lost = scan_kinds - compare_kinds
+    expected = frozenset(ALL_EXPECTED_GAPS)
+    return ParityReport(
+        unexplained_losses=lost - expected,
+        expected_losses=lost & expected,
+        healed_gaps=expected & scan_kinds & compare_kinds,
+        compare_only=compare_kinds - scan_kinds,
+    )
+
+
+def assert_no_capability_loss(
+    *, scan_kinds: frozenset[str], compare_kinds: frozenset[str], context: str
+) -> ParityReport:
+    """Fail loudly, naming the check, for any loss `gaps.py` doesn't explain.
+
+    Also fails when a *registered* gap turns out to no longer be a gap
+    (``compare`` now produces the kind too) — the harness must not keep
+    asserting a red state the migration already turned green, or the
+    registry silently stops being "the migration's definition of done".
+    """
+    report = diff_kind_sets(scan_kinds=scan_kinds, compare_kinds=compare_kinds)
+    if report.unexplained_losses:
+        names = ", ".join(sorted(report.unexplained_losses))
+        raise AssertionError(
+            f"{context}: capability loss -- present under `scan`, absent under "
+            f"`compare`, and NOT a recorded parity gap: {names}. Either this is "
+            "a real regression (fix it), or it belongs in "
+            "tests/parity/gaps.py's EXPECTED_GAPS with the plan phase that "
+            "will close it."
+        )
+    if report.healed_gaps:
+        entries = ", ".join(
+            f"{k} ({ALL_EXPECTED_GAPS[k].plan_phase})"
+            for k in sorted(report.healed_gaps)
+        )
+        raise AssertionError(
+            f"{context}: parity gap closed but tests/parity/gaps.py still "
+            f"lists it as scan-only: {entries}. Delete the EXPECTED_GAPS "
+            "entry -- once `compare` produces the finding, the registry "
+            "must shrink to match (that shrinking IS the migration's "
+            "definition of done, plan §6 Phase 0/3)."
+        )
+    return report

--- a/tests/parity/test_abi3_and_changed_path_parity.py
+++ b/tests/parity/test_abi3_and_changed_path_parity.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity for two more scan-only capabilities from ADR-068 §1's list:
+the ``abi3`` single-artifact stable-ABI audit and changed-path
+localization (``--since``/``--changed-path``).
+
+Neither is a cross-source check, so neither goes through
+``run_crosschecks`` -- but both are, just as concretely, capabilities a
+``compare`` user cannot reach at all: `compare` has no ``--abi3``,
+``--since``, or ``--changed-path`` option (not hidden, not aliased --
+absent), while ``scan`` has all three.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .gaps import EXPECTED_GAPS
+from .runner import invoke_cli, scan_json, write_snapshot
+
+
+def _abi3_snapshot():
+    from abicheck.model import AbiSnapshot
+    from abicheck.python_ext import PythonExtMetadata
+
+    return AbiSnapshot(
+        library="foo.abi3.so",
+        version="1.0",
+        python_ext=PythonExtMetadata(
+            module_name="foo",
+            init_symbol="PyInit_foo",
+            # PyType_GetName only entered the stable ABI in 3.11 -- a
+            # violation under a 3.9 floor.
+            cpython_imports=["PyList_New", "PyType_GetName"],
+        ),
+    )
+
+
+def test_abi3_audit_fires_under_scan(tmp_path: Path) -> None:
+    assert "abi3_audit" in EXPECTED_GAPS
+
+    path = write_snapshot(_abi3_snapshot(), tmp_path / "foo.abi3.so.abi.json")
+    report = scan_json(path, "--abi3", "3.9")
+    assert report["mode"] == "audit"
+    assert (
+        report["crosscheck"]["counts_by_check"].get("python_stable_abi_violation") == 1
+    ), report["crosscheck"]
+
+
+def test_compare_has_no_abi3_option(tmp_path: Path) -> None:
+    path = write_snapshot(_abi3_snapshot(), tmp_path / "foo.abi3.so.abi.json")
+    result = invoke_cli("compare", str(path), str(path), "--abi3", "3.9")
+    assert result.exit_code == 64, result.output
+    assert "No such option" in result.output and "--abi3" in result.output
+
+
+def test_scan_supports_changed_path_localization(tmp_path: Path) -> None:
+    assert "changed_path_localization" in EXPECTED_GAPS
+
+    from abicheck.model import AbiSnapshot
+
+    path = write_snapshot(
+        AbiSnapshot(library="libfoo.so", version="1.0"), tmp_path / "snap.abi.json"
+    )
+    report = scan_json(path, "--changed-path", "src/foo.h")
+    assert report["changed_paths"]["count"] == 1
+
+
+@pytest.mark.parametrize("flag", ["--since", "--changed-path"])
+def test_compare_has_no_changed_path_option(flag: str, tmp_path: Path) -> None:
+    from abicheck.model import AbiSnapshot
+
+    path = write_snapshot(
+        AbiSnapshot(library="libfoo.so", version="1.0"), tmp_path / "snap.abi.json"
+    )
+    value = "origin/main" if flag == "--since" else "src/foo.h"
+    result = invoke_cli("compare", str(path), str(path), flag, value)
+    assert result.exit_code == 64, result.output
+    assert "No such option" in result.output and flag in result.output

--- a/tests/parity/test_abi3_and_changed_path_parity.py
+++ b/tests/parity/test_abi3_and_changed_path_parity.py
@@ -67,6 +67,39 @@ def test_scan_supports_changed_path_localization(tmp_path: Path) -> None:
     assert report["changed_paths"]["count"] == 1
 
 
+def test_changed_path_promotes_public_to_internal_dependency_confidence() -> None:
+    """The bookkeeping check above only proves scan *counted* the changed
+    path; this proves it actually reaches a real cross-source finding
+    (case181's public_to_internal_dependency) through `CrosscheckConfig`,
+    not merely a report-summary field. When the internal declaration's own
+    file is a changed path, the finding is promoted from MEDIUM to HIGH
+    confidence and gains that file as `source_location` (ADR-035 D4's
+    "L5 reachability <-> PR changed files" note in `crosscheck.py`)."""
+    from abicheck.buildsource.crosscheck import CrosscheckConfig, run_crosschecks
+    from abicheck.checker_policy import Confidence
+
+    from .test_crosscheck_parity import _g20_snapshot
+
+    snapshot = _g20_snapshot("case181_xcheck_public_to_internal_dependency")
+    internal_file = "src/json_internal.cc"
+
+    baseline = run_crosschecks(snapshot)
+    unscoped = next(
+        c for c in baseline.findings if c.kind.value == "public_to_internal_dependency"
+    )
+    assert unscoped.confidence == Confidence.MEDIUM
+    assert unscoped.source_location is None
+
+    scoped = run_crosschecks(
+        snapshot, CrosscheckConfig(changed_paths=frozenset({internal_file}))
+    )
+    promoted = next(
+        c for c in scoped.findings if c.kind.value == "public_to_internal_dependency"
+    )
+    assert promoted.confidence == Confidence.HIGH
+    assert promoted.source_location == internal_file
+
+
 @pytest.mark.parametrize("flag", ["--since", "--changed-path"])
 def test_compare_has_no_changed_path_option(flag: str, tmp_path: Path) -> None:
     from abicheck.model import AbiSnapshot

--- a/tests/parity/test_crosscheck_parity.py
+++ b/tests/parity/test_crosscheck_parity.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity for the eleven cross-source checks (plan §7 F-5/F-6/F-7/F-10 and
+the rest of ADR-068 §1's list).
+
+Each check is exercised on a **committed, compiler-free** snapshot fixture —
+the G20 audit/cross-source example corpus (``catalog/cases/case14x-18x``,
+also used by ``tests/test_g20_catalog.py``) for the eight checks it covers,
+plus three small synthetic snapshots (``_synthetic_snapshots.py``) for the
+checks that corpus doesn't happen to exercise on its own
+(``compile_context_conflict``, ``source_surface_dso_mismatch``,
+``identity_collision_detected``).
+
+For each check: ``run_crosschecks`` (the production function
+``scan_engine.py`` is the sole caller of) must find it; the real ``compare``
+CLI, given the same evidence self-compared, must NOT — that absence is
+exactly what ``tests/parity/gaps.py`` records as an expected, phase-owned
+gap. If either side of that ever flips, ``assert_no_capability_loss`` fails
+loudly, naming the check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+if str(_REPO / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO / "scripts"))
+import example_catalog  # noqa: E402
+
+from abicheck.model import AbiSnapshot  # noqa: E402
+from abicheck.serialization import load_snapshot  # noqa: E402
+
+from . import _synthetic_snapshots as synth  # noqa: E402
+from .gaps import EXPECTED_GAPS  # noqa: E402
+from .runner import (  # noqa: E402
+    assert_no_capability_loss,
+    compare_finding_set,
+    crosscheck_finding_set,
+    kinds_of,
+    write_snapshot,
+)
+
+
+def _g20_snapshot(case_name: str, filename: str = "snapshot.abi.json") -> AbiSnapshot:
+    path = example_catalog.case_dir(case_name) / filename
+    assert path.is_file(), f"missing committed G20 fixture: {path}"
+    return load_snapshot(path)
+
+
+#: check name -> (snapshot factory, source, F-row) -- covers all eleven
+#: crosscheck.ALL_CHECKS entries. "source" documents where the fixture
+#: comes from, for a reader diffing this against ADR-068 §1's own list.
+_SCENARIOS: dict[str, tuple[object, str]] = {
+    # F-7: exported symbol not publicly declared.
+    "exported_not_public": (
+        lambda: _g20_snapshot("case143_audit_accidental_export"),
+        "case143_audit_accidental_export",
+    ),
+    # F-6: public declaration not exported (case150 exercises both halves
+    # of the bidirectional pair -- see test_both_halves_of_case150 below).
+    "public_not_exported": (
+        lambda: _g20_snapshot("case150_xcheck_export_public_pair"),
+        "case150_xcheck_export_public_pair",
+    ),
+    # F-10: preprocessing/build-context inconsistency.
+    "header_build_context_mismatch": (
+        lambda: _g20_snapshot("case148_xcheck_header_build_mismatch"),
+        "case148_xcheck_header_build_mismatch",
+    ),
+    # F-5: private header leak.
+    "private_header_leak": (
+        lambda: _g20_snapshot("case144_audit_private_header_leak"),
+        "case144_audit_private_header_leak",
+    ),
+    "odr_type_variant": (
+        lambda: _g20_snapshot("case149_xcheck_odr_variant"),
+        "case149_xcheck_odr_variant",
+    ),
+    "public_to_internal_dependency": (
+        lambda: _g20_snapshot("case181_xcheck_public_to_internal_dependency"),
+        "case181_xcheck_public_to_internal_dependency",
+    ),
+    "unversioned_exported_symbol": (
+        lambda: _g20_snapshot("case145_audit_unversioned_export"),
+        "case145_audit_unversioned_export",
+    ),
+    "rtti_for_internal_type": (
+        lambda: _g20_snapshot("case146_audit_rtti_for_internal"),
+        "case146_audit_rtti_for_internal",
+    ),
+    # F-10's sibling: also a preprocessing/build-context class of check.
+    "compile_context_conflict": (
+        synth.compile_context_conflict_snapshot,
+        "synthetic (tests/parity/_synthetic_snapshots.py)",
+    ),
+    "source_surface_dso_mismatch": (
+        synth.source_surface_dso_mismatch_snapshot,
+        "synthetic (tests/parity/_synthetic_snapshots.py)",
+    ),
+    "identity_collision_detected": (
+        synth.identity_collision_snapshot,
+        "synthetic (tests/parity/_synthetic_snapshots.py)",
+    ),
+}
+
+
+def test_scenarios_cover_every_crosscheck() -> None:
+    """Guard against silently dropping a check from the corpus above."""
+    from abicheck.buildsource.crosscheck import ALL_CHECKS
+
+    assert set(_SCENARIOS) == set(ALL_CHECKS)
+    # Every one of these must also be a registered, phase-owned gap --
+    # otherwise a real loss here would (correctly) fail as "unexplained".
+    assert set(_SCENARIOS) <= set(EXPECTED_GAPS)
+
+
+@pytest.mark.parametrize("check_name", sorted(_SCENARIOS))
+def test_crosscheck_is_scan_only(check_name: str, tmp_path: Path) -> None:
+    factory, source = _SCENARIOS[check_name]
+    snapshot = factory()
+
+    scan_kinds = kinds_of(crosscheck_finding_set(snapshot))
+    assert check_name in scan_kinds, (
+        f"fixture regression: {source} no longer makes run_crosschecks "
+        f"produce {check_name!r} -- fix the fixture, not this assertion"
+    )
+
+    snap_path = write_snapshot(snapshot, tmp_path / "snap.abi.json")
+    # Self-compared: the same evidence on both sides. Any OLD/NEW pairing
+    # would do -- compare's pipeline never calls run_crosschecks at all
+    # (ADR-068 §1), so this is not about diffing two releases.
+    compare_kinds = kinds_of(compare_finding_set(snap_path, snap_path))
+
+    assert_no_capability_loss(
+        scan_kinds=scan_kinds,
+        compare_kinds=compare_kinds,
+        context=f"crosscheck {check_name!r} ({source})",
+    )
+
+
+def test_case150_covers_both_halves_of_the_bidirectional_pair() -> None:
+    """case150 is the one G20 fixture that fires two checks at once
+    (F-6 exported_not_public and F-7 public_not_exported) -- assert both,
+    not just the one this module's scenario table happens to key it under.
+    """
+    snapshot = _g20_snapshot("case150_xcheck_export_public_pair")
+    kinds = kinds_of(crosscheck_finding_set(snapshot))
+    assert {"exported_not_public", "public_not_exported"} <= kinds
+
+
+def test_findings_carry_resolved_identity_severity_and_evidence() -> None:
+    """Spot-check the Finding projection itself, not just kind presence --
+    plan §6 Phase 0 requires diffing on identity/severity/evidence, not
+    only "did this kind fire"."""
+    snapshot = _g20_snapshot("case144_audit_private_header_leak")
+    findings = crosscheck_finding_set(snapshot)
+    leaks = [f for f in findings if f.kind == "private_header_leak"]
+    assert leaks, "fixture regression: expected a private_header_leak finding"
+    finding = leaks[0]
+    assert finding.identity, "a crosscheck finding must resolve to a real symbol"
+    assert finding.severity == "COMPATIBLE_WITH_RISK"
+    assert finding.evidence_refs, "expected at least one corroborating provider"

--- a/tests/parity/test_crosscheck_parity.py
+++ b/tests/parity/test_crosscheck_parity.py
@@ -122,8 +122,8 @@ def test_crosscheck_is_scan_only(check_name: str, tmp_path: Path) -> None:
     factory, source = _SCENARIOS[check_name]
     snapshot = factory()
 
-    scan_kinds = kinds_of(crosscheck_finding_set(snapshot))
-    assert check_name in scan_kinds, (
+    scan_findings = crosscheck_finding_set(snapshot)
+    assert check_name in kinds_of(scan_findings), (
         f"fixture regression: {source} no longer makes run_crosschecks "
         f"produce {check_name!r} -- fix the fixture, not this assertion"
     )
@@ -132,11 +132,11 @@ def test_crosscheck_is_scan_only(check_name: str, tmp_path: Path) -> None:
     # Self-compared: the same evidence on both sides. Any OLD/NEW pairing
     # would do -- compare's pipeline never calls run_crosschecks at all
     # (ADR-068 §1), so this is not about diffing two releases.
-    compare_kinds = kinds_of(compare_finding_set(snap_path, snap_path))
+    compare_findings = compare_finding_set(snap_path, snap_path)
 
     assert_no_capability_loss(
-        scan_kinds=scan_kinds,
-        compare_kinds=compare_kinds,
+        scan_findings=scan_findings,
+        compare_findings=compare_findings,
         context=f"crosscheck {check_name!r} ({source})",
     )
 

--- a/tests/parity/test_engine_primitive_call_sites.py
+++ b/tests/parity/test_engine_primitive_call_sites.py
@@ -52,22 +52,100 @@ _ENGINE_PRIMITIVES: dict[str, tuple[str, str, str]] = {
 }
 
 
-def _call_sites(function_name: str) -> dict[Path, int]:
-    """Repo-relative module -> number of *call expressions* naming
-    ``function_name`` as the called function (``foo()``, not ``x.foo()``,
-    an import, a re-export, or a bare mention in a docstring/comment)."""
+def _posix(path: Path) -> str:
+    """POSIX-style repo-relative spelling, independent of host OS separator
+    (Windows CI reports ``abicheck\\scan_engine.py`` from ``str(path)``)."""
+    return path.as_posix()
+
+
+def _module_dotted_name(path: Path) -> str:
+    """Dotted module name for a file under the repo root, e.g.
+    ``abicheck/buildsource/crosscheck.py`` -> ``abicheck.buildsource.crosscheck``."""
+    parts = list(path.relative_to(_ABICHECK_ROOT.parent).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _resolve_from_import(current_module: str, node: ast.ImportFrom) -> str:
+    """Absolute dotted module a ``from X import Y`` targets, X's own
+    relativity (``node.level``) resolved against *current_module*."""
+    if node.level == 0:
+        return node.module or ""
+    package_parts = current_module.split(".")[:-1]  # current module's own package
+    # level=1 -> that package itself; level=2 -> its parent; etc.
+    trim = node.level - 1
+    base_parts = package_parts[: len(package_parts) - trim] if trim else package_parts
+    base = ".".join(base_parts)
+    return f"{base}.{node.module}" if node.module else base
+
+
+def _bindings_for(
+    tree: ast.AST, current_module: str, target_module: str, function_name: str
+) -> tuple[set[str], set[str]]:
+    """Local names in *tree* that resolve to ``target_module.function_name``.
+
+    Returns ``(direct, module_aliases)``: ``direct`` names are bound to the
+    function itself (``from target import function_name [as alias]``);
+    ``module_aliases`` are bound to the *module* (``import target [as
+    alias]``, ``from target's package import target [as alias]``), so a
+    later ``alias.function_name(...)`` attribute call is still counted.
+    Resolves relative imports (``from . import x`` / ``from .x import y``)
+    against *current_module*'s own package -- a plain string/substring match
+    would miss exactly the aliasing/qualified-call shapes this exists to
+    catch (Codex review).
+    """
+    direct: set[str] = set()
+    module_aliases: set[str] = set()
+    target_parent, _, target_leaf = target_module.rpartition(".")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == target_module and alias.asname:
+                    module_aliases.add(alias.asname)
+        elif isinstance(node, ast.ImportFrom):
+            resolved = _resolve_from_import(current_module, node)
+            if resolved == target_module:
+                for alias in node.names:
+                    if alias.name == function_name:
+                        direct.add(alias.asname or alias.name)
+            elif resolved == target_parent:
+                for alias in node.names:
+                    if alias.name == target_leaf:
+                        module_aliases.add(alias.asname or alias.name)
+    return direct, module_aliases
+
+
+def _call_sites(function_name: str, defining_module: str) -> dict[Path, int]:
+    """Repo-relative module -> number of *call expressions* resolving to
+    ``function_name`` from *defining_module* (a repo-relative path, e.g.
+    ``buildsource/crosscheck.py``) -- ``foo()`` after a direct import,
+    ``mod.foo()``/``alias.foo()`` after a module import, an aliased import
+    of either shape, or a relative import. Not a bare textual mention (a
+    docstring, a comment, an unrelated ``foo`` in a different module)."""
+    target_module = f"abicheck.{defining_module[:-3].replace('/', '.')}"
     hits: dict[Path, int] = {}
     for path in sorted(_ABICHECK_ROOT.rglob("*.py")):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         except (SyntaxError, UnicodeDecodeError):
             continue
+        current_module = _module_dotted_name(path)
+        direct, module_aliases = _bindings_for(
+            tree, current_module, target_module, function_name
+        )
         count = 0
         for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == function_name
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in direct:
+                count += 1
+            elif (
+                isinstance(func, ast.Attribute)
+                and func.attr == function_name
+                and isinstance(func.value, ast.Name)
+                and func.value.id in module_aliases
             ):
                 count += 1
         if count:
@@ -75,18 +153,12 @@ def _call_sites(function_name: str) -> dict[Path, int]:
     return hits
 
 
-def _posix(path: Path) -> str:
-    """POSIX-style repo-relative spelling, independent of host OS separator
-    (Windows CI reports ``abicheck\\scan_engine.py`` from ``str(path)``)."""
-    return path.as_posix()
-
-
 @pytest.mark.parametrize("function_name", sorted(_ENGINE_PRIMITIVES))
 def test_only_scan_engine_calls_it(function_name: str) -> None:
     defining_module, expected_caller, gap_key = _ENGINE_PRIMITIVES[function_name]
     assert gap_key in EXPECTED_GAPS, f"{gap_key!r} must be a registered parity gap"
 
-    sites = _call_sites(function_name)
+    sites = _call_sites(function_name, defining_module)
     # Drop the defining module itself (recursive helpers / the module's own
     # internal dispatch don't count as an external caller).
     sites = {p: n for p, n in sites.items() if p != Path("abicheck") / defining_module}
@@ -104,3 +176,54 @@ def test_only_scan_engine_calls_it(function_name: str) -> None:
         f"{function_name}() has no production caller at all under abicheck/ "
         f"-- expected exactly {expected_caller!r} (ADR-068 §1)"
     )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from abicheck.buildsource.crosscheck import run_crosschecks\n"
+        "run_crosschecks(snap)\n",
+        "from abicheck.buildsource.crosscheck import run_crosschecks as check\n"
+        "check(snap)\n",
+        "from abicheck.buildsource import crosscheck\n"
+        "crosscheck.run_crosschecks(snap)\n",
+        "from abicheck.buildsource import crosscheck as cc\ncc.run_crosschecks(snap)\n",
+        "import abicheck.buildsource.crosscheck as cc\ncc.run_crosschecks(snap)\n",
+        "from .crosscheck import run_crosschecks\n"  # relative, as scan_engine.py itself uses
+        "run_crosschecks(snap)\n",
+    ],
+)
+def test_bindings_for_resolves_every_aliasing_and_qualified_call_shape(
+    source: str,
+) -> None:
+    """Codex review: a bare ``ast.Name`` match alone misses ``crosscheck.
+    run_crosschecks()`` and an aliased import -- both real Python a new
+    caller could legitimately write. Exercises every shape ``_bindings_for``
+    claims to resolve, each as its own module so a caller written from
+    ``abicheck.buildsource`` (the relative-import case, matching
+    ``scan_engine.py``'s own real import site) and one written from
+    ``abicheck`` itself are both covered."""
+    tree = ast.parse(source)
+    current_module = (
+        "abicheck.buildsource.scan_engine"
+        if source.lstrip().startswith("from .")
+        else "abicheck.scan_engine"
+    )
+    direct, module_aliases = _bindings_for(
+        tree, current_module, "abicheck.buildsource.crosscheck", "run_crosschecks"
+    )
+    calls = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in direct:
+            calls += 1
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "run_crosschecks"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in module_aliases
+        ):
+            calls += 1
+    assert calls == 1, source

--- a/tests/parity/test_engine_primitive_call_sites.py
+++ b/tests/parity/test_engine_primitive_call_sites.py
@@ -75,6 +75,12 @@ def _call_sites(function_name: str) -> dict[Path, int]:
     return hits
 
 
+def _posix(path: Path) -> str:
+    """POSIX-style repo-relative spelling, independent of host OS separator
+    (Windows CI reports ``abicheck\\scan_engine.py`` from ``str(path)``)."""
+    return path.as_posix()
+
+
 @pytest.mark.parametrize("function_name", sorted(_ENGINE_PRIMITIVES))
 def test_only_scan_engine_calls_it(function_name: str) -> None:
     defining_module, expected_caller, gap_key = _ENGINE_PRIMITIVES[function_name]
@@ -85,7 +91,7 @@ def test_only_scan_engine_calls_it(function_name: str) -> None:
     # internal dispatch don't count as an external caller).
     sites = {p: n for p, n in sites.items() if p != Path("abicheck") / defining_module}
 
-    callers = {str(p) for p in sites}
+    callers = {_posix(p) for p in sites}
     if callers - {f"abicheck/{expected_caller}"}:
         raise AssertionError(
             f"{function_name}() gained a caller outside {expected_caller!r}: "

--- a/tests/parity/test_engine_primitive_call_sites.py
+++ b/tests/parity/test_engine_primitive_call_sites.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Call-site proof that the three scan-only analysis engines have exactly
+one production caller: ``scan_engine.py``.
+
+ADR-068 §1 states the capability-loss defect by call site, not by import:
+
+    Verified by call site, not by import: the only production callers of
+    ``buildsource.crosscheck.run_crosschecks``, ``buildsource.pattern_scan.
+    scan_files`` and ``buildsource.preprocessor_scan.run_preprocessor_scan``
+    anywhere under ``abicheck/`` are ``scan_engine.py``... Check by call
+    site, not import: ``workflows/extraction.py`` imports two of the three
+    and calls neither.
+
+This module makes that claim executable instead of only a prose citation --
+a real AST scan over every ``abicheck/**/*.py`` module, not a grep that a
+comment or an unrelated identifier could fool. It is the parity harness's
+proof, for ``pattern_scan``/``preprocessor_scan`` (and a second angle on
+``crosscheck``, alongside ``test_crosscheck_parity.py``'s behavioral one),
+that ``compare``'s pipeline *cannot* reach them today -- not merely that it
+happens not to in the fixtures exercised elsewhere.
+
+Once Phase 2a/2b (docs/contribute/plans/one-comparison-product.md §6) gives
+one of these functions a second caller reachable from `compare`, this test
+starts failing -- which is the point: it is the signal to delete the
+corresponding tests/parity/gaps.py entry in that same PR.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from .gaps import EXPECTED_GAPS
+
+_ABICHECK_ROOT = Path(__file__).resolve().parent.parent.parent / "abicheck"
+
+#: function name -> (defining module, expected sole-caller module, gap key)
+_ENGINE_PRIMITIVES: dict[str, tuple[str, str, str]] = {
+    "run_crosschecks": (
+        "buildsource/crosscheck.py",
+        "scan_engine.py",
+        "private_header_leak",  # any of the 11 crosscheck gap keys will do
+    ),
+    "scan_files": ("buildsource/pattern_scan.py", "scan_engine.py", "pattern_scan"),
+    "run_preprocessor_scan": (
+        "buildsource/preprocessor_scan.py",
+        "scan_engine.py",
+        "preprocessor_scan",
+    ),
+}
+
+
+def _call_sites(function_name: str) -> dict[Path, int]:
+    """Repo-relative module -> number of *call expressions* naming
+    ``function_name`` as the called function (``foo()``, not ``x.foo()``,
+    an import, a re-export, or a bare mention in a docstring/comment)."""
+    hits: dict[Path, int] = {}
+    for path in sorted(_ABICHECK_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        count = 0
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == function_name
+            ):
+                count += 1
+        if count:
+            hits[path.relative_to(_ABICHECK_ROOT.parent)] = count
+    return hits
+
+
+@pytest.mark.parametrize("function_name", sorted(_ENGINE_PRIMITIVES))
+def test_only_scan_engine_calls_it(function_name: str) -> None:
+    defining_module, expected_caller, gap_key = _ENGINE_PRIMITIVES[function_name]
+    assert gap_key in EXPECTED_GAPS, f"{gap_key!r} must be a registered parity gap"
+
+    sites = _call_sites(function_name)
+    # Drop the defining module itself (recursive helpers / the module's own
+    # internal dispatch don't count as an external caller).
+    sites = {p: n for p, n in sites.items() if p != Path("abicheck") / defining_module}
+
+    callers = {str(p) for p in sites}
+    if callers - {f"abicheck/{expected_caller}"}:
+        raise AssertionError(
+            f"{function_name}() gained a caller outside {expected_caller!r}: "
+            f"{sorted(callers)}. If this is Phase 2a/2b landing "
+            f"({EXPECTED_GAPS[gap_key].plan_phase}), delete the "
+            f"{gap_key!r} entry from tests/parity/gaps.py in the same PR "
+            "instead of leaving this assertion to rot."
+        )
+    assert callers == {f"abicheck/{expected_caller}"}, (
+        f"{function_name}() has no production caller at all under abicheck/ "
+        f"-- expected exactly {expected_caller!r} (ADR-068 §1)"
+    )

--- a/tests/parity/test_evolution_state_gap.py
+++ b/tests/parity/test_evolution_state_gap.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-8/F-9 (plan §7): the ``FindingEvolution`` axis doesn't exist yet.
+
+F-8: a private-header leak present in **both** OLD and NEW, with OLD's
+evidence too weak to have proven the leak at the time, must read as
+``not_evaluated`` -- never as ``introduced`` (that would be a manufactured
+finding, ADR-068's "second risk"). F-9: a leak present in OLD and fixed in
+NEW must read as ``resolved``, and that must be visible on a passing run.
+
+Unlike every other module in this package, this is **not** "scan has it,
+compare doesn't" -- ADR-068 D3/plan §5 P2 state plainly that this
+vocabulary (``introduced``/``resolved``/``persistent``/``not_evaluated``)
+is *new* Phase-1 work. Even ``scan --against``'s own crosscheck pass runs
+single-sided today: it evaluates the *candidate* snapshot only and has no
+per-side evolution tracking at all, baseline-lacking-evidence case
+included. So this module documents an absence on both tools, tracked
+separately in ``gaps.py``'s ``NOT_YET_IMPLEMENTED_ANYWHERE`` (not
+``EXPECTED_GAPS``, which is specifically "scan-only today").
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+if str(_REPO / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO / "scripts"))
+import example_catalog  # noqa: E402
+
+from abicheck.model import AbiSnapshot  # noqa: E402
+from abicheck.serialization import load_snapshot  # noqa: E402
+
+from .gaps import NOT_YET_IMPLEMENTED_ANYWHERE  # noqa: E402
+from .runner import crosscheck_finding_set, kinds_of  # noqa: E402
+
+
+def _g20_snapshot(case_name: str, filename: str = "snapshot.abi.json") -> AbiSnapshot:
+    path = example_catalog.case_dir(case_name) / filename
+    assert path.is_file(), f"missing committed G20 fixture: {path}"
+    return load_snapshot(path)
+
+
+def test_finding_evolution_is_registered_as_not_yet_implemented() -> None:
+    assert "finding_evolution" in NOT_YET_IMPLEMENTED_ANYWHERE
+
+
+def test_f8_pre_existing_leak_has_no_not_evaluated_state_to_assert() -> None:
+    """F-8: with a fixed, single (candidate-only) snapshot -- case144's
+    private-header leak -- there is no OLD-side evidence-weakness input to
+    give run_crosschecks at all: it takes one snapshot, not an OLD/NEW
+    pair, so it cannot distinguish "leak is new" from "leak is
+    pre-existing but OLD's evidence couldn't see it" even in principle.
+    This is the concrete shape of the Phase-1 gap: the finding fires
+    (correctly, per crosscheck's own single-sided contract) with no
+    evolution axis attached at all -- neither `introduced` nor
+    `not_evaluated` exists on the `Change` object to check.
+    """
+    snapshot = _g20_snapshot("case144_audit_private_header_leak")
+    findings = crosscheck_finding_set(snapshot)
+    assert "private_header_leak" in kinds_of(findings)
+
+    leak = next(f for f in findings if f.kind == "private_header_leak")
+    # The gap, made concrete: Change has no evolution field at all.
+    from abicheck.checker_types import Change
+
+    field_names = {f.name for f in __import__("dataclasses").fields(Change)}
+    assert "evolution" not in field_names, (
+        "Change gained an `evolution` field -- Phase 1 "
+        f"({NOT_YET_IMPLEMENTED_ANYWHERE['finding_evolution'].plan_phase}) "
+        "has landed. Delete the 'finding_evolution' entry from "
+        "tests/parity/gaps.py's NOT_YET_IMPLEMENTED_ANYWHERE and replace "
+        "this module with a real not_evaluated/resolved assertion over a "
+        "baseline pair, per plan F-8/F-9."
+    )
+    assert leak.identity if hasattr(leak, "identity") else leak.kind  # sanity
+
+
+def test_f9_scan_against_has_no_per_side_crosscheck_at_all() -> None:
+    """F-9: `resolved` (present in OLD, fixed in NEW) needs crosscheck to
+    run over BOTH sides and diff the two outcomes. `scan --against` runs
+    the always-on crosscheck tier over the **candidate** snapshot only
+    (scan_engine.py's single `run_crosschecks(new_snap, ...)` call) --
+    there is no second, OLD-side crosscheck pass to diff against, so
+    "resolved" cannot be expressed even in scan's own report today."""
+    import inspect
+
+    from abicheck import scan_engine
+
+    source = inspect.getsource(scan_engine)
+    # A crude but honest count: run_crosschecks is called exactly once
+    # per scan_engine.py's own pipeline (the candidate side), never twice
+    # (which a baseline-diffed crosscheck pass would require).
+    assert source.count("run_crosschecks(") == 1, (
+        "scan_engine.py now calls run_crosschecks() more than once -- "
+        "if this is a baseline-side crosscheck pass landing, the F-9 gap "
+        "may be closing; update this test and reconsider the "
+        "'finding_evolution' entry in tests/parity/gaps.py accordingly."
+    )

--- a/tests/parity/test_evolution_state_gap.py
+++ b/tests/parity/test_evolution_state_gap.py
@@ -83,17 +83,33 @@ def test_f9_scan_against_has_no_per_side_crosscheck_at_all() -> None:
     (scan_engine.py's single `run_crosschecks(new_snap, ...)` call) --
     there is no second, OLD-side crosscheck pass to diff against, so
     "resolved" cannot be expressed even in scan's own report today."""
+    import ast
     import inspect
 
     from abicheck import scan_engine
 
-    source = inspect.getsource(scan_engine)
-    # A crude but honest count: run_crosschecks is called exactly once
-    # per scan_engine.py's own pipeline (the candidate side), never twice
-    # (which a baseline-diffed crosscheck pass would require).
-    assert source.count("run_crosschecks(") == 1, (
-        "scan_engine.py now calls run_crosschecks() more than once -- "
+    tree = ast.parse(inspect.getsource(scan_engine))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_crosschecks"
+    ]
+    # A real AST match, not a textual count that a comment or docstring
+    # mentioning "run_crosschecks(" could inflate (Codex review): exactly
+    # one call expression, over the *candidate* snapshot (new_snap) --
+    # never a second, OLD-side pass, which a baseline-diffed crosscheck
+    # would require to express "resolved".
+    assert len(calls) == 1, (
+        f"scan_engine.py calls run_crosschecks() {len(calls)} time(s), not 1 -- "
         "if this is a baseline-side crosscheck pass landing, the F-9 gap "
         "may be closing; update this test and reconsider the "
         "'finding_evolution' entry in tests/parity/gaps.py accordingly."
+    )
+    (call,) = calls
+    assert call.args and isinstance(call.args[0], ast.Name)
+    assert call.args[0].id == "new_snap", (
+        f"run_crosschecks() is now called with {call.args[0].id!r}, not "
+        "new_snap -- re-examine whether it now runs over the baseline side too"
     )

--- a/tests/parity/test_gap_registry_contract.py
+++ b/tests/parity/test_gap_registry_contract.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Structural checks on the expected-gap registry itself.
+
+The registry (``tests/parity/gaps.py``) *is* the migration's definition of
+done (plan §6 Phase 0): it must name exactly the sixteen capabilities
+ADR-068 §1 and the plan's requirements enumerate, each with a real reason
+and a real plan-phase reference -- never an empty placeholder, and never
+silently missing an entry.
+"""
+
+from __future__ import annotations
+
+from .gaps import ALL_EXPECTED_GAPS, EXPECTED_GAPS, NOT_YET_IMPLEMENTED_ANYWHERE
+
+#: The eleven cross-source checks (crosscheck.ALL_CHECKS) + pattern_scan +
+#: preprocessor_scan + changed_path_localization + abi3_audit -- exactly
+#: the list this task's own requirements name as the red set.
+_REQUIRED_SCAN_ONLY_KEYS = {
+    "exported_not_public",
+    "public_not_exported",
+    "header_build_context_mismatch",
+    "private_header_leak",
+    "odr_type_variant",
+    "public_to_internal_dependency",
+    "unversioned_exported_symbol",
+    "rtti_for_internal_type",
+    "identity_collision_detected",
+    "compile_context_conflict",
+    "source_surface_dso_mismatch",
+    "pattern_scan",
+    "preprocessor_scan",
+    "changed_path_localization",
+    "abi3_audit",
+}
+
+
+def test_registry_names_exactly_the_required_scan_only_capabilities() -> None:
+    assert set(EXPECTED_GAPS) == _REQUIRED_SCAN_ONLY_KEYS
+
+
+def test_every_gap_has_a_non_empty_reason_and_phase() -> None:
+    for key, gap in ALL_EXPECTED_GAPS.items():
+        assert gap.reason.strip(), f"{key}: empty reason"
+        assert gap.plan_phase.strip(), f"{key}: empty plan_phase"
+        assert "Phase" in gap.plan_phase, f"{key}: plan_phase must name a phase"
+
+
+def test_evolution_gap_tracked_separately_from_scan_only_gaps() -> None:
+    """finding_evolution is a "not implemented anywhere" gap, not a
+    "scan has it, compare doesn't" one -- it must never leak into the set
+    the crosscheck/pattern/preprocessor tests treat as scan-only losses."""
+    assert "finding_evolution" not in EXPECTED_GAPS
+    assert "finding_evolution" in NOT_YET_IMPLEMENTED_ANYWHERE
+    assert ALL_EXPECTED_GAPS == {**EXPECTED_GAPS, **NOT_YET_IMPLEMENTED_ANYWHERE}
+
+
+def test_crosscheck_keys_match_all_checks() -> None:
+    from abicheck.buildsource.crosscheck import ALL_CHECKS
+
+    crosscheck_keys = {
+        k
+        for k in EXPECTED_GAPS
+        if k
+        not in {
+            "pattern_scan",
+            "preprocessor_scan",
+            "changed_path_localization",
+            "abi3_audit",
+        }
+    }
+    assert crosscheck_keys == set(ALL_CHECKS)

--- a/tests/parity/test_no_baseline_parity.py
+++ b/tests/parity/test_no_baseline_parity.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-22/F-23 (plan §7): ``--no-baseline`` audit parity.
+
+``compare --no-baseline NEW`` (plan §3 #2/#16, ADR-068 D2) is the intended
+replacement for ``scan ARTIFACT`` without ``--against`` (a single-artifact
+audit) and for ``scan --artifact-set`` (an N-library audit, over a
+directory). Neither exists on ``compare`` yet — Phase 1 (``declared_absent``
+acquisition state) and Phase 2e haven't landed — so both scenarios are
+expected-gap today. This module pins the exact usage-error shape so its own
+tests start failing the moment ``--no-baseline`` is accepted at all,
+prompting the ``tests/parity/gaps.py`` entries to be reconsidered (a
+usage-error test failing "for the right reason" is exactly this harness's
+job, per plan §6 Phase 0).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .runner import invoke_cli, scan_json, write_snapshot
+
+
+def _empty_snapshot(name: str = "libfoo.so"):
+    from abicheck.model import AbiSnapshot
+
+    return AbiSnapshot(library=name, version="1.0")
+
+
+def test_scan_supports_single_artifact_audit_without_against(tmp_path: Path) -> None:
+    """F-22: scan's audit mode -- candidate-side findings, no compatibility
+    verdict, no --against baseline required at all."""
+    path = write_snapshot(_empty_snapshot(), tmp_path / "libfoo.so.abi.json")
+    report = scan_json(path)
+    assert report["mode"] == "audit"
+    assert "diff" not in report or report.get("diff") is None
+
+
+def test_compare_has_no_no_baseline_option(tmp_path: Path) -> None:
+    """F-22: `compare` cannot express "declare OLD absent" at all today."""
+    path = write_snapshot(_empty_snapshot(), tmp_path / "libfoo.so.abi.json")
+    result = invoke_cli("compare", "--no-baseline", str(path))
+    assert result.exit_code == 64, result.output
+    assert "No such option" in result.output and "--no-baseline" in result.output
+
+
+def test_compare_single_operand_is_a_usage_error_not_an_audit(tmp_path: Path) -> None:
+    """ADR-068 D2: arity must never silently imply audit mode -- `compare
+    NEW` (one operand) is a declared usage error (exit 64), not a quiet
+    fallback to "no baseline". Confirms the gap is a genuine missing
+    capability, not merely an unadvertised existing one."""
+    path = write_snapshot(_empty_snapshot(), tmp_path / "libfoo.so.abi.json")
+    result = invoke_cli("compare", str(path))
+    assert result.exit_code == 64, result.output
+    assert "Missing argument" in result.output
+
+
+def test_scan_supports_directory_audit_without_against() -> None:
+    """F-23: `scan --artifact-set` is an audit (no baseline) over N
+    libraries in one directory -- `--against` is optional, matching the
+    single-artifact audit shape scaled up to a whole release. Checked via
+    `--help-all` rather than a real multi-library discovery run:
+    `discover_artifact_set` parses real ELF program/dynamic tables, which
+    is real-binary-fixture territory (`integration`), not a fast-lane
+    concern -- this module's own compare-side test below is what actually
+    proves the gap, this is just "scan really has the option"."""
+    result = invoke_cli("scan", "--help-all")
+    assert result.exit_code == 0, result.output
+    assert "--artifact-set" in result.output
+    # --against is documented as optional even in --artifact-set mode
+    # (an audit, not a comparison) -- see cli_scan.py's own help text.
+    assert "Without --against" in result.output
+
+
+def test_compare_directory_no_baseline_is_unreachable(tmp_path: Path) -> None:
+    """F-23: the directory form of --no-baseline (plan §3 #16's "compare
+    --no-baseline DIR" replacement for --artifact-set) is unreachable for
+    the same reason the single-artifact form is -- the flag doesn't exist."""
+    lib_dir = tmp_path / "release"
+    lib_dir.mkdir()
+    write_snapshot(_empty_snapshot(), lib_dir / "libfoo.so.abi.json")
+
+    result = invoke_cli("compare", "--no-baseline", str(lib_dir))
+    assert result.exit_code == 64, result.output
+    assert "No such option" in result.output and "--no-baseline" in result.output

--- a/tests/parity/test_pattern_scan_behavior.py
+++ b/tests/parity/test_pattern_scan_behavior.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral half of the pattern_scan gap (plan §3 #6, F-row context).
+
+``test_engine_primitive_call_sites.py`` proves ``scan_files`` structurally
+has no caller outside ``scan_engine.py``. This module proves the positive
+side concretely and cheaply -- ``scan_files`` is pure lexical text
+scanning (no compiler, no castxml) and really does find an ABI-risk
+construct scan surfaces today, over a tiny fixture file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.buildsource.pattern_scan import scan_files
+
+from .gaps import EXPECTED_GAPS
+from .runner import invoke_cli
+
+
+def test_scan_files_finds_explicit_template_instantiation(tmp_path: Path) -> None:
+    assert "pattern_scan" in EXPECTED_GAPS
+
+    header = tmp_path / "risky.hpp"
+    header.write_text("template class Widget<int>;\n", encoding="utf-8")
+
+    result = scan_files([tmp_path])
+    kinds = {f.kind.value for f in result.facts}
+    assert "explicit_template_instantiation" in kinds
+    assert result.files_scanned == 1
+
+
+def test_compare_has_no_pattern_scan_surface(tmp_path: Path) -> None:
+    """`compare` accepts `--sources`, but (per the call-site proof) never
+    routes it through `scan_files` -- there is no flag or report field
+    that surfaces a lexical-pattern finding on `compare` at all."""
+    result = invoke_cli("compare", "--help-all")
+    assert result.exit_code == 0
+    # None of pattern_scan's own vocabulary appears anywhere in compare's
+    # option surface (no flag *named* for it, unlike --pattern-verdicts
+    # which modulates verdicts using pre-existing, unrelated risk facts).
+    assert "pattern-scan" not in result.output.lower()
+    assert "pattern_scan" not in result.output.lower()

--- a/tests/parity/test_preprocessor_scan_behavior.py
+++ b/tests/parity/test_preprocessor_scan_behavior.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral half of the preprocessor_scan gap (plan §3 #8).
+
+``test_engine_primitive_call_sites.py`` proves ``run_preprocessor_scan``
+structurally has no caller outside ``scan_engine.py``. This module proves
+the positive side concretely: it really does capture a private-header
+leak via a real ``clang -E`` invocation. Needs a real ``clang++`` on PATH
+(``ClangPreprocessorExtractor``), so it's ``integration``-marked per this
+package's own cheapness rule, even though the check itself is otherwise
+pure-Python.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+from abicheck.buildsource.preprocessor_scan import (
+    ClangPreprocessorExtractor,
+    run_preprocessor_scan,
+)
+
+from .gaps import EXPECTED_GAPS
+from .runner import invoke_cli
+
+
+@pytest.mark.integration
+def test_run_preprocessor_scan_finds_a_private_header_leak(tmp_path: Path) -> None:
+    assert "preprocessor_scan" in EXPECTED_GAPS
+    if not ClangPreprocessorExtractor().available():
+        pytest.skip("clang++ not on PATH")
+
+    private = tmp_path / "widget_impl.h"
+    private.write_text("#define WIDGET_MAGIC 42\n", encoding="utf-8")
+    public = tmp_path / "widget.h"
+    public.write_text(
+        '#include "widget_impl.h"\nint widget_get(void);\n', encoding="utf-8"
+    )
+    src = tmp_path / "widget.c"
+    src.write_text(
+        '#include "widget.h"\nint widget_get(void) { return WIDGET_MAGIC; }\n'
+    )
+
+    unit = CompileUnit(
+        id="tu",
+        source=str(src),
+        directory=str(tmp_path),
+        argv=["cc", "-c", str(src)],
+        language="C",
+    )
+    result = run_preprocessor_scan(
+        BuildEvidence(compile_units=[unit]), public_headers=[str(public)]
+    )
+    assert result.ran, result.skipped_reason
+    assert result.leaks, "expected a captured private-header leak"
+    assert any(str(private) == leak.leaked_header for leak in result.leaks), (
+        result.leaks
+    )
+
+
+def test_compare_has_no_preprocessor_scan_surface() -> None:
+    result = invoke_cli("compare", "--help-all")
+    assert result.exit_code == 0
+    assert "preprocessor-scan" not in result.output.lower()
+    assert "preprocessor_scan" not in result.output.lower()

--- a/tests/parity/test_source_depth_parity.py
+++ b/tests/parity/test_source_depth_parity.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""F-3/F-4 (plan §7): ``--depth source`` (L3-L5) parity.
+
+Unlike the crosscheck/pattern/preprocessor checks, source-ABI-replay (L4)
+and source-graph (L5) analysis is **already** shared between ``scan`` and
+``compare`` (plan §3 rows #10/#11, classed MERGE, not COMPARE-STAGE) --
+``scan --against``'s baseline path delegates to the same compare engine
+``compare OLD NEW`` calls. F-3 and F-4 are therefore this harness's *green*
+parity scenarios: they must show equality today, not a recorded gap. If
+either regresses, ``assert_no_capability_loss`` fails the same way it would
+for a real cross-source-check loss -- an empty ``EXPECTED_GAPS`` intersection
+here means no loss is excusable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+if str(_REPO / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO / "scripts"))
+import example_catalog  # noqa: E402
+
+from abicheck.buildsource.pack import BuildSourcePack  # noqa: E402
+from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity  # noqa: E402
+from abicheck.model import AbiSnapshot  # noqa: E402
+
+from .runner import (  # noqa: E402
+    assert_no_capability_loss,
+    compare_finding_set,
+    invoke_cli,
+    kinds_of,
+    scan_finding_set,
+    write_snapshot,
+)
+
+
+def test_f3_call_graph_break_finding_set_parity() -> None:
+    """case192: an L5 call-graph break (the plan's own "headline oneDAL-
+    style scenario"). `scan --against` and `compare --depth source` must
+    produce the same finding set -- kind AND resolved identity, not just
+    matching counts."""
+    case_dir = example_catalog.case_dir("case192_call_graph_break_survives_suppression")
+    old, new = case_dir / "old.abi.json", case_dir / "new.abi.json"
+    assert old.is_file() and new.is_file()
+
+    scan_findings = scan_finding_set(new, "--against", str(old))
+    compare_findings = compare_finding_set(old, new, "--depth", "source")
+
+    assert_no_capability_loss(
+        scan_kinds=kinds_of(scan_findings),
+        compare_kinds=kinds_of(compare_findings),
+        context="case192 (--depth source, F-3)",
+    )
+    # Identity, not just kind: both tools must resolve the same symbol.
+    scan_identities = {f.identity for f in scan_findings}
+    compare_identities = {f.identity for f in compare_findings}
+    assert scan_identities == compare_identities
+    assert scan_identities == {"_ZN4demo6detail13compute_avx2ERKNS_10DescriptorE"}
+
+    exit_scan = invoke_cli("scan", str(new), "--against", str(old)).exit_code
+    exit_compare = invoke_cli(
+        "compare", str(old), str(new), "--depth", "source"
+    ).exit_code
+    assert exit_scan == exit_compare == 4
+
+
+def test_f3_non_reachable_counterexample_finding_set_parity() -> None:
+    """case193: the deliberate counter-example -- an ordinary exported
+    function's call into a removed internal helper is NOT consumer-
+    reachable, so both tools must agree on a plain func_removed break with
+    NO internal_symbol_required_by_public_api promotion on either side."""
+    case_dir = example_catalog.case_dir(
+        "case193_ordinary_exported_fn_call_not_reachable"
+    )
+    old, new = case_dir / "old.abi.json", case_dir / "new.abi.json"
+
+    scan_findings = scan_finding_set(new, "--against", str(old))
+    compare_findings = compare_finding_set(old, new, "--depth", "source")
+
+    assert_no_capability_loss(
+        scan_kinds=kinds_of(scan_findings),
+        compare_kinds=kinds_of(compare_findings),
+        context="case193 (--depth source, F-3 counter-example)",
+    )
+    assert kinds_of(scan_findings) == kinds_of(compare_findings) == {"func_removed"}
+
+
+def _inline_removal_snapshots(tmp_path: Path) -> tuple[Path, Path]:
+    """A public inline function with no exported binary symbol, removed
+    between versions -- an API-only change genuinely invisible in the
+    binary (no ELF metadata at all on either side): only L4 source replay
+    can see it. Hand-built evidence (no compiler), mirroring
+    tests/test_l3l4l5_new_kinds.py::test_l4_inline_function_removed.
+    """
+    keeper = SourceEntity(
+        id="keep",
+        kind="function",
+        qualified_name="keep",
+        mangled_name="_Z4keepv",
+        visibility="public_header",
+    )
+    old_surface = SourceAbiSurface(
+        reachable_inline_bodies=[
+            SourceEntity(
+                id="clamp", kind="inline", qualified_name="clamp", body_hash="h1"
+            )
+        ],
+        reachable_declarations=[keeper],
+    )
+    new_surface = SourceAbiSurface(reachable_declarations=[keeper])
+
+    old_snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_abi=old_surface),
+    )
+    new_snap = AbiSnapshot(
+        library="libfoo.so",
+        version="2.0",
+        build_source=BuildSourcePack(root="", source_abi=new_surface),
+    )
+    return (
+        write_snapshot(old_snap, tmp_path / "old.abi.json"),
+        write_snapshot(new_snap, tmp_path / "new.abi.json"),
+    )
+
+
+def test_f4_source_only_change_classed_api_break_not_breaking(tmp_path: Path) -> None:
+    """F-4: a source-only change invisible in the binary is classed
+    API_BREAK, never BREAKING, on BOTH tools (the authority rule, ADR-028
+    D3/ADR-035 D1) -- and both tools actually agree on the finding, not
+    just the verdict bucket."""
+    old, new = _inline_removal_snapshots(tmp_path)
+
+    scan_findings = scan_finding_set(new, "--against", str(old))
+    compare_findings = compare_finding_set(old, new, "--depth", "source")
+
+    assert (
+        kinds_of(scan_findings)
+        == kinds_of(compare_findings)
+        == {"inline_function_removed"}
+    )
+    assert_no_capability_loss(
+        scan_kinds=kinds_of(scan_findings),
+        compare_kinds=kinds_of(compare_findings),
+        context="inline_function_removed (F-4)",
+    )
+
+    from abicheck.checker_policy import API_BREAK_KINDS, BREAKING_KINDS, ChangeKind
+
+    assert ChangeKind.INLINE_FUNCTION_REMOVED in API_BREAK_KINDS
+    assert ChangeKind.INLINE_FUNCTION_REMOVED not in BREAKING_KINDS
+
+    scan_report_verdict = invoke_cli(
+        "scan", str(new), "--against", str(old), "--format", "json"
+    )
+    compare_report_verdict = invoke_cli(
+        "compare", str(old), str(new), "--depth", "source", "--format", "json"
+    )
+    import json
+
+    assert json.loads(scan_report_verdict.stdout)["verdict"] == "API_BREAK"
+    assert json.loads(compare_report_verdict.stdout)["verdict"] == "API_BREAK"

--- a/tests/parity/test_source_depth_parity.py
+++ b/tests/parity/test_source_depth_parity.py
@@ -49,8 +49,8 @@ def test_f3_call_graph_break_finding_set_parity() -> None:
     compare_findings = compare_finding_set(old, new, "--depth", "source")
 
     assert_no_capability_loss(
-        scan_kinds=kinds_of(scan_findings),
-        compare_kinds=kinds_of(compare_findings),
+        scan_findings=scan_findings,
+        compare_findings=compare_findings,
         context="case192 (--depth source, F-3)",
     )
     # Identity, not just kind: both tools must resolve the same symbol.
@@ -80,8 +80,8 @@ def test_f3_non_reachable_counterexample_finding_set_parity() -> None:
     compare_findings = compare_finding_set(old, new, "--depth", "source")
 
     assert_no_capability_loss(
-        scan_kinds=kinds_of(scan_findings),
-        compare_kinds=kinds_of(compare_findings),
+        scan_findings=scan_findings,
+        compare_findings=compare_findings,
         context="case193 (--depth source, F-3 counter-example)",
     )
     assert kinds_of(scan_findings) == kinds_of(compare_findings) == {"func_removed"}
@@ -143,8 +143,8 @@ def test_f4_source_only_change_classed_api_break_not_breaking(tmp_path: Path) ->
         == {"inline_function_removed"}
     )
     assert_no_capability_loss(
-        scan_kinds=kinds_of(scan_findings),
-        compare_kinds=kinds_of(compare_findings),
+        scan_findings=scan_findings,
+        compare_findings=compare_findings,
         context="inline_function_removed (F-4)",
     )
 


### PR DESCRIPTION
## Summary

Phase 0 of [`docs/contribute/plans/one-comparison-product.md`](docs/contribute/plans/one-comparison-product.md) (owner ADR: [ADR-068](docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md)): the scan-vs-compare parity harness. It exists while both `scan` and `compare` are still public commands — the only point at which the two can be compared directly — and its job is to make a silent capability loss during the eventual `scan` retirement loud instead of silent.

## Motivation

ADR-068 identifies capabilities `compare` cannot reach today: the eleven cross-source checks (`abicheck/buildsource/crosscheck.py`), the lexical pattern pre-scan (`pattern_scan.py`), the preprocessor scan (`preprocessor_scan.py`), changed-path localization, and the `abi3` audit. The plan's own Phase 0 deliverable is "an executable capability-loss detector, not a document" — this PR is that detector.

## Changes

- `tests/parity/runner.py` — CLI-invocation and `Finding`/`FindingSet` helpers. `compare`/`scan` are driven through the real public CLI (Click's `CliRunner`); the scan-only cross-source checks are exercised through the same production functions ADR-068 §1 identifies as scan-only (`run_crosschecks`), not a reimplementation.
- `tests/parity/gaps.py` — the expected-gap registry, i.e. the migration's own definition of done. Names all sixteen known gaps (11 cross-source checks + pattern scan + preprocessor scan + changed-path localization + abi3 audit), each with the plan phase expected to close it — never a bare `xfail`. `finding_evolution` (F-8/F-9) is tracked separately since it doesn't exist under *either* tool yet.
- `tests/parity/test_*` — one module per capability group:
  - `test_crosscheck_parity.py` — all eleven cross-source checks (F-5/F-6/F-7/F-10), using the committed compiler-free G20 example corpus (`catalog/cases/case14x-18x`) plus three small synthetic `AbiSnapshot` builders for the checks that corpus doesn't happen to cover on its own.
  - `test_engine_primitive_call_sites.py` — makes ADR-068 §1's own call-site claim executable (a real AST scan, not a citation): `run_crosschecks`/`scan_files`/`run_preprocessor_scan` have no caller under `abicheck/` besides `scan_engine.py`.
  - `test_pattern_scan_behavior.py` / `test_preprocessor_scan_behavior.py` — the positive behavioral half (only the preprocessor one needs real `clang`, so it's `integration`-marked).
  - `test_abi3_and_changed_path_parity.py`, `test_no_baseline_parity.py` — abi3 audit, `--since`/`--changed-path`, and `--no-baseline` (F-22/F-23) are usage errors on `compare` today.
  - `test_source_depth_parity.py` — F-3/F-4, the harness's *green* scenarios: source-ABI-replay (L4/L5) is already shared between the two commands, so these assert equality, including a hand-built inline-function-removal fixture proving both tools classify a source-only, binary-invisible change as `API_BREAK`, never `BREAKING` (the authority rule).
  - `test_evolution_state_gap.py`, `test_gap_registry_contract.py` — F-8/F-9's "not implemented anywhere yet" gap, and structural checks on the registry itself.

Everything runs in the default fast lane except the one preprocessor-scan behavioral test (`integration`, needs real `clang++`).

**No production code changed.** Recording each gap is the deliverable; fixing one is explicitly out of scope for this PR (and for Phase 0 generally — ADR-068 D9's ordering requires the parity suite to exist and go green before any capability moves).

## Checklist

- [x] Tests added (this PR *is* tests)
- [ ] Changelog fragment — not needed, no `abicheck/**/*.py` change
- [ ] Docs updated — not needed, no user-visible behavior changed
- [x] `ruff check`/`ruff format --check` pass on `tests/parity/`
- [x] `mypy abicheck/` clean (no production files touched)
- [x] `python scripts/check_ai_readiness.py` — 0 errors (pre-existing warning set unchanged)
- [x] `tests/parity/` (40 tests) passes in the default fast lane; the one `integration`-marked preprocessor test passes too, verified locally with a real `clang++`
- [x] Targeted regression check: `tests/test_g20_catalog.py`, `tests/test_crosscheck.py`, `tests/test_scan_compare_parity.py`, `tests/test_python_ext.py`, `tests/test_scan_dry_run_abi3.py` all still pass alongside the new package (477 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017BopDNoNMXgqviLesm4ncC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added parity coverage comparing `scan` and `compare` findings across cross-source checks, source-depth analysis, ABI3 auditing, changed-path localization, and no-baseline behavior.
  * Added validation for pattern and preprocessor scanning capabilities.
  * Added checks for finding identity, severity, evidence references, and expected capability gaps.
  * Added safeguards ensuring scan-only engine checks have controlled production call sites.
  * Added synthetic fixtures and shared helpers to support comprehensive parity testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->