### PR TITLE
feat: compare --dry-run cost preview (Phase 2f)

### DIFF
--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -377,6 +377,20 @@ def _render_compare_dry_run(
         if collect_mode in ("source-target", "source-changed", "graph-full")
         else None,
     )
+    from .frontends.cli.compare_dry_run import add_compare_cost_preview_section
+    from .workflows.compare_cost_preview import estimate_compare_dry_run_cost
+
+    add_compare_cost_preview_section(
+        result,
+        *estimate_compare_dry_run_cost(
+            old_input=old_input, new_input=new_input,
+            depth=depth, source_method=source_method,
+            headers=headers, includes=includes,
+            old_headers_only=old_headers_only, new_headers_only=new_headers_only,
+            old_sources=old_sources, new_sources=new_sources,
+            old_build_info=old_build_info, new_build_info=new_build_info,
+        ),
+    )
     all_headers = list(headers) + list(old_headers_only) + list(new_headers_only)
     result.add(
         "Headers and compile context",

--- a/abicheck/dry_run.py
+++ b/abicheck/dry_run.py
@@ -54,6 +54,15 @@ SECTION_ORDER: tuple[str, ...] = (
     "Headers and compile context",
     "Build/source inputs",
     "Build query (trust)",
+    # ADR-035 D10 evidence-collection cost projection, folded straight into
+    # `scan --dry-run`'s "Resolved depth and source scope" section
+    # (`frontends/cli/scan_dry_run.py`); `compare --dry-run`'s own combined
+    # old+new preview (one-comparison-product.md #35, Phase 2f;
+    # `cli_compare_helpers._render_compare_dry_run`) gets a titled section
+    # of its own instead, since a compare has two operands' worth of cost
+    # to show and folding both into the depth section read as one side's
+    # numbers.
+    "Cost preview",
     "Tools and frontends",
     "Configuration and value origins",
     # ADR-063 Track T4 ("Dump request contract"): `dump --dry-run`'s own

--- a/abicheck/frontends/cli/compare_dry_run.py
+++ b/abicheck/frontends/cli/compare_dry_run.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``compare --dry-run``'s "Cost preview" section -- the *render* half
+(one-comparison-product.md #35, Phase 2f).
+
+Takes the caller's already-computed
+:func:`~abicheck.workflows.compare_cost_preview.estimate_compare_dry_run_cost`
+result (a list of :class:`~abicheck.service_scan.CostEstimate` rows, or an
+error string) and turns it into ``DryRunResult`` section lines -- the same
+split :mod:`abicheck.frontends.cli.scan_dry_run` already applies between a
+workflow's computed estimate and its CLI rendering, and for the identical
+reason: this module lives under ``frontends/cli`` (may import ``model``/
+``workflows``/``report`` only, per ``architecture/modules.yaml``), so the
+*computation* -- which needs ``service_scan`` -- stays in
+:mod:`abicheck.workflows.compare_cost_preview` (the ``workflows`` layer,
+where ``service_scan.py`` itself is classified).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...dry_run import DryRunResult
+    from ...service_scan import CostEstimate
+
+
+def add_compare_cost_preview_section(
+    result: DryRunResult,
+    estimates: list[CostEstimate] | None,
+    estimate_error: str | None,
+) -> None:
+    """Append the "Cost preview" section (or a warning) to *result*."""
+    if estimate_error is not None:
+        result.warn(
+            f"could not project per-layer evidence-collection cost: {estimate_error}"
+        )
+        return
+    assert estimates is not None
+    total = sum(e.est_seconds for e in estimates)
+    result.add(
+        "Cost preview",
+        *(
+            f"{e.layer}: TU count/cost unknown -- {e.note}"
+            if "[UNKNOWN" in e.note
+            else f"{e.layer}: {e.tus} TU(s), ~{e.est_seconds:.2f}s -- {e.note}"
+            for e in estimates
+        ),
+        f"projected total (old + new sides): {total:.2f}s",
+        "note: at least one layer's TU count/cost is unknown (see above) "
+        "-- it contributes 0.0s to the projected total, understating it"
+        if any("[UNKNOWN" in e.note for e in estimates)
+        else None,
+    )

--- a/abicheck/workflows/compare_cost_preview.py
+++ b/abicheck/workflows/compare_cost_preview.py
@@ -19,17 +19,17 @@
 ``scan --dry-run`` already projects L0-L5 evidence-collection cost via
 :func:`abicheck.service_scan.estimate_scan` (see ``cli_scan.py``'s own
 ``--dry-run`` branch); ``compare --dry-run`` had no equivalent preview. This
-module reuses :func:`~abicheck.service_scan.estimate_scan`/
-:func:`~abicheck.service_scan.estimate_compare_cost` directly -- no new cost
-model -- and adds only the compare-specific glue: resolving compare's own
-``--depth``/``.abicheck.yml`` ``source.method``/``--sources``/``--build-info``
-precedence into the ``(SourceMethod, EvidenceDepth)`` pair
-``estimate_scan``'s ``resolved_level`` takes, and building one
-:class:`~abicheck.service_scan.ScanRequest` per side (a real ``compare`` run
-with live source/build evidence extracts *both* operands, so the preview
-sums each side's own projection -- the same per-operand aggregation
-:func:`~abicheck.service_scan.estimate_artifact_set` already applies across
-a scan set's members).
+module reuses :func:`~abicheck.service_scan.estimate_scan` directly -- no
+new cost model -- and adds only the compare-specific glue: resolving
+compare's own ``--depth``/``.abicheck.yml`` ``source.method``/
+``--sources``/``--build-info`` precedence into the
+``(SourceMethod, EvidenceDepth)`` pair ``estimate_scan``'s ``resolved_level``
+takes, building one :class:`~abicheck.service_scan.ScanRequest` per side, and
+summing both sides' rows layer-by-layer (:func:`_merge_layer_estimates`) --
+a real ``compare`` run with live source/build evidence extracts *both*
+operands, so the preview sums each side's own projection, the same
+per-operand aggregation :func:`~abicheck.service_scan.estimate_artifact_set`
+already applies across a scan set's members.
 
 A new, dedicated leaf module rather than an addition to
 :mod:`abicheck.cli_compare_helpers` or :mod:`abicheck.service_scan`: both

--- a/abicheck/workflows/compare_cost_preview.py
+++ b/abicheck/workflows/compare_cost_preview.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``compare --dry-run``'s "Cost preview" section -- the *compute* half
+(one-comparison-product.md #3, plan item #35, Phase 2f).
+
+``scan --dry-run`` already projects L0-L5 evidence-collection cost via
+:func:`abicheck.service_scan.estimate_scan` (see ``cli_scan.py``'s own
+``--dry-run`` branch); ``compare --dry-run`` had no equivalent preview. This
+module reuses :func:`~abicheck.service_scan.estimate_scan`/
+:func:`~abicheck.service_scan.estimate_compare_cost` directly -- no new cost
+model -- and adds only the compare-specific glue: resolving compare's own
+``--depth``/``.abicheck.yml`` ``source.method``/``--sources``/``--build-info``
+precedence into the ``(SourceMethod, EvidenceDepth)`` pair
+``estimate_scan``'s ``resolved_level`` takes, and building one
+:class:`~abicheck.service_scan.ScanRequest` per side (a real ``compare`` run
+with live source/build evidence extracts *both* operands, so the preview
+sums each side's own projection -- the same per-operand aggregation
+:func:`~abicheck.service_scan.estimate_artifact_set` already applies across
+a scan set's members).
+
+A new, dedicated leaf module rather than an addition to
+:mod:`abicheck.cli_compare_helpers` or :mod:`abicheck.service_scan`: both
+already sit at their own ``architecture/debt.yaml`` ``no_growth`` baseline
+with no room for a new function -- the same "prefer extending a split-out
+module over growing the parent toward the cap" guidance in the root
+``CLAUDE.md`` that :mod:`abicheck.frontends.cli.release_dry_run` already
+follows. Deliberately compute-only (no ``click``, no ``DryRunResult``):
+:mod:`abicheck.frontends.cli.compare_dry_run` owns turning this module's
+output into report lines, mirroring ``frontends/cli/scan_dry_run.py``'s own
+split between a workflow's computed result and its CLI rendering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..buildsource.scan_levels import EvidenceDepth, SourceMethod
+    from ..service_scan import CostEstimate
+
+
+def _resolve_compare_estimate_level(
+    depth: str | None,
+    source_method: str | None,
+    old_sources: Path | None, new_sources: Path | None,
+    old_build_info: Path | None, new_build_info: Path | None,
+) -> tuple[SourceMethod, EvidenceDepth]:
+    """The (S-method, L-depth) pair a compare's cost-preview probes are priced
+    at -- mirrors ``cli_compare_helpers._resolve_compare_collect_mode``'s own
+    precedence (explicit ``--depth`` > ``.abicheck.yml`` ``source.method`` >
+    inferred from ``--sources``/``--build-info`` > off), but returns the
+    resolved ``(SourceMethod, EvidenceDepth)`` pair rather than a
+    collect-mode string -- the shape
+    :func:`~abicheck.service_scan.estimate_scan`'s ``resolved_level`` takes,
+    mirroring how ``cli_scan.py`` pre-resolves its own ``(resolved,
+    eff_depth_enum)`` before calling it rather than letting the callee
+    re-derive a level from ``ScanRequest.mode``'s own preset default, which
+    has no notion of compare's --sources/--build-info inference rule (or of
+    compare having no PR change seed for ``auto`` to escalate against)."""
+    from ..buildsource.scan_levels import (
+        EvidenceDepth,
+        SourceMethod,
+        depth_to_method,
+        method_to_depth,
+    )
+
+    if depth is not None:
+        evidence_depth = EvidenceDepth(depth.lower())
+        return (depth_to_method(evidence_depth) or SourceMethod.S0), evidence_depth
+    if source_method:
+        method = SourceMethod(source_method)
+        if method is SourceMethod.AUTO:
+            # compare has no PR change seed for `auto` to score a risk-driven
+            # escalation against (unlike `scan --mode auto`) -- price the
+            # S0/headers-only floor rather than guessing a deeper level.
+            return SourceMethod.S0, EvidenceDepth.HEADERS
+        return method, method_to_depth(method)
+    if old_sources is not None or new_sources is not None:
+        return SourceMethod.S5, EvidenceDepth.SOURCE
+    if old_build_info is not None or new_build_info is not None:
+        return SourceMethod.S1, EvidenceDepth.BUILD
+    return SourceMethod.S0, EvidenceDepth.HEADERS
+
+
+def _merge_layer_estimates(
+    estimate_lists: tuple[list[CostEstimate], list[CostEstimate]],
+) -> list[CostEstimate]:
+    """Sum two :func:`~abicheck.service_scan.estimate_scan` results layer-by-
+    layer -- a real ``compare`` run with live source/build evidence extracts
+    *both* operands, so the projected cost is each side's own row summed,
+    the same per-operand aggregation
+    :func:`~abicheck.service_scan.estimate_artifact_set` already applies
+    across a scan set's members, applied here across a compare's two
+    operands instead. Introduces no separate cost model -- every row still
+    comes straight out of :func:`~abicheck.service_scan.estimate_scan`."""
+    from ..service_scan import CostEstimate
+
+    totals: dict[str, tuple[str | None, int, float]] = {}
+    order: list[str] = []
+    notes: dict[str, list[str]] = {}
+    for estimates in estimate_lists:
+        for e in estimates:
+            if e.layer not in totals:
+                order.append(e.layer)
+                totals[e.layer] = (e.method, 0, 0.0)
+                notes[e.layer] = []
+            method, tus, seconds = totals[e.layer]
+            totals[e.layer] = (method or e.method, tus + e.tus, seconds + e.est_seconds)
+            if e.note and e.note not in notes[e.layer]:
+                notes[e.layer].append(e.note)
+    return [
+        CostEstimate(
+            totals[layer][0],
+            layer,
+            totals[layer][1],
+            totals[layer][2],
+            0.0,
+            "; ".join(notes[layer]),
+        )
+        for layer in order
+    ]
+
+
+def estimate_compare_dry_run_cost(
+    *,
+    old_input: Path, new_input: Path,
+    depth: str | None, source_method: str | None,
+    headers: tuple[Path, ...], includes: tuple[Path, ...],
+    old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
+    old_sources: Path | None, new_sources: Path | None,
+    old_build_info: Path | None, new_build_info: Path | None,
+) -> tuple[list[CostEstimate] | None, str | None]:
+    """Combined old+new per-layer cost preview for ``compare --dry-run``.
+
+    Returns ``(estimates, None)`` on success or ``(None, error)`` when the
+    probe itself raised -- mirroring ``cli_scan.py``'s own best-effort
+    ``estimate_scan`` call, which the dry run must never let a probe failure
+    turn into a hard crash."""
+    from ..service_scan import ScanRequest, estimate_scan
+
+    try:
+        resolved_level = _resolve_compare_estimate_level(
+            depth, source_method, old_sources, new_sources, old_build_info, new_build_info,
+        )
+        common_headers = list(headers) + list(includes)
+        old_req = ScanRequest(
+            binaries=[old_input],
+            headers=common_headers + list(old_headers_only),
+            includes=list(includes),
+            sources=old_sources,
+            build_info=old_build_info,
+            mode="pr",
+        )
+        new_req = ScanRequest(
+            binaries=[new_input],
+            headers=common_headers + list(new_headers_only),
+            includes=list(includes),
+            sources=new_sources,
+            build_info=new_build_info,
+            mode="pr",
+        )
+        old_estimates = estimate_scan(old_req, resolved_level=resolved_level)
+        new_estimates = estimate_scan(new_req, resolved_level=resolved_level)
+        return _merge_layer_estimates((old_estimates, new_estimates)), None
+    except Exception as exc:  # noqa: BLE001 - best-effort dry-run probe
+        return None, str(exc)

--- a/changelog.d/20260907_202829_noreply_compare_dry_run_cost_preview_k110gt.md
+++ b/changelog.d/20260907_202829_noreply_compare_dry_run_cost_preview_k110gt.md
@@ -1,0 +1,8 @@
+### Added
+
+- **`compare --dry-run` now previews evidence-collection cost** — a new
+  "Cost preview" section projects the same per-layer (L0-L5) TU count and
+  wall-clock estimate `scan --dry-run` already shows, reusing
+  `service_scan.estimate_scan` directly and summing both operands' own
+  projection (one-comparison-product.md #35, Phase 2f). Advisory only: it
+  does not change `--budget` runtime enforcement, which remains `scan`-only.

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -517,7 +517,14 @@ One PR per capability group, each landing with parity tests going green:
   The floor is `.abicheck.yml`'s `python.abi3_floor` with the flag as the
   per-run override (ADR-068 D5). `abi3_audit` is gone from the gap registry;
 - **2e** `--no-baseline` (#2) — the audit-only comparison, on top of Phase 1.1;
-- **2f** dry-run/cost preview parity (#35).
+- **2f** dry-run/cost preview parity (#35) — **landed**: `compare --dry-run`
+  now shows a "Cost preview" section, reusing `service_scan.estimate_scan`
+  directly (summed across both operands via
+  `workflows/compare_cost_preview.py`) rather than a second cost model —
+  the same L0-L5 per-layer projection `scan --dry-run` already shows. Pure
+  UX parity, not a `tests/parity/gaps.py` entry (no finding is gained or
+  lost): the projection is advisory only and does not touch `--budget`'s
+  runtime enforcement (still `scan`-only).
 
 ### Phase 3 — Parity is the gate
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1602,6 +1602,27 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 # not a new dependency direction.
                 "cli_compare_release_matrix",
                 "cli_compare_release_pairwise",
+                # one-comparison-product.md #35 Phase 2f: `compare --dry-run`'s
+                # new "Cost preview" section is a same-session size-split out
+                # of `cli_compare_helpers` (already a member, above) -- both
+                # `cli_compare_helpers.py` and `service_scan.py` (also already
+                # members) were already at their own `architecture/debt.yaml`
+                # `no_growth` baseline with no room for the new function, so
+                # the compute half (`workflows.compare_cost_preview`, reaching
+                # `service_scan.ScanRequest`/`estimate_scan` function-locally
+                # -- an edge `cli_scan.py`, already a member, already carries)
+                # and the render half (`frontends.cli.compare_dry_run`,
+                # reaching nothing outside `TYPE_CHECKING`) landed as two new
+                # leaf modules instead of growing either. `cli_compare_helpers`
+                # imports both back function-locally (the identical shape
+                # `frontends.cli.commands.compare`/`cli_compare_release_
+                # pairwise` above already reach their own split siblings
+                # through), so this closes the same cluster of cycles through
+                # already-member modules, not a new dependency direction. No
+                # init deadlock: neither new module imports anything outside
+                # this cluster or the stdlib at module load.
+                "frontends.cli.compare_dry_run",
+                "workflows.compare_cost_preview",
             }
         ),
         # TYPE_CHECKING-only typing cycle (no runtime import): AbiSnapshot

--- a/tests/test_compare_cost_preview.py
+++ b/tests/test_compare_cost_preview.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Direct unit coverage for ``compare --dry-run``'s "Cost preview" leaf
+modules (one-comparison-product.md #35, Phase 2f): the compute half
+(``workflows/compare_cost_preview.py``) and the render half
+(``frontends/cli/compare_dry_run.py``). ``tests/test_dry_run_contract.py``
+covers the end-to-end CLI path; this file exercises the branches that path
+doesn't reach on its own (each precedence rung of the level resolver, and
+the probe-failure path both modules share)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.buildsource.scan_levels import EvidenceDepth, SourceMethod
+from abicheck.dry_run import DryRunResult
+from abicheck.frontends.cli.compare_dry_run import add_compare_cost_preview_section
+from abicheck.workflows.compare_cost_preview import (
+    _resolve_compare_estimate_level,
+    estimate_compare_dry_run_cost,
+)
+
+
+class TestResolveCompareEstimateLevel:
+    def test_explicit_depth_wins_over_everything(self, tmp_path: Path) -> None:
+        assert _resolve_compare_estimate_level(
+            "build", "s5", tmp_path, tmp_path, None, None,
+        ) == (SourceMethod.S1, EvidenceDepth.BUILD)
+
+    def test_explicit_depth_binary_has_no_source_method(self) -> None:
+        assert _resolve_compare_estimate_level(
+            "binary", None, None, None, None, None,
+        ) == (SourceMethod.S0, EvidenceDepth.BINARY)
+
+    def test_source_method_config_wins_over_sources_inference(
+        self, tmp_path: Path
+    ) -> None:
+        assert _resolve_compare_estimate_level(
+            None, "s1", tmp_path, None, None, None,
+        ) == (SourceMethod.S1, EvidenceDepth.BUILD)
+
+    def test_source_method_auto_prices_the_headers_only_floor(self) -> None:
+        # compare has no PR change seed for `auto` to score a risk-driven
+        # escalation against (unlike `scan --mode auto`).
+        assert _resolve_compare_estimate_level(
+            None, "auto", None, None, None, None,
+        ) == (SourceMethod.S0, EvidenceDepth.HEADERS)
+
+    def test_sources_given_infers_source_depth(self, tmp_path: Path) -> None:
+        assert _resolve_compare_estimate_level(
+            None, None, tmp_path, None, None, None,
+        ) == (SourceMethod.S5, EvidenceDepth.SOURCE)
+
+    def test_build_info_given_infers_build_depth(self, tmp_path: Path) -> None:
+        assert _resolve_compare_estimate_level(
+            None, None, None, None, tmp_path, None,
+        ) == (SourceMethod.S1, EvidenceDepth.BUILD)
+
+    def test_nothing_given_prices_the_headers_only_floor(self) -> None:
+        assert _resolve_compare_estimate_level(
+            None, None, None, None, None, None,
+        ) == (SourceMethod.S0, EvidenceDepth.HEADERS)
+
+
+class TestEstimateCompareDryRunCost:
+    def test_success_sums_both_sides(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.so"
+        new = tmp_path / "new.so"
+        old.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        new.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        estimates, error = estimate_compare_dry_run_cost(
+            old_input=old, new_input=new,
+            depth="binary", source_method=None,
+            headers=(), includes=(),
+            old_headers_only=(), new_headers_only=(),
+            old_sources=None, new_sources=None,
+            old_build_info=None, new_build_info=None,
+        )
+        assert error is None
+        assert estimates is not None
+        assert estimates
+        # L0_binary prices `len(binaries)` — one per side, summed to 2.
+        l0 = next(e for e in estimates if e.layer == "L0_binary")
+        assert l0.tus == 2
+
+    def test_probe_failure_is_reported_not_raised(self, tmp_path: Path) -> None:
+        # A header path that doesn't exist makes estimate_scan's own
+        # `expand_header_inputs` raise -- the dry run must degrade to an
+        # error string, never propagate the exception (mirrors cli_scan.py's
+        # own best-effort `estimate_scan` call under --dry-run).
+        old = tmp_path / "old.so"
+        new = tmp_path / "new.so"
+        old.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        new.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        missing_header = tmp_path / "does-not-exist.h"
+        estimates, error = estimate_compare_dry_run_cost(
+            old_input=old, new_input=new,
+            depth="headers", source_method=None,
+            headers=(missing_header,), includes=(),
+            old_headers_only=(), new_headers_only=(),
+            old_sources=None, new_sources=None,
+            old_build_info=None, new_build_info=None,
+        )
+        assert estimates is None
+        assert error is not None
+        assert "does-not-exist.h" in error
+
+
+class TestAddCompareCostPreviewSection:
+    def test_warns_on_error_and_adds_no_section(self) -> None:
+        result = DryRunResult(command="compare")
+        add_compare_cost_preview_section(result, None, "boom")
+        assert "Cost preview" not in result.sections
+        assert any("boom" in w for w in result.warnings)
+
+    def test_adds_section_on_success(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.so"
+        new = tmp_path / "new.so"
+        old.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        new.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        estimates, error = estimate_compare_dry_run_cost(
+            old_input=old, new_input=new,
+            depth="binary", source_method=None,
+            headers=(), includes=(),
+            old_headers_only=(), new_headers_only=(),
+            old_sources=None, new_sources=None,
+            old_build_info=None, new_build_info=None,
+        )
+        assert error is None
+        result = DryRunResult(command="compare")
+        add_compare_cost_preview_section(result, estimates, error)
+        assert "Cost preview" in result.sections
+        assert any("projected total" in ln for ln in result.sections["Cost preview"])

--- a/tests/test_dry_run_contract.py
+++ b/tests/test_dry_run_contract.py
@@ -550,6 +550,47 @@ class TestCompareDryRun:
         assert "effective depth: source" in result.output
         assert "inferred" in result.output
 
+    def test_dry_run_shows_cost_preview_comparable_to_scan_dry_run(
+        self, tmp_path: Path, source_tree_with_compile_db: Path
+    ) -> None:
+        # Phase 2f (one-comparison-product.md #35): `compare --dry-run` must
+        # project L0-L5 evidence-collection cost the same way `scan --dry-run`
+        # already does -- reusing `estimate_scan`/`estimate_compare_cost`
+        # rather than a second cost model. Not asserting identical numbers
+        # (the two commands probe different operand shapes, and compare sums
+        # both sides) -- only that both previews are populated, on a
+        # comparable build/source-depth scenario.
+        old = tmp_path / "old.abi.json"
+        new = tmp_path / "new.abi.json"
+        _write_snapshot(old, "1.0")
+        _write_snapshot(new, "2.0")
+        result = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old), str(new), "--dry-run",
+                "--sources", "old=" + str(source_tree_with_compile_db),
+                "--sources", "new=" + str(source_tree_with_compile_db),
+                "--depth", "source",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Cost preview:" in result.output
+        assert "L0_binary" in result.output
+        assert "projected total" in result.output
+
+        scan_binary = tmp_path / "libfoo.so"
+        scan_binary.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        scan_result = CliRunner().invoke(
+            main,
+            [
+                "scan", str(scan_binary), "--dry-run",
+                "--sources", str(source_tree_with_compile_db),
+                "--depth", "source",
+            ],
+        )
+        assert scan_result.exit_code in (0, 1), scan_result.output
+        assert "projected total" in scan_result.output
+
 
 class TestDepsTreeDryRun:
     def test_writes_nothing_and_rejects_output(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`compare --dry-run` now shows a "Cost preview" section, projecting the same per-layer (L0-L5) evidence-collection cost `scan --dry-run` already shows (`docs/contribute/plans/one-comparison-product.md` §3 #35, Phase 2f).

## Motivation

Per the plan, Phase 2f ("dry-run/cost preview parity") was confirmed not started: `_render_compare_dry_run` never called `estimate_scan`/`estimate_artifact_set`, unlike `cli_scan.py`, where the cost estimate (budget totals for L3/L4/L5 evidence collection) is computed and shown under `--dry-run`.

## Changes

- `abicheck/workflows/compare_cost_preview.py` (new): the *compute* half — resolves compare's own `--depth` / `.abicheck.yml` `source.method` / `--sources` / `--build-info` precedence into the `(SourceMethod, EvidenceDepth)` pair `service_scan.estimate_scan`'s `resolved_level` expects, builds one `ScanRequest` per operand, and sums both sides' per-layer `CostEstimate` rows — mirroring the same per-member aggregation `estimate_artifact_set` already applies across a scan set's members. Reuses `estimate_scan` directly; introduces no second cost model.
- `abicheck/frontends/cli/compare_dry_run.py` (new): the *render* half — turns the computed estimate into the new "Cost preview" `DryRunResult` section, mirroring `frontends/cli/scan_dry_run.py`'s existing estimate rendering. Split into two modules (rather than one addition to `cli_compare_helpers.py` or `service_scan.py`) because both of those already sit at their own `architecture/debt.yaml` `no_growth` baseline with no room for a new function.
- `abicheck/cli_compare_helpers.py`: `_render_compare_dry_run` wires both in.
- `abicheck/dry_run.py`: registers `"Cost preview"` in the shared canonical `SECTION_ORDER`.
- `scripts/check_ai_readiness.py`: adds the two new modules to the existing, already-documented CLI-registration/service-routing `IMPORT_CYCLE_ALLOWLIST` strongly-connected component — this is a *split of an already-member module* (`cli_compare_helpers`) reaching back into another already-member module (`service_scan`), the identical precedent already recorded for `service_compare_pipeline`/`l0_export_delta`/`service_header_graph_attach`/etc. in that same allowlist entry.
- `tests/test_dry_run_contract.py`: new coverage (`TestCompareDryRun::test_dry_run_shows_cost_preview_comparable_to_scan_dry_run`) exercising a `--sources`/`--depth source` scenario and asserting both `compare --dry-run` and `scan --dry-run` populate their cost-preview content (not asserting identical numbers, since the two commands probe different operand shapes and compare sums both sides).
- Changelog fragment added; `docs/contribute/plans/one-comparison-product.md`'s 2f row marked landed.

**Explicitly out of scope** (per the task): `scan --dry-run`'s own behavior is unchanged; `--budget`'s runtime enforcement (exit 5) is untouched — this is preview only. Not a `tests/parity/gaps.py` entry: no finding is gained or lost, this is UX parity, not a capability change.

## Verification

```
python scripts/verify.py --profile pr --only lint,typecheck,unit-pr,architecture,ai-readiness
```

Ran individually (`lint`, `typecheck`, `architecture`, `ai-readiness` via `--only`) plus the full fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`, 40897 passed / 39 skipped / 4 xfailed, 0 failures) and `docs-contract`. All pass.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/contribute/plans/one-comparison-product.md`)
- [x] `ruff`/`mypy` clean on touched files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012bg87V6prNdmCZ91uszME6)_