### PR TITLE
fix: pass compile-context inputs via stdin, not env vars, on Windows

### DIFF
--- a/action/run.sh
+++ b/action/run.sh
@@ -355,7 +355,12 @@ add_compile_context_flags() {
     # same command always wins the stdin redirection, so the data pipe would
     # never reach the program at all. A real script file leaves stdin free
     # for the data.
-    _COMPILE_CONTEXT_HELPER_PY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context-helper.XXXXXX.py")
+    # No `.py` suffix after the X's: BSD mktemp (macOS's stock, non-GNU
+    # build) requires the replaceable X's to be the template's last
+    # characters, and this script deliberately has no `set -e` -- a rejected
+    # template here would silently continue with an empty helper path rather
+    # than failing loud (Codex review, fresh evidence, PR #1162).
+    _COMPILE_CONTEXT_HELPER_PY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context-helper.XXXXXX")
     cat > "$_COMPILE_CONTEXT_HELPER_PY" <<'PYEOF'
 # Synthesizes a minimal .abicheck.yml `compile:` block (as JSON, a valid
 # YAML subset abicheck's own yaml.safe_load parses identically) from this

--- a/action/run.sh
+++ b/action/run.sh
@@ -334,35 +334,63 @@ add_compile_context_flags() {
     # already applied to every other mktemp call in this file (see
     # PR_JSON/PR_BODY above).
     _COMPILE_CONTEXT_CONFIG_OVERLAY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context.XXXXXX")
-    ABICHECK_COMPILE_LANG="${INPUT_LANG:-}" \
-    ABICHECK_COMPILE_INCLUDE_LANG="$include_lang" \
-    ABICHECK_COMPILE_FRONTEND="${INPUT_AST_FRONTEND:-}" \
-    ABICHECK_COMPILE_GCC_PATH="${INPUT_GCC_PATH:-}" \
-    ABICHECK_COMPILE_GCC_PREFIX="${INPUT_GCC_PREFIX:-}" \
-    ABICHECK_COMPILE_GCC_OPTIONS="${INPUT_GCC_OPTIONS:-}" \
-    ABICHECK_COMPILE_SYSROOT="${INPUT_SYSROOT:-}" \
-    ABICHECK_COMPILE_NOSTDINC="${INPUT_NOSTDINC:-false}" \
-    python3 - "$_COMPILE_CONTEXT_CONFIG_OVERLAY" <<'PYEOF'
+    # The eight raw input values are passed on stdin, NUL-separated, not as
+    # env vars or argv (Codex review, fresh evidence: windows-latest CI
+    # failure, this function only). A value shaped like a POSIX absolute
+    # path (e.g. `gcc-path: /opt/gcc-14/bin/g++`, a real, common
+    # cross-compilation input) triggered Git Bash/MSYS's automatic path
+    # conversion when forwarded as an env var to this native, non-MSYS
+    # python.exe -- silently rewriting it into a Windows path (inserting
+    # "Program Files" and its embedded space) before this script ever saw
+    # it, e.g. `/opt/gcc-14/bin/g++` -> `C:/Program Files/Git/opt/gcc-14/
+    # bin/g++`. Only actual argv/envp entries are subject to that
+    # conversion -- stdin content never is (the same fix already applied to
+    # add_flag_shlex_split()'s single-value case above) -- so this sidesteps
+    # the whole class regardless of which of the eight fields triggers it.
+    #
+    # The script itself is written to its own $RUNNER_TEMP-anchored file
+    # rather than fed to `python3 -` via a second heredoc: `python3 -` reads
+    # its *program* from stdin, which would collide with (and silently
+    # discard) the piped data payload above -- a heredoc attached to the
+    # same command always wins the stdin redirection, so the data pipe would
+    # never reach the program at all. A real script file leaves stdin free
+    # for the data.
+    _COMPILE_CONTEXT_HELPER_PY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-compile-context-helper.XXXXXX.py")
+    cat > "$_COMPILE_CONTEXT_HELPER_PY" <<'PYEOF'
 # Synthesizes a minimal .abicheck.yml `compile:` block (as JSON, a valid
 # YAML subset abicheck's own yaml.safe_load parses identically) from this
 # Action's cross-compilation inputs -- the config-only replacement for the
 # per-run flags Phase 7 removed from compare/dump.
 import json
-import os
 import shlex
 import sys
 
 out_path = sys.argv[1]
+(
+    include_lang,
+    lang,
+    frontend,
+    gcc_path,
+    gcc_prefix,
+    gcc_options,
+    sysroot,
+    nostdinc,
+) = sys.stdin.buffer.read().split(b"\0")[:8]
+include_lang = include_lang.decode("utf-8")
+lang = lang.decode("utf-8")
+frontend = frontend.decode("utf-8")
+gcc_path = gcc_path.decode("utf-8")
+gcc_prefix = gcc_prefix.decode("utf-8")
+gcc_options = gcc_options.decode("utf-8")
+sysroot = sysroot.decode("utf-8")
+nostdinc = nostdinc.decode("utf-8")
+
 compile_blk: dict[str, object] = {}
-if os.environ.get("ABICHECK_COMPILE_INCLUDE_LANG") == "true":
-    lang = os.environ.get("ABICHECK_COMPILE_LANG", "")
+if include_lang == "true":
     if lang:
         compile_blk["lang"] = lang
-frontend = os.environ.get("ABICHECK_COMPILE_FRONTEND", "")
 if frontend and frontend != "auto":
     compile_blk["frontend"] = frontend
-gcc_path = os.environ.get("ABICHECK_COMPILE_GCC_PATH", "")
-gcc_prefix = os.environ.get("ABICHECK_COMPILE_GCC_PREFIX", "")
 # compile.compiler merges the former --compiler/--compiler-prefix pair
 # (Phase 7 -- one-comparison-product.md §4.1's "MERGE" disposition for
 # --compiler-prefix): a full compiler path is the more specific of the two,
@@ -370,7 +398,6 @@ gcc_prefix = os.environ.get("ABICHECK_COMPILE_GCC_PREFIX", "")
 compiler = gcc_path or gcc_prefix
 if compiler:
     compile_blk["compiler"] = compiler
-gcc_options = os.environ.get("ABICHECK_COMPILE_GCC_OPTIONS", "")
 if gcc_options:
     # CodeRabbit review, PR #1146, finding #7: BuildConfig.from_dict()
     # (abicheck/buildsource/build_config.py) rejects any compile.options
@@ -396,14 +423,18 @@ if gcc_options:
         if "\n" in gcc_options
         else shlex.split(gcc_options)
     )
-sysroot = os.environ.get("ABICHECK_COMPILE_SYSROOT", "")
 if sysroot:
     compile_blk["sysroot"] = sysroot
-if os.environ.get("ABICHECK_COMPILE_NOSTDINC") == "true":
+if nostdinc == "true":
     compile_blk["nostdinc"] = True
 with open(out_path, "w", encoding="utf-8") as f:
     json.dump({"compile": compile_blk}, f)
 PYEOF
+    printf '%s\0%s\0%s\0%s\0%s\0%s\0%s\0%s\0' \
+      "$include_lang" "${INPUT_LANG:-}" "${INPUT_AST_FRONTEND:-}" "${INPUT_GCC_PATH:-}" \
+      "${INPUT_GCC_PREFIX:-}" "${INPUT_GCC_OPTIONS:-}" "${INPUT_SYSROOT:-}" "${INPUT_NOSTDINC:-false}" |
+    python3 "$_COMPILE_CONTEXT_HELPER_PY" "$_COMPILE_CONTEXT_CONFIG_OVERLAY"
+    rm -f "$_COMPILE_CONTEXT_HELPER_PY"
   fi
   CMD+=(--config "$_COMPILE_CONTEXT_CONFIG_OVERLAY")
 }

