### PR TITLE
fix: two bounded_decoded_prefix boundary defects left open when #1165 merged

### DIFF
--- a/abicheck/storage/snapshot_prefix.py
+++ b/abicheck/storage/snapshot_prefix.py
@@ -139,19 +139,28 @@ def bounded_decoded_prefix(path: str | Path, n: int | None = None) -> bytes | No
                 if more_needed > 0:
                     probe += f.read(more_needed)
                 return probe[:n]
-            # Clamp to the budget *before* the first read, not only in the
-            # escalation step. `n` is caller-supplied and the only caller
-            # asking for a large window happens to pass exactly
-            # `_BOUNDED_PREFIX_MAX_RAW_BYTES` today -- one constant change
-            # away from this "bounded" function reading and allocating an
-            # unbounded amount on its very first pass, before the cap check
-            # below ever runs (CodeRabbit review). A request larger than the
-            # budget is answered from the budget, and falls through to the
-            # same past-budget `None` if that cannot produce `n` bytes.
-            raw_size = min(
-                max(n, len(probe)),
-                _BOUNDED_PREFIX_MAX_RAW_BYTES,
-            )
+            # What the budget bounds is *amplification* -- raw input read
+            # per decoded byte asked for -- not how much a caller may ask
+            # for. So the ceiling is `max(n, cap)`, not `cap`:
+            #
+            #   n <= cap (every caller in the tree today): unchanged. The
+            #     first read is `n`, escalation stops at the cap.
+            #   n  > cap: the first read is `n`, which is 1:1 with the
+            #     request and so amplifies nothing, and escalation stops
+            #     there too -- no raw read beyond what was asked for.
+            #
+            # Clamping to the cap outright (the previous commit's own fix,
+            # from a CodeRabbit finding) bounded the wrong quantity: it
+            # refused requests the function could serve. A 1.3 MB stored
+            # snapshot asked for a 4 MiB prefix returned `None`, because
+            # one cap-sized raw read cannot yield 4 MiB decoded -- while
+            # `read_snapshot_bytes` returned all 3.9 MB of it. The plain
+            # branch above never had that clamp at all, which is how the
+            # inconsistency surfaced (Codex review); with the ceiling
+            # expressed this way both branches read exactly `n` and there
+            # is no rule left for either to violate.
+            ceiling = max(n, _BOUNDED_PREFIX_MAX_RAW_BYTES)
+            raw_size = max(n, len(probe))
             while True:
                 f.seek(0)
                 # One byte past the window, purely as an EOF probe: a file
@@ -182,7 +191,7 @@ def bounded_decoded_prefix(path: str | Path, n: int | None = None) -> bytes | No
                     # answer rather than a truncation artifact. (`None`
                     # here means genuinely corrupt/undecodable.)
                     return result
-                if raw_size >= _BOUNDED_PREFIX_MAX_RAW_BYTES:
+                if raw_size >= ceiling:
                     # The cap was reached with more stored input left and
                     # fewer than `n` decoded bytes in hand. Unlike the
                     # exhausted case we do *not* know this is all the file
@@ -194,6 +203,6 @@ def bounded_decoded_prefix(path: str | Path, n: int | None = None) -> bytes | No
                     # 1-byte first frame. `None` says "no prefix within
                     # budget", which is what actually happened.
                     return None
-                raw_size = min(raw_size * 4, _BOUNDED_PREFIX_MAX_RAW_BYTES)
+                raw_size = min(raw_size * 4, ceiling)
     except OSError:
         return None

--- a/abicheck/storage/snapshot_prefix.py
+++ b/abicheck/storage/snapshot_prefix.py
@@ -142,10 +142,19 @@ def bounded_decoded_prefix(path: str | Path, n: int | None = None) -> bytes | No
             raw_size = max(n, len(probe))
             while True:
                 f.seek(0)
-                head = f.read(raw_size)
-                # A short read means EOF: `head` is the entire file, so
-                # no larger raw prefix exists and the decode is final.
-                exhausted = len(head) < raw_size
+                # One byte past the window, purely as an EOF probe: a file
+                # whose length is *exactly* `raw_size` is at EOF, but a
+                # plain `read(raw_size)` cannot say so -- it returns a full
+                # buffer either way. Reading one more byte distinguishes
+                # them, and the extra byte is then dropped so the decode
+                # window stays exactly the budget it claims to be. Without
+                # this, a file sitting exactly on the cap reported "not
+                # exhausted" and fell into the past-budget branch, which
+                # answered `None` for a snapshot that was entirely in hand
+                # (Codex review).
+                head = f.read(raw_size + 1)
+                exhausted = len(head) <= raw_size
+                head = head[:raw_size]
                 result = _try_decode_prefix(head, compression, n)
                 # "No exception" is not "decoded everything the file has to
                 # offer": a frame cut at the raw-byte boundary decodes short

