### PR TITLE
feat: compare --no-baseline NEW (ADR-068 D2, plan P1 + Phase 2e)

### DIFF
--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -480,7 +480,19 @@ def _embed_inline_source_side(
 @main.command("compare")
 @cli_help.compare_help_options  # curated --help + full --help-all (G21.8 collapse M2)
 @click.argument("old_input", type=click.Path(exists=True, path_type=Path))
-@click.argument("new_input", type=click.Path(exists=True, path_type=Path))
+@click.argument("new_input", type=click.Path(exists=True, path_type=Path), required=False)
+@click.option(
+    "--no-baseline",
+    "no_baseline",
+    is_flag=True,
+    default=False,
+    help="Declare that no prior surface exists for this candidate -- an "
+    "audit, not a comparison (ADR-068 D2). Takes exactly one operand (the "
+    "candidate build) instead of OLD NEW; the OLD side is recorded with "
+    "ADR-065's 'declared_absent' acquisition state. Replaces `scan`'s "
+    "audit-only mode (no --against): reports candidate-side facts only -- "
+    "never an addition, a removal, or a compatibility verdict.",
+)
 # Set-input fan-out (ADR-037 D7): -j/--jobs, --dso-only, --output-dir only bite
 # when the operands are directories/packages; a no-op-with-warning otherwise.
 @set_input_options
@@ -747,6 +759,14 @@ def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:
     # forwarded options (explicit flags always win) and drop the CLI-only
     # ``profile`` key before delegating to the typed run_compare signature.
     apply_compare_profile(ctx, kwargs)
+
+    # ADR-068 D2 / plan §6 Phase 2e: `--no-baseline` is an explicit
+    # declaration, never inferred from arity -- branch before the two-sided
+    # machinery below, which a plain `compare OLD NEW` never reaches.
+    from .compare_no_baseline import maybe_dispatch_no_baseline_compare
+
+    if maybe_dispatch_no_baseline_compare(ctx, kwargs):
+        return
 
     # CLI cleanup phase two, PR I: OLD_INPUT/NEW_INPUT are classified
     # automatically for bundle-facts routing, replacing the removed

--- a/abicheck/frontends/cli/commands/compare_no_baseline.py
+++ b/abicheck/frontends/cli/commands/compare_no_baseline.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``abicheck compare --no-baseline NEW`` -- the CLI-layer half (ADR-068 D2,
+plan §6 Phase 2e).
+
+Dispatched from :func:`abicheck.frontends.cli.commands.compare.compare_cmd`
+*before* any of the two-sided pipeline runs, so a normal `compare OLD NEW`
+invocation never touches this module at all (every existing two-sided
+invocation stays bit-for-bit unchanged). All the candidate-side work --
+resolving NEW, self-diffing it, recording OLD's `declared_absent`
+acquisition state -- lives in :mod:`abicheck.workflows.no_baseline_compare`;
+the report shape lives in :mod:`abicheck.report.no_baseline`. This module
+only translates CLI options in, and the resulting report out.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from ....report.no_baseline import (
+    no_baseline_exit_code,
+    no_baseline_json_report,
+    no_baseline_markdown_report,
+)
+from ....workflows.no_baseline_compare import (
+    resolve_no_baseline_candidate,
+    run_no_baseline_compare,
+)
+from ..options.params import _load_suppression_and_policy
+from ..runtime import _write_or_echo
+
+__all__ = ["maybe_dispatch_no_baseline_compare"]
+
+#: Formats this Phase 2e slice can render faithfully. `sarif`/`html`/`junit`/
+#: `review` all frame their output around a compatibility verdict, which a
+#: `--no-baseline` audit deliberately never has -- rather than force a
+#: misleading rendering through machinery built for a two-sided verdict,
+#: those stay a declared usage error until a later phase of
+#: `docs/contribute/plans/one-comparison-product.md` gives them one.
+_SUPPORTED_FORMATS = frozenset({"json", "markdown"})
+
+
+def maybe_dispatch_no_baseline_compare(
+    ctx: click.Context, kwargs: dict[str, Any]
+) -> bool:
+    """Validate and run a ``--no-baseline`` invocation if *kwargs* asked for
+    one; returns ``True`` when it did (the caller must stop -- the whole
+    two-sided pipeline below is skipped), ``False`` for an ordinary
+    two-operand ``compare OLD NEW``.
+
+    ADR-068 D2: ``--no-baseline`` is an explicit declaration, never inferred
+    from arity -- ``compare NEW`` (one operand, no flag) and
+    ``compare --no-baseline OLD NEW`` (the flag plus two operands) are both
+    usage errors (exit 64), raised here rather than left to Click's own
+    argument arity (which cannot express "required unless a flag is set").
+    """
+    no_baseline = kwargs.pop("no_baseline", False)
+    if not no_baseline:
+        if kwargs.get("new_input") is None:
+            raise click.UsageError("Missing argument 'NEW_INPUT'.")
+        return False
+    if kwargs.get("new_input") is not None:
+        raise click.UsageError(
+            "--no-baseline takes exactly one operand (the candidate build); "
+            "OLD is declared absent, so a second path is not accepted. Run "
+            "`abicheck compare OLD NEW` (without --no-baseline) to compare "
+            "against a real baseline."
+        )
+    candidate = kwargs.pop("old_input")
+    kwargs.pop("new_input", None)
+    if candidate.is_dir():
+        raise click.UsageError(
+            "--no-baseline does not support a directory/package operand yet "
+            "-- pass a single artifact (a binary or a stored snapshot)."
+        )
+    _run_no_baseline_compare_cmd(ctx, candidate, **kwargs)
+    return True
+
+
+def _run_no_baseline_compare_cmd(
+    ctx: click.Context, candidate: Path, **kwargs: Any
+) -> None:
+    """Run and report a ``compare --no-baseline`` audit of *candidate*."""
+    fmt = kwargs.get("fmt") or "markdown"
+    if fmt not in _SUPPORTED_FORMATS:
+        raise click.UsageError(
+            f"--no-baseline does not support --format {fmt} yet -- only "
+            f"{'/'.join(sorted(_SUPPORTED_FORMATS))} are available for an "
+            "audit report."
+        )
+    output = kwargs.get("output")
+
+    headers = list(kwargs.get("headers") or ()) + list(
+        kwargs.get("new_headers_only") or ()
+    )
+    includes = list(kwargs.get("includes") or ()) + list(
+        kwargs.get("new_includes_only") or ()
+    )
+    lang = kwargs.get("lang") or "c++"
+    lang_src = ctx.get_parameter_source("lang") if ctx is not None else None
+    lang_explicit = lang_src == click.core.ParameterSource.COMMANDLINE
+    public_headers = list(kwargs.get("public_headers") or ())
+    public_header_dirs = list(kwargs.get("public_header_dirs") or ())
+
+    new_snapshot = resolve_no_baseline_candidate(
+        candidate,
+        headers=headers,
+        includes=includes,
+        lang=lang,
+        lang_explicit=lang_explicit,
+        public_headers=public_headers,
+        public_header_dirs=public_header_dirs,
+    )
+
+    suppression, policy_file_obj = _load_suppression_and_policy(
+        kwargs.get("suppress"),
+        kwargs.get("policy") or "strict_abi",
+        kwargs.get("policy_file_path"),
+    )
+
+    result = run_no_baseline_compare(
+        new_snapshot,
+        suppression=suppression,
+        policy=kwargs.get("policy") or "strict_abi",
+        policy_file=policy_file_obj,
+        scope_to_public_surface=bool(kwargs.get("scope_public_headers", True)),
+        pattern_verdicts=bool(kwargs.get("pattern_verdicts", False)),
+        collapse_versioned_symbols=bool(
+            kwargs.get("collapse_versioned_symbols", False)
+        ),
+    )
+
+    require_complete_analysis = bool(kwargs.get("require_complete_analysis", False))
+
+    text = (
+        json.dumps(no_baseline_json_report(result), indent=2)
+        if fmt == "json"
+        else no_baseline_markdown_report(result)
+    )
+    _write_or_echo(output, text)
+
+    exit_code = no_baseline_exit_code(
+        result, require_complete_analysis=require_complete_analysis
+    )
+    if exit_code != 0:
+        sys.exit(exit_code)

--- a/abicheck/model/scope_acquisition.py
+++ b/abicheck/model/scope_acquisition.py
@@ -102,6 +102,17 @@ class AcquisitionState(str, Enum):
     #: Could pair with more than one counterpart (D3) -- a diagnostic, not
     #: a guess (S1 emits it; S2's filename matching never produces one).
     AMBIGUOUS = "ambiguous"
+    #: ADR-068 D2 / plan P1: the OLD side of an ``abicheck compare
+    #: --no-baseline NEW`` run. The user *declared* there is no prior
+    #: surface -- this is explicitly not ``NOT_SUPPLIED`` (which means
+    #: "unmatched, unproven, treat as incomplete scope"): a declared-absent
+    #: OLD side never makes the run read as incomplete, is never a proven-
+    #: removal input (:attr:`ScopeAcquisitionRecord.proven_removed_members`
+    #: only ever reads ``NOT_SUPPLIED``), and never yields an addition --
+    #: those all require a real OLD side to compare against, which by
+    #: construction does not exist here. See
+    #: :mod:`abicheck.workflows.no_baseline_compare`.
+    DECLARED_ABSENT = "declared_absent"
 
 
 #: The states D6 counts as "a selected, expected member that did not reach
@@ -278,8 +289,19 @@ class ScopeAcquisitionRecord:
 
     @property
     def completed_members(self) -> tuple[MemberAcquisition, ...]:
-        """Members whose comparison completed (``available``)."""
-        return tuple(m for m in self.members if m.state is AcquisitionState.AVAILABLE)
+        """Members that reached a completed outcome this run: ``available``
+        (a real two-sided comparison ran) or ``declared_absent`` (ADR-068
+        D2: no two-sided comparison was ever intended, but the audit that
+        *did* run over the candidate side completed). D7's ``no_comparison_
+        completed`` reads this property, so a ``--no-baseline`` run --
+        which by design never runs a comparison -- must not read as "the
+        selected scope produced no valid comparison at all"; it produced
+        exactly the (different-shaped) result it declared it would."""
+        return tuple(
+            m
+            for m in self.members
+            if m.state in (AcquisitionState.AVAILABLE, AcquisitionState.DECLARED_ABSENT)
+        )
 
     @property
     def unchecked_members(self) -> tuple[MemberAcquisition, ...]:

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``compare --no-baseline`` report (ADR-068 D2, plan §6 Phase 2e).
+
+Builds the JSON/Markdown report for a ``--no-baseline`` audit directly,
+rather than through the legacy ``reporter.to_json`` chokepoint every
+two-sided ``compare`` report renders through: that module is unclassified
+(ADR-061), so a migrated-layer caller (``frontends``, this module's own
+``report`` layer) cannot reach it at all
+(``check_architecture.py``'s ``unclassified-import`` gate) -- and a
+``--no-baseline`` report is trivial enough (an empty change set, by
+construction; see :mod:`abicheck.workflows.no_baseline_compare`) that
+reusing the two-sided severity/change-rendering machinery would be a much
+larger dependency for no real benefit. This is the ADR-061 ``report/``
+owner's job either way: "Add a report field, report schema, or output
+format".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..policy.outcome import OperationalStatus, PolicyGateDecision, RunOutcome
+from ..policy.scope_completeness import resolve_scope_decision
+from .comparison_scope import build_comparison_scope_section
+
+if TYPE_CHECKING:
+    from ..policy.scope_completeness import ScopeDecision
+    from ..workflows.no_baseline_compare import NoBaselineCompareResult
+
+__all__ = [
+    "no_baseline_exit_code",
+    "no_baseline_json_report",
+    "no_baseline_markdown_report",
+]
+
+#: Independent of ``reporter.REPORT_SCHEMA_VERSION`` (the two-sided report's
+#: own schema) -- this report carries a different, much smaller shape (no
+#: ``changes``/``summary``/``severity`` blocks worth versioning the same
+#: way), so it gets its own counter rather than borrowing one that promises
+#: a shape this report doesn't have.
+NO_BASELINE_REPORT_SCHEMA_VERSION = "1.0"
+
+
+def _scope_decision(result: NoBaselineCompareResult) -> ScopeDecision:
+    return resolve_scope_decision(result.acquisition, policy=None)
+
+
+def _run_outcome(result: NoBaselineCompareResult) -> RunOutcome:
+    """ADR-068 D2: OLD is ``declared_absent``, so this run never carries a
+    compatibility contribution -- ``compatibility``/``gate``/``operational``
+    read exactly as they would for a report that never ran a real
+    comparison at all (:class:`~abicheck.policy.outcome.RunOutcome`'s own
+    documented convention), while ``scope`` is decided the same way a
+    two-sided run's would be."""
+    return RunOutcome(
+        compatibility=None,
+        assurance=getattr(result.diff, "analysis_assurance", None),
+        gate=PolicyGateDecision.NONE,
+        operational=OperationalStatus.NONE,
+        scope=_scope_decision(result).completeness,
+    )
+
+
+def no_baseline_exit_code(
+    result: NoBaselineCompareResult, *, require_complete_analysis: bool = False
+) -> int:
+    """The whole exit-code contribution of a ``--no-baseline`` run.
+
+    The compatibility axis contributes nothing (ADR-068 D2) -- coverage and
+    analysis-assurance still apply exactly as they would for a two-sided
+    run, and the completeness axis (D6/D7) reads ``0`` for the same reason
+    ``no_comparison_completed``/``is_incomplete`` never fire for a
+    ``declared_absent`` member -- all folded via the same ``max`` discipline
+    every other orthogonal axis in this codebase uses (never an inline
+    ``sys.exit`` computation of its own).
+    """
+    from ..analysis_assurance import analysis_assurance_exit_contribution
+    from ..policy.contract_coverage_exit import coverage_exit_floor
+
+    scope_decision = _scope_decision(result)
+    coverage = coverage_exit_floor(result.diff)
+    assurance = analysis_assurance_exit_contribution(
+        result.diff, require_complete=require_complete_analysis
+    )
+    return max(
+        coverage,
+        assurance,
+        scope_decision.incomplete_scope_exit_contribution,
+        scope_decision.no_comparison_completed_exit_contribution,
+    )
+
+
+def no_baseline_json_report(result: NoBaselineCompareResult) -> dict[str, Any]:
+    """The full JSON report for a ``--no-baseline`` audit.
+
+    Deliberately not a projection of the two-sided report's shape padded
+    out with nulls: ``no_baseline: true`` marks the shape up front, there is
+    no ``old_version``/``old_file`` (OLD was never supplied, not merely
+    empty), and ``verdict``/``changes`` read as the audit they are -- no
+    verdict, an empty change set by construction (see the self-diff
+    identity argument in :mod:`abicheck.workflows.no_baseline_compare`).
+    """
+    diff = result.diff
+    return {
+        "report_schema_version": NO_BASELINE_REPORT_SCHEMA_VERSION,
+        "no_baseline": True,
+        "library": diff.library,
+        "new_version": diff.new_version,
+        "verdict": None,
+        "changes": [],
+        "evidence_tiers": list(diff.evidence_tiers),
+        "run_outcome": _run_outcome(result).to_dict(),
+        "comparison_scope": build_comparison_scope_section(_scope_decision(result)),
+    }
+
+
+def no_baseline_markdown_report(result: NoBaselineCompareResult) -> str:
+    """The Markdown rendering of :func:`no_baseline_json_report`."""
+    diff = result.diff
+    member = result.acquisition.members[0]
+    lines = [
+        f"# ABI audit: {diff.library} (no baseline)",
+        "",
+        "OLD side: **declared absent** (`--no-baseline`) -- this is an audit "
+        "of the candidate build alone, not a compatibility comparison. No "
+        "additions, removals, or compatibility verdict are reported.",
+        "",
+        f"- Candidate version: `{diff.new_version or '(unspecified)'}`",
+        f"- Acquisition state (OLD): `{member.state.value}`",
+        f"- Evidence tiers: {', '.join(diff.evidence_tiers) or '(none recorded)'}",
+    ]
+    return "\n".join(lines) + "\n"

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -1926,7 +1926,8 @@
             "not_supplied",
             "unsupported",
             "out_of_scope",
-            "ambiguous"
+            "ambiguous",
+            "declared_absent"
           ],
           "additionalProperties": false,
           "properties": {
@@ -1955,6 +1956,10 @@
               "minimum": 0
             },
             "ambiguous": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "declared_absent": {
               "type": "integer",
               "minimum": 0
             }
@@ -1991,9 +1996,10 @@
                   "not_supplied",
                   "unsupported",
                   "out_of_scope",
-                  "ambiguous"
+                  "ambiguous",
+                  "declared_absent"
                 ],