--- a/tests/test_action_compile_context_parity.py
+++ b/tests/test_action_compile_context_parity.py
@@ -389,6 +389,54 @@ class TestCompileContextOverlayMktempIsRunnerTempAnchored:
         ), line
 
 
+class TestCompileContextInputsTravelViaStdinNotEnvVars:
+    """Regression: ``add_compile_context_flags()`` used to forward its eight
+    raw input values (lang/frontend/gcc-path/gcc-prefix/gcc-options/sysroot/
+    nostdinc) as environment variables (``ABICHECK_COMPILE_GCC_PATH=...``)
+    prefixed onto a ``python3`` invocation on windows-latest. A value shaped
+    like a POSIX absolute path -- a normal cross-compilation ``gcc-path``,
+    e.g. ``/opt/gcc-14/bin/g++`` -- triggers Git Bash/MSYS's automatic path
+    conversion when forwarded that way to a native, non-MSYS ``python3.exe``,
+    silently rewriting it into a Windows path (inserting ``Program Files``
+    and its embedded space) before the script ever saw it -- confirmed as
+    the windows-latest unit-tests CI job's failure once the mktemp fix let
+    these tests reach their real assertions for the first time.
+
+    Only actual argv/envp entries are subject to that conversion; stdin
+    content never is (the same fix already applied to
+    ``add_flag_shlex_split()``'s single-value case, above). Like the mktemp
+    regression above, a platform-specific end-to-end reproduction only fails
+    on windows-latest, so this asserts the *source pattern* directly: no
+    ``ABICHECK_COMPILE_*`` env-var assignment remains anywhere in the
+    function, and the helper script is invoked with its data piped in via
+    stdin rather than baked into its environment."""
+
+    def _function_source(self) -> str:
+        text = RUN_SH.read_text(encoding="utf-8")
+        start = text.index(_COMPILE_CONTEXT_FN_START)
+        end = text.index(_COMPILE_CONTEXT_FN_END, start) + len(_COMPILE_CONTEXT_FN_END)
+        return text[start:end]
+
+    def test_no_abicheck_compile_env_var_assignment_remains(self) -> None:
+        source = self._function_source()
+        assert "ABICHECK_COMPILE_" not in source, source
+
+    def test_helper_invocation_pipes_data_via_stdin(self) -> None:
+        source = self._function_source()
+        assert (
+            'python3 "$_COMPILE_CONTEXT_HELPER_PY" "$_COMPILE_CONTEXT_CONFIG_OVERLAY"'
+            in source
+        ), source
+        # The invocation is fed by a `printf ... | python3 ...` pipe, not a
+        # bare call -- confirms the eight values really travel on stdin.
+        idx = source.index(
+            'python3 "$_COMPILE_CONTEXT_HELPER_PY" "$_COMPILE_CONTEXT_CONFIG_OVERLAY"'
+        )
+        preceding = source[:idx]
+        assert preceding.rstrip().endswith("|"), preceding[-200:]
+        assert "printf " in preceding, preceding
+
+
 class TestCompileContextForwardingParity:
     """scan forwards the six flags directly; dump/compare (Phase 7) forward
     the identical settings via a synthesized --config compile: block."""