--- a/abicheck/storage/snapshot_prefix.py
+++ b/abicheck/storage/snapshot_prefix.py
@@ -139,7 +139,19 @@ def bounded_decoded_prefix(path: str | Path, n: int | None = None) -> bytes | No
                 if more_needed > 0:
                     probe += f.read(more_needed)
                 return probe[:n]
-            raw_size = max(n, len(probe))
+            # Clamp to the budget *before* the first read, not only in the
+            # escalation step. `n` is caller-supplied and the only caller
+            # asking for a large window happens to pass exactly
+            # `_BOUNDED_PREFIX_MAX_RAW_BYTES` today -- one constant change
+            # away from this "bounded" function reading and allocating an
+            # unbounded amount on its very first pass, before the cap check
+            # below ever runs (CodeRabbit review). A request larger than the
+            # budget is answered from the budget, and falls through to the
+            # same past-budget `None` if that cannot produce `n` bytes.
+            raw_size = min(
+                max(n, len(probe)),
+                _BOUNDED_PREFIX_MAX_RAW_BYTES,
+            )
             while True:
                 f.seek(0)
                 # One byte past the window, purely as an EOF probe: a file

--- a/changelog.d/1789000001_claude_bounded-prefix-boundary-followup.md
+++ b/changelog.d/1789000001_claude_bounded-prefix-boundary-followup.md
@@ -9,9 +9,13 @@
   EOF probe and then dropped, making the exhausted/not-exhausted decision
   exact at every escalation step. Follow-up to the fix released in #1165,
   which introduced the past-budget branch this depends on.
-- **`bounded_decoded_prefix` now honours its raw-input budget on the first
-  read.** The cap was only consulted in the escalation step, so a
-  caller-supplied prefix length above it was read (and allocated) in full
-  before the cap was ever checked. Nothing over-read in practice — the one
-  large-window caller passes exactly the cap — but the bound is the
-  function's contract.
+- **A prefix request larger than `bounded_decoded_prefix`'s raw-input cap is
+  served rather than refused.** The cap bounds *amplification* — raw input
+  read per decoded byte asked for — not how much a caller may ask for, and
+  the escalation ceiling now says so (`max(n, cap)`). This restores the
+  behaviour that shipped before an intermediate attempt in this branch
+  clamped the first read to the cap outright: that clamp refused prefixes
+  the function could produce (a 1.3 MB stored snapshot asked for a 4 MiB
+  prefix returned `None` while `read_snapshot_bytes` returned all 3.9 MB of
+  it), and applied to the compressed path only, leaving the plain branch
+  inconsistent. No released version carried the clamp.

--- a/changelog.d/1789000001_claude_bounded-prefix-boundary-followup.md
+++ b/changelog.d/1789000001_claude_bounded-prefix-boundary-followup.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **A compressed snapshot whose stored length lands exactly on
+  `bounded_decoded_prefix`'s raw-input cap is no longer rejected.** A plain
+  `read(raw_size)` cannot distinguish "the file is exactly this long" from
+  "there is more past the window", so a file sitting exactly on the cap
+  reported itself as not exhausted and fell into the past-budget branch,
+  which answers `None`. One byte is now read past the window purely as an
+  EOF probe and then dropped, making the exhausted/not-exhausted decision
+  exact at every escalation step. Follow-up to the fix released in #1165,
+  which introduced the past-budget branch this depends on.
+- **`bounded_decoded_prefix` now honours its raw-input budget on the first
+  read.** The cap was only consulted in the escalation step, so a
+  caller-supplied prefix length above it was read (and allocated) in full
+  before the cap was ever checked. Nothing over-read in practice — the one
+  large-window caller passes exactly the cap — but the bound is the
+  function's contract.

--- a/tests/test_bounded_decoded_prefix_properties.py
+++ b/tests/test_bounded_decoded_prefix_properties.py
@@ -59,6 +59,7 @@ rather than pinned to the one reported oneDAL file.
 
 from __future__ import annotations
 
+import functools
 import io
 import json
 import random