-                "description": "ADR-065 D1 acquisition state: available (a completed comparison), expected_not_produced, failed (extraction/classification failed, or a stored capture marked degraded), not_supplied (no counterpart on the other side; a removal/addition only when that side's inventory is proven), unsupported (this build cannot analyze the artifact), out_of_scope (deliberately unselected, D9), ambiguous."
+                "description": "ADR-065 D1 acquisition state: available (a completed comparison), expected_not_produced, failed (extraction/classification failed, or a stored capture marked degraded), not_supplied (no counterpart on the other side; a removal/addition only when that side's inventory is proven), unsupported (this build cannot analyze the artifact), out_of_scope (deliberately unselected, D9), ambiguous, declared_absent (ADR-068 D2: the OLD side of a `compare --no-baseline` run -- explicitly declared absent, never counted as unchecked/incomplete and never a proven removal/addition input)."
               },
               "old_present": {
                 "type": "boolean"

--- a/abicheck/workflows/no_baseline_compare.py
+++ b/abicheck/workflows/no_baseline_compare.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``abicheck compare --no-baseline NEW`` -- ADR-068 D2, plan §6 Phase 2e.
+
+Replaces `scan`'s audit-only mode (plan §3 #2) and ADR-047 §8's S5
+("single-build audit, no baseline"). The OLD side of this run carries
+ADR-065's new :attr:`~abicheck.model.scope_acquisition.AcquisitionState.
+DECLARED_ABSENT` acquisition state (plan §5 P1) -- an explicit user
+declaration that no prior surface exists, never inferred from a missing
+argument and never confused with :attr:`~abicheck.model.scope_acquisition.
+AcquisitionState.NOT_SUPPLIED` (an *unproven*, possibly-incomplete-scope
+absence).
+
+**How this reports candidate-side facts without a real OLD snapshot**:
+:func:`run_no_baseline_compare` diffs *new* against itself. Two identical
+:class:`~abicheck.model.AbiSnapshot` objects can never produce an addition,
+a removal, or a modification -- so the real detector/suppression/policy
+pipeline (:func:`abicheck.checker.compare`) runs completely unmodified, and
+every candidate-side fact the resulting :class:`~abicheck.checker_types.
+DiffResult` carries (evidence tiers, coverage, analysis assurance) is
+genuine evidence about *new*, not a synthesized stand-in. The empty change
+set falls out of the identity comparison by construction, rather than from
+a change-kind filter that could silently drift out of sync with the
+detector registry (a filter is a second place a new ``ChangeKind`` would
+need to be taught about "no-baseline mode"; identity needs no such
+maintenance).
+
+The one thing this module does *not* do is decide how the resulting
+:class:`~abicheck.checker_types.DiffResult` gets reported: ``NO_CHANGE`` is
+the *true* verdict of "new compared to itself", but the whole point of
+``--no-baseline`` is that no compatibility comparison was ever intended --
+so a caller (:mod:`abicheck.frontends.cli.commands.compare_no_baseline`)
+must null the compatibility-shaped fields (``verdict``,
+``run_outcome.compatibility``) before this reaches a report; ADR-068 D2:
+"never emits an addition, removal, or compatibility verdict -- run_outcome
+carries no compatibility contribution".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..checker import compare as _diff_pair
+from ..model.scope_acquisition import (
+    AcquisitionState,
+    InventoryCompleteness,
+    MemberAcquisition,
+    ScopeAcquisitionRecord,
+    SideInventory,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..checker_types import DiffResult
+    from ..model import AbiSnapshot
+    from ..policy_file import PolicyFile
+    from ..suppression import SuppressionList
+
+__all__ = [
+    "NoBaselineCompareResult",
+    "declared_absent_acquisition_record",
+    "resolve_no_baseline_candidate",
+    "run_no_baseline_compare",
+]
+
+
+def resolve_no_baseline_candidate(
+    path: Path,
+    *,
+    headers: list[Path] | None = None,
+    includes: list[Path] | None = None,
+    lang: str = "c++",
+    lang_explicit: bool = False,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+) -> AbiSnapshot:
+    """Resolve the sole ``--no-baseline`` operand into an
+    :class:`~abicheck.model.AbiSnapshot`.
+
+    A thin, workflows-internal call to :func:`abicheck.workflows.
+    input_resolution.resolve_input` -- the single-input primitive `dump`
+    and `compare`'s own per-side resolution are both ultimately built on
+    (``service_input_resolution.resolve_side_snapshot``, ADR-061's `service_
+    input_resolution.py` module docstring). Called from here rather than
+    from the CLI layer directly so the ``cli-contract`` AI-readiness gate's
+    "front end may not call Tier-1 core directly" rule is satisfied by
+    construction: the CLI module calls this workflow, this workflow calls
+    the resolver."""
+    from .input_resolution import resolve_input
+
+    return resolve_input(
+        path,
+        headers=headers or [],
+        includes=includes or [],
+        lang=lang,
+        lang_explicit=lang_explicit,
+        public_headers=public_headers or [],
+        public_header_dirs=public_header_dirs or [],
+    )
+
+
+#: The one selection value a ``--no-baseline`` run's
+#: :class:`~abicheck.model.scope_acquisition.ScopeAcquisitionRecord` carries
+#: -- distinct from ``"direct_pair"`` (a real two-sided scalar comparison,
+#: which today never even builds a record) and from the release fan-out's
+#: ``"all_expected"``/``"current_artifact"``.
+NO_BASELINE_SELECTION = "no_baseline"
+
+
+@dataclass(frozen=True)
+class NoBaselineCompareResult:
+    """The two things a ``--no-baseline`` run produces: the candidate-side
+    :class:`~abicheck.checker_types.DiffResult` (self-diffed; always an
+    empty change set) and the :class:`~abicheck.model.scope_acquisition.
+    ScopeAcquisitionRecord` recording OLD's ``declared_absent`` state."""
+
+    diff: DiffResult
+    acquisition: ScopeAcquisitionRecord
+
+
+def declared_absent_acquisition_record(new: AbiSnapshot) -> ScopeAcquisitionRecord:
+    """The one-member :class:`ScopeAcquisitionRecord` a ``--no-baseline``
+    run carries: OLD is ``declared_absent`` (not "unmatched" -- the user
+    said so), NEW is present. Never incomplete
+    (:attr:`~abicheck.model.scope_acquisition.AcquisitionState.
+    DECLARED_ABSENT` is excluded from ``UNCHECKED_STATES``) and never a
+    proven removal/addition input (only ``NOT_SUPPLIED`` members are read
+    by :attr:`~abicheck.model.scope_acquisition.ScopeAcquisitionRecord.
+    proven_removed_members`/``proven_added_members``)."""
+    member_key = new.library or "candidate"
+    member = MemberAcquisition(
+        member=member_key,
+        state=AcquisitionState.DECLARED_ABSENT,
+        old_present=False,
+        new_present=True,
+        reason="--no-baseline: no prior surface declared for this run",
+        display_name=new.library,
+    )
+    return ScopeAcquisitionRecord(
+        members=(member,),
+        old_inventory=SideInventory(
+            completeness=InventoryCompleteness.UNPROVEN,
+            provenance="--no-baseline: OLD declared absent, not supplied",
+        ),
+        new_inventory=SideInventory(
+            completeness=InventoryCompleteness.UNPROVEN,
+            provenance="candidate build",
+        ),
+        selection=NO_BASELINE_SELECTION,
+        selection_reason="abicheck compare --no-baseline: single candidate audit",
+    )
+
+
+def run_no_baseline_compare(
+    new: AbiSnapshot,
+    *,
+    suppression: SuppressionList | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+    scope_to_public_surface: bool = True,
+    force_public_symbols: set[str] | None = None,
+    pattern_verdicts: bool = False,
+    collapse_versioned_symbols: bool = False,
+    contract_evaluation: bool = False,
+    contract_mode: str | None = None,
+) -> NoBaselineCompareResult:
+    """Audit *new* alone via a self-diff (see module docstring for why this
+    is exact, not an approximation) and pair it with OLD's
+    ``declared_absent`` acquisition record."""
+    diff = _diff_pair(
+        new,
+        new,
+        suppression=suppression,
+        policy=policy,
+        policy_file=policy_file,
+        scope_to_public_surface=scope_to_public_surface,
+        force_public_symbols=force_public_symbols,
+        pattern_verdicts=pattern_verdicts,
+        collapse_versioned_symbols=collapse_versioned_symbols,
+        contract_evaluation=contract_evaluation,
+        contract_mode=contract_mode,
+    )
+    assert not diff.changes, (
+        "a snapshot compared against itself must never produce a change -- "
+        "if this fires, a detector is reading non-identity state"
+    )
+    return NoBaselineCompareResult(
+        diff=diff, acquisition=declared_absent_acquisition_record(new)
+    )

--- a/changelog.d/1788000000_claude_compare-no-baseline.md
+++ b/changelog.d/1788000000_claude_compare-no-baseline.md
@@ -1,0 +1,18 @@
+### Added
+
+- **`abicheck compare --no-baseline NEW`** (ADR-068 D2, plan §5 P1 / §6
+  Phase 2e): declare that no prior surface exists for a candidate build and
+  run an audit instead of a comparison -- the first replacement for `scan`'s
+  audit-only mode (no `--against`) and ADR-047 §8's S5. `--no-baseline` is an
+  explicit declaration, never inferred from argument count: `compare NEW`
+  (one operand, no flag) and `compare --no-baseline OLD NEW` (the flag plus
+  two operands) are both usage errors (exit `64`). The OLD side carries a
+  new ADR-065 `MemberAcquisition` state, `declared_absent` -- distinct from
+  `not_supplied`, since the user explicitly declared there is no prior
+  surface rather than the run failing to find one. A `--no-baseline` report
+  never emits an addition, a removal, or a compatibility verdict --
+  `run_outcome.compatibility` is `null`, `changes` is always empty, and the
+  process exits `0` unless an orthogonal axis (analysis assurance, contract
+  coverage) independently contributes. Only a single artifact is supported
+  for now (`--format json`/`markdown`); a directory/package operand raises a
+  usage error until ADR-065 S3's package component inventories land.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -42,7 +42,7 @@ Compare two ABI surfaces and report changes.
 | Name | Required | Description |
 |---|:--:|---|
 | `old_input` | yes |  |
-| `new_input` | yes |  |
+| `new_input` | no |  |
 
 **Options**
 
@@ -50,6 +50,7 @@ Compare two ABI surfaces and report changes.
 |---|:--:|---|---|
 | `--help` | no | `False` | Show common options and exit. Use --help-all to see the remaining advanced options. |
 | `--help-all` | no | `False` | Show every option, including advanced/less-common ones. |
+| `--no-baseline` | no | `False` | Declare that no prior surface exists for this candidate -- an audit, not a comparison (ADR-068 D2). Takes exactly one operand (the candidate build) instead of OLD NEW; the OLD side is recorded with ADR-065's 'declared\_absent' acquisition state. Replaces `scan`'s audit-only mode (no --against): reports candidate-side facts only -- never an addition, a removal, or a compatibility verdict. |
 | `--jobs`, `-j` | no | `0` | Parallel library comparisons for directory/package inputs (0 = auto-detect CPU count, clamped to fit available memory -- see ABICHECK\_RELEASE\_JOB\_MEM\_GIB -- the default). An explicit positive value is never memory-clamped. |
 | `--dso-only` | no | `False` | Only compare shared objects, skip executables (directory/package inputs only). |
 | `--output-dir` | no | — | Directory to write per-library reports (directory/package inputs only). |

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -150,6 +150,30 @@ can be demoted. Only legacy output without a gate block falls back from
 compatibility verdict to `2`/`4`. Existing command-specific `5`, `8`, and `64`
 behavior is as documented below.
 
+## `compare --no-baseline` (ADR-068 D2, single artifact)
+
+`abicheck compare --no-baseline NEW` declares that no prior surface exists
+for `NEW` and runs a candidate-side audit instead of a comparison — the
+first replacement for `scan`'s audit-only mode (no `--against`) and
+ADR-047 §8's S5. `--no-baseline` is an explicit declaration, never inferred
+from argument count: `compare NEW` (one operand, no flag) and
+`compare --no-baseline OLD NEW` (the flag plus two operands) are both usage
+errors, exit `64`. Only a single artifact is supported today; a
+directory/package operand is also a usage error until ADR-065 S3's package
+component inventories land (plan §5 P5).
+
+The OLD side is recorded with ADR-065's `declared_absent`
+`MemberAcquisition` state — distinct from `not_supplied` (an *unproven*
+absence that can leave the scope reading incomplete): the user declared
+there is no prior surface, so `run_outcome.scope` reads `complete` and the
+`comparison_scope` block names the one `declared_absent` member. The run
+never emits an addition, a removal, or a compatibility verdict —
+`run_outcome.compatibility` and the top-level `verdict` are JSON `null`,
+and `changes` is always `[]`. The compatibility axis therefore always
+contributes `0` to the exit code; the orthogonal analysis-assurance and
+contract-coverage axes below still apply exactly as they would for a
+two-sided run, folded with the same `max` discipline.
+
 ## Analysis-assurance contribution (P0.4)
 
 `compare`, and `scan --against`, always compute and report

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -1926,7 +1926,8 @@
             "not_supplied",
             "unsupported",
             "out_of_scope",
-            "ambiguous"
+            "ambiguous",
+            "declared_absent"
           ],
           "additionalProperties": false,
           "properties": {
@@ -1955,6 +1956,10 @@
               "minimum": 0
             },
             "ambiguous": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "declared_absent": {
               "type": "integer",
               "minimum": 0
             }
@@ -1991,9 +1996,10 @@
                   "not_supplied",
                   "unsupported",
                   "out_of_scope",
-                  "ambiguous"
+                  "ambiguous",
+                  "declared_absent"
                 ],
-                "description": "ADR-065 D1 acquisition state: available (a completed comparison), expected_not_produced, failed (extraction/classification failed, or a stored capture marked degraded), not_supplied (no counterpart on the other side; a removal/addition only when that side's inventory is proven), unsupported (this build cannot analyze the artifact), out_of_scope (deliberately unselected, D9), ambiguous."
+                "description": "ADR-065 D1 acquisition state: available (a completed comparison), expected_not_produced, failed (extraction/classification failed, or a stored capture marked degraded), not_supplied (no counterpart on the other side; a removal/addition only when that side's inventory is proven), unsupported (this build cannot analyze the artifact), out_of_scope (deliberately unselected, D9), ambiguous, declared_absent (ADR-068 D2: the OLD side of a `compare --no-baseline` run -- explicitly declared absent, never counted as unchecked/incomplete and never a proven removal/addition input)."
               },
               "old_present": {
                 "type": "boolean"

--- a/tests/_cli_option_set_snapshot.py
+++ b/tests/_cli_option_set_snapshot.py
@@ -72,6 +72,7 @@ OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
         "--lang",
         "--ld-library-path",
         "--max-json-object-nodes",
+        "--no-baseline",
         "--no-bundle-analysis",
         "--no-debuginfod",
         "--no-demangle",

--- a/tests/parity/test_no_baseline_parity.py
+++ b/tests/parity/test_no_baseline_parity.py
@@ -4,17 +4,17 @@
 ``compare --no-baseline NEW`` (plan §3 #2/#16, ADR-068 D2) is the intended
 replacement for ``scan ARTIFACT`` without ``--against`` (a single-artifact
 audit) and for ``scan --artifact-set`` (an N-library audit, over a
-directory). Neither exists on ``compare`` yet — Phase 1 (``declared_absent``
-acquisition state) and Phase 2e haven't landed — so both scenarios are
-expected-gap today. This module pins the exact usage-error shape so its own
-tests start failing the moment ``--no-baseline`` is accepted at all,
-prompting the ``tests/parity/gaps.py`` entries to be reconsidered (a
-usage-error test failing "for the right reason" is exactly this harness's
-job, per plan §6 Phase 0).
+directory). Prerequisite P1 (the ``declared_absent`` acquisition state) and
+Phase 2e have now landed for the **single-artifact** shape (plan §3 #2). The
+**directory** shape (plan §3 #16, the eventual replacement for
+``scan --artifact-set``) still depends on ADR-065 S3's package component
+inventories (plan §5 P5, "not started"), so it stays a declared, tested gap
+below rather than a silent one.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from .runner import invoke_cli, scan_json, write_snapshot
@@ -35,12 +35,21 @@ def test_scan_supports_single_artifact_audit_without_against(tmp_path: Path) -> 
     assert "diff" not in report or report.get("diff") is None
 
 
-def test_compare_has_no_no_baseline_option(tmp_path: Path) -> None:
-    """F-22: `compare` cannot express "declare OLD absent" at all today."""
+def test_compare_no_baseline_single_artifact_audit(tmp_path: Path) -> None:
+    """F-22, closed: `compare --no-baseline NEW` reports candidate-side
+    facts with no addition, no removal, and no compatibility verdict --
+    ADR-068 D2, over ADR-065's `declared_absent` acquisition state (plan
+    §5 P1)."""
     path = write_snapshot(_empty_snapshot(), tmp_path / "libfoo.so.abi.json")
-    result = invoke_cli("compare", "--no-baseline", str(path))
-    assert result.exit_code == 64, result.output
-    assert "No such option" in result.output and "--no-baseline" in result.output
+    result = invoke_cli("compare", "--no-baseline", str(path), "--format", "json")
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.stdout)
+    assert report["changes"] == []
+    assert report["verdict"] is None
+    assert report["run_outcome"]["compatibility"] is None
+    assert report["run_outcome"]["scope"] == "complete"
+    member = report["comparison_scope"]["members"][0]
+    assert member["state"] == "declared_absent"
 
 
 def test_compare_single_operand_is_a_usage_error_not_an_audit(tmp_path: Path) -> None:
@@ -52,6 +61,16 @@ def test_compare_single_operand_is_a_usage_error_not_an_audit(tmp_path: Path) ->
     result = invoke_cli("compare", str(path))
     assert result.exit_code == 64, result.output
     assert "Missing argument" in result.output
+
+
+def test_compare_no_baseline_rejects_two_operands(tmp_path: Path) -> None:
+    """ADR-068 D2: `compare --no-baseline OLD NEW` is a usage error too --
+    `--no-baseline` and a real OLD operand are mutually exclusive, never
+    "OLD is ignored"."""
+    old_path = write_snapshot(_empty_snapshot("old.so"), tmp_path / "old.so.abi.json")
+    new_path = write_snapshot(_empty_snapshot("new.so"), tmp_path / "new.so.abi.json")
+    result = invoke_cli("compare", "--no-baseline", str(old_path), str(new_path))
+    assert result.exit_code == 64, result.output
 
 
 def test_scan_supports_directory_audit_without_against() -> None:
@@ -73,12 +92,15 @@ def test_scan_supports_directory_audit_without_against() -> None:
 
 def test_compare_directory_no_baseline_is_unreachable(tmp_path: Path) -> None:
     """F-23: the directory form of --no-baseline (plan §3 #16's "compare
-    --no-baseline DIR" replacement for --artifact-set) is unreachable for
-    the same reason the single-artifact form is -- the flag doesn't exist."""
+    --no-baseline DIR" replacement for --artifact-set) stays an explicit,
+    declared gap -- ADR-065 S3's package component inventories (plan §5 P5)
+    haven't landed, so `--no-baseline` itself now exists (Phase 2e) but
+    refuses a directory operand with a real usage error rather than
+    silently mis-auditing it."""
     lib_dir = tmp_path / "release"
     lib_dir.mkdir()
     write_snapshot(_empty_snapshot(), lib_dir / "libfoo.so.abi.json")
 
     result = invoke_cli("compare", "--no-baseline", str(lib_dir))
     assert result.exit_code == 64, result.output
-    assert "No such option" in result.output and "--no-baseline" in result.output
+    assert "directory" in result.output

--- a/tests/test_no_baseline_compare.py
+++ b/tests/test_no_baseline_compare.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-068 D2 / plan §5 P1, §6 Phase 2e: the ``declared_absent`` acquisition
+state and ``abicheck compare --no-baseline NEW``.
+
+Covers the model primitive directly (never incomplete, never a proven
+removal input), the workflow (self-diff identity, always an empty change
+set), the report shape (no verdict, no compatibility contribution), and the
+CLI's arity enforcement -- complementing (not duplicating)
+``tests/parity/test_no_baseline_parity.py``'s end-to-end scan/compare
+parity assertions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.model import AbiSnapshot, Function
+from abicheck.model.scope_acquisition import (
+    AcquisitionState,
+    InventoryCompleteness,
+    MemberAcquisition,
+    ScopeAcquisitionRecord,
+    SideInventory,
+)
+
+
+def _declared_absent_record(member: str = "libfoo.so") -> ScopeAcquisitionRecord:
+    return ScopeAcquisitionRecord(
+        members=(
+            MemberAcquisition(
+                member=member,
+                state=AcquisitionState.DECLARED_ABSENT,
+                old_present=False,
+                new_present=True,
+                reason="--no-baseline",
+            ),
+        ),
+        old_inventory=SideInventory(
+            completeness=InventoryCompleteness.UNPROVEN, provenance="--no-baseline"
+        ),
+        new_inventory=SideInventory(
+            completeness=InventoryCompleteness.UNPROVEN, provenance="candidate build"
+        ),
+        selection="no_baseline",
+    )
+
+
+class TestDeclaredAbsentAcquisitionState:
+    """P1: the model primitive's completeness/outcome consequences."""
+
+    def test_never_incomplete(self) -> None:
+        record = _declared_absent_record()
+        assert not record.is_incomplete
+        assert record.unchecked_members == ()
+
+    def test_never_no_comparison_completed(self) -> None:
+        """D7 must not fire for a run that never intended a two-sided
+        comparison in the first place -- it completed the (different-shaped)
+        outcome it declared it would."""
+        record = _declared_absent_record()
+        assert not record.no_comparison_completed
+        assert record.completed_members == record.members
+
+    def test_never_a_proven_removal_or_addition_input(self) -> None:
+        """Only ``not_supplied`` members feed the proven-removed/-added
+        properties -- a declared-absent OLD side must never manufacture a
+        removal finding, however complete NEW's inventory is."""
+        record = _declared_absent_record()
+        assert record.proven_removed_members == ()
+        assert record.proven_added_members == ()
+
+    def test_round_trips_through_dict(self) -> None:
+        record = _declared_absent_record()
+        rebuilt = ScopeAcquisitionRecord.from_dict(record.to_dict())
+        assert rebuilt.members[0].state is AcquisitionState.DECLARED_ABSENT
+        assert not rebuilt.is_incomplete
+
+    def test_distinct_from_not_supplied(self) -> None:
+        """Never conflated with NOT_SUPPLIED: that state IS counted as
+        unchecked/incomplete, DECLARED_ABSENT never is."""
+        not_supplied = ScopeAcquisitionRecord(
+            members=(
+                MemberAcquisition(
+                    member="libfoo.so",
+                    state=AcquisitionState.NOT_SUPPLIED,
+                    old_present=True,
+                    new_present=False,
+                ),
+            ),
+            old_inventory=SideInventory(
+                completeness=InventoryCompleteness.UNPROVEN, provenance="dir"
+            ),
+            new_inventory=SideInventory(
+                completeness=InventoryCompleteness.UNPROVEN, provenance="dir"
+            ),
+            selection="all_expected",
+        )
+        assert not_supplied.is_incomplete
+        assert _declared_absent_record().is_incomplete is False
+
+
+class TestRunNoBaselineCompare:
+    """Phase 2e: the workflow that turns a resolved NEW snapshot into a
+    candidate-only audit."""
+
+    def _snapshot(self) -> AbiSnapshot:
+        return AbiSnapshot(
+            library="libfoo.so",
+            version="1.0",
+            functions=[Function(name="foo", mangled="foo", return_type="void")],
+        )
+
+    def test_empty_change_set_by_construction(self) -> None:
+        from abicheck.workflows.no_baseline_compare import run_no_baseline_compare
+
+        result = run_no_baseline_compare(self._snapshot())
+        assert result.diff.changes == []
+
+    def test_acquisition_record_marks_old_declared_absent(self) -> None:
+        from abicheck.workflows.no_baseline_compare import run_no_baseline_compare
+
+        result = run_no_baseline_compare(self._snapshot())
+        member = result.acquisition.members[0]
+        assert member.state is AcquisitionState.DECLARED_ABSENT
+        assert member.old_present is False
+        assert member.new_present is True
+
+
+class TestNoBaselineReport:
+    """The report shape: no verdict, no compatibility contribution."""
+
+    def _result(self):
+        from abicheck.workflows.no_baseline_compare import run_no_baseline_compare
+
+        snapshot = AbiSnapshot(library="libfoo.so", version="1.0")
+        return run_no_baseline_compare(snapshot)
+
+    def test_json_report_has_no_verdict_or_additions(self) -> None:
+        from abicheck.report.no_baseline import no_baseline_json_report
+
+        report = no_baseline_json_report(self._result())
+        assert report["verdict"] is None
+        assert report["changes"] == []
+        assert report["run_outcome"]["compatibility"] is None
+        assert report["run_outcome"]["gate"] == "none"
+        assert report["run_outcome"]["operational"] == "none"
+        assert report["run_outcome"]["scope"] == "complete"
+        assert report["comparison_scope"]["members"][0]["state"] == "declared_absent"
+
+    def test_exit_code_contributes_zero_by_default(self) -> None:
+        from abicheck.report.no_baseline import no_baseline_exit_code
+
+        assert no_baseline_exit_code(self._result()) == 0
+
+    def test_markdown_report_names_declared_absent(self) -> None:
+        from abicheck.report.no_baseline import no_baseline_markdown_report
+
+        text = no_baseline_markdown_report(self._result())
+        assert "declared_absent" in text
+        assert "no baseline" in text.lower()
+
+
+class TestNoBaselineCli:
+    """CLI-layer arity enforcement (ADR-068 D2) -- see
+    ``tests/parity/test_no_baseline_parity.py`` for the full end-to-end
+    coverage; these are the fast, direct-import cases."""
+
+    def test_single_artifact_audit_exits_zero(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        from abicheck.serialization import snapshot_to_json
+
+        snap = AbiSnapshot(library="libfoo.so", version="1.0")
+        path = tmp_path / "libfoo.so.abi.json"
+        path.write_text(snapshot_to_json(snap), encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main, ["compare", "--no-baseline", str(path), "--format", "json"]
+        )
+        assert result.exit_code == 0, result.output
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [
+            pytest.param((), id="no_flag_one_operand"),
+        ],
+    )
+    def test_missing_new_operand_is_usage_error(
+        self, tmp_path: Path, extra_args: tuple[str, ...]
+    ) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        from abicheck.serialization import snapshot_to_json
+
+        snap = AbiSnapshot(library="libfoo.so", version="1.0")
+        path = tmp_path / "libfoo.so.abi.json"
+        path.write_text(snapshot_to_json(snap), encoding="utf-8")
+
+        result = CliRunner().invoke(main, ["compare", str(path), *extra_args])
+        assert result.exit_code == 64


### PR DESCRIPTION
## Summary

Adds ADR-065's `declared_absent` `MemberAcquisition` state (prerequisite P1) and `abicheck compare --no-baseline NEW` (plan §6 Phase 2e) — the first slice of `scan`'s audit-only-mode retirement (ADR-068).

## Motivation

`docs/contribute/plans/one-comparison-product.md` retires `scan` in favor of one comparison product built on `compare`. `--no-baseline` replaces `scan`'s audit-only mode (no `--against`) and ADR-047 §8's S5 scenario, without which the retirement's audit half has no home on `compare` at all.

## Changes

- `abicheck/model/scope_acquisition.py`: new `AcquisitionState.DECLARED_ABSENT` — distinct from `NOT_SUPPLIED` (an *unproven* absence that reads as incomplete scope): the user explicitly declared there is no prior surface. Never counted as unchecked/incomplete, and never a proven-removal/-addition input. `completed_members` now recognizes it so D7's `no_comparison_completed` never fires for a run that never intended a two-sided comparison.
- `abicheck/workflows/no_baseline_compare.py`: resolves the candidate and audits it via a self-diff (`new` vs. `new`), which by construction can never produce an addition, removal, or modification — the real detector/policy/suppression pipeline runs completely unmodified, so every candidate-side fact in the result is genuine evidence, not a synthesized stand-in. Pairs the result with OLD's `declared_absent` acquisition record.
- `abicheck/report/no_baseline.py`: the report shape — no verdict, no compatibility contribution (`run_outcome.compatibility` is `null`, `changes` is always `[]`), the `comparison_scope` block names the `declared_absent` member, and the exit code folds only the orthogonal coverage/assurance/completeness axes via `max` (never an inline `sys.exit`).
- `abicheck/frontends/cli/commands/compare_no_baseline.py` + `compare.py`: `--no-baseline` is an **explicit declaration**, never inferred from arity — `compare NEW` (one operand, no flag) and `compare --no-baseline OLD NEW` (flag + two operands) are both usage errors (exit `64`). A directory/package operand is a declared usage error until ADR-065 S3's package component inventories land (plan §5 P5) — out of scope here. `json`/`markdown` formats only for this slice; `sarif`/`html`/`junit`/`review` are out of scope (they frame output around a compatibility verdict this audit never has).
- `tests/parity/test_no_baseline_parity.py`'s gap tests updated to their closed shape (single-artifact); the directory gap stays pinned, now with the real usage-error message.
- `tests/test_no_baseline_compare.py`: direct unit coverage of the model/workflow/report primitives.
- `docs/reference/exit-codes.md` gains a `--no-baseline` section; `docs/reference/cli-reference.md` regenerated.
- Changelog fragment added.

Every existing two-sided `compare` invocation is unaffected — the whole no-baseline path is a new branch taken before any of the two-sided machinery runs, and no shared function's signature changed.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`exit-codes.md`, regenerated `cli-reference.md`)
- [x] `ruff check`, `ruff format --check` (new/touched files), `mypy abicheck/`, `python scripts/check_architecture.py`, `python scripts/check_ai_readiness.py` all clean
- [x] Targeted test suites pass (parity, CLI compare, scope_acquisition/scope_completeness, new unit tests) — full `pytest tests/` fast lane run in progress

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UmrFRBevSm1oBJKsLd1pow)_