### PR TITLE
fix(action): stale comment on scan's compile-context helper, verified against native scan

### DIFF
--- a/action/run.sh
+++ b/action/run.sh
@@ -1068,34 +1068,34 @@ _old_library_is_stored_snapshot() {
 # --sources tree's own compile:/debug: could leak into, so both stay
 # single-sided.
 #
-# `scan --against` internally routed through `compare` (ADR-068 D2; the
-# `elif [[ "$MODE" == "scan" ]]; then` branch below, reached only when
-# `$_SCAN_NEEDS_LEGACY_CLI` is false) is, structurally, a genuine two-sided
-# `compare $INPUT_AGAINST $SCAN_ARTIFACT` -- if `--against` is itself a
-# LIVE binary (not the common stored-baseline-snapshot case), it undergoes
-# real header/debug extraction under the SAME shared compile context as
-# the scanned artifact, exactly like `compare`'s own OLD operand (Codex
-# review, fresh evidence, PR #1171, ninth round: this was still
-# unconditionally single-sided for every `scan`, keyed on `$MODE` alone,
-# which silently discarded the candidate's own sources-root compile:/
-# source:/debug: settings whenever `--against` genuinely had none of its
-# own to leak them into, i.e. was itself live). The *legacy* `scan` CLI
-# branch (`$_SCAN_NEEDS_LEGACY_CLI == "true"`) never reaches this helper at
-# all -- it keeps every one of these flags as literal CLI options instead
-# of synthesizing a `--config` overlay -- so `$MODE == "scan"` here always
-# means the translated-to-`compare` branch.
+# `scan --against` -- both its *legacy* CLI branch and the branch
+# internally routed through `compare` (ADR-068 D2) -- stays single-sided
+# UNCONDITIONALLY, regardless of whether `--against` is itself live: unlike
+# `compare`'s genuinely independent, two-sided OLD/NEW model, native scan
+# resolves ONE shared `compile_context` for the whole invocation
+# (`resolve_compile_context()`, `cli_scan.py`) and applies it to BOTH the
+# baseline and the candidate -- `cli_scan_baseline.py`'s own
+# `_run_baseline_compare` threads that same `compile_context` into the
+# baseline's own `InputSpec`/`SideEvidence` too (a bare `-H`/`--include`
+# applies to both sides per ADR-040; even a genuinely live `--against`
+# reuses the candidate's own headers/compile context, with a warning, when
+# no `old=`-scoped ones are given). So the `--sources`-root's own
+# `compile:`/`source:`/`debug:` block being the intended, single source for
+# that ONE shared context is scan's own real, native, already-established
+# behavior -- NOT a "no other side to leak into" special case the way
+# dump's true single operand is (Codex review, fresh evidence, PR #1171,
+# tenth round: a ninth-round fix mistakenly modeled scan's translated branch
+# on `compare`'s asymmetric OLD/NEW liveness distinction, which does NOT
+# apply to scan at all -- excluding the sources-root promotion for a live
+# `--against` would have made the translated route silently diverge from
+# what `_discover_scan_project_config()` already does on the untranslated,
+# legacy route for the exact same `scan --against` request).
 #
 # The release-style directory/package `compare` fan-out never calls
 # add_compile_context_flags at all (it rejects every compile-context input
 # outright), so it never reaches this helper either.
 _compile_context_sources_pairwise() {
-  local old_like_operand
-  case "$MODE" in
-    compare) old_like_operand="${INPUT_OLD_LIBRARY:-}" ;;
-    scan) old_like_operand="${INPUT_AGAINST:-}" ;;
-    *) return ;;
-  esac
-  if ! _old_library_is_stored_snapshot "$old_like_operand"; then
+  if [[ "$MODE" == "compare" ]] && ! _old_library_is_stored_snapshot "${INPUT_OLD_LIBRARY:-}"; then
     echo "pairwise"
   fi
 }

