### PR TITLE
fix(ci): never let apt-get update's exit status gate a job

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -110,6 +110,27 @@ never be surprised by a required CI job it had no way to reproduce.
   `Step`, then call `python scripts/verify.py --profile <profile> --only
   <name>` from the job) over inlining a fresh raw command — see
   `scripts/CLAUDE.md`'s "Adding a new script" section.
+- **Installing apt packages goes through
+  `./.github/actions/install-system-deps`**, never a hand-written
+  `sudo apt-get update && sudo apt-get install`. `apt-get update` fails as a
+  *whole* when any configured source fails, and GitHub's runner images ship
+  third-party vendor repositories (dl.google.com/linux/chrome-stable,
+  packages.microsoft.com) that nothing in this repo installs from -- so an
+  `update && install` chain aborts before `install` runs, and a Chrome index
+  serving a stale `Packages.gz` takes out lanes that only wanted gcc. The
+  shared action makes `update` advisory and `install` the gate, bounds and
+  retries each attempt, and verifies afterwards that the packages really are
+  installed. `tests/test_apt_install_hardening.py` executes that behaviour
+  against a simulated apt and asserts the invariant over every workflow, so
+  a re-hand-rolled `update && install` fails CI. A job that must add its own
+  repository first (`clang-plugin.yml`) keeps its inline `apt-get`, but
+  still absorbs `update`'s exit status with `||`.
+- A job that checks the repo out into a subdirectory (`base/`, `head/`) has
+  no repo at the workspace root for a `uses: ./...` path to resolve against;
+  run the shared script directly instead (`bash
+  head/.github/actions/install-system-deps/install.sh` with
+  `INPUT_PACKAGES`), the same way those jobs already run
+  `head/action/install-castxml.sh`.
 - Action pins are inconsistent across workflows: some steps pin by commit SHA
   (e.g. `actions/upload-artifact@ea165f8d...`), most use a floating major tag
   (`actions/checkout@v6`). If you're touching a workflow that executes

--- a/.github/actions/install-system-deps/action.yml
+++ b/.github/actions/install-system-deps/action.yml
@@ -4,7 +4,7 @@ description: >-
   per-attempt timeout and retried a few times, instead of a bare `sudo
   apt-get ...` with no timeout of its own.
 
-  Motivation: PR #800's CI run hit a real, reproducible hang in a bare
+  Motivation (1): PR #800's CI run hit a real, reproducible hang in a bare
   `apt-get update && apt-get install` step on a GitHub-hosted runner -- the
   step produced zero output (not even the download-progress lines a slow but
   progressing install would print) for the entire duration until GitHub's own
@@ -19,6 +19,12 @@ description: >-
   unavailable mirror, since no CI-side retry substitutes for the mirror
   actually coming back.
 
+  Motivation (2): `apt-get update`'s exit status must never gate the job.
+  It fails as a whole when *any* configured source fails, including the
+  third-party vendor repositories pre-baked into GitHub's runner images that
+  none of the packages asked for here ever come from -- see install.sh's own
+  header for the full account. `install` is the gate; `update` is advisory.
+
 inputs:
   packages:
     description: Space-separated apt package list to install.
@@ -29,27 +35,9 @@ runs:
   steps:
     - name: apt-get update/install (retried, each attempt bounded)
       shell: bash
-      run: |
-        set -u
-        attempts=3
-        for attempt in $(seq 1 "$attempts"); do
-          # `timeout`'s default signal is SIGTERM, which a caught/ignored
-          # signal in apt-get, dpkg, or sudo's own child-signal handling can
-          # survive indefinitely -- `timeout` then just waits forever for the
-          # process to exit, never escalating on its own (Codex review,
-          # confirmed against a real TERM-ignoring subprocess: `timeout N
-          # cmd` alone did not bound it, `timeout -k 10 N cmd` did). Without
-          # `--kill-after` this reintroduces the exact silent-hang failure
-          # mode this action exists to close. `-k 10` sends SIGKILL 10s after
-          # the initial SIGTERM if the process is still alive.
-          if timeout -k 10 120 sudo apt-get update -qq \
-              && timeout -k 10 240 sudo apt-get install -y ${{ inputs.packages }}; then
-            exit 0
-          fi
-          if [ "$attempt" -lt "$attempts" ]; then
-            echo "::warning::apt-get attempt $attempt/$attempts failed or timed out, retrying in 10s..."
-            sleep 10
-          fi
-        done
-        echo "::error::apt-get install failed after $attempts attempts (packages: ${{ inputs.packages }})"
-        exit 1
+      # `packages` is passed through the environment, never interpolated into
+      # this command line, so a workflow expression cannot be spliced into the
+      # shell the script runs in.
+      env:
+        INPUT_PACKAGES: ${{ inputs.packages }}
+      run: bash "$GITHUB_ACTION_PATH/install.sh"

--- a/.github/actions/install-system-deps/install.sh
+++ b/.github/actions/install-system-deps/install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install apt packages on a GitHub-hosted runner, resiliently.
+#
+# Reads the space-separated package list from $INPUT_PACKAGES (deliberately
+# an environment variable, not a command-line interpolation, so a workflow
+# expression can never be spliced into this script's own command line).
+#
+# The invariant this script exists to hold: **`apt-get update`'s exit status
+# never gates the job; `apt-get install`'s does.** `apt-get update` fails as
+# a whole when *any* configured source fails, including the third-party
+# vendor repositories pre-baked into GitHub's runner images
+# (dl.google.com/linux/chrome-stable, packages.microsoft.com, ...) that none
+# of the packages we ask for ever come from. When one of those serves a
+# stale index ("Hash Sum mismatch") or a 403, an `update && install` chain
+# aborts before `install` runs at all -- so a Chrome index that nothing here
+# uses takes out gcc/g++/cmake and every downstream step. apt itself is
+# explicit that this is survivable: it prints "They have been ignored, or
+# old ones used instead" and keeps the previously-fetched indexes, which on
+# a runner image are already populated for every Ubuntu archive.
+#
+# Failing loudly is still preserved, just moved to the step that can
+# actually speak to it: if a package really is unavailable (a genuinely
+# broken *Ubuntu* mirror, a typo, a repository the caller added that did not
+# fetch), `apt-get install` fails, the attempt is retried, and the run ends
+# with a clear diagnostic naming the packages.
+set -uo pipefail
+
+read -r -a packages <<<"${INPUT_PACKAGES:-}"
+if [ "${#packages[@]}" -eq 0 ]; then
+  echo "::error::install-system-deps: no packages given (INPUT_PACKAGES is empty)" >&2
+  exit 2
+fi
+
+attempts="${APT_INSTALL_ATTEMPTS:-3}"
+retry_delay="${APT_INSTALL_RETRY_DELAY:-10}"
+update_timeout="${APT_INSTALL_UPDATE_TIMEOUT:-120}"
+install_timeout="${APT_INSTALL_INSTALL_TIMEOUT:-240}"
+
+# Post-condition: every requested package is actually installed. `apt-get
+# install -y` exiting 0 is the primary signal, but with `update` no longer
+# gating, this is the check standing between a degraded package index and a
+# lane that believes it has a toolchain it does not have.
+#
+# `dpkg-query -W` exits non-zero for a name it holds no record of, which is
+# the answer for a package that was never installed -- and, indistinguishably,
+# for a purely virtual name satisfied through another package's `Provides:`.
+# Since the two cannot be told apart here, this treats "no record" as
+# missing: every package list in this repository names a real package, and a
+# false failure that says exactly which package is absent is recoverable,
+# whereas a false success hands the lane a missing compiler and lets it fail
+# later, somewhere less legible.
+verify_installed() {
+  missing=()
+  local pkg status
+  for pkg in "${packages[@]}"; do
+    # Skip anything that is an apt option rather than a package name.
+    case "$pkg" in -*) continue ;; esac
+    status="$(dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null)" || status=""
+    if [ "$status" != "install ok installed" ]; then
+      missing+=("$pkg")
+    fi
+  done
+  [ "${#missing[@]}" -eq 0 ]
+}
+
+for attempt in $(seq 1 "$attempts"); do
+  # `timeout`'s default signal is SIGTERM, which a caught/ignored signal in
+  # apt-get, dpkg, or sudo's own child-signal handling can survive
+  # indefinitely -- `timeout` then just waits forever for the process to
+  # exit, never escalating on its own (Codex review, confirmed against a
+  # real TERM-ignoring subprocess: `timeout N cmd` alone did not bound it,
+  # `timeout -k 10 N cmd` did). Without `--kill-after` this reintroduces the
+  # exact silent-hang failure mode this action exists to close. `-k 10`
+  # sends SIGKILL 10s after the initial SIGTERM if still alive.
+  if ! timeout -k 10 "$update_timeout" sudo apt-get update -qq; then
+    echo "::warning::apt-get update reported an error on attempt $attempt/$attempts (an unrelated third-party source is the usual cause); continuing with the existing package index"
+  fi
+  if timeout -k 10 "$install_timeout" sudo apt-get install -y "${packages[@]}"; then
+    if verify_installed; then
+      exit 0
+    fi
+    echo "::warning::apt-get install exited 0 but these packages are not installed: ${missing[*]}"
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "::warning::apt-get attempt $attempt/$attempts failed or timed out, retrying in ${retry_delay}s..."
+    sleep "$retry_delay"
+  fi
+done
+echo "::error::apt-get install failed after $attempts attempts (packages: ${packages[*]})"
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,13 +386,14 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
-        run: |
-          # Don't let a flaky pre-baked third-party apt repo (e.g. the runner's
-          # packages.microsoft.com returning 403/"no longer signed") fail the lane:
-          # tolerate `update` errors — the `install` below still fails loudly if any
-          # of the packages it needs are genuinely unavailable.
-          sudo apt-get update -qq || sudo apt-get update -qq || true
-          sudo apt-get install -y gcc g++ cmake clang curl ca-certificates
+        # Routed through the shared action rather than a hand-rolled
+        # `update || true` here: tolerating a flaky pre-baked third-party apt
+        # repo is the *general* rule for every apt lane in this repo, not a
+        # local workaround for the one that happened to trip first (this step
+        # previously carried its own copy of it).
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: gcc g++ cmake clang curl ca-certificates
       - name: Set up pinned CastXML (Linux)
         if: runner.os == 'Linux'
         uses: ./.github/actions/setup-castxml
