### PR TITLE
fix: use RUNNER_TEMP for compile-context config overlay's mktemp

### DIFF
--- a/action/run.sh
+++ b/action/run.sh
@@ -321,7 +321,19 @@ add_compile_context_flags() {
     exit 1
   fi
   if [[ -z "$_COMPILE_CONTEXT_CONFIG_OVERLAY" ]]; then
-    _COMPILE_CONTEXT_CONFIG_OVERLAY=$(mktemp)
+    # Template-based mktemp under $RUNNER_TEMP (Codex review, fresh evidence:
+    # windows-latest CI failure, tests/test_action_compile_context_parity.py
+    # only) -- a bare `mktemp` on windows-latest's Git Bash resolves under
+    # its own MSYS-internal /tmp mount, which only Git Bash processes can
+    # translate back to a real filesystem path. This file is later opened
+    # directly by a native (non-MSYS) Python process (the test harness's own
+    # `_read_compile_config_overlay`, and any consumer downstream of the
+    # synthesized --config path), which cannot resolve that MSYS-only
+    # spelling and fails with FileNotFoundError. $RUNNER_TEMP is a real,
+    # native-resolvable path on every runner OS, matching the same fix
+    # already applied to every other mktemp call in this file (see
+    # PR_JSON/PR_BODY above).
+    _COMPILE_CONTEXT_CONFIG_OVERLAY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context.XXXXXX")
     ABICHECK_COMPILE_LANG="${INPUT_LANG:-}" \
     ABICHECK_COMPILE_INCLUDE_LANG="$include_lang" \
     ABICHECK_COMPILE_FRONTEND="${INPUT_AST_FRONTEND:-}" \

--- a/tests/test_action_compile_context_parity.py
+++ b/tests/test_action_compile_context_parity.py
@@ -357,6 +357,38 @@ def _read_compile_config_overlay(cmd: list[str]) -> dict[str, Any]:
     return doc.get("compile", {})
 
 
+class TestCompileContextOverlayMktempIsRunnerTempAnchored:
+    """Regression: the mktemp call minting the synthesized --config overlay
+    path used to be a bare ``mktemp`` -- unlike every other temp-file mktemp
+    call in run.sh -- which on windows-latest's Git Bash resolves under its
+    own MSYS-internal /tmp mount. That path is later opened directly by a
+    native (non-MSYS) Python process (this module's own
+    ``_read_compile_config_overlay``, and the real `--config`-consuming CLI
+    invocation `run.sh` itself makes), which cannot resolve an MSYS-only
+    spelling and fails with FileNotFoundError -- confirmed as the
+    windows-latest unit-tests CI job's only failure on main.
+
+    A platform-specific end-to-end reproduction only fails on windows-latest,
+    so it can't by itself guard against a regression on the Linux/macOS
+    lanes that run every PR. This asserts the *source pattern* directly
+    (same technique test_action_run_sh_py_safe_path.py and siblings already
+    use for adjacent mktemp calls), which fails on every platform the moment
+    the anchored template reverts to a bare mktemp."""
+
+    def test_mktemp_is_anchored_under_runner_temp(self) -> None:
+        text = RUN_SH.read_text(encoding="utf-8")
+        start = text.index(_COMPILE_CONTEXT_FN_START)
+        # Only the overlay's own creation site, not every mktemp in the file.
+        marker = "_COMPILE_CONTEXT_CONFIG_OVERLAY=$(mktemp"
+        idx = text.index(marker, start)
+        line_end = text.index("\n", idx)
+        line = text[idx:line_end]
+        assert line == (
+            "_COMPILE_CONTEXT_CONFIG_OVERLAY=$(mktemp "
+            '"${RUNNER_TEMP:-/tmp}/abicheck-compile-context.XXXXXX")'
+        ), line
+
+
 class TestCompileContextForwardingParity:
     """scan forwards the six flags directly; dump/compare (Phase 7) forward
     the identical settings via a synthesized --config compile: block."""


### PR DESCRIPTION
## Summary

Fixes the only CI failure on `main`: the `unit-tests (windows-latest, 3.13, false)` job, red on every recent push.

## Motivation

`action/run.sh`'s `add_compile_context_flags()` minted the synthesized `--config` overlay path with a bare `mktemp`, unlike every other temp-file `mktemp` call in the script (which already use `mktemp "${RUNNER_TEMP:-/tmp}/...XXXXXX"`, added for exactly this class of bug — see the `PR_JSON`/`PR_BODY`/`BASELINE_DIR` comments in the same file). On `windows-latest`, Git Bash's bare `mktemp` resolves under its own MSYS-internal `/tmp` mount, which only Git Bash processes can translate back to a real filesystem path. The overlay file is later opened directly by a native (non-MSYS) Python process — both the test harness's `_read_compile_config_overlay`/`_compile_overlay_from_cmd`, and, in the real Action, any process reading the `--config` path outside the originating Git Bash session — and fails with `FileNotFoundError` on that MSYS-only spelling.

## Changes

- `action/run.sh`: anchor `_COMPILE_CONTEXT_CONFIG_OVERLAY`'s `mktemp` under `${RUNNER_TEMP:-/tmp}`, matching the established pattern elsewhere in this file.
- `tests/test_action_compile_context_parity.py`: add a platform-independent regression test asserting the exact anchored-mktemp source line, so a future regression fails on every CI lane (not only `windows-latest`).

## Bug-fix test contract

- Bug class: a bare `mktemp` call in `action/run.sh` producing an MSYS-only path spelling that native (non-Git-Bash) processes on Windows can't resolve — the same class already fixed for `PR_JSON`/`PR_BODY`/`BASELINE_DIR` in this file, just not this call site.
- Publicly observable failure: `windows-latest` unit-tests CI job fails with `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp.XXXXXXXX'` in 8 tests across `tests/test_action_compile_context_parity.py` and `tests/test_action_run_sh_compare_build_source.py`.
- Regression test fails on base: yes — `TestCompileContextOverlayMktempIsRunnerTempAnchored::test_mktemp_is_anchored_under_runner_temp` asserts the exact `mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context.XXXXXX"` source line, which fails against `main`'s bare `mktemp`.
- Negative control: n/a (source-pattern assertion, not a behavior toggle).
- Public-surface test: the pre-existing `TestCompileContextForwardingParity` suite already exercises the real `--config` overlay end-to-end via `action/run.sh`; this PR's new test guards the specific line those tests depend on, on every platform.
- Axes covered: the fix mirrors an already-established pattern (4 other mktemp call sites in the same file use identical anchoring), so no new axis of behavior is introduced — the change is a one-line consistency fix plus a regression test for the line itself.
- General invariant: every `mktemp`/`mktemp -d` call in `action/run.sh` that produces a path consumed outside the originating Git Bash process must be anchored under `${RUNNER_TEMP:-/tmp}` (or otherwise canonicalized), never a bare call. This PR doesn't add a repo-wide gate for that invariant (out of scope for the CI-failure fix), but the new test closes the gap for this specific, previously-unguarded call site.
- Malicious fixture + side-effect absence: Not a hostile-input case — `_COMPILE_CONTEXT_CONFIG_OVERLAY`'s `mktemp` template is a static string (`"${RUNNER_TEMP:-/tmp}/abicheck-compile-context.XXXXXX"`) with no Action-input interpolation, so there is no attacker-controlled fixture that could redirect where this file is created; the change only moves *where* a fixed-shape temp path resolves, not what gets written into it or from what input. The existing `TestCompileContextForwardingParity` suite (`test_gcc_options_quoted_value_stays_one_token`, `test_gcc_options_hash_character_is_not_treated_as_a_comment`, `test_gcc_options_backslash_escaped_space_is_honored`, `test_gcc_options_unquoted_backslash_matches_the_real_python_helper`) already runs adversarial/edge-case `INPUT_GCC_OPTIONS` values (embedded quotes, `#`, backslash-escaped spaces, backslash-before-non-space) end-to-end through this exact `add_compile_context_flags` code path and asserts the synthesized overlay's *content*, unaffected by this change — those are the executing tests for the values that do reach this boundary.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added — not required (change is confined to `action/run.sh` and `tests/`, not `abicheck/**/*.py`)
- [ ] Docs updated — no user-visible behavior changed, only a Windows CI reliability fix
- [x] `pre-commit`-equivalent checks passed locally (`ruff check`/`ruff format --check`, `bash -n`, `scripts/check_ai_readiness.py` — 0 errors, `scripts/check_bugfix_test_contract.py` structural pass)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjJkCxLP8oTxKEFNmjWiUg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compile-context processing on Windows Git Bash runners by ensuring temporary configuration files use a native-resolvable path.
* **Tests**
  * Added regression coverage to prevent future issues with temporary file location handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->