### PR DESCRIPTION
## Summary

Follow-up to #1161 (merged): that PR fixed the `mktemp` path issue but merged one commit before this second, related fix landed, so `unit-tests (windows-latest, 3.13, false)` is still red on `main` for a *different* reason surfaced once the first fix let these tests reach their real assertions.

## Motivation

`action/run.sh`'s `add_compile_context_flags()` forwards `gcc-path`/`gcc-prefix`/`gcc-options`/`sysroot` as environment variables to a native (non-MSYS) `python3` on `windows-latest`. A value shaped like a POSIX absolute path — a normal cross-compilation `gcc-path`, e.g. `/opt/gcc-14/bin/g++` — triggers Git Bash/MSYS's automatic path conversion when forwarded that way, silently rewriting it into a Windows path (inserting `Program Files` and its embedded space) before the script ever sees it: `/opt/gcc-14/bin/g++` → `C:/Program Files/Git/opt/gcc-14/bin/g++`.

Only actual argv/envp entries are subject to that conversion; stdin content never is — the same fix this file already applies to `add_flag_shlex_split()`'s single-value case (see its own comment, added earlier in this file's history for the identical class of bug). The eight raw input values are now passed on stdin, NUL-separated, to a helper script written to its own file — `python3 -` reading its *program* from stdin would otherwise collide with (and silently discard) a same-command heredoc's piped data, so the script needed a real file instead of `python3 - <<EOF`.

## Changes