@@ -466,9 +467,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y zlib1g-dev curl ca-certificates
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: zlib1g-dev curl ca-certificates
       - uses: ./.github/actions/setup-castxml
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -607,10 +608,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ curl ca-certificates
-          sudo apt-get install -y abigail-tools || sudo apt-get install -y libabigail-tools
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: gcc g++ curl ca-certificates
+      - name: Install abidiff
+        # Spelled `abigail-tools` on some releases, `libabigail-tools` on
+        # others -- kept as its own either/or step rather than a package in
+        # the list above, which has no way to express an alternative. If
+        # neither lands, the lane's own ABICHECK_MIN_EXECUTED guard fails it
+        # loudly rather than skipping every test (tests/conftest.py).
+        run: sudo apt-get install -y abigail-tools || sudo apt-get install -y libabigail-tools
       - uses: ./.github/actions/setup-castxml
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -637,9 +644,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ abi-compliance-checker curl ca-certificates
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: gcc g++ abi-compliance-checker curl ca-certificates
       - uses: ./.github/actions/setup-castxml
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:

--- a/.github/workflows/clang-plugin.yml
+++ b/.github/workflows/clang-plugin.yml
@@ -109,7 +109,15 @@ jobs:
           codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
           echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${{ matrix.llvm }} main" \
             | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
-          sudo apt-get update
+          # `update`'s exit status is deliberately not a gate: it fails as a
+          # whole when *any* configured source fails, including the runner
+          # image's pre-baked third-party repos (dl.google.com, packages.
+          # microsoft.com) that none of these packages come from. The
+          # `install` below is the gate -- if the llvm.list repo just added
+          # above did not fetch, it fails there, loudly and specifically.
+          # Same rule the shared install-system-deps action applies; kept
+          # inline here because this step must add its repo first.
+          sudo apt-get update || echo "::warning::apt-get update reported an error; continuing with the existing package index"
           sudo apt-get install -y \
             llvm-${{ matrix.llvm }}-dev \
             libclang-${{ matrix.llvm }}-dev \

--- a/.github/workflows/eval-suite.yml
+++ b/.github/workflows/eval-suite.yml
@@ -60,12 +60,16 @@ jobs:
           python-version: "3.13"
           cache: "pip"
 
+      - name: Install system tools
+        # zstd: extract .conda archives; binutils: readelf for symbol counts.
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: zstd binutils
+
       - name: Install abicheck + tools
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" pyyaml
-          # zstd: extract .conda archives; binutils: readelf for symbol counts.
-          sudo apt-get update -qq && sudo apt-get install -y zstd binutils
 
       - name: Run binary tier (fail on verdict drift)
         # workflow_dispatch's `only` input is attacker-shapeable free text --
@@ -123,12 +127,17 @@ jobs:
           python-version: "3.13"
           cache: "pip"
 
+      - name: Install source-tier system toolchain
+        # git+cmake produce the compile DB; clang makes L4 decls/types
+        # non-partial. zstd extracts .conda archives; binutils gives readelf.
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: zstd binutils git cmake clang
+
       - name: Install abicheck + source-tier toolchain
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" pyyaml
-          # git+cmake produce the compile DB; clang makes L4 decls/types non-partial.
-          sudo apt-get update -qq && sudo apt-get install -y zstd binutils git cmake clang
 
       - name: Run source tier (coverage; gated only against systemic breakage)
         # See the binary-tier step's identical comment on why `only` is

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -155,12 +155,16 @@ jobs:
           python-version: "3.14"
           cache: "pip"
 
+      - name: Install system tools
+        # c++filt for the ELF-only / namespace demangling scenario.
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: binutils
+
       - name: Install package
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          # c++filt for the ELF-only / namespace demangling scenario.
-          sudo apt-get update -qq && sudo apt-get install -y binutils
 
       - name: Run scaling benchmark
         # workflow_dispatch inputs are attacker-shapeable free text (unlike
@@ -283,10 +287,18 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install system tools
+        # This job checks the repo out into base/ and head/ rather than the
+        # workspace root, so a `uses: ./.github/actions/...` path would not
+        # resolve; run head's copy of the same script directly, exactly as
+        # the castxml step below runs `head/action/install-castxml.sh`.
+        env:
+          INPUT_PACKAGES: binutils
+        run: bash head/.github/actions/install-system-deps/install.sh
+
       - name: Measure base branch
         run: |
           set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y binutils
           python -m venv base_env
           ./base_env/bin/pip install -q --upgrade pip
           ./base_env/bin/pip install -q -e "./base[dev]"
@@ -392,11 +404,15 @@ jobs:
           python-version: "3.14"
           cache: "pip"
 
-      - name: Install package + toolchain
+      - name: Install system toolchain
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: clang g++
+
+      - name: Install package
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          sudo apt-get update -qq && sudo apt-get install -y clang g++
 
       - uses: ./.github/actions/setup-castxml
 
@@ -470,7 +486,11 @@ jobs:
           python-version: "3.14"
 
       - name: Install toolchain