@@ -434,68 +435,58 @@ def test_a_file_one_byte_past_the_cap_still_answers_none(tmp_path):
     assert bounded_decoded_prefix(path) is None
 
 
-def test_a_request_larger_than_the_budget_never_reads_past_it(tmp_path, monkeypatch):
-    """A caller-supplied `n` above the raw-input budget must not make this
-    bounded function read (and allocate) `n` raw bytes on its first pass.
+@functools.lru_cache(maxsize=1)
+def _over_cap_payload() -> bytes:
+    """Low-ratio JSON whose *stored* form exceeds the raw cap -- the regime
+    where clamping to the cap changed the answer. Cached: the three
+    envelope parametrizations below share identical, deterministic content,
+    so regenerating ~1.4 MB of it per case was pure repeated cost."""
+    return _payload(entries=70000, entropy_bits=60, seed=21)
 
-    The cap was only consulted in the *escalation* step, so the initial
-    `raw_size = max(n, len(probe))` went straight past it (CodeRabbit
-    review). The one large-window caller in the tree passes exactly
-    `MARKER_SCAN_BYTES == _BOUNDED_PREFIX_MAX_RAW_BYTES` today, so nothing
-    over-read in practice -- but "bounded" is this function's whole
-    contract, and it was one constant change away from being false.
 
-    Asserted against the real read sizes rather than the return value,
-    because the return value is identical either way: this is a resource
-    bug, and a test that only checked the answer would have passed before
-    the fix.
+@pytest.mark.parametrize("compression", [None, *_ALGORITHMS])
+def test_a_request_larger_than_the_cap_is_still_served(tmp_path, compression):
+    """A prefix request above the raw-input cap must still be answered.
+
+    The cap bounds *amplification* -- raw input read per decoded byte asked
+    for -- not how much a caller may ask for. Clamping the first read to the
+    cap outright refuses prefixes the function can produce: one cap-sized
+    raw read cannot yield `n` decoded bytes once `n` exceeds
+    `cap x compression ratio`, so the request came back `None` while
+    `read_snapshot_bytes` returned the whole document.
+
+    `n` is deliberately 16x the cap rather than 4x: this fixture compresses
+    about 7.5:1, so at 4x a single cap-sized read *already* satisfies the
+    request and the failing regime is never entered -- the first version of
+    this test made exactly that mistake and passed against the bug it was
+    written for.
+
+    Covers plain, gzip and zstd, because the clamp lived on the compressed
+    path only and the plain branch returns before it -- a zstd-only test
+    said nothing about either of the other two (Codex review).
     """
-    zstandard = pytest.importorskip("zstandard")
+    if compression is SnapshotCompression.ZSTD:
+        pytest.importorskip("zstandard")
 
     from abicheck.snapshot_io import _BOUNDED_PREFIX_MAX_RAW_BYTES
 
-    data = _payload(entries=4000, entropy_bits=48, seed=21)
-    path = tmp_path / "budget.json.zst"
-    path.write_bytes(zstandard.ZstdCompressor(write_checksum=False).compress(data))
+    data = _over_cap_payload()
+    if compression is None:
+        path = tmp_path / "big.json"
+        path.write_bytes(data)
+    else:
+        suffix = ".json.zst" if compression is SnapshotCompression.ZSTD else ".json.gz"
+        path, encoded = _write(tmp_path, f"big{suffix}", data, compression)
+        assert len(encoded) > _BOUNDED_PREFIX_MAX_RAW_BYTES, (
+            "fixture no longer exceeds the cap in stored form, so one "
+            "cap-sized read would reach EOF and the regime this test "
+            "exists for is never entered"
+        )
 
-    reads: list[int] = []
-    real_open = open
+    n = _BOUNDED_PREFIX_MAX_RAW_BYTES * 16
+    assert n > len(data), "n must exceed the payload so the whole of it is the answer"
 
-    class _RecordingFile:
-        def __init__(self, fh):
-            self._fh = fh
-
-        def read(self, size=-1):
-            reads.append(size)
-            return self._fh.read(size)
-
-        def __getattr__(self, name):
-            return getattr(self._fh, name)
-
-        # `with open(...) as f:` resolves the context-manager protocol on
-        # the type, so `__getattr__` never sees these two.
-        def __enter__(self):
-            self._fh.__enter__()
-            return self
-
-        def __exit__(self, *exc):
-            return self._fh.__exit__(*exc)
-
-    def _patched_open(*args, **kwargs):
-        return _RecordingFile(real_open(*args, **kwargs))
-
-    monkeypatch.setattr(
-        "abicheck.storage.snapshot_prefix.open", _patched_open, raising=False
-    )
-
-    # Ask for far more than the budget allows.
-    bounded_decoded_prefix(path, _BOUNDED_PREFIX_MAX_RAW_BYTES * 8)
-
-    largest = max(reads)
-    assert largest <= _BOUNDED_PREFIX_MAX_RAW_BYTES + 1, (
-        f"read {largest} raw bytes, past the "
-        f"{_BOUNDED_PREFIX_MAX_RAW_BYTES}-byte budget (+1 EOF probe): {reads}"
-    )
+    assert bounded_decoded_prefix(path, n) == read_snapshot_bytes(path)[:n]
 
 
 # ── The reported symptom, through the real public surface ───────────────────

--- a/tests/test_bounded_decoded_prefix_properties.py
+++ b/tests/test_bounded_decoded_prefix_properties.py
@@ -434,6 +434,70 @@ def test_a_file_one_byte_past_the_cap_still_answers_none(tmp_path):
     assert bounded_decoded_prefix(path) is None
 
 
+def test_a_request_larger_than_the_budget_never_reads_past_it(tmp_path, monkeypatch):
+    """A caller-supplied `n` above the raw-input budget must not make this
+    bounded function read (and allocate) `n` raw bytes on its first pass.
+
+    The cap was only consulted in the *escalation* step, so the initial
+    `raw_size = max(n, len(probe))` went straight past it (CodeRabbit
+    review). The one large-window caller in the tree passes exactly
+    `MARKER_SCAN_BYTES == _BOUNDED_PREFIX_MAX_RAW_BYTES` today, so nothing
+    over-read in practice -- but "bounded" is this function's whole
+    contract, and it was one constant change away from being false.
+
+    Asserted against the real read sizes rather than the return value,
+    because the return value is identical either way: this is a resource
+    bug, and a test that only checked the answer would have passed before
+    the fix.
+    """
+    zstandard = pytest.importorskip("zstandard")
+
+    from abicheck.snapshot_io import _BOUNDED_PREFIX_MAX_RAW_BYTES
+
+    data = _payload(entries=4000, entropy_bits=48, seed=21)
+    path = tmp_path / "budget.json.zst"
+    path.write_bytes(zstandard.ZstdCompressor(write_checksum=False).compress(data))
+
+    reads: list[int] = []
+    real_open = open
+
+    class _RecordingFile:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def read(self, size=-1):
+            reads.append(size)
+            return self._fh.read(size)
+
+        def __getattr__(self, name):
+            return getattr(self._fh, name)
+
+        # `with open(...) as f:` resolves the context-manager protocol on
+        # the type, so `__getattr__` never sees these two.
+        def __enter__(self):
+            self._fh.__enter__()
+            return self
+
+        def __exit__(self, *exc):
+            return self._fh.__exit__(*exc)
+
+    def _patched_open(*args, **kwargs):
+        return _RecordingFile(real_open(*args, **kwargs))
+
+    monkeypatch.setattr(
+        "abicheck.storage.snapshot_prefix.open", _patched_open, raising=False
+    )
+
+    # Ask for far more than the budget allows.
+    bounded_decoded_prefix(path, _BOUNDED_PREFIX_MAX_RAW_BYTES * 8)
+
+    largest = max(reads)
+    assert largest <= _BOUNDED_PREFIX_MAX_RAW_BYTES + 1, (
+        f"read {largest} raw bytes, past the "
+        f"{_BOUNDED_PREFIX_MAX_RAW_BYTES}-byte budget (+1 EOF probe): {reads}"
+    )
+
+
 # ── The reported symptom, through the real public surface ───────────────────
 
 

--- a/tests/test_bounded_decoded_prefix_properties.py
+++ b/tests/test_bounded_decoded_prefix_properties.py
@@ -377,6 +377,63 @@ def test_a_payload_inside_the_raw_cap_still_resolves(tmp_path):
     assert bounded_decoded_prefix(path) == full[:4096]
 
 
+@pytest.mark.parametrize("offset", [-4096, -1, 0])
+def test_a_file_ending_at_or_before_the_cap_is_recognized_as_exhausted(
+    tmp_path, offset
+):
+    """A file whose length lands exactly on the raw cap is at EOF, and must
+    be read as such.
+
+    `read(raw_size)` cannot distinguish "the file is exactly this long" from
+    "there is more past the window" -- it returns a full buffer either way.
+    That made a snapshot sitting exactly on the cap report "not exhausted"
+    and fall into the past-budget branch, which answers `None` for content
+    that was entirely in hand (Codex review, a regression introduced by the
+    past-budget branch itself). `offset=0` is that case; the other two are
+    its neighbours, which never had the bug and must not acquire one.
+    """
+    zstandard = pytest.importorskip("zstandard")
+
+    from abicheck.snapshot_io import _BOUNDED_PREFIX_MAX_RAW_BYTES
+
+    data = _payload(entries=1, entropy_bits=8, seed=13)
+    cctx = zstandard.ZstdCompressor(write_checksum=False, write_content_size=True)
+    core = cctx.compress(data)
+    target = _BOUNDED_PREFIX_MAX_RAW_BYTES + offset
+    blob = core + _skippable_frame(target - len(core) - 8)
+    assert len(blob) == target
+
+    path = tmp_path / f"boundary_{offset}.json.zst"
+    path.write_bytes(blob)
+
+    full = read_snapshot_bytes(path)
+    assert full == data
+    assert bounded_decoded_prefix(path) == full[:4096]
+
+
+def test_a_file_one_byte_past_the_cap_still_answers_none(tmp_path):
+    """The complement, pinning where the boundary actually is: one byte more
+    and the reader genuinely cannot know whether that byte begins another
+    frame, so the documented past-budget answer applies. Without this the
+    EOF fix above could drift into reading unboundedly."""
+    zstandard = pytest.importorskip("zstandard")
+
+    from abicheck.snapshot_io import _BOUNDED_PREFIX_MAX_RAW_BYTES
+
+    data = _payload(entries=1, entropy_bits=8, seed=14)
+    cctx = zstandard.ZstdCompressor(write_checksum=False, write_content_size=True)
+    core = cctx.compress(data)
+    target = _BOUNDED_PREFIX_MAX_RAW_BYTES + 1
+    blob = core + _skippable_frame(target - len(core) - 8)
+    assert len(blob) == target
+
+    path = tmp_path / "boundary_plus_one.json.zst"
+    path.write_bytes(blob)
+
+    assert read_snapshot_bytes(path) == data
+    assert bounded_decoded_prefix(path) is None
+
+
 # ── The reported symptom, through the real public surface ───────────────────
 
 


### PR DESCRIPTION
## Summary

Two boundary defects in `bounded_decoded_prefix` that [#1165](https://github.com/abicheck/abicheck/pull/1165) left open. One is a regression that PR itself introduced and is **currently on `main`**; the other is a review finding raised two minutes before it merged.

## Motivation

**A file whose stored length lands exactly on the raw-input cap is rejected (regression, on `main` now).**

`#1165` added a past-budget branch: at `_BOUNDED_PREFIX_MAX_RAW_BYTES` with a short decode and no EOF, answer `None` rather than a short value that would read as the file's real prefix. That fix was right, and it exposed a latent ambiguity one layer down.

`read(raw_size)` cannot distinguish *"the file is exactly this long"* from *"there is more past the window"* — it returns a full buffer either way. Before the past-budget branch, that ambiguity only cost a wasted re-read: a file exactly `raw_size` long reported "not exhausted", escalated, and got the right answer on the next pass. At the cap there is no next pass, so the same ambiguity became a wrong answer.

Reproduced with a 15-byte zstd snapshot padded by a valid skippable frame to exactly 1 MiB: `read_snapshot_bytes()` returns the snapshot, `bounded_decoded_prefix()` returns `None`.

Found by Codex on #1165; the fix was pushed ~30 minutes after that PR merged and so missed it.

**A prefix request larger than the cap is refused rather than served.**

CodeRabbit flagged on #1165 that `raw_size` was not clamped to the cap before the first read, so "a caller that requests a large `n` can make this bounded function read and allocate beyond its raw-input budget". The first commit of this branch took that at face value and clamped. Codex then found the clamp applied to the compressed path only — the plain branch returns before it.

Investigating that asymmetry showed the clamp was the wrong fix, not an incomplete one. **Reading `n` raw bytes to answer an `n`-byte request is 1:1; it amplifies nothing.** What the cap exists to bound is the *escalation* loop, which can read far more raw input than the caller asked for when a decode comes up short — that is the runaway it was introduced for. The clamp conflated the two and refused work the function could do: a 1.3 MB stored snapshot asked for a 4 MiB prefix returned `None`, while `read_snapshot_bytes` returned all 3.9 MB of it.

So this PR ends up **reverting its own second commit**. Net effect on that axis versus `main`: none — the ceiling is expressed as `max(n, cap)`, which is what the code already did. The clamp existed only on this branch and was never released.

## Changes

- One byte past the window is read purely as an EOF probe and then dropped, so the decode window stays exactly the budget it claims to be while `exhausted` becomes exact. Fixed at the read rather than at the branch, which makes it exact at *every* escalation step and removes the wasted re-read the off-by-one was costing elsewhere.
- The escalation ceiling is stated explicitly as `max(n, _BOUNDED_PREFIX_MAX_RAW_BYTES)`, with a comment recording why it is not `cap`: for `n <= cap` (every caller in the tree) nothing changes; for `n > cap` the first read is the request itself and escalation stops there, so no raw read ever exceeds what was asked for. Both envelope branches read exactly `n`, so the plain/compressed asymmetry has no rule left to violate.

Behaviour past the budget is unchanged: still `None`, still documented, still pinned by the cap+1 test.

## Bug-fix test contract

- Bug class: `storage.short_decode_mistaken_for_complete_decode` (existing; registered in `tests/regressions/manifest.py` by #1165)
- Publicly observable failure: a valid `.json.zst` snapshot whose stored length is exactly 1,048,576 bytes resolves through `read_snapshot_bytes()` but is rejected by `CompressedAbiJsonClassifier` / `service.resolve_input` as unrecognisable.
- Regression test fails on base: yes. `test_a_file_ending_at_or_before_the_cap_is_recognized_as_exhausted[0]` fails on `main`. `test_a_request_larger_than_the_cap_is_still_served` fails on both compressed paths with the clamp restored. Each verified by reverting only the implementation.
- Negative control: `test_a_file_one_byte_past_the_cap_still_answers_none` — one byte further and the reader genuinely cannot know whether that byte begins another frame, so the documented past-budget answer must still apply. Without it, the EOF fix could drift into reading unboundedly and still look correct.
- Public-surface test: the pre-existing `test_zstd_snapshot_resolves_through_service_entry_point` / `test_zstd_snapshot_classifies_as_abi_json` continue to cover `abicheck.service.resolve_input` and the classifier.
- Axes covered: the three boundary positions (cap−4096, cap−1, exactly cap) plus the cap+1 complement; a large request (16× the cap) across plain, gzip and zstd.
- General invariant: unchanged from #1165 — `bounded_decoded_prefix(p, n) == read_snapshot_bytes(p)[:n]` for every valid envelope whose first `n` decoded bytes are reachable within the reader's raw-input budget, `None` past it. These fixes restore cases that fell on the wrong side of that line by accident rather than by the stated rule: a file *at* the cap is inside the budget, and a request above the cap is not the same thing as amplification above it.

**One test in this PR is worth reading before trusting the others.** The first version of `test_a_request_larger_than_the_cap_is_still_served` passed against the bug it was written for. It asked for 4× the cap against a fixture compressing ~7.5:1, so a single cap-sized read already satisfied the request and the failing regime was never entered — it passed with the clamp in place, with the clamp removed, *and* with a deliberately over-wide ceiling. It was only caught by running those three variants rather than trusting a green result. It now asks for 16× the cap and asserts the fixture's stored form really does exceed the cap, so it fails loudly if it ever stops exercising the regime. Same failure shape as the toy fixtures behind the original #1165 bug.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated if user-visible behaviour changed (n/a — the documented contract is unchanged; these restore cases it already promised)
- [x] `ruff check`/`format` clean; `check_ai_readiness.py` 0 errors; `check_architecture.py` 0 errors
- [x] No new `mypy` or `ruff` errors (`mypy abicheck/`: no issues in 720 source files)

Full fast unit suite: **41,252 passed, 0 failed, 40 skipped, 4 xfailed**.

Context a reviewer should have: `bounded_decoded_prefix` has now taken six rounds across #1165 and this PR, and three of those defects were introduced by the fix for the previous one — including one in this PR, reverted above. Each fix was correct about its target and wrong about an adjacent boundary; the function juggles "decoded short", "stream exhausted", "raw budget spent", "file ended exactly here" and "the caller asked for more than the budget", and sharpening one kept blurring another. The suite is now 71 cases across ratio, size, frame layout, requested length and both sides of the budget. That history is a better argument for reading the diff closely than any assurance in this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ihacAjVKfU3fpTdZEVU44