- `action/run.sh`: `add_compile_context_flags()` now writes its Python helper to a `$RUNNER_TEMP`-anchored file and feeds it the eight compile-context values via NUL-separated stdin, instead of environment variables.
- `tests/test_action_compile_context_parity.py`: add a platform-independent regression test (`TestCompileContextInputsTravelViaStdinNotEnvVars`) asserting the source pattern — no `ABICHECK_COMPILE_*` env-var assignment remains, and the helper is invoked via a `printf | python3` stdin pipe — so a regression fails on every CI lane, not only `windows-latest`.

## Bug-fix test contract

- Bug class: an env var shaped like a POSIX absolute path silently mangled by Git Bash/MSYS's automatic path conversion when forwarded to a native `python3.exe` on Windows — the same class `add_flag_shlex_split()` already defends against for its own single value (stdin, not argv/env), just not yet applied to this newer call site.
- Publicly observable failure: `windows-latest` unit-tests CI job fails with `AssertionError: assert 'C:/Program F...cc-14/bin/g++' == '/opt/gcc-14/bin/g++'` (and the equivalent for `gcc-prefix`) in `tests/test_action_compile_context_parity.py::test_dump_forwards_all_six_flags`/`test_compare_forwards_all_six_flags` and `tests/test_action_run_sh_compare_build_source.py::TestCompareModeForwardsCrossCompilerFlags::test_all_four_reach_the_cli`.
- Regression test fails on base: yes, both halves — the pre-existing `TestCompileContextForwardingParity` suite already asserts the exact forwarded compiler path end-to-end (fails on `windows-latest` against `main`'s env-var-based forwarding, confirmed via CI logs; passes on Linux where MSYS conversion doesn't apply, which is exactly why a platform-independent guard was also needed), and the new `TestCompileContextInputsTravelViaStdinNotEnvVars` source-pattern test fails against `main`'s `ABICHECK_COMPILE_*` env-var assignments on every platform.
- Negative control: n/a (mechanism change — how a value reaches the script — not a new behavior toggle).
- Public-surface test: `TestCompileContextForwardingParity` exercises the real `--config` overlay end-to-end via `action/run.sh`, asserting the synthesized `compile.compiler`/`compile.options`/`compile.sysroot`/`compile.nostdinc` fields the Action actually writes — the same fields `dump`/`compare` read at runtime.
- Axes covered: all eight forwarded fields (`lang`, `include_lang`, `ast-frontend`, `gcc-path`, `gcc-prefix`, `gcc-options`, `sysroot`, `nostdinc`) move through the same stdin channel; the existing suite's multi-line/quoted/hash/backslash `gcc-options` cases and the plain `gcc-path`/`sysroot` cases together cover every field this change touches.
- General invariant: any value forwarded from this Action's inputs to a native Windows `python3` invocation must travel via stdin, never argv or an environment variable, whenever the value could plausibly be shaped like a POSIX absolute path (a real, common shape for `gcc-path`/`gcc-prefix`/`sysroot`/`gcc-options` cross-compilation inputs) — MSYS's conversion heuristic can't be reliably predicted from the call site, so the safe rule is channel-based, not value-based. This PR closes the one call site the fresh CI evidence surfaced; the `add_flag`/`add_flag_shlex_split` scan-mode path already followed this rule for its own single value.
- Malicious fixture + side-effect absence: not a hostile-input case — the stdin payload is built entirely from the Action's own declared inputs (already trusted at the level every other forwarded flag in this file is), and the change only moves the *channel* a value travels on, not what is written into the synthesized overlay or from what input. The existing quoted/hash/backslash `gcc-options` regression tests already exercise adversarial-shaped values end-to-end through this exact code path and assert the synthesized overlay's content, unaffected by the channel change.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added — not required (change confined to `action/run.sh` and `tests/`, not `abicheck/**/*.py`)
- [ ] Docs updated — no user-visible behavior changed, only a Windows CI reliability fix
- [x] `pre-commit`-equivalent checks passed locally (`bash -n`, `ruff check`/`ruff format --check`, the full `TestCompileContextForwardingParity`/`TestCompileContextOverlayMktempIsRunnerTempAnchored`/`TestCompileContextInputsTravelViaStdinNotEnvVars`/`TestCompareModeForwardsCrossCompilerFlags` suites — 51 passed, `scripts/check_bugfix_test_contract.py` structural + declared checks both pass locally)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjJkCxLP8oTxKEFNmjWiUg