-        run: sudo apt-get update -qq && sudo apt-get install -y clang g++
+        # base/ + head/ checkouts, no repo at the workspace root -- see the
+        # identical note on the other split-checkout job above.
+        env:
+          INPUT_PACKAGES: clang g++
+        run: bash head/.github/actions/install-system-deps/install.sh
 
       - name: Set up pinned CastXML
         # A system binary, not a per-venv package -- installing it once

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,9 +69,16 @@ jobs:
           persist-credentials: false
 
       - name: Install system deps (oracles + toolchain)
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: gcc g++ cmake curl ca-certificates
+
+      - name: Install comparison oracles
+        # Both are best-effort here (the benchmark reports whichever oracles
+        # it found): `abigail-tools` is spelled `libabigail-tools` on some
+        # releases, and abi-compliance-checker may be absent entirely. Kept
+        # out of the package list above, which cannot express either.
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ cmake curl ca-certificates
           sudo apt-get install -y abigail-tools || sudo apt-get install -y libabigail-tools
           sudo apt-get install -y abi-compliance-checker || true
 

--- a/.github/workflows/realworld-validation.yml
+++ b/.github/workflows/realworld-validation.yml
@@ -57,9 +57,9 @@ jobs:
           cache: "pip"
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ binutils zstd abigail-tools zlib1g-dev curl ca-certificates
+        uses: ./.github/actions/install-system-deps
+        with:
+          packages: gcc g++ binutils zstd abigail-tools zlib1g-dev curl ca-certificates
 
       - uses: ./.github/actions/setup-castxml
 

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -629,6 +629,36 @@ BUG_CLASSES: tuple[BugClass, ...] = (
         ),
     ),
     BugClass(
+        id="ci.unrelated_apt_source_gates_the_job",
+        invariant=(
+            "A CI lane never fails because of a package repository none "
+            "of its packages come from. `apt-get update` fails as a whole "
+            "when any configured source fails -- including the "
+            "third-party vendor repositories pre-baked into GitHub's "
+            "runner images -- so its exit status must never gate a step; "
+            "`apt-get install` is the gate, and a post-install check "
+            "confirms the packages are actually present so relaxing the "
+            "first gate cannot turn into a silent false success."
+        ),
+        fixed_by=(1182,),
+        seed_tests=("tests/test_apt_install_hardening.py",),
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The workflow-wide half of the invariant is "
+                    "structural (parsed YAML), not executed: a step's own "
+                    "wiring needs a real GitHub Actions runner. The "
+                    "script's behaviour is executed against a simulated "
+                    "apt; that a given lane calls the script is asserted "
+                    "over the workflow files only. A lane could still "
+                    "install packages through a mechanism this scan does "
+                    "not model (a Makefile, a setup script it invokes)."
+                ),
+                reference="tests/test_apt_install_hardening.py",
+            ),
+        ),
+    ),
+    BugClass(
         id="scoping.aggregate_view_starvation",
         invariant=(
             "A detector that reasons across multiple already-scoped "

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -374,39 +374,82 @@ class TestPackagesAreNotInterpolatedIntoTheShell:
 
 
 #: Commands that genuinely *absorb* a failure: each exits 0 no matter what
-#: preceded it, so a step ending in one cannot abort. Deliberately a small
-#: allowlist rather than "the line contains `||`" — that weaker rule accepts
-#: `apt-get update || exit 1`, `|| false`, or `|| apt-get update` (a retry
-#: whose own failure still aborts), which reintroduce the exact gating this
-#: whole change removes while keeping the guard green (Codex review, P2 on
-#: PR #1182).
-_NON_FAILING_SINKS = frozenset({"true", ":", "echo", "printf"})
+#: preceded it. Deliberately a small allowlist rather than "the line contains
+#: `||`" -- that weaker rule accepts `apt-get update || exit 1`, `|| false`,
+#: or `|| apt-get update` (a retry whose own failure still aborts), which
+#: reintroduce the exact gating this change removes while keeping the guard
+#: green (Codex review, P2 on PR #1182).
+#:
+#: `printf` is deliberately NOT here: it exits non-zero on a bad format
+#: (`printf '%d' abc`), so it is not unconditionally absorbing the way
+#: `true`, `:` and a plain `echo` are.
+_NON_FAILING_SINKS = frozenset({"true", ":", "echo"})
 
 
 def update_failure_is_absorbed(line: str) -> bool:
     """True when this line's ``apt-get update`` cannot abort its step.
 
-    The status a shell line exits with is the status of its *last* command,
-    so a chain `a || b || c` is absorbed only if `c` is. Anything this cannot
-    parse is reported as NOT absorbed: for a guard, an unreadable line is a
-    line to look at, not one to wave through.
+    ``a || b || c`` short-circuits at the *first* success, so the line exits
+    0 if **any** fallback succeeds -- not only the last one. (`false || true
+    || false` exits 0; an earlier revision of this predicate claimed
+    otherwise, and differential-testing it against real bash --
+    ``test_predicate_agrees_with_real_bash`` below -- is what caught it.)
+    A fallback that always succeeds therefore absorbs the failure wherever
+    it sits in the chain.
+
+    Checking a fallback's first word is not enough, though: a pipeline takes
+    its status from its last element, so ``|| echo warn | false`` exits 1
+    while opening with an allowlisted command, and ``|| echo hi; false``
+    replaces the status outright with a second statement (Codex review,
+    second P2 on PR #1182). So any shell operator other than ``||`` after
+    the first ``||`` disqualifies the line: ``;``, ``&``, ``&&``, ``|`` and
+    redirections all make the outcome something this cannot vouch for, and a
+    guard that cannot vouch for a line should flag it, not pass it.
+
+    Quoting is respected -- the ``;`` inside ``echo "...; ..."`` is text, not
+    a separator -- which is why this tokenizes rather than scanning
+    characters. Anything unparseable is reported as NOT absorbed.
     """
     if "||" not in line:
         return False
-    tail = line.rsplit("||", 1)[1].strip().rstrip(";&").strip()
-    if not tail:
-        return False
+
+    lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
     try:
-        words = shlex.split(tail)
+        tokens = list(lexer)
     except ValueError:
         return False
-    if not words:
+
+    punctuation = set(lexer.punctuation_chars)
+
+    def is_operator(tok: str) -> bool:
+        return bool(tok) and set(tok) <= punctuation
+
+    if "||" not in tokens:
         return False
-    # `sudo true` absorbs exactly as `true` does; skip a leading sudo.
-    head = words[0]
-    if head == "sudo" and len(words) > 1:
-        head = words[1]
-    return head in _NON_FAILING_SINKS
+    after = tokens[tokens.index("||") + 1 :]
+    if any(is_operator(tok) and tok != "||" for tok in after):
+        return False
+
+    # Split the remaining fallbacks on `||`; any one of them succeeding ends
+    # the chain at 0.
+    segments: list[list[str]] = [[]]
+    for tok in after:
+        if tok == "||":
+            segments.append([])
+        else:
+            segments[-1].append(tok)
+
+    for segment in segments:
+        if not segment:
+            continue
+        head = segment[0]
+        # `sudo true` absorbs exactly as `true` does; skip a leading sudo.
+        if head == "sudo" and len(segment) > 1:
+            head = segment[1]
+        if head in _NON_FAILING_SINKS:
+            return True
+    return False
 
 
 class TestNoWorkflowGatesInstallOnUpdate:
@@ -486,7 +529,9 @@ class TestUpdateFailureAbsorptionPredicate:
             "sudo apt-get update -qq || sudo apt-get update -qq || true",
             "apt-get update||true",
             "sudo apt-get update || sudo true",
-            "sudo apt-get update -qq || printf 'stale\\n'",
+            # A `;` inside quotes is text, not a statement separator -- this
+            # is clang-plugin.yml's real line.
+            'sudo apt-get update || echo "::warning::stale; continuing"',
         ],
     )
     def test_absorbed_forms_are_accepted(self, line: str) -> None:
@@ -507,12 +552,71 @@ class TestUpdateFailureAbsorptionPredicate:
             "sudo apt-get update ||",
             # Unparseable is not a pass.
             "sudo apt-get update || 'unterminated",
+            # A pipeline takes its status from its LAST element, and a second
+            # statement replaces it outright -- an allowlisted first word
+            # proves nothing (Codex review, second P2; each verified to exit
+            # 1 under real bash).
+            "sudo apt-get update || echo warning | false",
+            "sudo apt-get update || echo hi; false",
+            "sudo apt-get update || true && false",
+            "sudo apt-get update || echo hi & false",
+            # printf is not unconditionally absorbing: a bad format exits 1.
+            "sudo apt-get update || printf '%d' abc",
         ],
     )
     def test_gating_forms_are_rejected(self, line: str) -> None:
         assert not update_failure_is_absorbed(line)
 
-    def test_only_the_last_link_of_a_chain_decides(self) -> None:
-        """`a || b || c` exits with c's status, so only c can absorb."""
+    def test_a_sink_anywhere_in_a_chain_absorbs(self) -> None:
+        """`||` short-circuits at the first success, so position is irrelevant.
+
+        Both of these exit 0 under real bash. An earlier revision asserted
+        the second was NOT absorbed, on a "only the last link decides"
+        reading that is simply wrong -- the kind of self-derived oracle
+        AGENTS.md warns about, caught by the differential test below.
+        """
         assert update_failure_is_absorbed("apt-get update || false || true")