--- a/action/run.sh
+++ b/action/run.sh
@@ -1057,28 +1057,54 @@ _old_library_is_stored_snapshot() {
 # function's docstring. Only single-pair `compare OLD NEW` with a genuinely
 # *live* OLD operand is pairwise: both operands are then independently-
 # parsed live headers under the SAME resolved compile context. `dump` has
-# one operand; `scan --against`'s own -H/-I have always applied only to the
-# scanned ARTIFACT, never to --against (never live headers on that side at
-# all); and a `compare` whose OLD operand is a stored snapshot or resolved
-# ABI baseline (_old_library_is_stored_snapshot) does no header/debug
-# extraction on that side either (Codex review, fresh evidence, PR #1171,
-# fifth round: the earlier `$MODE == "compare"` check alone was too coarse
-# and silently discarded a live NEW-with-`--sources` operand's own
-# compile:/source:/debug: settings whenever OLD was a stored/baseline
-# snapshot) -- none of these three shapes has an "other side" a --sources
-# tree's own compile:/debug: could leak into, so all three stay
-# single-sided. The release-style directory/package `compare` fan-out never
-# calls add_compile_context_flags at all (it rejects every compile-context
-# input outright), so it never reaches this helper.
+# one operand, period, live or not; a `compare` (or a translated `scan
+# --against`, see below) whose OLD-like operand is a stored snapshot or
+# resolved ABI baseline (_old_library_is_stored_snapshot) does no
+# header/debug extraction on that side either (Codex review, fresh
+# evidence, PR #1171, fifth round: the earlier `$MODE == "compare"` check
+# alone was too coarse and silently discarded a live NEW-with-`--sources`
+# operand's own compile:/source:/debug: settings whenever OLD was a
+# stored/baseline snapshot) -- neither shape has an "other side" a
+# --sources tree's own compile:/debug: could leak into, so both stay
+# single-sided.
+#
+# `scan --against` internally routed through `compare` (ADR-068 D2; the
+# `elif [[ "$MODE" == "scan" ]]; then` branch below, reached only when
+# `$_SCAN_NEEDS_LEGACY_CLI` is false) is, structurally, a genuine two-sided
+# `compare $INPUT_AGAINST $SCAN_ARTIFACT` -- if `--against` is itself a
+# LIVE binary (not the common stored-baseline-snapshot case), it undergoes
+# real header/debug extraction under the SAME shared compile context as
+# the scanned artifact, exactly like `compare`'s own OLD operand (Codex
+# review, fresh evidence, PR #1171, ninth round: this was still
+# unconditionally single-sided for every `scan`, keyed on `$MODE` alone,
+# which silently discarded the candidate's own sources-root compile:/
+# source:/debug: settings whenever `--against` genuinely had none of its
+# own to leak them into, i.e. was itself live). The *legacy* `scan` CLI
+# branch (`$_SCAN_NEEDS_LEGACY_CLI == "true"`) never reaches this helper at
+# all -- it keeps every one of these flags as literal CLI options instead
+# of synthesizing a `--config` overlay -- so `$MODE == "scan"` here always
+# means the translated-to-`compare` branch.
+#
+# The release-style directory/package `compare` fan-out never calls
+# add_compile_context_flags at all (it rejects every compile-context input
+# outright), so it never reaches this helper either.
 _compile_context_sources_pairwise() {
-  if [[ "$MODE" == "compare" ]] && ! _old_library_is_stored_snapshot "${INPUT_OLD_LIBRARY:-}"; then
+  local old_like_operand
+  case "$MODE" in
+    compare) old_like_operand="${INPUT_OLD_LIBRARY:-}" ;;
+    scan) old_like_operand="${INPUT_AGAINST:-}" ;;
+    *) return ;;
+  esac
+  if ! _old_library_is_stored_snapshot "$old_like_operand"; then
     echo "pairwise"
   fi
 }
 
 add_compile_context_flags() {
   # $1: "true" to also fold the `lang` input into the synthesized overlay
-  # (dump and single-pair compare take --lang here; scan keeps its own
+  # (dump, single-pair compare, and scan's translated-to-compare branch --
+  # see _compile_context_sources_pairwise's own docstring above -- all take
+  # --lang here; only the *legacy* scan CLI branch keeps its own literal
   # --lang flag and never calls this function at all).
   local include_lang="${1:-true}"
   # action.yml maps an omitted `lang` input to INPUT_LANG=c++ -- that is the

--- a/tests/test_action_compile_context_old_library_liveness.py
+++ b/tests/test_action_compile_context_old_library_liveness.py
@@ -603,23 +603,31 @@ class TestCompileContextPairwiseOldLibraryClassification:
         assert "debug" not in doc
 
 
-class TestCompileContextPairwiseCoversTranslatedScan:
-    """Codex review, PR #1171 (P1, fresh evidence, ninth round): ``scan
-    --against`` internally routed through ``compare`` (ADR-068 D2) is,
-    structurally, a genuine two-sided ``compare $INPUT_AGAINST
-    $SCAN_ARTIFACT`` -- if ``--against`` is itself a LIVE binary, it
-    undergoes real header/debug extraction under the SAME shared compile
-    context as the scanned artifact, exactly like ``compare``'s own OLD
-    operand. ``_compile_context_sources_pairwise()`` used to be keyed on
-    ``$MODE`` alone (pairwise only for ``compare``, always single-sided for
-    ``scan``), which silently discarded the candidate's own sources-root
-    compile:/source:/debug: settings whenever a live ``--against`` had none
-    of its own to leak them into. Fixed by keying the decision on the
-    OLD-like operand for whichever mode actually has one
-    (``$INPUT_OLD_LIBRARY`` for ``compare``, ``$INPUT_AGAINST`` for the
-    translated ``scan`` branch), so both branches share one rule."""
+class TestCompileContextTranslatedScanStaysSingleSidedRegardlessOfLiveness:
+    """Codex review, PR #1171 (P1, fresh evidence, ninth AND tenth rounds).
 
-    def test_translated_scan_is_pairwise_when_against_is_a_live_binary(
+    The ninth round argued ``scan --against`` internally routed through
+    ``compare`` (ADR-068 D2) should be treated pairwise whenever
+    ``--against`` is itself a live binary, by analogy with ``compare``'s own
+    OLD/NEW liveness distinction. That analogy does not hold: unlike
+    ``compare``'s genuinely independent, two-sided model, native ``scan``
+    resolves ONE shared ``compile_context`` for the whole invocation
+    (``resolve_compile_context()``, ``abicheck/cli_scan.py``) and applies it
+    to BOTH the baseline and the candidate regardless of whether the
+    baseline is live -- ``cli_scan_baseline.py``'s own
+    ``_run_baseline_compare`` threads that identical ``compile_context``
+    into the baseline's own ``InputSpec``/``SideEvidence`` too. So the
+    ``--sources``-root's own ``compile:``/``source:``/``debug:`` block being
+    the intended, single source for that one shared context is scan's own
+    real, native, already-established behavior for a live baseline just as
+    much as for a stored one -- the tenth round found the ninth round's fix
+    would have made the Action's translated route silently diverge from
+    that native behavior for the exact same user-facing `scan --against`
+    request. Reverted: ``scan``'s translated branch is single-sided
+    UNCONDITIONALLY, the same as before the ninth round, proven here for
+    both operand shapes so neither direction regresses silently again."""
+
+    def test_translated_scan_is_single_sided_when_against_is_a_live_binary(
         self, tmp_path: Path
     ) -> None:
         (tmp_path / ".abicheck.yml").write_text(
@@ -628,7 +636,7 @@ class TestCompileContextPairwiseCoversTranslatedScan:
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         (src_dir / ".abicheck.yml").write_text(
-            "compile:\n  sysroot: /opt/new-side-only-sysroot\n"
+            "compile:\n  sysroot: /opt/sources-root-sysroot\n"
             "source:\n  method: s6\n"
             "debug:\n  format: dwarf\n",
             encoding="utf-8",
@@ -647,11 +655,12 @@ class TestCompileContextPairwiseCoversTranslatedScan:
         doc = json.loads(
             Path(cmd[cmd.index("--config") + 1]).read_text(encoding="utf-8")
         )
-        # Pairwise: the checkout-root's own compile.sysroot survives, and
-        # the sources-root's source:/debug: never reach the shared config.
-        assert doc["compile"]["sysroot"] == "/opt/checkout-sysroot"
-        assert "source" not in doc
-        assert "debug" not in doc
+        # Single-sided even though --against is a live binary: matches
+        # native scan's own one-shared-compile_context behavior, which
+        # applies the sources-root config to the baseline too.
+        assert doc["compile"]["sysroot"] == "/opt/sources-root-sysroot"
+        assert doc["source"] == {"method": "s6"}
+        assert doc["debug"] == {"format": "dwarf"}
 
     def test_translated_scan_is_single_sided_when_against_is_a_stored_baseline(
         self, tmp_path: Path

--- a/tests/test_action_compile_context_old_library_liveness.py
+++ b/tests/test_action_compile_context_old_library_liveness.py
@@ -54,6 +54,22 @@ RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
 
 _COMPARE_MODE_MARKER = 'elif [[ "$MODE" == "compare" ]]; then'
 
+# The FIRST `elif [[ "$MODE" == "scan" ]]; then` in the file is scan's
+# translated-to-compare branch (ADR-068 D2) -- reached only when
+# `$_SCAN_NEEDS_LEGACY_CLI` is false. Anchored on its own unique header
+# comment rather than the bare mode-test line itself: that exact substring
+# also appears inside a comment in `_compile_context_sources_pairwise()`'s
+# own docstring in `action/run.sh` (referencing this very branch), which
+# sits well before the real branch and would make a plain `text.index()`
+# search anchor to the wrong (and non-executable) location.
+_SCAN_TRANSLATED_MODE_MARKER = "# ── Scan mode, internally routed through"
+# This branch's own call to the shared helper -- a one-line region, mirroring
+# dump's identical single-line extraction (`_run_region_with_cwd` only needs
+# `add_compile_context_flags` to actually run; it does not need every other
+# flag this branch also forwards).
+_SCAN_TRANSLATED_COMPILE_CONTEXT_START = "add_compile_context_flags true"
+_SCAN_TRANSLATED_COMPILE_CONTEXT_END = "add_compile_context_flags true"
+
 _COMPILE_CONTEXT_START = 'add_single_flag "--ast-frontend" "${INPUT_AST_FRONTEND:-}"'
 
 # compare's region (Phase 7) starts at the gating comment (these inputs are
@@ -67,6 +83,12 @@ _COMPARE_COMPILE_CONTEXT_END = "else\n    add_compile_context_flags true\n  fi"
 
 _END_MARKER_FOR_START: dict[str, str] = {
     _COMPARE_COMPILE_CONTEXT_START: _COMPARE_COMPILE_CONTEXT_END,
+    _SCAN_TRANSLATED_COMPILE_CONTEXT_START: _SCAN_TRANSLATED_COMPILE_CONTEXT_END,
+}
+
+_MODE_VALUE_FOR_MARKER: dict[str, str] = {
+    _COMPARE_MODE_MARKER: "compare",
+    _SCAN_TRANSLATED_MODE_MARKER: "scan",
 }
 
 # add_compile_context_flags() itself (Phase 7): extracted verbatim, since
@@ -260,7 +282,7 @@ def _run_region_with_cwd(
     ``.abicheck.yml``/``--sources`` discovery sees the real fixtures each
     test below writes to ``tmp_path``."""
     harness = (
-        'MODE="compare"\n'
+        f'MODE="{_MODE_VALUE_FOR_MARKER[mode_marker]}"\n'
         'add_single_flag() { [[ -n "$2" ]] && CMD+=("$1" "$2"); }\n'
         '_PY_BIN="$(command -v python3 || command -v python || true)"\n'
         + _py_safe_dir_source()
@@ -579,3 +601,89 @@ class TestCompileContextPairwiseOldLibraryClassification:
         assert doc["compile"]["sysroot"] == "/opt/checkout-sysroot"
         assert "source" not in doc
         assert "debug" not in doc
+
+
+class TestCompileContextPairwiseCoversTranslatedScan:
+    """Codex review, PR #1171 (P1, fresh evidence, ninth round): ``scan
+    --against`` internally routed through ``compare`` (ADR-068 D2) is,
+    structurally, a genuine two-sided ``compare $INPUT_AGAINST
+    $SCAN_ARTIFACT`` -- if ``--against`` is itself a LIVE binary, it
+    undergoes real header/debug extraction under the SAME shared compile
+    context as the scanned artifact, exactly like ``compare``'s own OLD
+    operand. ``_compile_context_sources_pairwise()`` used to be keyed on
+    ``$MODE`` alone (pairwise only for ``compare``, always single-sided for
+    ``scan``), which silently discarded the candidate's own sources-root
+    compile:/source:/debug: settings whenever a live ``--against`` had none
+    of its own to leak them into. Fixed by keying the decision on the
+    OLD-like operand for whichever mode actually has one
+    (``$INPUT_OLD_LIBRARY`` for ``compare``, ``$INPUT_AGAINST`` for the
+    translated ``scan`` branch), so both branches share one rule."""
+
+    def test_translated_scan_is_pairwise_when_against_is_a_live_binary(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".abicheck.yml").write_text(
+            "compile:\n  sysroot: /opt/checkout-sysroot\n", encoding="utf-8"
+        )
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / ".abicheck.yml").write_text(
+            "compile:\n  sysroot: /opt/new-side-only-sysroot\n"
+            "source:\n  method: s6\n"
+            "debug:\n  format: dwarf\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "baseline.so").write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8)
+        cmd, _ = _run_region_with_cwd(
+            _SCAN_TRANSLATED_MODE_MARKER,
+            {
+                "INPUT_GCC_PATH": "/opt/gcc-14/bin/g++",
+                "INPUT_SOURCES": "src",
+                "INPUT_AGAINST": "baseline.so",
+            },
+            tmp_path,
+            _SCAN_TRANSLATED_COMPILE_CONTEXT_START,
+        )
+        doc = json.loads(
+            Path(cmd[cmd.index("--config") + 1]).read_text(encoding="utf-8")
+        )
+        # Pairwise: the checkout-root's own compile.sysroot survives, and
+        # the sources-root's source:/debug: never reach the shared config.
+        assert doc["compile"]["sysroot"] == "/opt/checkout-sysroot"
+        assert "source" not in doc
+        assert "debug" not in doc
+
+    def test_translated_scan_is_single_sided_when_against_is_a_stored_baseline(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".abicheck.yml").write_text(
+            "compile:\n  sysroot: /opt/checkout-sysroot\n", encoding="utf-8"
+        )
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / ".abicheck.yml").write_text(
+            "compile:\n  sysroot: /opt/sources-root-sysroot\n"
+            "source:\n  method: s6\n"
+            "debug:\n  format: dwarf\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "baseline.abicheck.json").write_bytes(b'{"schema_version": 1}')
+        cmd, _ = _run_region_with_cwd(
+            _SCAN_TRANSLATED_MODE_MARKER,
+            {
+                "INPUT_GCC_PATH": "/opt/gcc-14/bin/g++",
+                "INPUT_SOURCES": "src",
+                "INPUT_AGAINST": "baseline.abicheck.json",
+            },
+            tmp_path,
+            _SCAN_TRANSLATED_COMPILE_CONTEXT_START,
+        )
+        doc = json.loads(
+            Path(cmd[cmd.index("--config") + 1]).read_text(encoding="utf-8")
+        )
+        # Single-sided: the stored baseline does no header/debug extraction
+        # of its own, so the sources-root's own compile:/source:/debug: are
+        # the intended, only source for the scanned ARTIFACT.
+        assert doc["compile"]["sysroot"] == "/opt/sources-root-sysroot"
+        assert doc["source"] == {"method": "s6"}
+        assert doc["debug"] == {"format": "dwarf"}


### PR DESCRIPTION
## Summary

Follow-up to #1171 (merged at `48cf3b81c`, before this fix was pushed — restarting per this repo's merged-PR protocol, since the original PR was already closed). Two Codex review rounds on `_compile_context_sources_pairwise()` in `action/run.sh` — the second correcting an over-generalization the first one introduced.

## Motivation

**Ninth round:** `_compile_context_sources_pairwise()` was keyed purely on `$MODE` (pairwise only for `compare`, always single-sided for `scan`). Codex argued `scan --against`, once routed internally through `compare` (ADR-068 D2), is structurally a two-sided `compare $INPUT_AGAINST $SCAN_ARTIFACT` — so a live `--against` should be treated pairwise, by analogy with `compare`'s own OLD/NEW liveness distinction.

**Tenth round (this PR's actual net change):** that analogy doesn't hold. I verified against the real Python CLI: unlike `compare`'s genuinely independent, two-sided model, native `scan` resolves ONE shared `compile_context` for the whole invocation (`resolve_compile_context()`, `abicheck/cli_scan.py`, folding in the `--sources`-root's own `compile:` block via `_discover_scan_project_config()`) and applies it to BOTH the baseline and the candidate — `cli_scan_baseline.py`'s own `_run_baseline_compare` threads that identical `compile_context` into the baseline's own `InputSpec`/`SideEvidence` too, and a bare `-H`/`--include` applies to both sides per ADR-040. So the sources-root's `compile:`/`source:`/`debug:` block being the single, intended source for that one shared context is scan's own real, native, already-established behavior for a live baseline exactly as much as for a stored one. Treating a live `--against` as pairwise (the ninth round's fix) would have made the Action's translated route silently diverge from what `_discover_scan_project_config()` already does on the untranslated, legacy route for the identical `scan --against` request.

Net effect of this PR: `_compile_context_sources_pairwise()` is unchanged in behavior from before PR #1171's ninth round — `compare` only, keyed on OLD's liveness; `scan` (translated or legacy) stays single-sided unconditionally. A stale comment on `add_compile_context_flags()` (claiming scan never calls it at all — true only of the legacy branch) is fixed, and the pre-existing scan-translation region now has direct test coverage proving single-sidedness holds for *both* a live and a stored `--against`, closing the gap that let the ninth round's regression land unnoticed.

## Changes

- `_compile_context_sources_pairwise()`: net no-op vs. pre-#1171-ninth-round behavior (reverts the intermediate pairwise-for-live-scan change), with an updated docstring recording *why* scan differs from compare and citing the native-CLI code that proves it.
- Fixed the stale `add_compile_context_flags()` comment.
- New tests in `tests/test_action_compile_context_old_library_liveness.py` cover the scan-translated branch directly for both a live and a stored `--against`, both asserting single-sided promotion.

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: A shared config-merge helper's per-side/per-mode scoping decision generalized incorrectly by analogy to a superficially similar case — `compare`'s two independently-parsed operands vs. `scan`'s one-shared-context design, which look alike at the call-site level (`add_compile_context_flags` called once per invocation either way) but differ in the underlying data flow that actually matters.
- Publicly observable failure: A GitHub Action `scan` run with a compile-context input, a `--sources` tree carrying its own `compile:`/`source:`/`debug:` block, and a genuinely live `--against` baseline would (under the ninth round's now-reverted code) have silently excluded those sources-root settings for the scanned candidate, diverging from what the same request produces on scan's legacy CLI route.
- Regression test fails on base: `test_translated_scan_is_single_sided_when_against_is_a_live_binary` (`tests/test_action_compile_context_old_library_liveness.py`) fails against the ninth-round commit (`f9682bce7`, immediately before this PR's fix), which returned `pairwise` for a live `--against`.
- Negative control: `test_translated_scan_is_single_sided_when_against_is_a_stored_baseline` continues to pass unchanged in both states — the common stored-baseline case was never affected by either round.
- Public-surface test: Yes — invoked through the real `add_compile_context_flags()` shell function via `_run_region_with_cwd`, which extracts and executes the actual translated-scan script region under `$MODE=scan`, asserting on the real JSON `--config` overlay it writes.
- Axes covered: `scan`'s translated branch × both operand shapes (live `--against`, stored-baseline `--against`) — both now asserting the same (single-sided) outcome.
- General invariant: A shared per-invocation compile context's intended source (sources-root vs. checkout-root) depends on whether the command's own architecture treats its operands as independently-parsed (promotion excluded, to avoid leaking a NEW-only setting onto OLD) or as sharing one context by design (promotion included, since there is no "other side" whose parsing that context could distort differently) — verified against the actual data-flow code for each command, not inferred from surface-level call-site similarity. No existing entry in `tests/regressions/manifest.py` covers this exact class; not adding one, since this PR's own change is a revert back to previously-verified behavior rather than a newly-discovered class.
- Malicious fixture + side-effect absence: Both new tests in `TestCompileContextTranslatedScanStaysSingleSidedRegardlessOfLiveness` write a real, untrusted (repo-discovered, not operator-authored) `--sources`-tree `.abicheck.yml` fixture carrying a hostile-shaped `compile.sysroot`/`source.method`/`debug.format` override, then run it through `_run_region_with_cwd`, which executes the actual extracted `add_compile_context_flags`/`_merge_config_overlay_with_discovered_project_config` shell functions and their real Python subprocess (not a mock, and not a text-only assertion of the fixture's own YAML). Each test asserts, against the *real, executed* merged `--config` JSON the script produced, that the sources-root's settings **are** present in the shared config (single-sided promotion) for both a live-binary and a stored-snapshot `--against` — the side effect this whole line of fixes exists to get right in both directions (neither silently excluded when it should apply, nor silently applied pair-wide when it shouldn't) is asserted from the real artifact, not the input fixture's own text.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md` (N/A — only `action/run.sh`, `tests/` touched)
- [ ] Docs updated if user-visible behaviour changed (N/A — internal Action config-merge fix, no public interface change; net behavior unchanged from before PR #1171's ninth round)
- [x] `pre-commit run --all-files`-equivalent checks (`bash -n`, `check_architecture.py`) pass locally
- [x] No new `mypy` or `ruff` errors introduced

## Verification

- `bash -n action/run.sh` — clean.
- `pytest tests/test_action_compile_context_parity.py tests/test_action_compile_context_old_library_liveness.py` — 62 passed.
- Broader sweep `pytest tests/ -k "action_run_sh or action_compile_context or action_release_topology or action_scan"` — 598 passed.
- `ruff check` / `ruff format --check` — clean.
- `python scripts/check_architecture.py` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD2nKTWjYyh4zKeWLgPtCP)_