-        assert not update_failure_is_absorbed("apt-get update || true || false")
+        assert update_failure_is_absorbed("apt-get update || true || false")
+
+    @requires_apt_harness
+    @pytest.mark.parametrize(
+        "form",
+        [
+            "CMD || true",
+            "CMD || :",
+            'CMD || echo "::warning::stale"',
+            'CMD || echo "::warning::stale; continuing"',
+            "CMD || sudo true",
+            "CMD || CMD || true",
+            "CMD||true",
+            "CMD",
+            "CMD && echo installed",
+            "CMD || exit 1",
+            "CMD || false",
+            "CMD || CMD",
+            "CMD || echo warning | false",
+            "CMD || echo hi; false",
+            "CMD || true && false",
+            "CMD || printf '%d' abc",
+            "CMD || false || true",
+            "CMD || true || false",
+        ],
+    )
+    def test_predicate_agrees_with_real_bash(self, form: str) -> None:
+        """The oracle is bash itself, not this module's own reasoning.
+
+        AGENTS.md: a general invariant needs "a stated oracle that is not the
+        same formula/helper the implementation itself uses". Here the failing
+        `apt-get update` is stood in for by `false`, and bash's own exit
+        status for the whole line is the ground truth the predicate must
+        reproduce. This is the check that falsified the chain-ordering claim
+        an earlier revision shipped.
+        """
+        executable = form.replace("CMD", "false")
+        real_exit = subprocess.run(
+            ["bash", "-c", executable], capture_output=True
+        ).returncode
+        predicted = update_failure_is_absorbed(form.replace("CMD", "apt-get update"))
+        assert predicted == (real_exit == 0), (
+            f"{form!r}: predicate says absorbed={predicted}, bash exits {real_exit}"
+        )

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -1,0 +1,402 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The apt-install hardening contract:
+``.github/actions/install-system-deps/install.sh``.
+
+Bug class (`tests/regressions/manifest.py`,
+``ci.unrelated_apt_source_gates_the_job``): a CI lane must not fail because
+of a package repository none of its packages come from. ``apt-get update``
+fails *as a whole* when any configured source fails, and GitHub's runner
+images ship third-party vendor repositories (dl.google.com/linux/chrome-
+stable, packages.microsoft.com) nothing here installs from. An
+``update && install`` chain therefore aborts before ``install`` runs at all
+-- which is exactly how a Google Chrome index serving a stale
+``Packages.gz`` ("Hash Sum mismatch") took out five Examples Validation
+jobs plus ``CI / e2e`` on main, none of which install Chrome.
+
+These tests **execute the real script** against a simulated apt, rather than
+asserting the text of the workflow files -- the #705 -> #758 lesson recorded
+in AGENTS.md ("a workflow-injection defense that asserted file *text*
+instead of executing the attack"). The failure is reproduced through the
+script's own entry point, with the fake ``apt-get`` recording what it was
+actually asked to do, so a regression that reinstates the gating (or breaks
+the retry, timeout, or verification behaviour around it) fails here.
+
+The generalization beyond the one reported input is deliberate and runs on
+three axes: the *shape* of the update failure (exit status, and which of
+apt's sources broke), the *package list*, and the *number* of failing
+attempts. The last test then states the class invariant over every workflow
+in the repository at once, so a new lane cannot reintroduce the gating
+pattern in a file none of the executable tests happen to name.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTION_DIR = REPO_ROOT / ".github" / "actions" / "install-system-deps"
+INSTALL_SH = ACTION_DIR / "install.sh"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+# The real diagnostic dl.google.com served during the incident, verbatim
+# enough to be recognisable in a log; the point is that apt exits non-zero
+# while still reporting the index as usable ("old ones used instead").
+CHROME_HASH_MISMATCH = (
+    "E: Failed to fetch "
+    "https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/"
+    "binary-amd64/Packages.gz  Hash Sum mismatch\n"
+    "E: Some index files failed to download. "
+    "They have been ignored, or old ones used instead."
+)
+MICROSOFT_403 = (
+    "E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/"
+    "dists/noble/InRelease  403  Forbidden\n"
+    "E: Some index files failed to download. "
+    "They have been ignored, or old ones used instead."
+)
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_apt_env(
+    tmp_path: Path,
+    *,
+    update_exit: int = 0,
+    update_stderr: str = "",
+    install_exit: int = 0,
+    installed: tuple[str, ...] | None = None,
+    install_fail_first: int = 0,
+) -> tuple[dict[str, str], Path]:
+    """Build a PATH holding a fake ``sudo``/``apt-get``/``dpkg-query``.
+
+    ``installed`` is what dpkg reports as installed after a successful
+    install (``None`` means "whatever install was asked for", the honest
+    case). ``install_fail_first`` makes the first N install invocations fail, so a
+    test can observe the retry loop rather than only its endpoints.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "apt.log"
+    state = tmp_path / "installed"
+    state.write_text("", encoding="utf-8")
+    if installed is not None:
+        state.write_text("\n".join(installed) + "\n", encoding="utf-8")
+
+    # `sudo` simply drops its own name and execs the rest, like the real one
+    # does for our purposes.
+    _write(bindir / "sudo", '#!/usr/bin/env bash\nexec "$@"\n')
+
+    _write(
+        bindir / "apt-get",
+        f"""#!/usr/bin/env bash
+log={log!s}
+state={state!s}
+sub="$1"; shift
+echo "apt-get $sub $*" >> "$log"
+if [ "$sub" = update ]; then
+  printf '%s\\n' {update_stderr!r} >&2
+  exit {update_exit}
+fi
+if [ "$sub" = install ]; then
+  n=$(grep -c '^apt-get install' "$log")
+  if [ "$n" -le {install_fail_first} ]; then
+    echo "E: Unable to locate package" >&2
+    exit 100
+  fi
+  if [ {install_exit} -ne 0 ]; then
+    exit {install_exit}
+  fi
+  if [ {"1" if installed is None else "0"} -eq 1 ]; then
+    for a in "$@"; do
+      case "$a" in -*) continue;; esac
+      echo "$a" >> "$state"
+    done
+  fi
+  exit 0
+fi
+exit 0
+""",
+    )
+
+    # Real `dpkg-query -W` exits non-zero for a name it holds no record of
+    # -- a package that was never installed -- and prints the status line
+    # only for one it knows.
+    _write(
+        bindir / "dpkg-query",
+        f"""#!/usr/bin/env bash
+state={state!s}
+pkg="${{@: -1}}"
+if grep -qx "$pkg" "$state" 2>/dev/null; then
+  printf 'install ok installed'
+  exit 0
+fi
+exit 1
+""",
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["APT_INSTALL_RETRY_DELAY"] = "0"
+    return env, log
+
+
+def _run(env: dict[str, str], packages: str) -> subprocess.CompletedProcess[str]:
+    env = dict(env)
+    env["INPUT_PACKAGES"] = packages
+    return subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _installs(log: Path) -> list[str]:
+    lines = log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+    return [ln for ln in lines if ln.startswith("apt-get install")]
+
+
+class TestUpdateFailureNeverGatesInstall:
+    """The reported incident's class, executed rather than described."""
+
+    # Axis 1: the shape of the `update` failure. The incident was a Chrome
+    # index hash mismatch (exit 100); the same class covers any exit status
+    # from any third-party source, so several independently-chosen ones run
+    # here rather than only the reported value.
+    @pytest.mark.parametrize(
+        ("update_exit", "stderr"),
+        [
+            (100, CHROME_HASH_MISMATCH),
+            (100, MICROSOFT_403),
+            (1, CHROME_HASH_MISMATCH),
+            (255, "E: Could not get lock /var/lib/apt/lists/lock"),
+            (2, "E: Some index files failed to download."),
+        ],
+    )
+    # Axis 2: the package list -- every real caller's list in this repo,
+    # not just the gcc/g++/cmake one the incident happened to name.
+    @pytest.mark.parametrize(
+        "packages",
+        [
+            "gcc g++ cmake curl ca-certificates",
+            "gcc g++ clang cmake curl ca-certificates",
+            "zlib1g-dev curl ca-certificates",
+            "binutils",
+            "zstd binutils git cmake clang",
+        ],
+    )
+    def test_install_still_runs_and_succeeds(
+        self, tmp_path: Path, update_exit: int, stderr: str, packages: str
+    ) -> None:
+        env, log = _fake_apt_env(
+            tmp_path, update_exit=update_exit, update_stderr=stderr
+        )
+        result = _run(env, packages)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        # The load-bearing assertion: `install` was actually reached, with
+        # every requested package, despite `update` exiting non-zero.
+        installs = _installs(log)
+        assert len(installs) == 1, installs
+        for pkg in packages.split():
+            assert pkg in installs[0]
+
+    def test_update_failure_is_reported_not_hidden(self, tmp_path: Path) -> None:
+        """Tolerated is not the same as silent: the run still says so."""
+        env, _ = _fake_apt_env(
+            tmp_path, update_exit=100, update_stderr=CHROME_HASH_MISMATCH
+        )
+        result = _run(env, "gcc")
+
+        assert result.returncode == 0
+        assert "::warning::" in result.stdout
+        assert "apt-get update" in result.stdout
+
+
+class TestInstallIsTheGate:
+    """Moving the gate must not remove it."""
+
+    def test_unavailable_package_still_fails_loudly(self, tmp_path: Path) -> None:
+        env, log = _fake_apt_env(tmp_path, install_exit=100)
+        env["APT_INSTALL_ATTEMPTS"] = "3"
+        result = _run(env, "definitely-not-a-real-package")
+
+        assert result.returncode == 1
+        assert "::error::" in result.stdout
+        assert "definitely-not-a-real-package" in result.stdout
+        # Axis 3: it retried rather than giving up on the first failure.
+        assert len(_installs(log)) == 3
+
+    @pytest.mark.parametrize("failures_before_success", [1, 2])
+    def test_a_transient_install_failure_is_retried_to_success(
+        self, tmp_path: Path, failures_before_success: int
+    ) -> None:
+        env, log = _fake_apt_env(
+            tmp_path,
+            update_exit=100,
+            update_stderr=CHROME_HASH_MISMATCH,
+            install_fail_first=failures_before_success,
+        )
+        env["APT_INSTALL_ATTEMPTS"] = "3"
+        result = _run(env, "gcc g++")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert len(_installs(log)) == failures_before_success + 1
+
+    def test_install_reporting_success_without_installing_is_caught(
+        self, tmp_path: Path
+    ) -> None:
+        """`apt-get install` exiting 0 is necessary, not sufficient.
+
+        With `update` no longer gating, the post-condition check is the only
+        thing standing between a degraded index and a lane that claims a
+        toolchain it does not have.
+        """
+        env, _ = _fake_apt_env(tmp_path, installed=("gcc",))
+        env["APT_INSTALL_ATTEMPTS"] = "2"
+        result = _run(env, "gcc g++")
+
+        assert result.returncode == 1
+        assert "g++" in result.stdout
+
+    @pytest.mark.parametrize(
+        ("requested", "actually_installed"),
+        [
+            ("gcc g++", ("gcc",)),
+            ("gcc g++ cmake", ("gcc", "cmake")),
+            ("zstd binutils git cmake clang", ("zstd", "binutils", "git")),
+            ("binutils", ()),
+        ],
+    )
+    def test_a_partially_installed_set_is_caught(
+        self, tmp_path: Path, requested: str, actually_installed: tuple[str, ...]
+    ) -> None:
+        """Every shortfall is caught, not only a single missing package."""
+        env, _ = _fake_apt_env(tmp_path, installed=actually_installed)
+        env["APT_INSTALL_ATTEMPTS"] = "2"
+        result = _run(env, requested)
+
+        assert result.returncode == 1
+        for pkg in set(requested.split()) - set(actually_installed):
+            assert pkg in result.stdout
+
+    def test_apt_options_in_the_list_are_not_verified_as_packages(
+        self, tmp_path: Path
+    ) -> None:
+        """An option token is not a package dpkg could ever know about."""
+        env, _ = _fake_apt_env(tmp_path)
+        result = _run(env, "--no-install-recommends gcc")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_empty_package_list_is_a_usage_error(self, tmp_path: Path) -> None:
+        env, log = _fake_apt_env(tmp_path)
+        result = _run(env, "")
+
+        assert result.returncode == 2
+        assert not _installs(log)
+
+
+class TestPackagesAreNotInterpolatedIntoTheShell:
+    """The action passes `packages` through the environment, not the command
+    line, so a workflow expression can never be spliced into the shell that
+    runs apt (AGENTS.md's #705 -> #758 lesson: execute the attack)."""
+
+    def test_shell_metacharacters_in_packages_do_not_execute(
+        self, tmp_path: Path
+    ) -> None:
+        canary = tmp_path / "pwned"
+        env, _ = _fake_apt_env(tmp_path, install_exit=100)
+        env["APT_INSTALL_ATTEMPTS"] = "1"
+
+        result = _run(env, f"gcc; touch {canary}")
+
+        assert not canary.exists(), "package list reached a shell as code"
+        assert result.returncode == 1
+
+    def test_action_yml_passes_packages_through_env(self) -> None:
+        action = yaml.safe_load((ACTION_DIR / "action.yml").read_text())
+        (step,) = action["runs"]["steps"]
+        assert step["env"]["INPUT_PACKAGES"] == "${{ inputs.packages }}"
+        assert "${{" not in step["run"]
+
+
+class TestNoWorkflowGatesInstallOnUpdate:
+    """The class invariant, over every workflow at once.
+
+    The executable tests above prove the shared script behaves; this proves
+    no lane bypasses it by hand-rolling the pattern again. It is a structural
+    check by necessity -- a workflow's own step wiring needs a real runner to
+    execute -- and it is the *complement* of the tests above, not a
+    substitute for them.
+    """
+
+    @staticmethod
+    def _run_scripts() -> list[tuple[str, str]]:
+        out: list[tuple[str, str]] = []
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            for job in (data.get("jobs") or {}).values():
+                for step in job.get("steps") or []:
+                    if isinstance(step, dict) and isinstance(step.get("run"), str):
+                        out.append((path.name, step["run"]))
+        return out
+
+    def test_no_step_lets_apt_get_update_abort_it(self) -> None:
+        offenders: list[str] = []
+        for name, script in self._run_scripts():
+            for line in script.splitlines():
+                stripped = line.strip()
+                if not re.search(r"\bapt-get\s+update\b", stripped):
+                    continue
+                if stripped.lstrip().startswith("#"):
+                    continue
+                # Tolerated iff the line cannot abort the step: its failure
+                # is absorbed by `||`.
+                if "||" not in stripped:
+                    offenders.append(f"{name}: {stripped}")
+        assert not offenders, (
+            "`apt-get update`'s exit status must never gate a step -- an "
+            "unrelated third-party source on the runner image fails it. Use "
+            "./.github/actions/install-system-deps (or absorb the failure "
+            "with `||`) instead:\n" + "\n".join(offenders)
+        )
+
+    def test_the_shared_action_is_what_lanes_use(self) -> None:
+        """At least the lanes that broke in the incident route through it."""
+        users = {
+            path.name
+            for path in WORKFLOWS_DIR.glob("*.yml")
+            if "install-system-deps" in path.read_text(encoding="utf-8")
+        }
+        for expected in ("ci.yml", "examples-validation.yml"):
+            assert expected in users, f"{expected} no longer uses the shared action"
+
+    def test_install_sh_is_executable_and_shellcheck_clean_syntax(self) -> None:
+        assert INSTALL_SH.exists()
+        assert os.access(INSTALL_SH, os.X_OK)
+        assert subprocess.run(["bash", "-n", str(INSTALL_SH)]).returncode == 0

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -389,6 +389,11 @@ _NON_FAILING_SINKS = frozenset({"true", ":", "echo"})
 #: so no later fallback in the chain is reachable at all.
 _CONTROL_TERMINATORS = frozenset({"exit", "return", "exec"})
 
+#: Characters that introduce a shell expansion. An expansion is evaluated
+#: *before* the command runs and can fail on its own (`$((1/0))`,
+#: `${x:?msg}`), so a sink carrying one is not something this can vouch for.
+_EXPANSION_MARKERS = frozenset({"$", "`"})
+
 
 def update_failure_is_absorbed(line: str) -> bool:
     """True when this line's ``apt-get update`` cannot abort its step.
@@ -452,6 +457,14 @@ def update_failure_is_absorbed(line: str) -> bool:
         if head == "sudo" and len(segment) > 1:
             head = segment[1]
         if head in _NON_FAILING_SINKS:
+            # ...but only when the whole command is literal. An expansion can
+            # abort the command before it ever runs: `echo "$((1/0))"` exits
+            # 1 on the arithmetic error and `echo "${UNSET:?boom}"` exits 127,
+            # both while *looking* like a plain echo (Codex review, fourth P2
+            # on PR #1182). shlex strips the quotes but leaves the expansion
+            # in the token, so this catches it.
+            if any(_EXPANSION_MARKERS & set(tok) for tok in segment):
+                return False
             return True
         if head in _CONTROL_TERMINATORS:
             # Nothing after this runs, so a later sink is unreachable:
@@ -611,6 +624,14 @@ class TestUpdateFailureAbsorptionPredicate:
         "sudo true",
         "false && true",
         "true && false",
+        # Expansions: evaluated before the command runs, and able to fail on
+        # their own. The first two really do abort (1 and 127); the rest are
+        # harmless and are here so the matrix covers both outcomes.
+        'echo "$((1/0))"',
+        'echo "${UNSET:?boom}"',
+        'echo "$(false)"',
+        "echo `false`",
+        'echo "$UNSET"',
     )
 
     @requires_apt_harness

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -372,6 +373,42 @@ class TestPackagesAreNotInterpolatedIntoTheShell:
         assert "${{" not in step["run"]
 
 
+#: Commands that genuinely *absorb* a failure: each exits 0 no matter what
+#: preceded it, so a step ending in one cannot abort. Deliberately a small
+#: allowlist rather than "the line contains `||`" — that weaker rule accepts
+#: `apt-get update || exit 1`, `|| false`, or `|| apt-get update` (a retry
+#: whose own failure still aborts), which reintroduce the exact gating this
+#: whole change removes while keeping the guard green (Codex review, P2 on
+#: PR #1182).
+_NON_FAILING_SINKS = frozenset({"true", ":", "echo", "printf"})
+
+
+def update_failure_is_absorbed(line: str) -> bool:
+    """True when this line's ``apt-get update`` cannot abort its step.
+
+    The status a shell line exits with is the status of its *last* command,
+    so a chain `a || b || c` is absorbed only if `c` is. Anything this cannot
+    parse is reported as NOT absorbed: for a guard, an unreadable line is a
+    line to look at, not one to wave through.
+    """
+    if "||" not in line:
+        return False
+    tail = line.rsplit("||", 1)[1].strip().rstrip(";&").strip()
+    if not tail:
+        return False
+    try:
+        words = shlex.split(tail)
+    except ValueError:
+        return False
+    if not words:
+        return False
+    # `sudo true` absorbs exactly as `true` does; skip a leading sudo.
+    head = words[0]
+    if head == "sudo" and len(words) > 1:
+        head = words[1]
+    return head in _NON_FAILING_SINKS
+
+
 class TestNoWorkflowGatesInstallOnUpdate:
     """The class invariant, over every workflow at once.
 
@@ -402,9 +439,7 @@ class TestNoWorkflowGatesInstallOnUpdate:
                     continue
                 if stripped.lstrip().startswith("#"):
                     continue
-                # Tolerated iff the line cannot abort the step: its failure
-                # is absorbed by `||`.
-                if "||" not in stripped:
+                if not update_failure_is_absorbed(stripped):
                     offenders.append(f"{name}: {stripped}")
         assert not offenders, (
             "`apt-get update`'s exit status must never gate a step -- an "
@@ -431,3 +466,53 @@ class TestNoWorkflowGatesInstallOnUpdate:
     def test_install_sh_is_executable_and_syntactically_valid(self) -> None:
         assert os.access(INSTALL_SH, os.X_OK)
         assert subprocess.run(["bash", "-n", str(INSTALL_SH)]).returncode == 0
+
+
+class TestUpdateFailureAbsorptionPredicate:
+    """The guard's own primitive, tested directly.
+
+    A repository-wide structural scan is only as good as the predicate
+    deciding what counts as an offender, and that predicate is exactly the
+    kind of reusable rule AGENTS.md asks to be stated as invariants rather
+    than trusted because one caller happens to pass.
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "sudo apt-get update -qq || true",
+            "sudo apt-get update || :",
+            'sudo apt-get update || echo "::warning::index stale, continuing"',
+            "sudo apt-get update -qq || sudo apt-get update -qq || true",
+            "apt-get update||true",
+            "sudo apt-get update || sudo true",
+            "sudo apt-get update -qq || printf 'stale\\n'",
+        ],
+    )
+    def test_absorbed_forms_are_accepted(self, line: str) -> None:
+        assert update_failure_is_absorbed(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # The bare gating form this whole change exists to remove.
+            "sudo apt-get update -qq && sudo apt-get install -y gcc",
+            "sudo apt-get update -qq",
+            # Forms a bare `"||" in line` check would have wrongly accepted.
+            "sudo apt-get update || exit 1",
+            "sudo apt-get update || false",
+            "sudo apt-get update || sudo apt-get update",
+            "sudo apt-get update -qq || apt-get install -y gcc",
+            "sudo apt-get update || return 1",
+            "sudo apt-get update ||",
+            # Unparseable is not a pass.
+            "sudo apt-get update || 'unterminated",
+        ],
+    )
+    def test_gating_forms_are_rejected(self, line: str) -> None:
+        assert not update_failure_is_absorbed(line)
+
+    def test_only_the_last_link_of_a_chain_decides(self) -> None:
+        """`a || b || c` exits with c's status, so only c can absorb."""
+        assert update_failure_is_absorbed("apt-get update || false || true")
+        assert not update_failure_is_absorbed("apt-get update || true || false")

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -47,7 +47,9 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -73,6 +75,28 @@ MICROSOFT_403 = (
     "dists/noble/InRelease  403  Forbidden\n"
     "E: Some index files failed to download. "
     "They have been ignored, or old ones used instead."
+)
+
+
+#: The tests that *execute* `install.sh` need what the script itself needs: a
+#: POSIX shell, GNU `timeout` (the script relies on `-k/--kill-after`, which
+#: BSD/macOS `timeout` does not ship at all), and dpkg/sudo call semantics the
+#: fake tools model. The unit-test matrix in `ci.yml` runs this suite on
+#: macOS and Windows too, where none of that holds -- an unmarked module would
+#: turn those legs red for a script that only ever runs on an Ubuntu runner.
+#:
+#: Deliberately a *capability* probe rather than a bare `sys.platform` check:
+#: a Linux host without GNU `timeout` would otherwise fail the same way, and
+#: the honest precondition is "the tools this script calls are here".
+_HAS_POSIX_APT_HARNESS = (
+    sys.platform.startswith("linux")
+    and shutil.which("bash") is not None
+    and shutil.which("timeout") is not None
+)
+
+requires_apt_harness = pytest.mark.skipif(
+    not _HAS_POSIX_APT_HARNESS,
+    reason="needs a POSIX shell and GNU timeout (install.sh runs on Ubuntu runners only)",
 )
 
 
@@ -158,7 +182,7 @@ exit 1
     )
 
     env = dict(os.environ)
-    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["PATH"] = str(bindir) + os.pathsep + env["PATH"]
     env["APT_INSTALL_RETRY_DELAY"] = "0"
     return env, log
 
@@ -180,6 +204,7 @@ def _installs(log: Path) -> list[str]:
     return [ln for ln in lines if ln.startswith("apt-get install")]
 
 
+@requires_apt_harness
 class TestUpdateFailureNeverGatesInstall:
     """The reported incident's class, executed rather than described."""
 
@@ -237,6 +262,7 @@ class TestUpdateFailureNeverGatesInstall:
         assert "apt-get update" in result.stdout
 
 
+@requires_apt_harness
 class TestInstallIsTheGate:
     """Moving the gate must not remove it."""
 
@@ -326,6 +352,7 @@ class TestPackagesAreNotInterpolatedIntoTheShell:
     line, so a workflow expression can never be spliced into the shell that
     runs apt (AGENTS.md's #705 -> #758 lesson: execute the attack)."""
 
+    @requires_apt_harness
     def test_shell_metacharacters_in_packages_do_not_execute(
         self, tmp_path: Path
     ) -> None:
@@ -396,7 +423,11 @@ class TestNoWorkflowGatesInstallOnUpdate:
         for expected in ("ci.yml", "examples-validation.yml"):
             assert expected in users, f"{expected} no longer uses the shared action"
 
-    def test_install_sh_is_executable_and_shellcheck_clean_syntax(self) -> None:
+    def test_install_sh_exists(self) -> None:
+        """Portable half: the script the action names is really there."""
         assert INSTALL_SH.exists()
+
+    @requires_apt_harness
+    def test_install_sh_is_executable_and_syntactically_valid(self) -> None:
         assert os.access(INSTALL_SH, os.X_OK)
         assert subprocess.run(["bash", "-n", str(INSTALL_SH)]).returncode == 0

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -385,6 +385,10 @@ class TestPackagesAreNotInterpolatedIntoTheShell:
 #: `true`, `:` and a plain `echo` are.
 _NON_FAILING_SINKS = frozenset({"true", ":", "echo"})
 
+#: Commands that end the shell (or the enclosing function) where they stand,
+#: so no later fallback in the chain is reachable at all.
+_CONTROL_TERMINATORS = frozenset({"exit", "return", "exec"})
+
 
 def update_failure_is_absorbed(line: str) -> bool:
     """True when this line's ``apt-get update`` cannot abort its step.
@@ -449,6 +453,11 @@ def update_failure_is_absorbed(line: str) -> bool:
             head = segment[1]
         if head in _NON_FAILING_SINKS:
             return True
+        if head in _CONTROL_TERMINATORS:
+            # Nothing after this runs, so a later sink is unreachable:
+            # `|| exit 1 || true` never reaches `true` and bash exits 1
+            # (Codex review, third P2 on PR #1182).
+            return False
     return False
 
 
@@ -578,45 +587,86 @@ class TestUpdateFailureAbsorptionPredicate:
         assert update_failure_is_absorbed("apt-get update || false || true")
         assert update_failure_is_absorbed("apt-get update || true || false")
 
+    # One fallback command per entry, spanning every shape this predicate has
+    # had to reason about: absorbing sinks, plain failures, pipelines whose
+    # last element decides, statement separators, control terminators, and a
+    # stand-in for a retried `apt-get update`. Crossed with itself below, so
+    # the suite covers the *combinations* rather than the handful of forms a
+    # reviewer happened to name -- three consecutive review rounds each found
+    # one more single case, which is the signature of a class that wants
+    # generating rather than enumerating. (The cross-product then found
+    # `exec false`, which no reviewer had named.)
+    _FALLBACKS = (
+        "true",
+        ":",
+        "false",
+        "exit 1",
+        "return 1",
+        "exec false",
+        "echo hi",
+        'echo "::warning::stale; continuing"',
+        "echo hi | false",
+        "echo hi; false",
+        "printf '%d' abc",
+        "sudo true",
+        "false && true",
+        "true && false",
+    )
+
+    @requires_apt_harness
+    @pytest.mark.parametrize("first", _FALLBACKS)
+    def test_single_fallback_is_sound_against_real_bash(self, first: str) -> None:
+        self._assert_sound(f"CMD || {first}")
+
+    @requires_apt_harness
+    @pytest.mark.parametrize("second", _FALLBACKS)
+    @pytest.mark.parametrize("first", _FALLBACKS)
+    def test_chained_fallbacks_are_sound_against_real_bash(
+        self, first: str, second: str
+    ) -> None:
+        self._assert_sound(f"CMD || {first} || {second}")
+
     @requires_apt_harness
     @pytest.mark.parametrize(
-        "form",
-        [
-            "CMD || true",
-            "CMD || :",
-            'CMD || echo "::warning::stale"',
-            'CMD || echo "::warning::stale; continuing"',
-            "CMD || sudo true",
-            "CMD || CMD || true",
-            "CMD||true",
-            "CMD",
-            "CMD && echo installed",
-            "CMD || exit 1",
-            "CMD || false",
-            "CMD || CMD",
-            "CMD || echo warning | false",
-            "CMD || echo hi; false",
-            "CMD || true && false",
-            "CMD || printf '%d' abc",
-            "CMD || false || true",
-            "CMD || true || false",
-        ],
+        "form", ["CMD", "CMD && echo installed", "CMD -qq && CMD2 -y gcc"]
     )
-    def test_predicate_agrees_with_real_bash(self, form: str) -> None:
+    def test_non_fallback_forms_are_sound_against_real_bash(self, form: str) -> None:
+        self._assert_sound(form)
+
+    @staticmethod
+    def _assert_sound(form: str) -> None:
         """The oracle is bash itself, not this module's own reasoning.
 
-        AGENTS.md: a general invariant needs "a stated oracle that is not the
-        same formula/helper the implementation itself uses". Here the failing
-        `apt-get update` is stood in for by `false`, and bash's own exit
-        status for the whole line is the ground truth the predicate must
-        reproduce. This is the check that falsified the chain-ordering claim
-        an earlier revision shipped.
+        AGENTS.md asks a general invariant to be checked "against a stated
+        oracle that is not the same formula/helper the implementation itself
+        uses". The failing `apt-get update` is stood in for by `false`, and
+        bash's own exit status for the whole line is ground truth.
+
+        The invariant is **one-directional, by design**: whenever the
+        predicate says "absorbed", bash must really exit 0. That is the
+        direction with consequences -- the one that would wave a still-gating
+        line past the repository guard. The converse is deliberately not
+        asserted: the predicate refuses to vouch for a fallback containing
+        `&&`, `|`, or `;`, and some such lines do survive in bash
+        (`false || false && true || true` exits 0). Flagging one asks a human
+        to look, which is the safe failure for a guard; the accepted-forms
+        tests above are what keep that conservatism from degrading into
+        "flags everything".
+
+        Not decoration: this has falsified three separate beliefs of mine
+        about shell semantics -- chain ordering, pipeline status, and
+        reachability past `exit` -- each of which a hand-written assertion
+        would have agreed with.
         """
-        executable = form.replace("CMD", "false")
+        executable = form.replace("CMD2", "false").replace("CMD", "false")
         real_exit = subprocess.run(
             ["bash", "-c", executable], capture_output=True
         ).returncode
-        predicted = update_failure_is_absorbed(form.replace("CMD", "apt-get update"))
-        assert predicted == (real_exit == 0), (
-            f"{form!r}: predicate says absorbed={predicted}, bash exits {real_exit}"
+        predicted = update_failure_is_absorbed(
+            form.replace("CMD2", "apt-get install").replace("CMD", "apt-get update")
         )
+        if predicted:
+            assert real_exit == 0, (
+                f"{form!r}: predicate says the failure is absorbed, but bash "
+                f"exits {real_exit} -- the guard would pass a gating line"
+            )


### PR DESCRIPTION
## Summary

Fix the CI failures on `main`: `apt-get update`'s exit status was gating every apt lane, so an unrelated third-party repository on the runner image took out six jobs.

## Motivation

Five *Examples Validation* jobs and *CI / e2e* failed on `main` ([run 34382714356](https://github.com/abicheck/abicheck/actions/runs/34382714356)) for a reason none of them had anything to do with. `dl.google.com`'s `chrome-stable` repository served a stale `Packages.gz`:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/.../Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

`apt-get update` fails as a *whole* when any configured source fails, so it exited non-zero and every lane's `update && install` chain aborted before `apt-get install` ran at all. Nothing in this repo installs Chrome; the packages those lanes wanted (gcc, g++, cmake, clang) were in an already-populated Ubuntu index the whole time — apt says so itself in the second line above. The downstream damage was total: no toolchain, `ERROR: required tool 'castxml' not found in PATH`, an empty results JSON, and finally a `JSONDecodeError` in `tests/check_stripped_fp.py` reading it.

The general rule this establishes: **`apt-get update`'s exit status never gates a job; `apt-get install`'s does.** `update`'s status answers a question no lane here is asking.

This is fixed at the class level rather than at the lane that tripped first, deliberately. `ci.yml`'s cross-platform leg *already* carried a private copy of this workaround (`update -qq || update -qq || true`, with a comment about `packages.microsoft.com` returning 403) — that instance-local patch is exactly how the rule stayed local while six other lanes kept the bug.

## Changes

- **`.github/actions/install-system-deps/install.sh` (new)** — the shared action's logic, extracted from its inline `run:` so it is executable and testable. `update` failure is warned about and tolerated; `install` is the gate, still bounded by `timeout -k` and retried; a post-install `dpkg-query` check confirms the packages really are present, so relaxing the first gate cannot become a silent false success. Packages reach the script through the environment (`INPUT_PACKAGES`) rather than an interpolated command line.
- **Every hand-rolled `apt-get update && apt-get install` in the workflows** now routes through that action (`ci.yml` ×4, `eval-suite.yml` ×2, `performance.yml` ×4, `publish.yml`, `realworld-validation.yml`). The two split-checkout `performance.yml` jobs (`base/` + `head/`, no repo at the workspace root for a `uses: ./...` path) run head's copy of the script directly, as they already do for `install-castxml.sh`. `clang-plugin.yml` must add its own LLVM repo first, so it keeps an inline `apt-get` — with `update`'s status absorbed and the reason stated.
- **`tests/test_apt_install_hardening.py` (new)** — 41 tests that execute the real script against a simulated apt.
- **`.github/AGENTS.md`** — the convention, so the next lane doesn't hand-roll it again.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `ci.unrelated_apt_source_gates_the_job` (`tests/regressions/manifest.py`) — a CI lane must never fail because of a package repository none of its packages come from.
- Publicly observable failure: six jobs on `main` red at the `Install system deps` step; downstream, `castxml not found` and a `JSONDecodeError` on an empty results file.
- Regression test fails on base: yes — reverting `install.sh` to the old `update && install` chain fails 33 of the 41 tests in `tests/test_apt_install_hardening.py` (measured, not asserted in prose).
- Negative control: `TestInstallIsTheGate::test_unavailable_package_still_fails_loudly` — moving the gate must not remove it; a genuinely unavailable package still exits 1 after retrying, and `test_install_reporting_success_without_installing_is_caught` covers the new failure mode the relaxation could have introduced.
- Public-surface test: `TestPackagesAreNotInterpolatedIntoTheShell::test_action_yml_passes_packages_through_env` plus `TestNoWorkflowGatesInstallOnUpdate`, which asserts the invariant over the parsed YAML of every workflow in the repository — the composite action's own public surface.
- Axes covered: update-failure shape (5 exit statuses × 2 real vendor-repo diagnostics), package list (5 real caller lists), failing-attempt count (0/1/2 before success, and exhausting all attempts), partial-install shortfall (4 requested/installed combinations), option tokens in the package list.
- General invariant: for *any* update-failure shape and *any* package list, `apt-get install` is still reached with every requested package and the script exits 0 iff every package is installed afterwards. The oracle is the fake `apt-get`'s own recorded invocation log and a separate installed-package state file — not the script's own logic.
- Malicious fixture + side-effect absence: `test_shell_metacharacters_in_packages_do_not_execute` runs the script with `INPUT_PACKAGES="gcc; touch <canary>"` and asserts the canary file does not exist — the injection is executed, not described (the #705 → #758 lesson).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — n/a, no `abicheck/**/*.py` changes
- [x] Docs updated if user-visible behaviour changed — `.github/AGENTS.md`
- [ ] `pre-commit run --all-files` passes locally — see note below
- [x] No new `mypy` or `ruff` errors introduced (`ruff check abicheck/ tests/` clean)

Note: this clone has truncated git history (463 commits), so `adr-status-sync`'s reachability probe reports three pre-existing ADR `**Verified:**` receipts as unreachable. It fails identically on an unmodified `main` tree here and is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BYGH9JxxLsBEEekwDwms2

---
_Generated by [Claude Code](https://claude.ai/code/session_015BYGH9JxxLsBEEekwDwms2)_