### PR TITLE
fix: four review findings on the merged --no-baseline audit path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,26 @@ jobs:
     # 29m19s with 99% of the suite passed. 45 restores headroom over that
     # 27-29m; the per-platform cost of the stored-package path is a
     # separate, unowned investigation, not something a test budget fixes.
-    timeout-minutes: 45
+    #
+    # ...and it drifted to zero again, on schedule. On 2026-09-09 the
+    # Windows leg's main-suite step measured 40m24s and 41m18s on two
+    # consecutive `main` runs (34405326160, 34407360410) -- 92-94% of the
+    # 45-minute job budget set days earlier against a 27-29m observation --
+    # and on 2026-09-10 run 34435814307, on `main` itself with no pull
+    # request in flight, was cancelled at 45m14s. So the budget is now
+    # per-leg rather than one number the slowest platform shares with legs
+    # that comfortably fit: the canonical Linux leg's own worst observation
+    # is 31m30s and macOS's is 18m, both of which 45 still covers with real
+    # headroom, so loosening them to accommodate Windows would discard a
+    # working gate to fix an unrelated one. The Windows figure is ~1.8x its
+    # own last-measured cost, deliberately more slack than the 45/29 ~= 1.55
+    # the previous bump chose, because the thing this comment keeps
+    # re-learning is that a multiple picked tight against today's
+    # measurement expires in days. This is still a budget, not a fix: the
+    # underlying question is why this suite costs 41 minutes on Windows and
+    # 20 on Linux under coverage, which remains the separate unowned
+    # investigation the paragraph above already names.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 75 || 45 }}
     permissions:
       contents: read
       id-token: write

--- a/abicheck/frontends/cli/commands/compare_no_baseline.py
+++ b/abicheck/frontends/cli/commands/compare_no_baseline.py
@@ -147,6 +147,25 @@ class _ScopeChoices:
 
 
 @dataclass(frozen=True)
+class _SuppressionChecks:
+    """The two `.abicheck.yml` `suppression:` settings that decide whether a
+    suppression *document* is acceptable at all, as opposed to which findings
+    it matches.
+
+    Carried on the resolved invocation rather than read at the load site
+    because both loads -- `--dry-run`'s validation-only one and the real
+    run's -- must apply them, and a preview that accepts a document the run
+    rejects approves a run that cannot start. They were dropped entirely
+    here until now, so `suppression.require_justification: true` was
+    enforced by two-sided `compare` and silently ignored by the audit, which
+    then suppressed the finding and exited 0 (Codex review, P1).
+    """
+
+    strict_suppressions: bool
+    require_justification: bool
+
+
+@dataclass(frozen=True)
 class _ResolvedInvocation:
     """One ``--no-baseline`` invocation, already validated and resolved.
 
@@ -169,6 +188,7 @@ class _ResolvedInvocation:
     compile: _CompileChoices
     contract: _ContractChoices
     scope: _ScopeChoices
+    suppression: _SuppressionChecks
 
 
 def maybe_dispatch_no_baseline_compare(
@@ -366,6 +386,10 @@ def _resolve_no_baseline_invocation(
             mode=resolve_contract_domain(contract_mode_raw, ctx),
             evaluation=resolve_contract_evaluation(contract_mode_raw),
         ),
+        suppression=_SuppressionChecks(
+            strict_suppressions=bool(resolved_cfg.strict_suppressions),
+            require_justification=bool(resolved_cfg.require_justification),
+        ),
     )
 
 
@@ -465,6 +489,8 @@ def _run_no_baseline_compare_cmd(
             kwargs.get("suppress"),
             kwargs.get("policy") or "strict_abi",
             kwargs.get("policy_file_path"),
+            strict_suppressions=inv.suppression.strict_suppressions,
+            require_justification=inv.suppression.require_justification,
         )
         emit_dry_run(
             build_no_baseline_dry_run_result(
@@ -494,6 +520,8 @@ def _run_no_baseline_compare_cmd(
         kwargs.get("suppress"),
         kwargs.get("policy") or "strict_abi",
         kwargs.get("policy_file_path"),
+        strict_suppressions=inv.suppression.strict_suppressions,
+        require_justification=inv.suppression.require_justification,
     )
 
     result = run_no_baseline_compare(

--- a/abicheck/frontends/cli/commands/no_baseline_rulings.py
+++ b/abicheck/frontends/cli/commands/no_baseline_rulings.py
@@ -391,14 +391,20 @@ def _reject_context_stashed_options(ctx: click.Context) -> None:
     silently dropped: ``compare --no-baseline snap.abi.json --variant v1``
     ran a normal audit and exited 0.
 
-    It is rejected rather than wired because there is nothing on this path
-    for it to select. ``--variant`` chooses among the ``VariantRef``s a
-    stored ``ProjectSnapshot`` *package* operand declares, and this dispatch
-    refuses a directory/package operand outright (see
-    ``maybe_dispatch_no_baseline_compare``); for a single artifact the flag
-    is a no-op by its own documented contract. Wiring it becomes real work
-    when ``--no-baseline`` grows a package operand (plan row F-23), and the
-    usage error is what makes that a visible gap rather than a silent one.
+    It is rejected rather than wired because this path implements no variant
+    *selection*. ``--variant`` chooses among the ``VariantRef``s a stored
+    ``ProjectSnapshot`` package declares; the audit resolves a package
+    operand through ``resolve_no_baseline_candidate``, which takes the
+    package's own single artifact and never consults a variant selector at
+    all. So the flag would name a selection nothing performs.
+
+    (This reason was originally "the dispatch refuses a package operand
+    outright", which stopped being true when a one-artifact
+    ``ProjectSnapshot`` package directory was accepted -- CodeRabbit review.
+    The rejection survives that narrowing; only its justification changed.)
+    Wiring it becomes real work when ``--no-baseline`` grows multi-variant
+    package support (plan row F-23), and the usage error is what makes that
+    a visible gap rather than a silent one.
     """
     from ..options.release import variant_kwargs_from_context
 
@@ -406,7 +412,8 @@ def _reject_context_stashed_options(ctx: click.Context) -> None:
         raise click.UsageError(
             "--variant is not available with --no-baseline: it selects among "
             "the variants a stored ProjectSnapshot package declares, and this "
-            "path accepts a single artifact only (ADR-068 D2). It is rejected "
+            "path performs no variant selection -- a package operand is "
+            "audited through its single artifact (ADR-068 D2). It is rejected "
             "rather than silently ignored so a CI job never believes it took "
             "effect."
         )

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -76,6 +76,7 @@ from .no_baseline_document import (
     # of how `suppressed` is shaped. A consumer wanting the type imports it
     # from `no_baseline_document`, which owns it.
     SuppressedFinding,
+    suppression_rule_label,
 )
 
 if TYPE_CHECKING:
@@ -529,12 +530,18 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
         for entry in doc.suppressed:
             finding = entry.finding
             change = finding.change
-            # The label alone answers "which rule"; a reader deciding whether
-            # the waiver still applies needs the reason it was written for,
-            # the file it lives in, and when it lapses. The display label
-            # collapses label and reason into one string, so a rule stating
-            # both showed only its label here (Codex review, P1).
-            rule = getattr(change, "suppression_rule", None) or "(rule gave no label)"
+            # A reader deciding whether the waiver still applies needs the
+            # reason it was written for, the file it lives in, and when it
+            # lapses -- so those get their own columns beside the label.
+            #
+            # The label comes from the shared resolver, never from
+            # `Change.suppression_rule` directly: that field is
+            # `label or reason`, so reading it here printed a reason-only
+            # rule's reason twice, once under a heading claiming it was a
+            # separate rule label (Codex review, P2).
+            rule = suppression_rule_label(change, entry.provenance) or (
+                "(rule gave no label)"
+            )
             prov = entry.provenance or {}
             reason = prov.get("reason") or "(none stated)"
             source = prov.get("source_file") or "(not recorded)"

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -74,7 +74,7 @@ from .no_baseline_document import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from ..checker_types import Change
     from ..policy.scope_completeness import ScopeDecision
@@ -240,6 +240,9 @@ def compute_no_baseline_document(
         evidence_tiers=tuple(diff.evidence_tiers),
         findings=resolve(result.findings),
         suppressed=resolve(result.suppressed_findings),
+        suppression_provenance=_suppression_provenance(
+            diff, result.suppressed_findings
+        ),
         evolution=compute_cross_source_evolution_summary(result.findings),
         pattern_preprocessor_scan=_candidate_side_scan(
             compute_pattern_preprocessor_scan_json(diff)
@@ -254,6 +257,36 @@ def compute_no_baseline_document(
         ),
         exit_axes=_no_baseline_exit_axes(result, require_complete_analysis),
     )
+
+
+def _suppression_provenance(
+    diff: Any, suppressed: Sequence[Any]
+) -> tuple[Mapping[str, Any] | None, ...]:
+    """ADR-067 D3's full rule provenance, one entry per suppressed finding.
+
+    Joined off the run's own ``disposition_ledger`` by object identity
+    (``DispositionLedger.rule_for``) -- the same lookup ``reporter.py``'s
+    two-sided ``suppression.suppressed_changes`` block uses, so the audit and
+    the comparison report name the same rule from one owner rather than two.
+    Deliberately not ``Change.suppression_rule``: that is
+    ``SuppressionOutcome.rule_label()``'s ``label or reason`` collapse, so a
+    rule carrying both dropped its reason, source file and expiry from every
+    audit projection (Codex review, P1).
+
+    ``None`` per entry, never a fabricated row, when the ledger holds no
+    record for that finding -- a ``DiffResult`` rebuilt from JSON has no
+    ledger at all, and inventing provenance there would be worse than
+    reporting none.
+    """
+    ledger = getattr(diff, "disposition_ledger", None)
+    if ledger is None:
+        return tuple(None for _ in suppressed)
+    return tuple(_provenance_row(ledger, change) for change in suppressed)
+
+
+def _provenance_row(ledger: Any, change: Any) -> Mapping[str, Any] | None:
+    rule = ledger.rule_for(change)
+    return None if rule is None else rule.to_dict()
 
 
 def _coverage_failures(diff: Any) -> tuple[dict[str, Any], ...]:
@@ -325,17 +358,29 @@ def _finding_json(finding: ReportFinding) -> dict[str, Any]:
     return row
 
 
-def _suppressed_json(finding: ReportFinding) -> dict[str, Any]:
+def _suppressed_json(
+    finding: ReportFinding, provenance: Mapping[str, Any] | None
+) -> dict[str, Any]:
     """One suppressed finding's JSON row: the finding, plus what hid it.
 
-    ``suppression_rule`` is the reason text the matching rule carried, so a
-    reader can answer "which rule, and why" without re-running with the
-    suppression file removed -- ADR-067's disposition-audit principle
-    applied to this report's own shape.
+    Two fields, because they answer different questions and one cannot stand
+    in for the other:
+
+    * ``suppression_rule`` -- the rule's short display label
+      (``SuppressionOutcome.rule_label()``'s ``label or reason``), kept
+      unchanged so an existing consumer reading it is unaffected.
+    * ``suppression_provenance`` -- ADR-067 D3's full record: rule id,
+      source file, reason, label, expiry. The display label collapses
+      ``label`` and ``reason`` into one string, so a rule stating both
+      published its label and silently dropped the reason and the file it
+      came from -- exactly the identify-and-review information the
+      disposition audit exists to preserve (Codex review, P1). ``null``
+      when the run kept no ledger entry for this finding.
     """
     row = _finding_json(finding)
     row["disposition"] = "suppressed"
     row["suppression_rule"] = getattr(finding.change, "suppression_rule", None)
+    row["suppression_provenance"] = dict(provenance) if provenance else None
     return row
 
 
@@ -362,7 +407,10 @@ def _document_json(doc: NoBaselineDocument) -> dict[str, Any]:
         # suppressed" must not look the same to a consumer checking whether
         # policy hid anything (the same convention `contract_coverage_
         # failures` follows -- `[]` rather than omitted).
-        "suppressed_findings": [_suppressed_json(f) for f in doc.suppressed],
+        "suppressed_findings": [
+            _suppressed_json(f, p)
+            for f, p in zip(doc.suppressed, doc.suppression_provenance, strict=True)
+        ],
         "suppressed_count": len(doc.suppressed),
         "cross_source_evolution": render_cross_source_evolution_json(doc.evolution),
         "pattern_preprocessor_scan": doc.pattern_preprocessor_scan,
@@ -472,15 +520,28 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
             "a *disposition*, not an absence -- a passing audit must still show "
             "what policy hid, and which rule hid it.",
             "",
-            "| Finding | Symbol | Severity | Suppressed by |",
-            "| --- | --- | --- | --- |",
+            "| Finding | Symbol | Severity | Suppressed by | Reason | Source | Expires |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
         ]
-        for finding in doc.suppressed:
+        for finding, prov in zip(
+            doc.suppressed, doc.suppression_provenance, strict=True
+        ):
             change = finding.change
-            rule = getattr(change, "suppression_rule", None) or "(rule gave no reason)"
+            # The label alone answers "which rule"; a reader deciding whether
+            # the waiver still applies needs the reason it was written for,
+            # the file it lives in, and when it lapses. The display label
+            # collapses label and reason into one string, so a rule stating
+            # both showed only its label here (Codex review, P1).
+            rule = getattr(change, "suppression_rule", None) or "(rule gave no label)"
+            prov = prov or {}
+            reason = prov.get("reason") or "(none stated)"
+            source = prov.get("source_file") or "(not recorded)"
+            expires = prov.get("expires") or "(never)"
             lines.append(
                 f"| `{md_cell(change.kind.value)}` | `{md_cell(change.symbol or '-')}` | "
-                f"{md_cell(finding.category.value)} | {md_cell(rule)} |"
+                f"{md_cell(finding.category.value)} | {md_cell(rule)} | "
+                f"{md_cell(str(reason))} | `{md_cell(str(source))}` | "
+                f"{md_cell(str(expires))} |"
             )
     lines += _exit_axis_notice_lines(doc)
     return "\n".join(lines) + "\n"

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -76,6 +76,7 @@ from .no_baseline_document import (
     # of how `suppressed` is shaped. A consumer wanting the type imports it
     # from `no_baseline_document`, which owns it.
     SuppressedFinding,
+    suppression_provenance_of,
     suppression_rule_label,
 )
 
@@ -389,7 +390,8 @@ def _suppressed_json(entry: SuppressedFinding) -> dict[str, Any]:
     row = _finding_json(entry)
     row["disposition"] = "suppressed"
     row["suppression_rule"] = getattr(entry.change, "suppression_rule", None)
-    row["suppression_provenance"] = dict(entry.provenance) if entry.provenance else None
+    provenance = suppression_provenance_of(entry)
+    row["suppression_provenance"] = dict(provenance) if provenance else None
     return row
 
 
@@ -541,10 +543,11 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
             # `label or reason`, so reading it here printed a reason-only
             # rule's reason twice, once under a heading claiming it was a
             # separate rule label (Codex review, P2).
-            rule = suppression_rule_label(change, entry.provenance) or (
+            entry_provenance = suppression_provenance_of(entry)
+            rule = suppression_rule_label(change, entry_provenance) or (
                 "(rule gave no label)"
             )
-            prov = entry.provenance or {}
+            prov = entry_provenance or {}
             reason = prov.get("reason") or "(none stated)"
             source = prov.get("source_file") or "(not recorded)"
             expires = prov.get("expires") or "(never)"

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -284,7 +284,9 @@ def _suppressed_entries(
     ledger = getattr(diff, "disposition_ledger", None)
     return tuple(
         SuppressedFinding(
-            finding=finding,
+            change=finding.change,
+            verdict=finding.verdict,
+            category=finding.category,
             provenance=_provenance_row(ledger, finding.change),
         )
         for finding in findings
@@ -384,9 +386,9 @@ def _suppressed_json(entry: SuppressedFinding) -> dict[str, Any]:
       disposition audit exists to preserve (Codex review, P1). ``null``
       when the run kept no ledger entry for this finding.
     """
-    row = _finding_json(entry.finding)
+    row = _finding_json(entry)
     row["disposition"] = "suppressed"
-    row["suppression_rule"] = getattr(entry.finding.change, "suppression_rule", None)
+    row["suppression_rule"] = getattr(entry.change, "suppression_rule", None)
     row["suppression_provenance"] = dict(entry.provenance) if entry.provenance else None
     return row
 
@@ -528,8 +530,8 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
             "| --- | --- | --- | --- | --- | --- | --- |",
         ]
         for entry in doc.suppressed:
-            finding = entry.finding
-            change = finding.change
+            finding = entry
+            change = entry.change
             # A reader deciding whether the waiver still applies needs the
             # reason it was written for, the file it lives in, and when it
             # lapses -- so those get their own columns beside the label.

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -71,6 +71,11 @@ from .no_baseline_document import (
     NO_BASELINE_SUPPORTED_FORMATS as NO_BASELINE_SUPPORTED_FORMATS,
     NO_BASELINE_UNSUPPORTED_FORMATS as NO_BASELINE_UNSUPPORTED_FORMATS,
     NoBaselineDocument as NoBaselineDocument,
+    # Deliberately not re-exported (`X as X`) like the names above: those are
+    # this module's published surface, while this one is an internal detail
+    # of how `suppressed` is shaped. A consumer wanting the type imports it
+    # from `no_baseline_document`, which owns it.
+    SuppressedFinding,
 )
 
 if TYPE_CHECKING:
@@ -239,10 +244,7 @@ def compute_no_baseline_document(
         old_acquisition_state=result.acquisition.members[0].state.value,
         evidence_tiers=tuple(diff.evidence_tiers),
         findings=resolve(result.findings),
-        suppressed=resolve(result.suppressed_findings),
-        suppression_provenance=_suppression_provenance(
-            diff, result.suppressed_findings
-        ),
+        suppressed=_suppressed_entries(diff, resolve(result.suppressed_findings)),
         evolution=compute_cross_source_evolution_summary(result.findings),
         pattern_preprocessor_scan=_candidate_side_scan(
             compute_pattern_preprocessor_scan_json(diff)
@@ -259,10 +261,10 @@ def compute_no_baseline_document(
     )
 
 
-def _suppression_provenance(
-    diff: Any, suppressed: Sequence[Any]
-) -> tuple[Mapping[str, Any] | None, ...]:
-    """ADR-067 D3's full rule provenance, one entry per suppressed finding.
+def _suppressed_entries(
+    diff: Any, findings: Sequence[ReportFinding]
+) -> tuple[SuppressedFinding, ...]:
+    """Pair each suppressed finding with ADR-067 D3's full rule provenance.
 
     Joined off the run's own ``disposition_ledger`` by object identity
     (``DispositionLedger.rule_for``) -- the same lookup ``reporter.py``'s
@@ -279,12 +281,18 @@ def _suppression_provenance(
     reporting none.
     """
     ledger = getattr(diff, "disposition_ledger", None)
-    if ledger is None:
-        return tuple(None for _ in suppressed)
-    return tuple(_provenance_row(ledger, change) for change in suppressed)
+    return tuple(
+        SuppressedFinding(
+            finding=finding,
+            provenance=_provenance_row(ledger, finding.change),
+        )
+        for finding in findings
+    )
 
 
 def _provenance_row(ledger: Any, change: Any) -> Mapping[str, Any] | None:
+    if ledger is None:
+        return None
     rule = ledger.rule_for(change)
     return None if rule is None else rule.to_dict()
 
@@ -358,9 +366,7 @@ def _finding_json(finding: ReportFinding) -> dict[str, Any]:
     return row
 
 
-def _suppressed_json(
-    finding: ReportFinding, provenance: Mapping[str, Any] | None
-) -> dict[str, Any]:
+def _suppressed_json(entry: SuppressedFinding) -> dict[str, Any]:
     """One suppressed finding's JSON row: the finding, plus what hid it.
 
     Two fields, because they answer different questions and one cannot stand
@@ -377,10 +383,10 @@ def _suppressed_json(
       disposition audit exists to preserve (Codex review, P1). ``null``
       when the run kept no ledger entry for this finding.
     """
-    row = _finding_json(finding)
+    row = _finding_json(entry.finding)
     row["disposition"] = "suppressed"
-    row["suppression_rule"] = getattr(finding.change, "suppression_rule", None)
-    row["suppression_provenance"] = dict(provenance) if provenance else None
+    row["suppression_rule"] = getattr(entry.finding.change, "suppression_rule", None)
+    row["suppression_provenance"] = dict(entry.provenance) if entry.provenance else None
     return row
 
 
@@ -407,10 +413,7 @@ def _document_json(doc: NoBaselineDocument) -> dict[str, Any]:
         # suppressed" must not look the same to a consumer checking whether
         # policy hid anything (the same convention `contract_coverage_
         # failures` follows -- `[]` rather than omitted).
-        "suppressed_findings": [
-            _suppressed_json(f, p)
-            for f, p in zip(doc.suppressed, doc.suppression_provenance, strict=True)
-        ],
+        "suppressed_findings": [_suppressed_json(entry) for entry in doc.suppressed],
         "suppressed_count": len(doc.suppressed),
         "cross_source_evolution": render_cross_source_evolution_json(doc.evolution),
         "pattern_preprocessor_scan": doc.pattern_preprocessor_scan,
@@ -523,9 +526,8 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
             "| Finding | Symbol | Severity | Suppressed by | Reason | Source | Expires |",
             "| --- | --- | --- | --- | --- | --- | --- |",
         ]
-        for finding, prov in zip(
-            doc.suppressed, doc.suppression_provenance, strict=True
-        ):
+        for entry in doc.suppressed:
+            finding = entry.finding
             change = finding.change
             # The label alone answers "which rule"; a reader deciding whether
             # the waiver still applies needs the reason it was written for,
@@ -533,7 +535,7 @@ def render_no_baseline_markdown(doc: NoBaselineDocument) -> str:
             # collapses label and reason into one string, so a rule stating
             # both showed only its label here (Codex review, P1).
             rule = getattr(change, "suppression_rule", None) or "(rule gave no label)"
-            prov = prov or {}
+            prov = entry.provenance or {}
             reason = prov.get("reason") or "(none stated)"
             source = prov.get("source_file") or "(not recorded)"
             expires = prov.get("expires") or "(never)"

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -204,6 +204,22 @@ class NoBaselineDocument:
     #: disposing" rule requires "detected, then suppressed by rule X" to
     #: stay visible on a passing run, never to read as "nothing found".
     suppressed: tuple[ReportFinding, ...]
+    #: One entry per :attr:`suppressed` finding, positionally aligned: the
+    #: already-serialized :class:`~abicheck.policy.disposition_ledger.
+    #: RuleProvenance` of the rule that actually fired (``None`` only when
+    #: the run recorded no ledger entry for it).
+    #:
+    #: ADR-067 D3's full provenance -- rule id, source file, reason, label,
+    #: expiry -- not a display label. This carried
+    #: ``Change.suppression_rule`` instead, which is
+    #: ``SuppressionOutcome.rule_label()``'s deliberate ``label or reason``
+    #: collapse, so a rule stating both lost its reason and its source file
+    #: in every audit projection (Codex review, P1). Resolved through the
+    #: run's own ledger by object identity -- the same ``rule_for`` join
+    #: ``reporter.py``'s two-sided suppression block uses -- rather than by
+    #: re-evaluating the rule set, which could name a different rule than
+    #: the one that hid the finding.
+    suppression_provenance: tuple[Mapping[str, Any] | None, ...]
     evolution: CrossSourceEvolutionSummary | None
     pattern_preprocessor_scan: dict[str, Any] | None
     run_outcome: dict[str, Any]

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -49,6 +49,8 @@ __all__ = [
     "NO_BASELINE_SUPPORTED_FORMATS",
     "NO_BASELINE_UNSUPPORTED_FORMATS",
     "NoBaselineDocument",
+    "SuppressedFinding",
+    "suppression_rule_label",
 ]
 
 
@@ -179,6 +181,34 @@ NO_BASELINE_EXIT_AXIS_NOTICES: dict[str, str] = {
         "as a clean pass (ADR-065)."
     ),
 }
+
+
+def suppression_rule_label(
+    change: Any, provenance: Mapping[str, Any] | None
+) -> str | None:
+    """The suppressing rule's *label*, or ``None`` when it stated none.
+
+    The one owner of this question, because getting it wrong is easy and has
+    now been gotten wrong three times in this package alone.
+    ``Change.suppression_rule`` is ``SuppressionOutcome.rule_label()``'s
+    ``label or reason`` collapse -- a single string that does not say which
+    of the two it holds -- so reading it as a label is a coin flip. When the
+    run recorded provenance, the real ``label`` is knowable and the collapsed
+    field must not be consulted at all; only a run with no ledger entry falls
+    back to it, and there nothing better is knowable.
+
+    Every projection that shows a label separately from a reason routes
+    through here (the Markdown table's "Suppressed by" column, and
+    ``no_baseline_render._suppression_justification`` for SARIF and JUnit),
+    so a fourth call site cannot quietly form its own opinion. The failure
+    this prevents is a reason printed twice, once under a heading claiming
+    it is a rule label (Codex review, P2, twice).
+    """
+    if provenance:
+        label = provenance.get("label")
+        return str(label) if label else None
+    collapsed = getattr(change, "suppression_rule", None)
+    return str(collapsed) if collapsed else None
 
 
 @dataclass(frozen=True)

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -87,16 +87,36 @@ __all__ = [
 #: field, which implied a version history in a namespace it never had.
 #:
 #: Bump MINOR for an additive field, MAJOR for a removal or a changed
-#: meaning -- the same policy ``REPORT_SCHEMA_VERSION`` follows.
+#: meaning -- the same policy ``REPORT_SCHEMA_VERSION`` follows. A third
+#: case the policy did not name, and should: **moving a field into
+#: ``required`` is a tightening, not an addition.** It does not change what
+#: a producer emits, but it changes what *validates* -- a document that was
+#: schema-valid without the field is rejected afterwards. On a published
+#: version that is a MAJOR change, or grounds for leaving the field
+#: optional; MINOR is not available for it.
 #:
-#: ``1.1`` adds ``suppression_provenance`` to a suppressed finding (ADR-067
-#: D3's full rule record beside the existing display label) and moves
-#: ``old_acquisition_state`` into the root ``required`` list, where it
-#: always belonged -- it is emitted unconditionally. Both are additive: a
-#: ``1.0`` consumer reading the fields it already knows is unaffected, which
-#: is exactly what MINOR promises. Bumped because a consumer that selects or
-#: caches a schema by this string could otherwise not tell the two contracts
-#: apart (Codex review, P2).
+#: ``1.1`` makes both kinds of change, and they are not the same kind.
+#: ``suppression_provenance`` on a suppressed finding (ADR-067 D3's full
+#: rule record beside the existing display label) is genuinely additive,
+#: which is what earns the MINOR bump: a consumer that selects or caches a
+#: schema by this string could otherwise not tell the two contracts apart.
+#: Moving ``old_acquisition_state`` into the root ``required`` list is the
+#: tightening. An earlier revision of this comment called both "additive"
+#: on the grounds that a ``1.0`` consumer reading known fields is
+#: unaffected -- that is the *producer's* view, and a schema's job is
+#: validation, where the change is strictly narrowing (Codex review, P2,
+#: correcting an earlier reply of mine that made the same conflation).
+#:
+#: It is accepted here for one reason, checked rather than assumed: version
+#: ``1.0`` was never released. This schema was introduced on 2026-09-10 in
+#: ``10c4de15``, after the last release (0.5.0, 2026-07-16), with every
+#: changelog fragment since still unreleased in ``changelog.d/`` -- so no
+#: published build has ever emitted a ``1.0`` audit document, and there is
+#: no such document anywhere to invalidate. ``required`` is also the
+#: truthful model, since the field is emitted unconditionally; a schema
+#: marking an always-present field optional describes the format less
+#: accurately. Once a release ships an audit document, the rule above
+#: applies with no such escape.
 AUDIT_REPORT_SCHEMA_VERSION = "1.1"
 
 #: Deprecated alias kept for one release so an in-flight import does not

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -37,9 +37,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from .finding import ReportFinding
+
 if TYPE_CHECKING:
     from .cross_source_evolution import CrossSourceEvolutionSummary
-    from .finding import ReportFinding
 
 __all__ = [
     "AUDIT_REPORT_SCHEMA_VERSION",
@@ -211,9 +212,19 @@ def suppression_rule_label(
     return str(collapsed) if collapsed else None
 
 
-@dataclass(frozen=True)
-class SuppressedFinding:
+@dataclass(frozen=True, slots=True)
+class SuppressedFinding(ReportFinding):
     """One suppressed finding and the rule that actually hid it.
+
+    **A** :class:`~abicheck.report.finding.ReportFinding`, not a wrapper
+    around one: a suppressed entry *is* a finding, and the rule that hid it
+    is one more resolved fact about it. So ``entry.change``/``.verdict``/
+    ``.category`` work exactly as they do on any other finding, and
+    ``isinstance(entry, ReportFinding)`` holds -- which is what keeps every
+    consumer of ``NoBaselineDocument.suppressed`` working unchanged, rather
+    than trading an `AttributeError` for a provenance field (Codex review,
+    P2). A first version paired the two side by side and did force that
+    change on callers.
 
     *provenance* is the already-serialized
     :class:`~abicheck.policy.disposition_ledger.RuleProvenance` -- ADR-067
@@ -232,8 +243,7 @@ class SuppressedFinding:
     ADR-067 record while carrying strictly less.
     """
 
-    finding: ReportFinding
-    provenance: Mapping[str, Any] | None
+    provenance: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -173,6 +173,31 @@ NO_BASELINE_EXIT_AXIS_NOTICES: dict[str, str] = {
 
 
 @dataclass(frozen=True)
+class SuppressedFinding:
+    """One suppressed finding and the rule that actually hid it.
+
+    *provenance* is the already-serialized
+    :class:`~abicheck.policy.disposition_ledger.RuleProvenance` -- ADR-067
+    D3's full record (rule id, source file, reason, label, expiry), not a
+    display label. The audit carried ``Change.suppression_rule`` instead,
+    which is ``SuppressionOutcome.rule_label()``'s deliberate ``label or
+    reason`` collapse, so a rule stating both lost its reason and its source
+    file in every projection (Codex review, P1).
+
+    Resolved through the run's own disposition ledger by object identity --
+    the same ``rule_for`` join ``reporter.py``'s two-sided suppression block
+    uses -- never by re-evaluating the rule set, which could name a
+    different rule than the one that fired. ``None`` when the run kept no
+    ledger entry for this finding (a ``DiffResult`` rebuilt from JSON keeps
+    none); inventing a row from the display label would look like a real
+    ADR-067 record while carrying strictly less.
+    """
+
+    finding: ReportFinding
+    provenance: Mapping[str, Any] | None
+
+
+@dataclass(frozen=True)
 class NoBaselineDocument:
     """The one frozen audit document every format projects.
 
@@ -203,23 +228,12 @@ class NoBaselineDocument:
     #: alongside rather than dropped: ``vision.md``'s "Record before
     #: disposing" rule requires "detected, then suppressed by rule X" to
     #: stay visible on a passing run, never to read as "nothing found".
-    suppressed: tuple[ReportFinding, ...]
-    #: One entry per :attr:`suppressed` finding, positionally aligned: the
-    #: already-serialized :class:`~abicheck.policy.disposition_ledger.
-    #: RuleProvenance` of the rule that actually fired (``None`` only when
-    #: the run recorded no ledger entry for it).
     #:
-    #: ADR-067 D3's full provenance -- rule id, source file, reason, label,
-    #: expiry -- not a display label. This carried
-    #: ``Change.suppression_rule`` instead, which is
-    #: ``SuppressionOutcome.rule_label()``'s deliberate ``label or reason``
-    #: collapse, so a rule stating both lost its reason and its source file
-    #: in every audit projection (Codex review, P1). Resolved through the
-    #: run's own ledger by object identity -- the same ``rule_for`` join
-    #: ``reporter.py``'s two-sided suppression block uses -- rather than by
-    #: re-evaluating the rule set, which could name a different rule than
-    #: the one that hid the finding.
-    suppression_provenance: tuple[Mapping[str, Any] | None, ...]
+    #: Each carries its own rule provenance rather than the document holding
+    #: a second, positionally-aligned tuple: a pairing invariant a renderer
+    #: has to honor is one a renderer can break, and the finding and the
+    #: rule that hid it are one fact.
+    suppressed: tuple[SuppressedFinding, ...]
     evolution: CrossSourceEvolutionSummary | None
     pattern_preprocessor_scan: dict[str, Any] | None
     run_outcome: dict[str, Any]

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -174,11 +174,22 @@ NO_BASELINE_EXIT_AXIS_NOTICES: dict[str, str] = {
 
 @dataclass(frozen=True)
 class NoBaselineDocument:
-    """The one frozen, plain-value audit document every format projects.
+    """The one frozen audit document every format projects.
 
     Holds resolved values only -- no ``DiffResult``, no live policy
     objects -- so a renderer cannot re-derive a verdict or reach past what
     the compute half decided.
+
+    **What "frozen" does and does not buy** (CodeRabbit review). ``frozen=
+    True`` and the tuple-typed collections stop a renderer from rebinding a
+    field or reordering a finding list. They do not deep-freeze the
+    ``Change`` each :class:`~abicheck.report.finding.ReportFinding` carries,
+    which is an ordinary mutable dataclass -- the same one every other
+    ``compute_*``/``render_*`` pair in this package hands to its renderers.
+    Deep-copying it here would fork that shared shape for one command and
+    silently double a large report's allocation, so the barrier this class
+    actually enforces is *structural* (no verdict, no policy object, nothing
+    to re-derive from) rather than a memory-level guarantee.
     """
 
     library: str

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -306,6 +306,24 @@ class NoBaselineDocument:
     #: a second, positionally-aligned tuple: a pairing invariant a renderer
     #: has to honor is one a renderer can break, and the finding and the
     #: rule that hid it are one fact.
+    #: Typed as :class:`SuppressedFinding`, deliberately, even though
+    #: :func:`suppression_provenance_of` lets every renderer tolerate a plain
+    #: :class:`~abicheck.report.finding.ReportFinding` at runtime. Those two
+    #: facts are not in conflict: the tolerance is defensive robustness for a
+    #: hand-built document (an ``AttributeError`` from inside a renderer is a
+    #: terrible failure), while the annotation states what this package
+    #: *produces* and what a consumer may therefore rely on.
+    #:
+    #: Widening it to ``ReportFinding`` was considered and rejected on
+    #: measurement, not taste (Codex review, P2): under that annotation mypy
+    #: reports ``"ReportFinding" has no attribute "provenance"`` for the one
+    #: consumer this whole feature exists to serve -- code reading a
+    #: suppression's rule record off a computed document -- and breaks this
+    #: package's own ``mypy abicheck/`` cleanliness at ``_suppressed_json``.
+    #: A union does not help either: ``ReportFinding | SuppressedFinding``
+    #: collapses to ``ReportFinding``, since the latter is a subclass. So the
+    #: choice is binary, and it favours the real consumer over a hypothetical
+    #: caller hand-constructing a fourteen-field document.
     suppressed: tuple[SuppressedFinding, ...]
     evolution: CrossSourceEvolutionSummary | None
     pattern_preprocessor_scan: dict[str, Any] | None

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -51,6 +51,7 @@ __all__ = [
     "NO_BASELINE_UNSUPPORTED_FORMATS",
     "NoBaselineDocument",
     "SuppressedFinding",
+    "suppression_provenance_of",
     "suppression_rule_label",
 ]
 
@@ -210,6 +211,29 @@ def suppression_rule_label(
         return str(label) if label else None
     collapsed = getattr(change, "suppression_rule", None)
     return str(collapsed) if collapsed else None
+
+
+def suppression_provenance_of(
+    entry: ReportFinding,
+) -> Mapping[str, Any] | None:
+    """The suppressing rule's record for *entry*, or ``None`` when it has none.
+
+    The one place any projection asks. ``NoBaselineDocument.suppressed`` is
+    typed as :class:`SuppressedFinding`, but the document is an ordinary
+    frozen dataclass a caller can build or ``dataclasses.replace`` by hand,
+    and a caller written against the pre-pairing shape passes plain
+    :class:`~abicheck.report.finding.ReportFinding` entries -- which made
+    every detailed renderer raise ``AttributeError`` on ``entry.provenance``
+    (Codex review, P2).
+
+    ``None`` for such an entry is the *truthful* answer, not a papered-over
+    one: a document carrying plain findings genuinely holds no ledger
+    record, so "no provenance recorded" is what it has to say. That is the
+    same distinction the renderers already draw for a run whose
+    ``DiffResult`` kept no ledger -- and the opposite of fabricating a
+    record, which is what this file's other rules forbid.
+    """
+    return getattr(entry, "provenance", None)
 
 
 @dataclass(frozen=True, slots=True)

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -84,7 +84,16 @@ __all__ = [
 #:
 #: Bump MINOR for an additive field, MAJOR for a removal or a changed
 #: meaning -- the same policy ``REPORT_SCHEMA_VERSION`` follows.
-AUDIT_REPORT_SCHEMA_VERSION = "1.0"
+#:
+#: ``1.1`` adds ``suppression_provenance`` to a suppressed finding (ADR-067
+#: D3's full rule record beside the existing display label) and moves
+#: ``old_acquisition_state`` into the root ``required`` list, where it
+#: always belonged -- it is emitted unconditionally. Both are additive: a
+#: ``1.0`` consumer reading the fields it already knows is unaffected, which
+#: is exactly what MINOR promises. Bumped because a consumer that selects or
+#: caches a schema by this string could otherwise not tell the two contracts
+#: apart (Codex review, P2).
+AUDIT_REPORT_SCHEMA_VERSION = "1.1"
 
 #: Deprecated alias kept for one release so an in-flight import does not
 #: break; it names the same string. Prefer the name above.

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -270,6 +270,24 @@ class SuppressedFinding(ReportFinding):
     P2). A first version paired the two side by side and did force that
     change on callers.
 
+    **Equality is per-class, deliberately.** The generated ``__eq__``
+    requires the same runtime class, so a ``SuppressedFinding`` never
+    compares equal to a bare ``ReportFinding`` holding the same three
+    fields, in either direction, and provenance participates in equality
+    between two suppressed entries. A review asked for the former
+    cross-class equality to be preserved (Codex, P2); it was measured
+    rather than argued, and declined. ``field(compare=False)`` does not
+    achieve it -- the class check blocks cross-class equality regardless --
+    so the only route is a hand-written ``__eq__`` ignoring both the class
+    and provenance. That works, and symmetry and transitivity do hold, but
+    the price is that two suppressions under *different waiver rules*
+    compare equal: provenance stops counting in equality at all. Dropping a
+    recorded field on the way to a consumer is the exact defect this class
+    exists to fix, and equality is a consumer. No caller compares these
+    entries either -- every use of ``NoBaselineDocument.suppressed`` in this
+    repository iterates or projects. Pinned by
+    ``test_suppressed_finding_equality_is_per_class``.
+
     *provenance* is the already-serialized
     :class:`~abicheck.policy.disposition_ledger.RuleProvenance` -- ADR-067
     D3's full record (rule id, source file, reason, label, expiry), not a

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -36,7 +36,10 @@ import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING, Any
 
 from .cross_source_evolution import change_cross_source_evolution_field
-from .no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
+from .no_baseline_document import (
+    NO_BASELINE_EXIT_AXIS_LABELS,
+    suppression_rule_label,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -74,17 +77,12 @@ def _suppression_justification(
     provenance at all -- the case where nothing better is knowable -- and
     then stands alone rather than being paired with anything.
     """
-    if provenance:
-        reason = provenance.get("reason")
-        label = provenance.get("label")
-        if reason and label:
-            return f"{label}: {reason}"
-        if reason or label:
-            return str(reason or label)
-    else:
-        collapsed = getattr(change, "suppression_rule", None)
-        if collapsed:
-            return str(collapsed)
+    label = suppression_rule_label(change, provenance)
+    reason = (provenance or {}).get("reason")
+    if reason and label:
+        return f"{label}: {reason}"
+    if reason or label:
+        return str(reason or label)
     return "suppressed by an abicheck --suppress rule"
 
 

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -293,6 +293,20 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
     ):
         ET.SubElement(props, "property", {"name": name, "value": value or ""})
 
+    # One property per orthogonal exit axis, carrying its own contribution.
+    # Without these the suite published only the total and the coverage
+    # contribution, so a JUnit consumer gated by (say) the evidence contract
+    # could not tell *which* axis fired -- the failure text merely listed
+    # every axis that might have (Codex review, P2). Every axis the run
+    # resolved is emitted, contributing or not, so a `0` is a real "this axis
+    # was evaluated and cleared" rather than an absent key.
+    for axis, contribution in doc.exit_axes.items():
+        ET.SubElement(
+            props,
+            "property",
+            {"name": f"exit_axis.{axis}", "value": str(contribution)},
+        )
+
     for finding in doc.findings:
         _junit_finding_case(suite, finding, suppressed=False)
     for finding in doc.suppressed:
@@ -316,13 +330,40 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
                 "message": f"audit exited {doc.exit_code}",
             },
         )
-        failure.text = (
-            f"exit code: {doc.exit_code}\n"
-            f"contract coverage contribution: {doc.coverage_exit_contribution}\n"
+        # Name the axes that actually fired, and what each one means -- the
+        # same resolved `exit_axes` the JSON, Markdown, oneline and SARIF
+        # projections read, so no format explains an exit the others cannot
+        # (Codex review, P2). Listing every possible axis instead, as this
+        # used to, tells a gated consumer nothing.
+        contributing = [
+            axis for axis, contribution in doc.exit_axes.items() if contribution
+        ]
+        detail = [
+            f"exit code: {doc.exit_code}",
+            f"contract coverage contribution: {doc.coverage_exit_contribution}",
             "note: a candidate-side hygiene finding never gates on its own "
-            "(ADR-028 D3 / ADR-035 D1); this is one of the orthogonal axes "
-            "(contract coverage, analysis assurance, evidence contract)."
-        )
+            "(ADR-028 D3 / ADR-035 D1); an audit's exit code is a max over "
+            "orthogonal axes.",
+        ]
+        if contributing:
+            detail.append("")
+            detail.append("contributing axes:")
+            detail += [
+                f"- {NO_BASELINE_EXIT_AXIS_LABELS.get(axis, axis)} "
+                f"(contributed {doc.exit_axes[axis]})"
+                for axis in contributing
+            ]
+        # The coverage ledger itself, for the one axis that can name a
+        # specific provider -- the number alone says nothing about which
+        # provider on which side fell short.
+        if doc.coverage_failures:
+            detail.append("")
+            detail.append("contract coverage failures:")
+            detail += [
+                "- " + ", ".join(f"{k}={v}" for k, v in sorted(f.items()))
+                for f in doc.coverage_failures
+            ]
+        failure.text = "\n".join(detail)
     ET.indent(suite, space="  ")
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(
         suite, encoding="unicode"

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -228,7 +228,7 @@ def render_no_baseline_sarif(doc: NoBaselineDocument) -> dict[str, Any]:
     # shows it as suppressed instead of never learning it existed
     # (``vision.md``'s "Record before disposing"; Codex review, P1).
     for finding, suppressed, provenance in [(f, False, None) for f in doc.findings] + [
-        (entry.finding, True, entry.provenance) for entry in doc.suppressed
+        (entry, True, entry.provenance) for entry in doc.suppressed
     ]:
         rule = _rule_for(finding.change.kind)
         rules.setdefault(rule["id"], rule)
@@ -371,9 +371,7 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
         # `suppressions` array for this and JUnit's nearest honest
         # equivalent is a skipped case -- the finding is reported, and its
         # disposition is legible, without claiming it broke anything.
-        _junit_finding_case(
-            suite, entry.finding, suppressed=True, provenance=entry.provenance
-        )
+        _junit_finding_case(suite, entry, suppressed=True, provenance=entry.provenance)
 
     gate = ET.SubElement(
         suite,

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -60,17 +60,32 @@ def _suppression_justification(
 ) -> str:
     """The human-readable half of a suppression, best information first.
 
-    The reason a rule states, then its label, then a generic fallback. The
-    display label (`Change.suppression_rule`) is `label or reason`, so
-    reading only it publishes whichever the rule happened to state first and
-    silently drops the other.
+    ``label: reason`` when the rule states both, otherwise whichever single
+    field it states, otherwise a generic fallback.
+
+    The two sources are read separately and never mixed, which is the whole
+    point. ``Change.suppression_rule`` is ``label or reason`` -- one string
+    that does not say *which* it holds -- so treating it as a label whenever
+    provenance lacked one rendered a reason-only rule as
+    ``"<reason>: <reason>"``, presenting the reason as a separate rule label
+    (Codex review, P2). That is the shape ``suppression.require_justification``
+    actively encourages, so it is the common case, not an edge one.
+    The collapsed field is therefore consulted *only* when there is no
+    provenance at all -- the case where nothing better is knowable -- and
+    then stands alone rather than being paired with anything.
     """
-    prov = provenance or {}
-    reason = prov.get("reason")
-    label = prov.get("label") or getattr(change, "suppression_rule", None)
-    if reason and label:
-        return f"{label}: {reason}"
-    return str(reason or label or "suppressed by an abicheck --suppress rule")
+    if provenance:
+        reason = provenance.get("reason")
+        label = provenance.get("label")
+        if reason and label:
+            return f"{label}: {reason}"
+        if reason or label:
+            return str(reason or label)
+    else:
+        collapsed = getattr(change, "suppression_rule", None)
+        if collapsed:
+            return str(collapsed)
+    return "suppressed by an abicheck --suppress rule"
 
 
 def _sarif_result(

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -176,7 +176,7 @@ def render_no_baseline_sarif(doc: NoBaselineDocument) -> dict[str, Any]:
     # shows it as suppressed instead of never learning it existed
     # (``vision.md``'s "Record before disposing"; Codex review, P1).
     for finding, suppressed in [(f, False) for f in doc.findings] + [
-        (f, True) for f in doc.suppressed
+        (entry.finding, True) for entry in doc.suppressed
     ]:
         rule = _rule_for(finding.change.kind)
         rules.setdefault(rule["id"], rule)
@@ -309,12 +309,12 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
 
     for finding in doc.findings:
         _junit_finding_case(suite, finding, suppressed=False)
-    for finding in doc.suppressed:
+    for entry in doc.suppressed:
         # `<skipped>`, not a silent omission and not a failure: SARIF has a
         # `suppressions` array for this and JUnit's nearest honest
         # equivalent is a skipped case -- the finding is reported, and its
         # disposition is legible, without claiming it broke anything.
-        _junit_finding_case(suite, finding, suppressed=True)
+        _junit_finding_case(suite, entry.finding, suppressed=True)
 
     gate = ET.SubElement(
         suite,

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 from .cross_source_evolution import change_cross_source_evolution_field
 from .no_baseline_document import (
     NO_BASELINE_EXIT_AXIS_LABELS,
+    suppression_provenance_of,
     suppression_rule_label,
 )
 
@@ -228,7 +229,7 @@ def render_no_baseline_sarif(doc: NoBaselineDocument) -> dict[str, Any]:
     # shows it as suppressed instead of never learning it existed
     # (``vision.md``'s "Record before disposing"; Codex review, P1).
     for finding, suppressed, provenance in [(f, False, None) for f in doc.findings] + [
-        (entry, True, entry.provenance) for entry in doc.suppressed
+        (entry, True, suppression_provenance_of(entry)) for entry in doc.suppressed
     ]:
         rule = _rule_for(finding.change.kind)
         rules.setdefault(rule["id"], rule)
@@ -371,7 +372,12 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
         # `suppressions` array for this and JUnit's nearest honest
         # equivalent is a skipped case -- the finding is reported, and its
         # disposition is legible, without claiming it broke anything.
-        _junit_finding_case(suite, entry, suppressed=True, provenance=entry.provenance)
+        _junit_finding_case(
+            suite,
+            entry,
+            suppressed=True,
+            provenance=suppression_provenance_of(entry),
+        )
 
     gate = ET.SubElement(
         suite,

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -39,6 +39,8 @@ from .cross_source_evolution import change_cross_source_evolution_field
 from .no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from .finding import ReportFinding
     from .no_baseline_document import NoBaselineDocument
 
@@ -53,14 +55,44 @@ _SARIF_SCHEMA_URL = (
 )
 
 
+def _suppression_justification(
+    change: Any, provenance: Mapping[str, Any] | None
+) -> str:
+    """The human-readable half of a suppression, best information first.
+
+    The reason a rule states, then its label, then a generic fallback. The
+    display label (`Change.suppression_rule`) is `label or reason`, so
+    reading only it publishes whichever the rule happened to state first and
+    silently drops the other.
+    """
+    prov = provenance or {}
+    reason = prov.get("reason")
+    label = prov.get("label") or getattr(change, "suppression_rule", None)
+    if reason and label:
+        return f"{label}: {reason}"
+    return str(reason or label or "suppressed by an abicheck --suppress rule")
+
+
 def _sarif_result(
-    finding: ReportFinding, *, rule_id: str, suppressed: bool
+    finding: ReportFinding,
+    *,
+    rule_id: str,
+    suppressed: bool,
+    provenance: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """One SARIF ``result`` for a candidate-side finding.
 
     Split out of :func:`render_no_baseline_sarif` so the envelope there reads
     as the run it describes, and the per-finding shape sits next to its JUnit
     counterpart (:func:`_junit_finding_case`) rather than buried in a loop.
+
+    *provenance* is the suppressing rule's full ADR-067 D3 record. It is
+    carried into the SARIF suppression rather than only the display label,
+    which is `label or reason` and so drops whichever the rule stated
+    second (Codex review, P2 -- the JSON and Markdown projections gained
+    this first, and a fact one format publishes while its siblings drop it
+    leaves a consumer of the quiet format unable to act on the run it was
+    handed).
     """
     from ..sarif import _parse_source_location
 
@@ -79,13 +111,20 @@ def _sarif_result(
         },
     }
     if suppressed:
-        entry["suppressions"] = [
-            {
-                "kind": "external",
-                "justification": getattr(change, "suppression_rule", None)
-                or "suppressed by an abicheck --suppress rule",
-            }
-        ]
+        suppression: dict[str, Any] = {
+            "kind": "external",
+            # SARIF's `justification` is free text, so it carries the reason
+            # a human wrote when the rule states one -- that is the field's
+            # actual purpose -- and falls back to the label only when there
+            # is no reason to give.
+            "justification": _suppression_justification(change, provenance),
+        }
+        if provenance:
+            # The structured record too: `justification` is one string, and a
+            # consumer deciding whether a waiver still applies needs the
+            # source file and expiry as data, not prose.
+            suppression["properties"] = dict(provenance)
+        entry["suppressions"] = [suppression]
     if change.source_location:
         uri, line, column = _parse_source_location(change.source_location)
         region: dict[str, Any] = {}
@@ -175,13 +214,18 @@ def render_no_baseline_sarif(doc: NoBaselineDocument) -> dict[str, Any]:
     # dispositioned" -- rather than dropped. A code-scanning consumer then
     # shows it as suppressed instead of never learning it existed
     # (``vision.md``'s "Record before disposing"; Codex review, P1).
-    for finding, suppressed in [(f, False) for f in doc.findings] + [
-        (entry.finding, True) for entry in doc.suppressed
+    for finding, suppressed, provenance in [(f, False, None) for f in doc.findings] + [
+        (entry.finding, True, entry.provenance) for entry in doc.suppressed
     ]:
         rule = _rule_for(finding.change.kind)
         rules.setdefault(rule["id"], rule)
         results.append(
-            _sarif_result(finding, rule_id=rule["id"], suppressed=suppressed)
+            _sarif_result(
+                finding,
+                rule_id=rule["id"],
+                suppressed=suppressed,
+                provenance=provenance,
+            )
         )
     return {
         "$schema": _SARIF_SCHEMA_URL,
@@ -314,7 +358,9 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
         # `suppressions` array for this and JUnit's nearest honest
         # equivalent is a skipped case -- the finding is reported, and its
         # disposition is legible, without claiming it broke anything.
-        _junit_finding_case(suite, entry.finding, suppressed=True)
+        _junit_finding_case(
+            suite, entry.finding, suppressed=True, provenance=entry.provenance
+        )
 
     gate = ET.SubElement(
         suite,
@@ -371,7 +417,11 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
 
 
 def _junit_finding_case(
-    suite: ET.Element, finding: ReportFinding, *, suppressed: bool
+    suite: ET.Element,
+    finding: ReportFinding,
+    *,
+    suppressed: bool,
+    provenance: Mapping[str, Any] | None = None,
 ) -> None:
     """One passing (or skipped) ``<testcase>`` for a candidate-side finding."""
     change = finding.change
@@ -393,12 +443,35 @@ def _junit_finding_case(
         "and a hygiene finding is advisory -- it does not gate."
     )
     if suppressed:
-        rule = getattr(change, "suppression_rule", None)
+        # The message carries the reason where the rule states one, not just
+        # the display label (`label or reason`, which drops whichever the
+        # rule stated second) -- the same statement the JSON, Markdown and
+        # SARIF projections make (Codex review, P2).
         skipped = ET.SubElement(
             case,
             "skipped",
-            {"message": f"suppressed: {rule or 'a --suppress rule matched'}"},
+            {
+                "message": f"suppressed: {_suppression_justification(change, provenance)}"
+            },
         )
-        skipped.text = detail
+        # The structured record below the message, so a consumer can read the
+        # source file and expiry as data rather than parsing prose out of an
+        # attribute.
+        skipped.text = "\n".join([detail, *_provenance_detail_lines(provenance)])
     else:
         ET.SubElement(case, "system-out").text = detail
+
+
+def _provenance_detail_lines(provenance: Mapping[str, Any] | None) -> list[str]:
+    """The suppressing rule's ADR-067 record, as plain ``key: value`` lines.
+
+    Empty when the run kept no ledger entry -- never a fabricated row, which
+    would look like a real record while carrying strictly less.
+    """
+    if not provenance:
+        return []
+    return [
+        "",
+        "suppression rule:",
+        *[f"  {key}: {value}" for key, value in sorted(provenance.items())],
+    ]

--- a/abicheck/report/no_baseline_render.py
+++ b/abicheck/report/no_baseline_render.py
@@ -416,6 +416,21 @@ def render_no_baseline_junit(doc: NoBaselineDocument) -> str:
                 f"(contributed {doc.exit_axes[axis]})"
                 for axis in contributing
             ]
+        else:
+            # A document this package builds cannot reach here: its exit
+            # code is `max(exit_axes.values())`, so a nonzero one always has
+            # a nonzero axis behind it. A *hand-built* document can, since
+            # `exit_axes` defaults to empty -- and the honest answer is to
+            # say the record is missing rather than to leave a gated
+            # consumer with a bare number, which is the very failure the
+            # comment above names. Inventing an axis would be worse than
+            # silence; saying nothing was recorded is neither.
+            detail.append("")
+            detail.append(
+                "contributing axes: none recorded -- this document carries an "
+                "exit code with no per-axis breakdown, so which axis gated "
+                "cannot be answered from it."
+            )
         # The coverage ledger itself, for the one axis that can name a
         # specific provider -- the number alone says nothing about which
         # provider on which side fell short.

--- a/abicheck/schemas/audit_report.schema.json
+++ b/abicheck/schemas/audit_report.schema.json
@@ -9,6 +9,7 @@
     "no_baseline",
     "library",
     "verdict",
+    "old_acquisition_state",
     "changes",
     "findings",
     "exit_code"

--- a/abicheck/schemas/audit_report.schema.json
+++ b/abicheck/schemas/audit_report.schema.json
@@ -58,7 +58,7 @@
   "properties": {
     "audit_report_schema_version": {
       "type": "string",
-      "description": "SemVer-style version of THIS schema (e.g. \"1.0\"). Consumers should accept any version with the same MAJOR component. Deliberately not named `report_schema_version`: that field identifies a compare report, and an audit is a different document.",
+      "description": "SemVer-style version of THIS schema (currently \"1.1\"). Consumers should accept any version with the same MAJOR component. Deliberately not named `report_schema_version`: that field identifies a compare report, and an audit is a different document.",
       "pattern": "^[0-9]+\\.[0-9]+$"
     },
     "no_baseline": {

--- a/abicheck/schemas/audit_report.schema.json
+++ b/abicheck/schemas/audit_report.schema.json
@@ -34,7 +34,24 @@
         },
         "candidate_side_enrichment": {"type": "boolean"},
         "observed_value": {"type": ["string", "null"]},
-        "suppression_rule": {"type": ["string", "null"]}
+        "suppression_rule": {
+          "type": ["string", "null"],
+          "description": "The rule's short display label (its `label`, else its `reason`). See `suppression_provenance` for the full record."
+        },
+        "suppression_provenance": {
+          "type": ["object", "null"],
+          "description": "ADR-067 D3's full provenance of the rule that hid this finding: rule id, source file, reason, label, expiry. Distinct from `suppression_rule`, which is only the short display label and so cannot carry both a label and a reason. `null` when the run recorded no ledger entry for this finding.",
+          "additionalProperties": true,
+          "properties": {
+            "rule_id": {"type": ["string", "null"], "description": "The rule's canonical selector-and-gate identity, so two rules sharing a label stay distinguishable."},
+            "source_file": {"type": ["string", "null"], "description": "The --suppress document the rule was loaded from."},
+            "reason": {"type": ["string", "null"]},
+            "label": {"type": ["string", "null"]},
+            "expires": {"type": ["string", "null"], "description": "ISO-8601 date, or null for a rule that never lapses."},
+            "intent": {"type": ["string", "null"]},
+            "allow_public_break": {"type": "boolean"}
+          }
+        }
       }
     }
   },

--- a/abicheck/workflows/input_resolution.py
+++ b/abicheck/workflows/input_resolution.py
@@ -195,7 +195,7 @@ def is_stored_snapshot_operand(path: Path) -> bool:
             # package's own `manifest.json` content rather than its
             # filename, which a `BuildSourcePack` shares.
             return is_project_snapshot_package_dir(path)
-        return sniff_text_format(path) in ("json", "perl")
+        return sniff_text_format(path) in {"json", "perl"}
     except OSError:
         return False
 

--- a/abicheck/workflows/input_resolution.py
+++ b/abicheck/workflows/input_resolution.py
@@ -154,22 +154,31 @@ def is_stored_snapshot_operand(path: Path) -> bool:
     ``detect_binary_format(path) is not None`` instead -- "is this a native
     binary?" -- which is a *narrower* question with a different answer for
     every operand that is neither: a ``Module.symvers`` manifest, a bare
-    BTF/CTF blob, an ABICC Perl dump. `resolve_input` parses each of those
-    into a brand-new snapshot that structurally cannot carry L3-L5 build or
-    source evidence, yet all three read as "stored" and were exempted, so
+    BTF/CTF blob. `resolve_input` derives a brand-new snapshot from each of
+    those, yet both read as "stored" and were exempted, so
     ``compare --no-baseline Module.symvers --depth source`` reported a clean
     audit with *no evidence tiers at all* and exit 0 (Codex review, P1 --
     and the two-sided ``compare a.symvers b.symvers --depth source`` did the
     same, so this is the shared cause, not one path's copy of it).
 
-    Only a real serialized snapshot is exempt, because only a real serialized
-    snapshot can *already carry* the pinned evidence -- and when it does not,
+    The line is **an already-serialized ABI description** (whoever wrote it)
+    versus **raw evidence this run derives a description from**. Only the
+    former can *already carry* the pinned evidence -- and when it does not,
     that is the separately-recorded ceiling question ("``--depth`` is a floor
     for live extraction, not a ceiling for a pre-built snapshot"), not a
-    floor failure. Covers both shapes `resolve_input` accepts: a single
+    floor failure. Covers the three shapes `resolve_input` accepts: a single
     ``.abi.json`` file (including the gzip/zstd-compressed spellings, via
-    :func:`sniff_text_format`'s bounded decoded prefix) and a directory-backed
-    storage-v2 ``ProjectSnapshot`` package.
+    :func:`sniff_text_format`'s bounded decoded prefix), a directory-backed
+    storage-v2 ``ProjectSnapshot`` package, and an ABICC Perl dump.
+
+    That last one was classified as raw evidence in this function's first
+    form, which made ``--depth source`` exit 7 on a saved ABICC dump and 0 on
+    the equivalent ``.abi.json`` (Codex review, P2). Both are pre-built,
+    tool-produced ABI descriptions that this run parses rather than extracts;
+    for a tool that advertises itself as an ABICC drop-in, splitting them on
+    serialization format alone is arbitrary. A ``Module.symvers`` manifest and
+    a bare BTF/CTF blob stay on the raw-evidence side: they are inputs an ABI
+    description is *derived* from, not one that was already written down.
 
     Errs toward "not stored" on an unreadable path, matching the callers'
     own fail-loud direction: resolution raises a real, specific error moments
@@ -186,7 +195,7 @@ def is_stored_snapshot_operand(path: Path) -> bool:
             # package's own `manifest.json` content rather than its
             # filename, which a `BuildSourcePack` shares.
             return is_project_snapshot_package_dir(path)
-        return sniff_text_format(path) == "json"
+        return sniff_text_format(path) in ("json", "perl")
     except OSError:
         return False
 

--- a/catalog/cases/case143_audit_accidental_export/README.md
+++ b/catalog/cases/case143_audit_accidental_export/README.md
@@ -5,15 +5,19 @@
 ## Verdict and consumer impact
 
 This is a **single-release audit** (ADR-035 "G20" corpus): there is no v1/v2
-pair to diff, just one build's evidence checked against itself. abicheck's
-verdict is `COMPATIBLE` — nothing here is a break today — but the audit flags
-an advisory ABI-hygiene finding: `debug_dump()` ships with default ELF
-visibility (so it's in the dynamic symbol table, and any consumer can `dlsym`
-or link against it) yet it is never declared in a public header. Whoever
-maintains this library believes `debug_dump()` is private and free to change
-or remove at will; in reality it's already load-bearing ABI for anyone who
-found it in `nm -D libdemo.so`. The fix belongs in *this* release, not after
-a consumer files a breakage report against a "private" function.
+pair to diff, just one build's evidence checked against itself. abicheck
+reports **no verdict at all** (`"verdict": null`): ADR-068 D2 — a single build
+has nothing to be compatible *with*, so the audit answers what is *present*,
+not whether something broke. (The catalog's own 🟢 COMPATIBLE classification
+above is a statement about the case, not about the command's output: nothing
+here is a break today.) The audit flags an advisory ABI-hygiene finding:
+`debug_dump()` ships with default ELF visibility (so it's in the dynamic
+symbol table, and any consumer can `dlsym` or link against it) yet it is never
+declared in a public header. Whoever maintains this library believes
+`debug_dump()` is private and free to change or remove at will; in reality
+it's already load-bearing ABI for anyone who found it in `nm -D libdemo.so`.
+The fix belongs in *this* release, not after a consumer files a breakage
+report against a "private" function.
 
 ## What this snapshot contains
 

--- a/catalog/cases/case144_audit_private_header_leak/README.md
+++ b/catalog/cases/case144_audit_private_header_leak/README.md
@@ -5,16 +5,19 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags an advisory finding: the public function `make_widget()`
-returns `detail::WidgetImpl*`, and `detail::WidgetImpl` is a type defined
-only in a **private, non-installed header**. Consumers linking against the
-public headers cannot legally name `detail::WidgetImpl` (they'd have to
-reach into a header the library never installs), yet the pointer type is
-already part of the exported signature. The maintainer never reasoned about
-this as public API surface, but it already is one — the day the private
-header's layout changes, every caller holding a `detail::WidgetImpl*` is
-silently exposed to a layout mismatch with no compiler warning to catch it.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags an advisory finding: the public
+function `make_widget()` returns `detail::WidgetImpl*`, and
+`detail::WidgetImpl` is a type defined only in a **private, non-installed
+header**. Consumers linking against the public headers cannot legally name
+`detail::WidgetImpl` (they'd have to reach into a header the library never
+installs), yet the pointer type is already part of the exported signature. The
+maintainer never reasoned about this as public API surface, but it already is
+one — the day the private header's layout changes, every caller holding a
+`detail::WidgetImpl*` is silently exposed to a layout mismatch with no
+compiler warning to catch it.
 
 ## What this snapshot contains
 

--- a/catalog/cases/case145_audit_unversioned_export/README.md
+++ b/catalog/cases/case145_audit_unversioned_export/README.md
@@ -5,15 +5,17 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: the library defines a symbol-versioning scheme
-(`DEMO_1.0` in `.gnu.version_d`) for `demo_init`/`demo_run`, yet a third
-export, `demo_experimental`, ships with **no version node at all**. Once
-consumers link against the bare (unversioned) `demo_experimental` symbol,
-the library has no way to later ship an incompatible `demo_experimental`
-under a new version node the way it can for the versioned symbols — the
-usual "add `DEMO_2.0`, keep `DEMO_1.0` for old binaries" escape hatch
-doesn't exist for a symbol that was never versioned in the first place.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: the library defines a symbol-versioning
+scheme (`DEMO_1.0` in `.gnu.version_d`) for `demo_init`/`demo_run`, yet a
+third export, `demo_experimental`, ships with **no version node at all**. Once
+consumers link against the bare (unversioned) `demo_experimental` symbol, the
+library has no way to later ship an incompatible `demo_experimental` under a
+new version node the way it can for the versioned symbols — the usual "add
+`DEMO_2.0`, keep `DEMO_1.0` for old binaries" escape hatch doesn't exist for a
+symbol that was never versioned in the first place.
 
 ## What this snapshot contains
 

--- a/catalog/cases/case146_audit_rtti_for_internal/README.md
+++ b/catalog/cases/case146_audit_rtti_for_internal/README.md
@@ -5,13 +5,15 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: `_ZTI12InternalNode`/`_ZTV12InternalNode` (the C++
-typeinfo and vtable for `InternalNode`) are both exported from the dynamic
-symbol table, but `InternalNode` is declared **only in a private header** —
-`render()` is the sole function the public headers actually declare.
-Consumers can't name `InternalNode` in their own code, so they can't be
-handed one directly, but the exported RTTI still lets any code that obtains
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: `_ZTI12InternalNode`/`_ZTV12InternalNode`
+(the C++ typeinfo and vtable for `InternalNode`) are both exported from the
+dynamic symbol table, but `InternalNode` is declared **only in a private
+header** — `render()` is the sole function the public headers actually
+declare. Consumers can't name `InternalNode` in their own code, so they can't
+be handed one directly, but the exported RTTI still lets any code that obtains
 an `InternalNode*` polymorphically (e.g. via a base-class pointer returned
 from elsewhere in the library) run `dynamic_cast`/`typeid` against it. That
 couples consumer binaries to an internal class's identity without the

--- a/catalog/cases/case147_scan_depth_ladder/README.md
+++ b/catalog/cases/case147_scan_depth_ladder/README.md
@@ -5,15 +5,17 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: `connect()` is a public function that takes
-`detail::SessionState&`, a type declared only in a private header — the same
-`private_header_leak` shape as case144, but this case exists to demonstrate
-*how much evidence abicheck needed to prove it*. ADR-035's honest-coverage
-promise is that a scan says exactly what each depth proved and what it
-could not, rather than silently upgrading a hint into a confirmed finding.
-This case is the legibility anchor for that promise: the same input, read at
-increasing evidence depth.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: `connect()` is a public function that
+takes `detail::SessionState&`, a type declared only in a private header — the
+same `private_header_leak` shape as case144, but this case exists to
+demonstrate *how much evidence abicheck needed to prove it*. ADR-035's
+honest-coverage promise is that a scan says exactly what each depth proved and
+what it could not, rather than silently upgrading a hint into a confirmed
+finding. This case is the legibility anchor for that promise: the same input,
+read at increasing evidence depth.
 
 ## What this snapshot contains
 

--- a/catalog/cases/case150_xcheck_export_public_pair/README.md
+++ b/catalog/cases/case150_xcheck_export_public_pair/README.md
@@ -5,9 +5,11 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags two advisory findings that are the two failure directions
-of the same L0-exports ↔ L2-decls contract:
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags two advisory findings that are the
+two failure directions of the same L0-exports ↔ L2-decls contract:
 
 | Direction | Symptom | Cross-check |
 |-----------|---------|--------------|

--- a/catalog/cases/case181_xcheck_public_to_internal_dependency/README.md
+++ b/catalog/cases/case181_xcheck_public_to_internal_dependency/README.md
@@ -5,20 +5,22 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags an advisory finding: the public, header-declared
-`json_parse()` calls straight into `validate_utf8()`, a helper declared
-only in `src/json_internal.cc`, a private implementation file with no
-public declaration anywhere. Nothing about `json_parse()`'s own signature
-says this — the dependency is only visible by walking the L5 source
-graph's `DECL_CALLS_DECL` edge from the public declaration to the internal
-one. If `validate_utf8()`'s behavior changes next release, `json_parse()`'s
-contract silently shifts with it, with no signal in a public-header diff
-at all. This is the intra-version counterpart to case150's
-`exported_not_public`/`public_not_exported` pair: that pair catches a
-mismatch between *what's exported* and *what's declared*; this one catches
-a mismatch **inside** a single public entry point — its behavior depends
-on an entity consumers cannot see, version, or reason about independently.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags an advisory finding: the public,
+header-declared `json_parse()` calls straight into `validate_utf8()`, a helper
+declared only in `src/json_internal.cc`, a private implementation file with no
+public declaration anywhere. Nothing about `json_parse()`'s own signature says
+this — the dependency is only visible by walking the L5 source graph's
+`DECL_CALLS_DECL` edge from the public declaration to the internal one. If
+`validate_utf8()`'s behavior changes next release, `json_parse()`'s contract
+silently shifts with it, with no signal in a public-header diff at all. This
+is the intra-version counterpart to case150's
+`exported_not_public`/`public_not_exported` pair: that pair catches a mismatch
+between *what's exported* and *what's declared*; this one catches a mismatch
+**inside** a single public entry point — its behavior depends on an entity
+consumers cannot see, version, or reason about independently.
 
 ## What this snapshot contains
 

--- a/changelog.d/1789000000_claude_no-baseline-audit-findings.md
+++ b/changelog.d/1789000000_claude_no-baseline-audit-findings.md
@@ -8,6 +8,23 @@
   `compare` would. Resolved through the same function at the same
   CLI > config > default precedence, and `--config` is accepted rather than
   rejected, since the discovered file is now honored.
+- **The audit honors `.abicheck.yml`'s suppression *acceptance* rules.**
+  `suppression.require_justification` and `suppression.strict` decide
+  whether a suppression document may be used at all, and the audit resolved
+  the project config without reading either — so a reasonless or
+  long-expired rule that ordinary `compare` rejects was accepted, suppressed
+  the finding, and exited `0`. Both settings now reach the audit's real run
+  *and* its `--dry-run` validation load, so a preview cannot approve a run
+  that then cannot start.
+- **A saved ABICC Perl dump is exempt from the `--depth` floor, like any
+  other pre-built ABI description.** `--depth build`/`--depth source` is a
+  floor for live extraction, not a ceiling for a description someone already
+  wrote down, but the carve-out recognized only `.abi.json` and
+  `ProjectSnapshot` packages — so `--depth source` exited `7` on a saved
+  ABICC dump and `0` on the equivalent `.abi.json`. A `Module.symvers`
+  manifest and a bare BTF/CTF blob stay on the raw-evidence side, where the
+  floor still applies. Applies to two-sided `compare` too, through the same
+  shared predicate.
 - **SARIF says why a gated audit exited.** The coverage ledger reaches the
   `toolExecutionNotifications` array (SARIF's shape for "the run itself was
   limited") and the run's properties, and the exit-code description names
@@ -116,7 +133,7 @@
   `--old-variant`/`--new-variant`, `--bundle-facts-*`,
   `--since`/`--changed-path`, `--select`/`--select-required`,
   `--output-dir`, `--abi3`, `--budget`, `--severity-preset`, `--pack`,
-  `--config`, `--instantiation-manifest`, `--follow-deps`, `--search-path`,
+  `--instantiation-manifest`, `--follow-deps`, `--search-path`,
   `--ld-library-path`, `--debug-info` and `--devel-pkg`.
 
 - **A suppressed finding no longer disappears from a `--no-baseline`

--- a/changelog.d/1789000000_claude_no-baseline-audit-findings.md
+++ b/changelog.d/1789000000_claude_no-baseline-audit-findings.md
@@ -8,23 +8,6 @@
   `compare` would. Resolved through the same function at the same
   CLI > config > default precedence, and `--config` is accepted rather than
   rejected, since the discovered file is now honored.
-- **The audit honors `.abicheck.yml`'s suppression *acceptance* rules.**
-  `suppression.require_justification` and `suppression.strict` decide
-  whether a suppression document may be used at all, and the audit resolved
-  the project config without reading either — so a reasonless or
-  long-expired rule that ordinary `compare` rejects was accepted, suppressed
-  the finding, and exited `0`. Both settings now reach the audit's real run
-  *and* its `--dry-run` validation load, so a preview cannot approve a run
-  that then cannot start.
-- **A saved ABICC Perl dump is exempt from the `--depth` floor, like any
-  other pre-built ABI description.** `--depth build`/`--depth source` is a
-  floor for live extraction, not a ceiling for a description someone already
-  wrote down, but the carve-out recognized only `.abi.json` and
-  `ProjectSnapshot` packages — so `--depth source` exited `7` on a saved
-  ABICC dump and `0` on the equivalent `.abi.json`. A `Module.symvers`
-  manifest and a bare BTF/CTF blob stay on the raw-evidence side, where the
-  floor still applies. Applies to two-sided `compare` too, through the same
-  shared predicate.
 - **SARIF says why a gated audit exited.** The coverage ledger reaches the
   `toolExecutionNotifications` array (SARIF's shape for "the run itself was
   limited") and the run's properties, and the exit-code description names
@@ -42,16 +25,17 @@
 - **`--dry-run` validates `--suppress`/`--policy-file` before previewing.** A
   malformed document exits `64` on the real run, so a preview that exited `0`
   approved a run that could not start.
-- **The pinned-depth floor now applies to every operand this run parses**,
-  not only to a recognized binary. `Module.symvers`, a bare BTF/CTF blob and
-  an ABICC Perl dump each become a fresh snapshot that structurally cannot
-  carry L3-L5 evidence, yet all three read as "already stored" and were
-  exempted: `compare --no-baseline Module.symvers --depth source` reported a
-  clean audit with no evidence tiers at all. The two-sided
-  `compare a.symvers b.symvers --depth source` did the same, so the rule now
-  has one owner (`workflows/input_resolution.side_is_live`) both forms call.
-  Only a genuinely serialized snapshot is exempt — in either of its shapes,
-  a `.abi.json` file or a directory-backed `ProjectSnapshot` package.
+- **The pinned-depth floor now applies to every operand this run derives a
+  description from**, not only to a recognized binary. A `Module.symvers`
+  manifest and a bare BTF/CTF blob each become a fresh snapshot that
+  structurally cannot carry L3-L5 evidence, yet both read as "already
+  stored" and were exempted: `compare --no-baseline Module.symvers --depth
+  source` reported a clean audit with no evidence tiers at all. The
+  two-sided `compare a.symvers b.symvers --depth source` did the same, so
+  the rule now has one owner (`workflows/input_resolution.side_is_live`)
+  both forms call. Exempt is an already-serialized ABI *description*, in any
+  of its shapes — a `.abi.json` file, a directory-backed `ProjectSnapshot`
+  package, or a saved ABICC Perl dump.
 - **`compare --no-baseline` accepts a `ProjectSnapshot` package directory.**
   It is a single artifact — `resolve_input` decodes one into exactly one
   snapshot, and a two-sided `compare` already accepted it — but a blanket

--- a/changelog.d/1789100000_claude_no-baseline-audit-followup.md
+++ b/changelog.d/1789100000_claude_no-baseline-audit-followup.md
@@ -1,0 +1,37 @@
+### Fixed
+
+- **The audit honors `.abicheck.yml`'s suppression *acceptance* rules.**
+  `suppression.require_justification` and `suppression.strict` decide whether
+  a suppression document may be used at all, and the audit resolved the
+  project config without reading either — so a reasonless or long-expired
+  rule that ordinary `compare` rejects was accepted, suppressed the finding,
+  and exited `0`. Both settings now reach the audit's real run *and* its
+  `--dry-run` validation load, so a preview cannot approve a run that then
+  cannot start.
+- **A saved ABICC Perl dump is exempt from the `--depth` floor, like any
+  other pre-built ABI description.** `--depth build`/`--depth source` is a
+  floor for live extraction, not a ceiling for a description someone already
+  wrote down, but the carve-out recognized only `.abi.json` and
+  `ProjectSnapshot` packages — so `--depth source` exited `7` on a saved
+  ABICC dump and `0` on the equivalent `.abi.json`. A `Module.symvers`
+  manifest and a bare BTF/CTF blob stay on the raw-evidence side, where the
+  floor still applies. Applies to two-sided `compare` too, through the same
+  shared predicate.
+- **A suppressed audit finding keeps its full ADR-067 rule provenance.** The
+  audit published `suppression_rule`, the rule's short *display label* —
+  `label` or `reason`, never both — so a waiver stating both lost the reason
+  it was written for and the file it lives in, which is exactly what a
+  reviewer needs to decide whether it still applies. Every projection now
+  carries the run's own disposition-ledger record (rule id, source file,
+  reason, label, expiry) as `suppression_provenance`, joined by object
+  identity through the same `rule_for` lookup the two-sided report uses;
+  the Markdown suppression table gains reason/source/expiry columns.
+  `suppression_rule` is unchanged for existing consumers.
+- **A gated audit's JUnit output names the axis that fired.** The suite
+  carried only the total exit code and the contract-coverage contribution,
+  and the failure text listed every axis that *might* have gated — so a
+  consumer stopped by the evidence contract could not tell which one it was.
+  Each orthogonal axis is now published as its own `exit_axis.<name>`
+  property with its own contribution, the failure text names only the axes
+  that actually contributed, and the contract-coverage ledger's provider
+  details are included. JSON, Markdown, oneline and SARIF already did this.

--- a/changelog.d/1789100000_claude_no-baseline-audit-followup.md
+++ b/changelog.d/1789100000_claude_no-baseline-audit-followup.md
@@ -29,7 +29,10 @@
   reason/source/expiry columns, the SARIF suppression's `justification`
   states the reason with the full record beside it in `properties`, and the
   JUnit `<skipped>` message and body do the same. `suppression_rule` is
-  unchanged for existing consumers.
+  unchanged for existing consumers, and `audit_report_schema_version` moves
+  to `1.1` — additive, so a `1.0` consumer is unaffected, but a consumer
+  that selects or caches a schema by that string can now tell the two
+  contracts apart.
 - **A gated audit's JUnit output names the axis that fired.** The suite
   carried only the total exit code and the contract-coverage contribution,
   and the failure text listed every axis that *might* have gated — so a

--- a/changelog.d/1789100000_claude_no-baseline-audit-followup.md
+++ b/changelog.d/1789100000_claude_no-baseline-audit-followup.md
@@ -41,3 +41,8 @@
   property with its own contribution, the failure text names only the axes
   that actually contributed, and the contract-coverage ledger's provider
   details are included. JSON, Markdown, oneline and SARIF already did this.
+  A gated document that carries *no* per-axis breakdown at all — reachable
+  only by a caller hand-building a `NoBaselineDocument`, whose `exit_axes`
+  defaults to empty — now says the record is missing rather than printing
+  the "contributing axes:" heading with nothing under it, which would read
+  as "every axis measured and cleared" for a suite that demonstrably gated.

--- a/changelog.d/1789100000_claude_no-baseline-audit-followup.md
+++ b/changelog.d/1789100000_claude_no-baseline-audit-followup.md
@@ -24,9 +24,12 @@
   reviewer needs to decide whether it still applies. Every projection now
   carries the run's own disposition-ledger record (rule id, source file,
   reason, label, expiry) as `suppression_provenance`, joined by object
-  identity through the same `rule_for` lookup the two-sided report uses;
-  the Markdown suppression table gains reason/source/expiry columns.
-  `suppression_rule` is unchanged for existing consumers.
+  identity through the same `rule_for` lookup the two-sided report uses.
+  Every projection carries it: the Markdown suppression table gains
+  reason/source/expiry columns, the SARIF suppression's `justification`
+  states the reason with the full record beside it in `properties`, and the
+  JUnit `<skipped>` message and body do the same. `suppression_rule` is
+  unchanged for existing consumers.
 - **A gated audit's JUnit output names the axis that fired.** The suite
   carried only the total exit code and the contract-coverage contribution,
   and the failure text listed every axis that *might* have gated — so a

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -7582,3 +7582,81 @@ Registered as open residuals on the `report.finding_entry_builder_parity`
 bug class in `tests/regressions/manifest.py`'s report sibling
 (`tests/regressions/manifest_report.py`), so the next person to touch that
 class sees them without re-deriving the grep.
+
+## `compare --no-baseline` crashes on any real ELF shared library
+
+Auditing a real ELF shared library raises an **uncaught**
+`NoBaselineInvariantError` — a Python traceback, not a diagnostic — from a
+bare CLI call:
+
+```console
+$ abicheck compare --no-baseline /lib/x86_64-linux-gnu/libm.so.6 --format json
+abicheck.policy.no_baseline_findings.NoBaselineInvariantError: a snapshot
+compared against itself must never produce a comparison finding -- if this
+fires, a detector is reading non-identity state. Offending findings:
+visibility_leak(<visibility>)
+```
+
+Reproduced on `main` at `f5df70dd` as well as on the branch that found it,
+so it is not a regression from any in-flight work. It was found only because
+a test fixture in `tests/test_compare_no_baseline_cli.py` was made more
+realistic (see that file's `_a_live_binary_this_host_can_audit`); every
+committed G20 fixture is a stored snapshot, so no existing test audits a
+real live library at all — which is why a crash on the command's most
+obvious input survived.
+
+**The invariant's own message misdiagnoses it.** Nothing is reading
+non-identity state. `diff_platform_elf_dynamic._diff_visibility_leak` is
+deliberately single-sided — its body opens `del new  # detector is
+intentionally old-library-only` — and reports internal-looking symbols
+exported from one snapshot under `elf_only_mode`. That is candidate-side
+hygiene, exactly the category `policy/no_baseline_findings.
+is_one_sided_finding` exists to recognise. But the detector emits a plain
+`make_change(...)` carrying **neither** marker that predicate looks for
+(`cross_source_evolution`, `candidate_side_enrichment`), so
+`partition_no_baseline_findings` files it under `identity`, and
+`check_no_baseline_partition` raises.
+
+There is an irony worth recording, because it is the actual lesson:
+`is_one_sided_finding`'s docstring argues at length against a `ChangeKind`
+allowlist on the grounds that it "would drift out of sync with the detector
+registry." The marker-based design it chose instead has drifted the *other*
+way — a genuinely one-sided detector that never got a marker. Neither
+mechanism is self-enforcing; the missing piece is a check that a detector
+ignoring its `new` argument emits marked findings.
+
+**Why it was not fixed where it was found.** The obvious patch — set
+`candidate_side_enrichment` on the finding — is not local. That marker is
+read on the ordinary two-sided `compare` path too, where this detector also
+runs and reports leaks in the OLD library, so setting it relabels a finding
+in the main command. And `_diff_visibility_leak` is unlikely to be alone:
+any detector that `del`s or ignores `new` is in the same position, so the
+real fix is an audit of that whole set plus a gate, not a one-line change
+to the one instance a traceback happened to name. That is a change with its
+own review surface, and it was out of scope for the pull request (#1188)
+that found it — which touches neither file.
+
+**Fix shape, for whoever takes it:**
+
+1. Enumerate every detector under `abicheck/diff_*.py` whose body ignores
+   its `new` snapshot argument (`del new`, or never referencing it). That
+   set is the population, not `visibility_leak` alone.
+2. Decide per detector whether it is candidate-side hygiene (mark it) or a
+   genuine comparison detector that happens not to need `new` yet.
+3. Mark the hygiene ones, and check what that does to two-sided `compare`'s
+   reports and gating before assuming it is inert there.
+4. Add the missing self-enforcement: a gate — the AI-readiness script is
+   the natural home, alongside `fact-detector-misuse` — asserting that a
+   detector which ignores `new` emits only marked findings. Without it the
+   next single-sided detector reintroduces this exact crash.
+5. Add a test that audits a **real live shared library**, not a stored
+   snapshot. Its absence is why this shipped;
+   `tests/test_compare_no_baseline_cli.py`'s helper documents the platform
+   traps (a soname is not a path; macOS keeps system libraries in the dyld
+   shared cache; a PE executable has no export directory).
+
+Registered as `test_fixture.host_artifact_assumed_capability` in
+`tests/regressions/manifest_report.py`'s sibling
+`tests/regressions/manifest_tool_surface.py` for the fixture half; the
+detector half above has no registry entry yet, deliberately — it is a real
+open defect, not a closed class.

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -7540,3 +7540,45 @@ deciding what `compare --depth binary` should do, which is a separate
 change with its own blast radius. Registered as a `KnownGap` on the
 `evidence.tier_shortcut_without_substitute` entry in
 `tests/regressions/manifest.py`.
+
+## Suppression provenance stops at the display label outside the audit path
+
+ADR-067 D3 says a disposition keeps the rule that made it — rule id, source
+file, reason, label, expiry. `Change.suppression_rule` is not that record: it
+is `SuppressionOutcome.rule_label()`'s deliberate `label or reason` collapse,
+so a waiver stating both publishes one and silently drops the other, along
+with the file it lives in and when it lapses — exactly what a reviewer needs
+to decide whether the waiver still applies.
+
+`compare --no-baseline` had this in all four of its projections and was fixed
+in PR #1188: each suppressed entry now carries the run's own
+`DispositionLedger.rule_for` record, and the regression test is parametrized
+over `NO_BASELINE_SUPPORTED_FORMATS` so a format added later is held to it.
+Two-sided `compare`'s **JSON** was already correct before that
+(`reporter.py`'s `_suppressed_change_entry` emits `rule.to_dict()`).
+
+Two readers are still on the display label alone. Both were found by grepping
+every `suppression_rule` reader once the audit's own were fixed, and both are
+outside the scope PR #1188 was opened for, so they are recorded here rather
+than folded into it:
+
+1. **`sarif.py`** (two-sided `compare`) — the suppression's `justification`
+   interpolates `change.suppression_rule` only. Since the same run's JSON
+   already publishes the full record, this is a *between-formats* split of one
+   report: a SARIF consumer sees strictly less than a JSON consumer of the
+   identical run.
+2. **`cli_scan_baseline.py`** (`scan --against`) — each suppressed
+   `findings[]` entry sets `entry["suppression_rule"]` and carries no
+   provenance field at all.
+
+Fixing either is the same shape as the audit's fix: route the run's
+`DispositionLedger` to that entry builder and read `rule_for(change)`, rather
+than re-evaluating the rule set (which can name a different rule than the one
+that actually fired, since a finding's fields may have been enriched after the
+match). Neither needs a new mechanism — only the existing one wired to one
+more builder.
+
+Registered as open residuals on the `report.finding_entry_builder_parity`
+bug class in `tests/regressions/manifest.py`'s report sibling
+(`tests/regressions/manifest_report.py`), so the next person to touch that
+class sees them without re-deriving the grep.

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -796,10 +796,13 @@ section's *actual* state, not the target it originally described:
     `report.no_baseline.NO_BASELINE_UNSUPPORTED_FORMATS`.
 
   **§3 row 2 is closed.** `tests/parity/test_no_baseline_audit_corpus_parity.py`
-  is the gate: `compare --no-baseline` and `scan` agree *exactly* on all
-  eleven G20 audit fixtures (twelve runs — `case151` contributes its
-  `thin.abi.json` variant), asserting no capability loss and nothing
-  manufactured as two separate statements. `tests/test_no_baseline_d3_properties.py`
+  is the gate over all eleven G20 audit fixtures (twelve runs — `case151`
+  contributes its `thin.abi.json` variant). The statement it makes is
+  *directional*, not "the two outputs are equal": `compare --no-baseline`
+  reports **at least** every kind `scan` reports (no capability loss), and
+  every finding it adds beyond that is a real candidate-side enrichment in a
+  permitted ADR-068 D3 state (nothing manufactured). Those are asserted as
+  two separate statements, per fixture and once corpus-wide. `tests/test_no_baseline_d3_properties.py`
   states D3 as a property over generated candidates rather than eleven fixed
   cases, per `AGENTS.md`'s bug-class rule. The nine G20 case READMEs and
   `examples/workflows/audit-release` are re-driven onto
@@ -1600,7 +1603,7 @@ under Phase 0's parity harness while both commands exist.
 | F-2 | Binary + public headers | Full L2 declaration result; header-origin scoping applied |
 | F-3 | Build + source evidence (`--depth source`) | L3–L5 findings identical to `scan --depth source` on the same inputs |
 | F-4 | Source-only/API change invisible in the binary | Detected through the available evidence, classed `API_BREAK`, not `BREAKING` (authority rule) |
-| F-5 | Private header leak | `private_header_leak` reported by `compare` (today: `scan` only) |
+| F-5 | Private header leak | `private_header_leak` reported by `compare` |
 | F-6 | Public declaration not exported | `public_not_exported` reported by `compare` |
 | F-7 | Exported symbol not publicly declared | `exported_not_public` reported by `compare` |
 | F-8 | **Pre-existing** leak, baseline lacking headers | `not_evaluated` on OLD — reported as a candidate-side finding with baseline evidence absent, **never** as `introduced` |

--- a/docs/reference/examples/case143_audit_accidental_export.md
+++ b/docs/reference/examples/case143_audit_accidental_export.md
@@ -18,15 +18,19 @@
 ## Verdict and consumer impact
 
 This is a **single-release audit** (ADR-035 "G20" corpus): there is no v1/v2
-pair to diff, just one build's evidence checked against itself. abicheck's
-verdict is `COMPATIBLE` — nothing here is a break today — but the audit flags
-an advisory ABI-hygiene finding: `debug_dump()` ships with default ELF
-visibility (so it's in the dynamic symbol table, and any consumer can `dlsym`
-or link against it) yet it is never declared in a public header. Whoever
-maintains this library believes `debug_dump()` is private and free to change
-or remove at will; in reality it's already load-bearing ABI for anyone who
-found it in `nm -D libdemo.so`. The fix belongs in *this* release, not after
-a consumer files a breakage report against a "private" function.
+pair to diff, just one build's evidence checked against itself. abicheck
+reports **no verdict at all** (`"verdict": null`): ADR-068 D2 — a single build
+has nothing to be compatible *with*, so the audit answers what is *present*,
+not whether something broke. (The catalog's own 🟢 COMPATIBLE classification
+above is a statement about the case, not about the command's output: nothing
+here is a break today.) The audit flags an advisory ABI-hygiene finding:
+`debug_dump()` ships with default ELF visibility (so it's in the dynamic
+symbol table, and any consumer can `dlsym` or link against it) yet it is never
+declared in a public header. Whoever maintains this library believes
+`debug_dump()` is private and free to change or remove at will; in reality
+it's already load-bearing ABI for anyone who found it in `nm -D libdemo.so`.
+The fix belongs in *this* release, not after a consumer files a breakage
+report against a "private" function.
 
 ## What this snapshot contains
 

--- a/docs/reference/examples/case144_audit_private_header_leak.md
+++ b/docs/reference/examples/case144_audit_private_header_leak.md
@@ -18,16 +18,19 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags an advisory finding: the public function `make_widget()`
-returns `detail::WidgetImpl*`, and `detail::WidgetImpl` is a type defined
-only in a **private, non-installed header**. Consumers linking against the
-public headers cannot legally name `detail::WidgetImpl` (they'd have to
-reach into a header the library never installs), yet the pointer type is
-already part of the exported signature. The maintainer never reasoned about
-this as public API surface, but it already is one — the day the private
-header's layout changes, every caller holding a `detail::WidgetImpl*` is
-silently exposed to a layout mismatch with no compiler warning to catch it.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags an advisory finding: the public
+function `make_widget()` returns `detail::WidgetImpl*`, and
+`detail::WidgetImpl` is a type defined only in a **private, non-installed
+header**. Consumers linking against the public headers cannot legally name
+`detail::WidgetImpl` (they'd have to reach into a header the library never
+installs), yet the pointer type is already part of the exported signature. The
+maintainer never reasoned about this as public API surface, but it already is
+one — the day the private header's layout changes, every caller holding a
+`detail::WidgetImpl*` is silently exposed to a layout mismatch with no
+compiler warning to catch it.
 
 ## What this snapshot contains
 

--- a/docs/reference/examples/case145_audit_unversioned_export.md
+++ b/docs/reference/examples/case145_audit_unversioned_export.md
@@ -18,15 +18,17 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: the library defines a symbol-versioning scheme
-(`DEMO_1.0` in `.gnu.version_d`) for `demo_init`/`demo_run`, yet a third
-export, `demo_experimental`, ships with **no version node at all**. Once
-consumers link against the bare (unversioned) `demo_experimental` symbol,
-the library has no way to later ship an incompatible `demo_experimental`
-under a new version node the way it can for the versioned symbols — the
-usual "add `DEMO_2.0`, keep `DEMO_1.0` for old binaries" escape hatch
-doesn't exist for a symbol that was never versioned in the first place.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: the library defines a symbol-versioning
+scheme (`DEMO_1.0` in `.gnu.version_d`) for `demo_init`/`demo_run`, yet a
+third export, `demo_experimental`, ships with **no version node at all**. Once
+consumers link against the bare (unversioned) `demo_experimental` symbol, the
+library has no way to later ship an incompatible `demo_experimental` under a
+new version node the way it can for the versioned symbols — the usual "add
+`DEMO_2.0`, keep `DEMO_1.0` for old binaries" escape hatch doesn't exist for a
+symbol that was never versioned in the first place.
 
 ## What this snapshot contains
 

--- a/docs/reference/examples/case146_audit_rtti_for_internal.md
+++ b/docs/reference/examples/case146_audit_rtti_for_internal.md
@@ -18,13 +18,15 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: `_ZTI12InternalNode`/`_ZTV12InternalNode` (the C++
-typeinfo and vtable for `InternalNode`) are both exported from the dynamic
-symbol table, but `InternalNode` is declared **only in a private header** —
-`render()` is the sole function the public headers actually declare.
-Consumers can't name `InternalNode` in their own code, so they can't be
-handed one directly, but the exported RTTI still lets any code that obtains
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: `_ZTI12InternalNode`/`_ZTV12InternalNode`
+(the C++ typeinfo and vtable for `InternalNode`) are both exported from the
+dynamic symbol table, but `InternalNode` is declared **only in a private
+header** — `render()` is the sole function the public headers actually
+declare. Consumers can't name `InternalNode` in their own code, so they can't
+be handed one directly, but the exported RTTI still lets any code that obtains
 an `InternalNode*` polymorphically (e.g. via a base-class pointer returned
 from elsewhere in the library) run `dynamic_cast`/`typeid` against it. That
 couples consumer binaries to an internal class's identity without the

--- a/docs/reference/examples/case147_scan_depth_ladder.md
+++ b/docs/reference/examples/case147_scan_depth_ladder.md
@@ -18,15 +18,17 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE`, but the audit flags an
-advisory finding: `connect()` is a public function that takes
-`detail::SessionState&`, a type declared only in a private header — the same
-`private_header_leak` shape as case144, but this case exists to demonstrate
-*how much evidence abicheck needed to prove it*. ADR-035's honest-coverage
-promise is that a scan says exactly what each depth proved and what it
-could not, rather than silently upgrading a hint into a confirmed finding.
-This case is the legibility anchor for that promise: the same input, read at
-increasing evidence depth.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output.)
+The audit flags an advisory finding: `connect()` is a public function that
+takes `detail::SessionState&`, a type declared only in a private header — the
+same `private_header_leak` shape as case144, but this case exists to
+demonstrate *how much evidence abicheck needed to prove it*. ADR-035's
+honest-coverage promise is that a scan says exactly what each depth proved and
+what it could not, rather than silently upgrading a hint into a confirmed
+finding. This case is the legibility anchor for that promise: the same input,
+read at increasing evidence depth.
 
 ## What this snapshot contains
 

--- a/docs/reference/examples/case150_xcheck_export_public_pair.md
+++ b/docs/reference/examples/case150_xcheck_export_public_pair.md
@@ -18,9 +18,11 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags two advisory findings that are the two failure directions
-of the same L0-exports ↔ L2-decls contract:
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags two advisory findings that are the
+two failure directions of the same L0-exports ↔ L2-decls contract:
 
 | Direction | Symptom | Cross-check |
 |-----------|---------|--------------|

--- a/docs/reference/examples/case181_xcheck_public_to_internal_dependency.md
+++ b/docs/reference/examples/case181_xcheck_public_to_internal_dependency.md
@@ -18,20 +18,22 @@
 ## Verdict and consumer impact
 
 Single-release audit: one build's evidence checked against itself, no
-baseline. abicheck's verdict is `COMPATIBLE` — the ABI hasn't broken — but
-the audit flags an advisory finding: the public, header-declared
-`json_parse()` calls straight into `validate_utf8()`, a helper declared
-only in `src/json_internal.cc`, a private implementation file with no
-public declaration anywhere. Nothing about `json_parse()`'s own signature
-says this — the dependency is only visible by walking the L5 source
-graph's `DECL_CALLS_DECL` edge from the public declaration to the internal
-one. If `validate_utf8()`'s behavior changes next release, `json_parse()`'s
-contract silently shifts with it, with no signal in a public-header diff
-at all. This is the intra-version counterpart to case150's
-`exported_not_public`/`public_not_exported` pair: that pair catches a
-mismatch between *what's exported* and *what's declared*; this one catches
-a mismatch **inside** a single public entry point — its behavior depends
-on an entity consumers cannot see, version, or reason about independently.
+baseline. abicheck reports **no verdict at all** (`"verdict": null`): ADR-068
+D2 — a single build has nothing to be compatible *with*. (The catalog's 🟢
+COMPATIBLE classification above describes the case, not the command's output:
+the ABI hasn't broken.) But the audit flags an advisory finding: the public,
+header-declared `json_parse()` calls straight into `validate_utf8()`, a helper
+declared only in `src/json_internal.cc`, a private implementation file with no
+public declaration anywhere. Nothing about `json_parse()`'s own signature says
+this — the dependency is only visible by walking the L5 source graph's
+`DECL_CALLS_DECL` edge from the public declaration to the internal one. If
+`validate_utf8()`'s behavior changes next release, `json_parse()`'s contract
+silently shifts with it, with no signal in a public-header diff at all. This
+is the intra-version counterpart to case150's
+`exported_not_public`/`public_not_exported` pair: that pair catches a mismatch
+between *what's exported* and *what's declared*; this one catches a mismatch
+**inside** a single public entry point — its behavior depends on an entity
+consumers cannot see, version, or reason about independently.
 
 ## What this snapshot contains
 

--- a/docs/reference/schemas/v1/audit_report.schema.json
+++ b/docs/reference/schemas/v1/audit_report.schema.json
@@ -9,6 +9,7 @@
     "no_baseline",
     "library",
     "verdict",
+    "old_acquisition_state",
     "changes",
     "findings",
     "exit_code"

--- a/docs/reference/schemas/v1/audit_report.schema.json
+++ b/docs/reference/schemas/v1/audit_report.schema.json
@@ -58,7 +58,7 @@
   "properties": {
     "audit_report_schema_version": {
       "type": "string",
-      "description": "SemVer-style version of THIS schema (e.g. \"1.0\"). Consumers should accept any version with the same MAJOR component. Deliberately not named `report_schema_version`: that field identifies a compare report, and an audit is a different document.",
+      "description": "SemVer-style version of THIS schema (currently \"1.1\"). Consumers should accept any version with the same MAJOR component. Deliberately not named `report_schema_version`: that field identifies a compare report, and an audit is a different document.",
       "pattern": "^[0-9]+\\.[0-9]+$"
     },
     "no_baseline": {

--- a/docs/reference/schemas/v1/audit_report.schema.json
+++ b/docs/reference/schemas/v1/audit_report.schema.json
@@ -34,7 +34,24 @@
         },
         "candidate_side_enrichment": {"type": "boolean"},
         "observed_value": {"type": ["string", "null"]},
-        "suppression_rule": {"type": ["string", "null"]}
+        "suppression_rule": {
+          "type": ["string", "null"],
+          "description": "The rule's short display label (its `label`, else its `reason`). See `suppression_provenance` for the full record."
+        },
+        "suppression_provenance": {
+          "type": ["object", "null"],
+          "description": "ADR-067 D3's full provenance of the rule that hid this finding: rule id, source file, reason, label, expiry. Distinct from `suppression_rule`, which is only the short display label and so cannot carry both a label and a reason. `null` when the run recorded no ledger entry for this finding.",
+          "additionalProperties": true,
+          "properties": {
+            "rule_id": {"type": ["string", "null"], "description": "The rule's canonical selector-and-gate identity, so two rules sharing a label stay distinguishable."},
+            "source_file": {"type": ["string", "null"], "description": "The --suppress document the rule was loaded from."},
+            "reason": {"type": ["string", "null"]},
+            "label": {"type": ["string", "null"]},
+            "expires": {"type": ["string", "null"], "description": "ISO-8601 date, or null for a rule that never lapses."},
+            "intent": {"type": ["string", "null"]},
+            "allow_public_break": {"type": "boolean"}
+          }
+        }
       }
     }
   },

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -112,11 +112,44 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
         invariant=(
             "Every per-finding entry-builder for a shared `Change` "
             "(`compare`'s `changes[]`, `scan --against`'s baseline dicts, "
-            "the release fan-out's capped `findings`) must resolve an "
-            "audit field (e.g. `reclassified_by`) via one canonical helper "
-            "-- never a sibling silently omitting a field another computes."
+            "the release fan-out's capped `findings`, `compare "
+            "--no-baseline`'s audit rows) must resolve an audit field (e.g. "
+            "`reclassified_by`, a suppression's rule provenance) via one "
+            "canonical helper -- never a sibling silently omitting a field "
+            "another computes. The same rule holds *between formats* of one "
+            "report: a fact one projection publishes and its siblings drop "
+            "leaves a consumer of the quiet format unable to act on the run "
+            "it was handed."
         ),
-        fixed_by=(1176,),
-        seed_tests=("tests/test_disposition_reclassification.py",),
+        # #1185-era follow-up, two instances of the same shape. The audit's
+        # suppressed rows read `Change.suppression_rule` -- the `label or
+        # reason` display collapse -- while `reporter.py`'s sibling already
+        # resolved the full ADR-067 record through
+        # `DispositionLedger.rule_for`, so a waiver stating both lost its
+        # reason and source file. And the JUnit projection published only
+        # the total exit code where JSON/Markdown/oneline/SARIF all named
+        # the orthogonal axis that fired.
+        fixed_by=(1176, 1185),
+        seed_tests=(
+            "tests/test_disposition_reclassification.py",
+            "tests/test_no_baseline_report_formats.py",
+        ),
+        axes={
+            # Only what a seed test really drives.
+            "renderer": ("json", "markdown", "junit"),
+            "record": ("suppression-provenance", "exit-axis"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The between-formats half is asserted for the audit "
+                    "document's suppression provenance and exit axes only. "
+                    "No gate enumerates a report's semantic fields and "
+                    "checks every projection carries each one, so a new "
+                    "field added to one renderer alone is still possible."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+        ),
     ),
 )

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -63,7 +63,12 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
             "tests/test_markdown_cell.py",
             "tests/test_no_baseline_report_formats.py",
         ),
-        public_surfaces=("cli",),
+        # `()` and not `("cli",)`: both seed tests call the renderers and the
+        # escaper directly, never through Click or `abicheck.service`. A
+        # claimed surface a seed test does not reach conceals exactly the
+        # missing cross-surface coverage this registry exists to surface
+        # (CodeRabbit review; the same rule Codex established in PR #885).
+        public_surfaces=(),
         axes={
             "hostile_character": (
                 "pipe",
@@ -72,7 +77,11 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
                 "newline",
                 "control",
             ),
-            "renderer": ("comparison-scope-table", "audit-findings-table"),
+            # Only what a seed test really renders. The scope table shares
+            # the escaper but no seed test drives a hostile value through
+            # it, so listing it here would overstate coverage -- recorded as
+            # a known gap below instead (CodeRabbit review).
+            "renderer": ("audit-findings-table",),
         },
         known_gaps=(
             KnownGap(
@@ -83,6 +92,16 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
                     "no gate asserts that a renderer interpolating an "
                     "untrusted value uses an escaper at all — a new renderer "
                     "can still interpolate one raw."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+            KnownGap(
+                description=(
+                    "`report/comparison_scope.py`'s scope tables route "
+                    "through the same shared escaper, but no seed test "
+                    "renders a hostile value through that table -- the "
+                    "escaper's own contract is covered, the scope table's "
+                    "use of it is covered only by construction."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md",
             ),

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -159,6 +159,21 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
             KnownGap(
                 description=(
+                    "Nothing enforces that an axis declared on a BugClass is "
+                    "actually exercised by an assertion in one of its "
+                    "`seed_tests`. Splitting a test module for a size "
+                    "violation left this entry naming only the file the "
+                    "suppression-provenance assertions had moved *out* of, "
+                    "and no gate noticed: the declared record and renderer "
+                    "axes stood with nothing behind them, and a contributor "
+                    "following AGENTS.md's 'check BUG_CLASSES first' advice "
+                    "would have been sent to the wrong file (Codex review, "
+                    "P2). Fixed by hand here; the class of error is open."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+            KnownGap(
+                description=(
                     "Two open instances of this class outside the audit "
                     "path, found by grepping every `suppression_rule` reader "
                     "after the audit's own two were fixed -- recorded rather "

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -132,6 +132,13 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
         fixed_by=(1176, 1185),
         seed_tests=(
             "tests/test_disposition_reclassification.py",
+            # The audit's own suppression-provenance suite moved here when
+            # `test_no_baseline_report_formats.py` crossed its module-size
+            # cap. That module still carries the exit-axis half of this
+            # class; naming only it left the `suppression-provenance` record
+            # and renderer axes declared below unbacked by any seed test
+            # (Codex review, P2).
+            "tests/test_no_baseline_suppression_provenance.py",
             "tests/test_no_baseline_report_formats.py",
         ),
         axes={

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -142,8 +142,15 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
             "tests/test_no_baseline_report_formats.py",
         ),
         axes={
-            # Only what a seed test really drives.
-            "renderer": ("json", "markdown", "junit"),
+            # Only what a seed test really drives -- and *all* of it. This
+            # tuple omitted `sarif` while
+            # `test_every_format_carries_the_reason_and_source_not_just_the_label`
+            # parametrizes over `NO_BASELINE_SUPPORTED_FORMATS` minus
+            # `oneline`, which includes it. Understating coverage sends a
+            # contributor to write a test that already exists, the mirror of
+            # the overstating case the known gap below describes (Codex
+            # review, P2).
+            "renderer": ("json", "markdown", "sarif", "junit"),
             "record": ("suppression-provenance", "exit-axis"),
         },
         known_gaps=(
@@ -159,9 +166,15 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
             KnownGap(
                 description=(
-                    "Nothing enforces that an axis declared on a BugClass is "
-                    "actually exercised by an assertion in one of its "
-                    "`seed_tests`. Splitting a test module for a size "
+                    "Nothing enforces that an axis declared on a BugClass "
+                    "matches what its `seed_tests` actually exercise, in "
+                    "either direction -- this entry has now been wrong both "
+                    "ways: a `seed_tests` list pointing at the file the "
+                    "assertions had moved out of, and a `renderer` tuple "
+                    "omitting `sarif` while the seed test parametrized over "
+                    "it. Overstating sends a reader to a test that does not "
+                    "exist; understating sends them to write one that does. "
+                    "Splitting a test module for a size "
                     "violation left this entry naming only the file the "
                     "suppression-provenance assertions had moved *out* of, "
                     "and no gate noticed: the declared record and renderer "

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -150,6 +150,27 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md",
             ),
+            KnownGap(
+                description=(
+                    "Two open instances of this class outside the audit "
+                    "path, found by grepping every `suppression_rule` reader "
+                    "after the audit's own two were fixed -- recorded rather "
+                    "than fixed here, since neither is in the scope the PR "
+                    "that found them was opened for. (1) `sarif.py`'s "
+                    "two-sided suppression `justification` reads only "
+                    "`Change.suppression_rule`, the `label or reason` "
+                    "display collapse, while the same run's JSON already "
+                    "publishes the full ADR-067 record via "
+                    "`reporter.py`'s `_suppressed_change_entry` -- the same "
+                    "between-formats split the audit's SARIF had. (2) "
+                    "`cli_scan_baseline.py`'s baseline `findings[]` entries "
+                    "carry the display label only, with no provenance field "
+                    "at all. Fixing either means routing "
+                    "`DispositionLedger.rule_for` to that builder, exactly "
+                    "as the audit now does."
+                ),
+                reference="docs/contribute/known-gaps.md",
+            ),
         ),
     ),
 )

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -143,6 +143,63 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         ),
     ),
     BugClass(
+        id="ci.shared_budget_over_heterogeneous_matrix",
+        invariant=(
+            "A resource budget a CI job declares once -- `timeout-minutes` "
+            "above all -- must resolve per matrix leg whenever the legs' "
+            "real costs differ by more than the budget's own headroom. One "
+            "shared number over a heterogeneous matrix has no correct "
+            "value: sized for the slowest leg it discards the gate on every "
+            "faster one, and sized for the faster ones it cancels the "
+            "slowest leg's healthy runs. The failure is silent in the worst "
+            "way -- a job-level timeout reports `cancelled`, which reads as "
+            "a superseded run or a reclaimed runner rather than as a "
+            "failure, so it can recur for days on `main` without being "
+            "diagnosed. Raising the shared number is not a fix but a "
+            "deferral: the budget's headroom decays as the suite grows, so "
+            "the same cancellation returns once the slowest leg catches up "
+            "again."
+        ),
+        fixed_by=(1188,),
+        seed_tests=("tests/test_verify_profiles.py",),
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The invariant's *quantitative* half is not executable "
+                    "here. Whether a leg's budget still clears its real "
+                    "cost can only be answered by wall-clock measurements "
+                    "from completed CI runs, which this repository does not "
+                    "ingest -- so the seed test pins the three figures read "
+                    "off `main` by hand (40.4/41.3/45.2 minutes) as a "
+                    "literal oracle. That catches a budget lowered below "
+                    "what was already observed, but nothing detects the "
+                    "decay this class names as the recurring shape: when "
+                    "the Windows leg reaches 75 minutes the test will still "
+                    "pass against its stale 45.2. Closing it needs the "
+                    "per-leg durations published as a queryable artifact "
+                    "(the canonical lane already emits `test-durations.json` "
+                    "for individual tests, but no lane records its own total "
+                    "against its budget) -- a real follow-up, not something "
+                    "a structural YAML scan can reach."
+                ),
+                reference="https://github.com/abicheck/abicheck/pull/1188",
+            ),
+            KnownGap(
+                description=(
+                    "Scoped to `unit-tests`, the one job observed "
+                    "cancelling. No audit was run over this repository's "
+                    "other matrix jobs (`integration-tests`, the PE/Mach-O "
+                    "and packaging lanes, `check-project.yml`'s own "
+                    "`plan`/`check`/`aggregate`) to find which of them also "
+                    "share one budget across legs of materially different "
+                    "cost -- the same defect, unlooked-for, in every job "
+                    "this fix did not touch."
+                ),
+                reference="https://github.com/abicheck/abicheck/pull/1188",
+            ),
+        ),
+    ),
+    BugClass(
         id="tooling.platform_dependent_path_key",
         invariant=(
             "A repo-relative path computed to serve as a lookup/comparison "

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -164,6 +164,10 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         ),
         fixed_by=(1188,),
         seed_tests=("tests/test_compare_no_baseline_cli.py",),
+        # A real Click invocation: the seed test drives `compare
+        # --no-baseline` through `CliRunner().invoke(abicheck_main, ...)`,
+        # which is exactly what this field's rule asks for (CodeRabbit).
+        public_surfaces=("cli",),
         known_gaps=(
             KnownGap(
                 description=(

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -143,6 +143,87 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         ),
     ),
     BugClass(
+        id="test_fixture.host_artifact_assumed_capability",
+        invariant=(
+            "A test that needs a real binary artifact must acquire one that "
+            "actually has the property under test, on every platform the "
+            "suite runs, and must fail in *setup* when it cannot -- never "
+            "grab whatever the host happens to have on PATH and let a "
+            "downstream assertion report the mismatch. The two halves of "
+            "this both bite: an artifact's *format* varies by host (the "
+            "same `shutil.which` name is ELF, Mach-O or PE), and so does "
+            "its *capability* (an ELF or Mach-O executable exposes "
+            "symbols; a PE executable has no export directory at all). A "
+            'fixture that conflates "a binary" with "a shared '
+            'library" therefore passes on two platforms and fails on the '
+            "third, and the failure surfaces as the tool refusing the "
+            "input -- which reads as a bug in the tool rather than in the "
+            "fixture. Renaming the artifact does not help and actively "
+            "misleads, because abicheck sniffs content, not extensions: a "
+            "PE file called `libfoo.so` is still a PE file."
+        ),
+        fixed_by=(1188,),
+        seed_tests=("tests/test_compare_no_baseline_cli.py",),
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The Windows and macOS halves of the fix are not "
+                    "verified on those platforms from the environment that "
+                    "wrote them. The Windows branch was exercised by "
+                    "forcing `sys.platform`, which proves it builds the "
+                    "expected `System32` paths and skips diagnosably rather "
+                    "than crashing -- not that abicheck dumps "
+                    "`kernel32.dll` and honours `--version` there. The "
+                    "specific defect cannot recur (a real DLL has an export "
+                    "directory), but a different platform-specific failure "
+                    "in the same test would be found by CI, not by this "
+                    "registry entry."
+                ),
+                reference="https://github.com/abicheck/abicheck/pull/1188",
+            ),
+            KnownGap(
+                description=(
+                    "Nothing detects the *silent fallthrough* shape "
+                    "generally. The first version of this fix checked "
+                    '`Path(ctypes.util.find_library("m")).is_file()` -- '
+                    "false, because that call answers a soname rather than "
+                    "a path -- and fell back to the very executable it was "
+                    "written to replace. It passed on Linux and proved "
+                    "nothing, and only a manual check of which artifact was "
+                    "actually selected caught it. The helper now asserts "
+                    "its chosen candidate is a binary abicheck recognises, "
+                    "which closes that hole for this one helper; no gate "
+                    "checks the other fixtures in this suite for a "
+                    "candidate-list fallback that quietly lands on the "
+                    "wrong element."
+                ),
+                reference="tests/test_compare_no_baseline_cli.py",
+            ),
+            KnownGap(
+                description=(
+                    "The fixture this class's fix *should* use -- a real "
+                    "ELF shared library -- cannot be used yet, so the POSIX "
+                    "branch still copies an executable. Auditing any real "
+                    "ELF library raises an uncaught "
+                    "`NoBaselineInvariantError`, because "
+                    "`diff_platform_elf_dynamic._diff_visibility_leak` is "
+                    "single-sided (`del new`) yet emits its finding with "
+                    "neither candidate-side marker, so ADR-068's partition "
+                    "files it as an identity-diff finding. That is a real "
+                    "open defect on `main`, not a fixture problem, and it is "
+                    "recorded in `docs/contribute/known-gaps.md` with a fix "
+                    "shape (audit every detector that ignores `new`, plus a "
+                    "gate, since neither the marker design nor the "
+                    "`ChangeKind` allowlist it rejected is self-enforcing). "
+                    "This class stays open in that sense: when the crash is "
+                    "fixed the POSIX branch should move to a real library, "
+                    "and nothing here will fail to remind anyone."
+                ),
+                reference="docs/contribute/known-gaps.md",
+            ),
+        ),
+    ),
+    BugClass(
         id="ci.shared_budget_over_heterogeneous_matrix",
         invariant=(
             "A resource budget a CI job declares once -- `timeout-minutes` "

--- a/tests/test_compare_no_baseline_cli.py
+++ b/tests/test_compare_no_baseline_cli.py
@@ -450,6 +450,80 @@ def test_a_dump_manifest_is_refused_rather_than_ignored(
     assert "--dump-manifest" in result.output
 
 
+def _a_live_binary_this_host_can_audit(tmp_path: Path) -> Path:
+    """A copy of a live binary artifact `--no-baseline` can actually audit.
+
+    Not "any binary on PATH", which is what this was and why it broke. The
+    original copied `shutil.which("true")` to `libfoo.so`: fine on Linux
+    and macOS, where an ELF or Mach-O executable exposes symbols, and
+    broken on Windows, where `true.exe` is a PE *executable* with no export
+    directory at all -- so abicheck correctly refused it ("has no exports
+    (named or ordinal)") and the test read that refusal as a broken
+    `--version`. The name was misleading too: the operand was called `.so`
+    on every platform while abicheck sniffs *content*, so on Windows it was
+    a PE file wearing an ELF extension. Hence: pick per platform, keep the
+    source's real filename, and assert the choice is a binary abicheck
+    recognises so a bad candidate fails here, in setup, rather than as a
+    puzzling exit code in the assertion.
+
+    **Why POSIX uses an executable and not a real `.so`.** It should use a
+    real shared library, and an earlier version of this helper did --
+    resolving `libm.so.6` through the standard library directories, since
+    `ctypes.util.find_library` answers a soname rather than a path. That
+    fixture immediately hit a *separate, pre-existing* crash: auditing any
+    real ELF library raises an uncaught `NoBaselineInvariantError`, because
+    `diff_platform_elf_dynamic._diff_visibility_leak` is a single-sided
+    detector (`del new  # detector is intentionally old-library-only`) that
+    emits its finding with neither candidate-side marker, so the ADR-068
+    partition files it as an identity-diff finding. It reproduces on `main`
+    from a bare CLI call and is recorded in `docs/contribute/known-gaps.md`
+    -- it is not this test's bug to fix and not this pull request's to
+    widen into. This helper deliberately steps around it rather than
+    silently, and the moment it is fixed the POSIX branch should go back to
+    a real library.
+
+    macOS additionally rules out `.dylib`: since macOS 11 the system
+    libraries live in the dyld shared cache, so the paths `find_library`
+    reports are not files on disk at all.
+    """
+    import os
+    import shutil
+
+    from abicheck.binary_utils import detect_binary_format
+
+    tried: list[str] = []
+    candidates: list[Path] = []
+
+    if sys.platform == "win32":
+        system32 = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "System32"
+        # Real DLLs, i.e. things with an export directory -- the property
+        # the previous fixture lacked on this platform.
+        candidates += [system32 / name for name in ("kernel32.dll", "ws2_32.dll")]
+    else:
+        which_true = shutil.which("true")
+        if which_true:
+            candidates.append(Path(which_true))
+
+    for candidate in candidates:
+        tried.append(str(candidate))
+        if not candidate.is_file():
+            continue
+        # Keep the source's own filename: the operand *is* that artifact, and
+        # a manufactured `.so` name is half of what made the original bug
+        # hard to read.
+        copy = tmp_path / candidate.name
+        copy.write_bytes(candidate.read_bytes())
+        detected = detect_binary_format(copy)
+        assert detected is not None, (
+            f"{candidate} is not a binary abicheck recognises (detected "
+            f"{detected!r}) -- a bad candidate in this helper, not a bug in "
+            "the command under test"
+        )
+        return copy
+
+    pytest.skip(f"no auditable live binary on this host; tried: {tried}")
+
+
 def test_a_candidate_version_label_is_honoured(candidate: Path, tmp_path: Path) -> None:
     """``--version new=`` was another silently-dropped generated destination.
 
@@ -457,13 +531,7 @@ def test_a_candidate_version_label_is_honoured(candidate: Path, tmp_path: Path) 
     recorded version on both the one- and two-sided paths -- asserting on the
     snapshot would pass whether or not the option was wired.
     """
-    import shutil
-
-    src = shutil.which("true")
-    if src is None:  # pragma: no cover - every supported CI image has it
-        pytest.skip("no native binary available to label")
-    binary = tmp_path / "libfoo.so"
-    binary.write_bytes(Path(src).read_bytes())
+    binary = _a_live_binary_this_host_can_audit(tmp_path)
     result = invoke_cli(
         "compare",
         "--no-baseline",

--- a/tests/test_compare_no_baseline_cli.py
+++ b/tests/test_compare_no_baseline_cli.py
@@ -608,7 +608,7 @@ def _project_snapshot_package(tmp_path: Path, case: str) -> Path:
 
 @pytest.mark.parametrize(
     "operand",
-    ["symvers", "perl_dump", "unknown_text"],
+    ["symvers", "unknown_text"],
 )
 def test_an_operand_this_run_parses_is_held_to_the_pinned_depth(
     tmp_path: Path, operand: str
@@ -617,23 +617,23 @@ def test_an_operand_this_run_parses_is_held_to_the_pinned_depth(
 
     The carve-out asked ``detect_binary_format(path) is not None`` — "is this
     a native binary?" — which is a narrower question with a different answer
-    for every operand that is neither a binary nor a snapshot. Each of those
-    is parsed into a brand-new snapshot that structurally cannot carry L3-L5
-    evidence, so a pinned ``--depth source`` was silently unsatisfiable:
-    ``Module.symvers --depth source`` reported no evidence tiers at all and
-    exit 0 (Codex review, P1).
+    for every operand that is neither a binary nor a serialized ABI
+    description. Each of those has an ABI description *derived* from it by
+    this run and structurally cannot carry L3-L5 evidence, so a pinned
+    ``--depth source`` was silently unsatisfiable: ``Module.symvers --depth
+    source`` reported no evidence tiers at all and exit 0 (Codex review, P1).
 
     Parametrized over the *class* rather than the reported input: the shared
-    property of all three is "not a binary, not a snapshot", and a fix keyed
-    to symvers alone would leave the siblings exempt. The oracle is the
-    predicate's own contract — anything not stored is live — checked here
-    against operands chosen to be exactly the ones that used to slip through.
+    property is "raw evidence, not an ABI description someone already wrote
+    down", and a fix keyed to symvers alone would leave the siblings exempt.
+    The oracle is the predicate's own contract — anything not already an ABI
+    description is live — checked here against operands chosen to be exactly
+    the ones that used to slip through.
     """
     from abicheck.workflows.no_baseline_compare import candidate_is_live_artifact
 
     bodies = {
         "symvers": "0x00000000\tvfs_read\tvmlinux\tEXPORT_SYMBOL\n",
-        "perl_dump": "$VAR1 = {\n  'ABI' => {}\n};\n",
         "unknown_text": "not a snapshot, not a binary\n",
     }
     path = tmp_path / operand
@@ -644,16 +644,16 @@ def test_an_operand_this_run_parses_is_held_to_the_pinned_depth(
     )
 
 
-def test_a_serialized_snapshot_stays_exempt_in_both_of_its_shapes(
+def test_a_serialized_description_stays_exempt_in_every_one_of_its_shapes(
     tmp_path: Path,
 ) -> None:
     """The complement, so the fix above cannot be 'gate everything'.
 
-    Both shapes `resolve_input` accepts as a stored snapshot are exempt — a
-    single ``.abi.json`` file and a directory-backed `ProjectSnapshot`
-    package — because only a serialized snapshot can already *carry* the
-    pinned evidence. A plain directory of libraries is neither, and must not
-    be swept into the exemption.
+    Every shape `resolve_input` accepts as an already-serialized ABI
+    description is exempt — a single ``.abi.json`` file, a directory-backed
+    `ProjectSnapshot` package, and an ABICC Perl dump — because only such a
+    description can already *carry* the pinned evidence. A plain directory of
+    libraries is none of them, and must not be swept into the exemption.
     """
     from abicheck.workflows.no_baseline_compare import candidate_is_live_artifact
 
@@ -662,6 +662,8 @@ def test_a_serialized_snapshot_stays_exempt_in_both_of_its_shapes(
         / "snapshot.abi.json"
     )
     package = _project_snapshot_package(tmp_path, "case143_audit_accidental_export")
+    perl_dump = tmp_path / "saved.dump"
+    perl_dump.write_text("$VAR1 = {\n  'ABI' => {}\n};\n")
     plain = tmp_path / "release"
     plain.mkdir()
     (plain / "libfoo.so").write_bytes(b"\x7fELF\x02\x01\x01\x00" + bytes(56))
@@ -670,6 +672,12 @@ def test_a_serialized_snapshot_stays_exempt_in_both_of_its_shapes(
     assert candidate_is_live_artifact(package) is False, (
         "a ProjectSnapshot package is the repository's own storage-v2 form of "
         "the same stored snapshot, so it carries the same exemption"
+    )
+    assert candidate_is_live_artifact(perl_dump) is False, (
+        "an ABICC Perl dump is a pre-built, tool-produced ABI description "
+        "this run parses rather than extracts, exactly like an .abi.json; "
+        "splitting the two on serialization format alone made --depth source "
+        "exit 7 on one and 0 on the other (Codex review, P2)"
     )
     assert candidate_is_live_artifact(plain) is True, (
         "a plain directory of libraries is not a stored snapshot; exempting "
@@ -808,8 +816,14 @@ def test_the_audit_sarif_names_why_it_exited(tmp_path: Path) -> None:
         run_no_baseline_compare,
     )
 
+    # `case145` under `--contract public` is short of evidence and really
+    # gates; `case143` closes the domain cleanly, so pointing this test at
+    # it and guarding on `if exit_code:` left the whole gated assertion
+    # unreachable (CodeRabbit review). The gate is asserted first, so the
+    # test fails loudly if the fixture ever stops gating instead of
+    # quietly passing on nothing.
     snapshot = (
-        example_catalog.case_dir("case143_audit_accidental_export")
+        example_catalog.case_dir("case145_audit_unversioned_export")
         / "snapshot.abi.json"
     )
     result = run_no_baseline_compare(
@@ -821,13 +835,103 @@ def test_the_audit_sarif_names_why_it_exited(tmp_path: Path) -> None:
     run = json.loads(payload)["runs"][0]
     invocation = run["invocations"][0]
 
-    if exit_code:
-        assert "contract coverage incomplete" in invocation["exitCodeDescription"]
-        notifications = invocation.get("toolExecutionNotifications") or []
-        assert notifications, "a gated audit must say which provider fell short"
-        assert any("provider" in n["message"]["text"] for n in notifications)
-        assert run["properties"]["contractCoverageFailures"]
+    assert exit_code != 0, "the gated fixture must actually gate"
+    assert "contract coverage incomplete" in invocation["exitCodeDescription"]
+    notifications = invocation.get("toolExecutionNotifications") or []
+    assert notifications, "a gated audit must say which provider fell short"
+    assert any("provider" in n["message"]["text"] for n in notifications)
+    assert run["properties"]["contractCoverageFailures"]
     assert invocation["executionSuccessful"] is True, (
         "SARIF's executionSuccessful means the tool ran to completion, not "
         "that it found nothing"
+    )
+
+
+@pytest.mark.parametrize(
+    ("config_text", "suppression_text"),
+    [
+        pytest.param(
+            "suppression:\n  require_justification: true\n",
+            'version: 1\nsuppressions:\n  - symbol_pattern: ".*"\n',
+            id="require_justification",
+        ),
+        pytest.param(
+            "suppression:\n  strict: true\n",
+            (
+                "version: 1\n"
+                "suppressions:\n"
+                '  - symbol_pattern: ".*"\n'
+                '    reason: "audited"\n'
+                '    expires: "2020-01-01"\n'
+            ),
+            id="strict_expiry",
+        ),
+    ],
+)
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_a_configs_suppression_acceptance_rules_bind_the_audit_too(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    config_text: str,
+    suppression_text: str,
+    dry_run: bool,
+) -> None:
+    """`.abicheck.yml`'s `suppression:` acceptance settings gate the audit.
+
+    These two settings decide whether a suppression *document* may be used at
+    all, not which findings it matches. The audit resolved the project config
+    but never read them, so a reasonless (or long-expired) rule that ordinary
+    `compare` rejects was accepted here — and then suppressed the finding and
+    exited 0, which is the worst possible direction for the failure to run in
+    (Codex review, P1).
+
+    Both settings are exercised, since honoring one would satisfy a
+    single-row test, and `--dry-run` is exercised alongside the real run: a
+    preview that accepts a document the run rejects approves a run that
+    cannot start. The oracle is the two-sided command's own exit code on the
+    same directory and the same document — not a hard-coded number — so the
+    two paths cannot drift apart again.
+    """
+    work, snapshot = _in_dir(tmp_path, config_text)
+    suppress = work / "sup.yaml"
+    suppress.write_text(suppression_text)
+    monkeypatch.chdir(work)
+
+    real_audit = invoke_cli(
+        "compare", "--no-baseline", str(snapshot), "--suppress", str(suppress)
+    )
+    two_sided = invoke_cli(
+        "compare", str(snapshot), str(snapshot), "--suppress", str(suppress)
+    )
+    assert two_sided.exit_code != 0, (
+        "the two-sided command is this test's oracle; if it stopped "
+        "rejecting the document there is nothing left to compare against"
+    )
+    assert real_audit.exit_code == two_sided.exit_code, (
+        f"audit exited {real_audit.exit_code}, two-sided "
+        f"{two_sided.exit_code} on the same rejected suppression document"
+    )
+
+    if not dry_run:
+        return
+
+    # `--dry-run`'s oracle is the audit's own real run, not the two-sided
+    # command's preview: two-sided `--dry-run` does not load the suppression
+    # document at all, while this path deliberately does, so that a preview
+    # cannot approve a run that then cannot start (an earlier Codex P2 on
+    # this same command). Comparing against the looser preview would pin the
+    # weaker behaviour, so the invariant asserted here is the one this path
+    # actually promises.
+    preview = invoke_cli(
+        "compare",
+        "--no-baseline",
+        str(snapshot),
+        "--suppress",
+        str(suppress),
+        "--dry-run",
+    )
+    assert preview.exit_code == real_audit.exit_code, (
+        f"the preview exited {preview.exit_code} where the real audit exits "
+        f"{real_audit.exit_code}; a preview that accepts a document the run "
+        "rejects approves a run that cannot start"
     )

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -785,23 +785,39 @@ def test_every_suppressed_finding_keeps_its_full_rule_provenance(
         assert row["suppression_provenance"]["source_file"] == "waivers.yaml"
 
 
-def test_the_markdown_suppression_table_shows_reason_and_source() -> None:
-    """The same record, in the projection a human actually reads.
+@pytest.mark.parametrize("fmt", sorted(NO_BASELINE_SUPPORTED_FORMATS - {"oneline"}))
+def test_every_format_carries_the_reason_and_source_not_just_the_label(
+    fmt: str,
+) -> None:
+    """The provenance reaches *every* projection, not the two wired first.
 
-    A machine-readable field a person never sees does not close this: the
-    Markdown audit is the "which waivers are still justified?" view, so the
-    reason and the file to edit belong in its table.
+    JSON and Markdown gained it first; SARIF and JUnit kept reading the
+    display label, so a consumer of either structured CI format still could
+    not tell why or where a finding was suppressed (Codex review, P2). A
+    fact one format publishes while its siblings drop it leaves a reader of
+    the quiet format unable to act on the run they were handed.
+
+    Parametrized over the supported set rather than naming today's four, so
+    a format added later is held to this without anyone remembering to.
+    `oneline` is excluded deliberately: it is one sentence by contract and
+    carries no per-finding detail at all.
     """
     result = _result(
         "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
     )
-    text = render_no_baseline(result, "markdown")[0]
+    assert compute_no_baseline_document(result).suppressed
+    text = render_no_baseline(result, fmt)[0]
 
-    assert "audit-waiver-17" in text
+    assert "audit-waiver-17" in text, f"{fmt} must name the rule"
     assert "temporary vendor debug hook" in text, (
-        "the reason is what tells a reviewer whether the waiver still applies"
+        f"{fmt} must carry the reason — it is what tells a reviewer whether "
+        "the waiver still applies, and the display label drops it whenever "
+        "the rule also states a label"
     )
-    assert "waivers.yaml" in text, "and the file is where they would edit it"
+    assert "waivers.yaml" in text, (
+        f"{fmt} must carry the source file — it is where a reviewer would "
+        "edit or remove the waiver"
+    )
 
 
 def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -> None:

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -49,6 +49,7 @@ from abicheck.report.no_baseline import (
     compute_no_baseline_document,
     render_no_baseline,
 )
+from abicheck.schemas import AUDIT_REPORT_SCHEMA_PATH
 from abicheck.suppression import Suppression, SuppressionList
 from abicheck.workflows.no_baseline_compare import (
     resolve_no_baseline_candidate,
@@ -718,133 +719,6 @@ def test_the_audit_json_validates_against_its_own_published_schema() -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Suppression provenance: the disposition audit's own record, not a label.
-# ---------------------------------------------------------------------------
-
-
-def _labelled_and_reasoned() -> SuppressionList:
-    """A rule stating BOTH a label and a reason.
-
-    This is the shape that exposed the bug: `SuppressionOutcome.rule_label()`
-    is `label or reason`, so a rule carrying both publishes its label and
-    silently drops the reason. A rule with only one of them cannot detect
-    that, which is why every test here uses both.
-    """
-    return SuppressionList(
-        [
-            Suppression(
-                symbol_pattern=".*",
-                label="audit-waiver-17",
-                reason="temporary vendor debug hook",
-            )
-        ],
-        source_path="waivers.yaml",
-    )
-
-
-@pytest.mark.parametrize(("case", "filename"), _FIXTURES)
-def test_every_suppressed_finding_keeps_its_full_rule_provenance(
-    case: str, filename: str
-) -> None:
-    """ADR-067 D3: a disposition keeps the rule *and the reason* that hid it.
-
-    The audit published `suppression_rule`, which is the display label —
-    `label or reason`, never both — so a reader could not tell why a waiver
-    was written or which file to edit to review it (Codex review, P1).
-
-    The oracle is the run's own disposition ledger, not the report: every
-    field the ledger recorded for the rule that fired must survive into the
-    projection. Asserted over the whole fixture corpus and over every
-    ledger-recorded field, so a projection that carries one field and drops
-    another still fails.
-    """
-    result = _result(case, filename, suppression=_labelled_and_reasoned())
-    doc = compute_no_baseline_document(result)
-    ledger = result.diff.disposition_ledger
-    assert doc.suppressed, "this fixture must have something to suppress"
-
-    body = json.loads(render_no_baseline(result, "json")[0])
-    rows = body["suppressed_findings"]
-    assert len(rows) == len(doc.suppressed)
-
-    for row, entry in zip(rows, doc.suppressed, strict=True):
-        recorded = ledger.rule_for(entry.finding.change)
-        assert recorded is not None, (
-            "the run recorded no ledger entry, so this test would pass "
-            "vacuously against a projection that emits nothing"
-        )
-        assert row["suppression_provenance"] == recorded.to_dict(), (
-            "every field the ledger recorded must reach the report; the "
-            "display label alone collapses label and reason into one string"
-        )
-        # The specific loss the fix closes, stated independently of the
-        # ledger comparison above so it cannot be satisfied by an equality
-        # that happens to compare two equally-lossy values.
-        assert row["suppression_provenance"]["reason"] == (
-            "temporary vendor debug hook"
-        )
-        assert row["suppression_provenance"]["label"] == "audit-waiver-17"
-        assert row["suppression_provenance"]["source_file"] == "waivers.yaml"
-
-
-@pytest.mark.parametrize("fmt", sorted(NO_BASELINE_SUPPORTED_FORMATS - {"oneline"}))
-def test_every_format_carries_the_reason_and_source_not_just_the_label(
-    fmt: str,
-) -> None:
-    """The provenance reaches *every* projection, not the two wired first.
-
-    JSON and Markdown gained it first; SARIF and JUnit kept reading the
-    display label, so a consumer of either structured CI format still could
-    not tell why or where a finding was suppressed (Codex review, P2). A
-    fact one format publishes while its siblings drop it leaves a reader of
-    the quiet format unable to act on the run they were handed.
-
-    Parametrized over the supported set rather than naming today's four, so
-    a format added later is held to this without anyone remembering to.
-    `oneline` is excluded deliberately: it is one sentence by contract and
-    carries no per-finding detail at all.
-    """
-    result = _result(
-        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
-    )
-    assert compute_no_baseline_document(result).suppressed
-    text = render_no_baseline(result, fmt)[0]
-
-    assert "audit-waiver-17" in text, f"{fmt} must name the rule"
-    assert "temporary vendor debug hook" in text, (
-        f"{fmt} must carry the reason — it is what tells a reviewer whether "
-        "the waiver still applies, and the display label drops it whenever "
-        "the rule also states a label"
-    )
-    assert "waivers.yaml" in text, (
-        f"{fmt} must carry the source file — it is where a reviewer would "
-        "edit or remove the waiver"
-    )
-
-
-def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -> None:
-    """The complement: absent provenance is `null`, never invented.
-
-    A `DiffResult` rebuilt from JSON carries no disposition ledger. Emitting
-    a row derived from `Change.suppression_rule` there would look like a real
-    ADR-067 record while carrying strictly less, which is worse than saying
-    nothing.
-    """
-    result = _result(
-        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
-    )
-    object.__setattr__(result.diff, "disposition_ledger", None)
-    doc = compute_no_baseline_document(result)
-
-    assert doc.suppressed
-    assert all(entry.provenance is None for entry in doc.suppressed)
-    body = json.loads(render_no_baseline(result, "json")[0])
-    assert all(
-        row["suppression_provenance"] is None for row in body["suppressed_findings"]
-    )
-
-
 def test_junit_names_the_axis_that_gated_not_every_axis_that_could_have() -> None:
     """JUnit must say *which* orthogonal axis fired.
 
@@ -915,8 +789,6 @@ def test_the_published_audit_schema_copy_matches_the_packaged_one() -> None:
     `jsonschema`'s `additionalProperties` tolerance will not flag a stale
     published copy, which is exactly how the first drift went unnoticed.
     """
-    from abicheck.schemas import AUDIT_REPORT_SCHEMA_PATH
-
     published = (
         AUDIT_REPORT_SCHEMA_PATH.parent.parent.parent
         / "docs"
@@ -933,73 +805,3 @@ def test_the_published_audit_schema_copy_matches_the_packaged_one() -> None:
         "run scripts/publish_schemas.py (or mirror the edit) so a consumer "
         "reading the documented schema sees what the tool actually emits"
     )
-
-
-@pytest.mark.parametrize(
-    ("label", "reason", "expected"),
-    [
-        pytest.param(
-            "audit-waiver-17",
-            "temporary vendor debug hook",
-            "audit-waiver-17: temporary vendor debug hook",
-            id="both",
-        ),
-        pytest.param(
-            None,
-            "temporary vendor debug hook",
-            "temporary vendor debug hook",
-            id="reason-only",
-        ),
-        pytest.param("audit-waiver-17", None, "audit-waiver-17", id="label-only"),
-    ],
-)
-def test_a_suppression_justification_never_repeats_one_field_as_two(
-    label: str | None, reason: str | None, expected: str
-) -> None:
-    """`label: reason` only when the rule really states both.
-
-    `Change.suppression_rule` is `label or reason` — one string that does
-    not say which of the two it holds. Reading it as a label whenever
-    provenance had none rendered a reason-only rule as
-    `"<reason>: <reason>"`, presenting the reason as a separate rule label
-    (Codex review, P2). That is the shape
-    `suppression.require_justification` actively encourages, so it is the
-    common case rather than an edge one.
-
-    All three stating combinations are exercised, not just the reported
-    reason-only one: a fix that special-cased equality would still get
-    label-only wrong, and the invariant is "never present one field as
-    two", not "handle this input".
-    """
-    rule = Suppression(symbol_pattern=".*", label=label, reason=reason)
-    result = _result(
-        "case143_audit_accidental_export",
-        suppression=SuppressionList([rule], source_path="waivers.yaml"),
-    )
-    doc = compute_no_baseline_document(result)
-    assert doc.suppressed, "this fixture must have something to suppress"
-
-    sarif = json.loads(render_no_baseline(result, "sarif")[0])
-    justifications = [
-        r["suppressions"][0]["justification"]
-        for r in sarif["runs"][0]["results"]
-        if r.get("suppressions")
-    ]
-    assert justifications, "a suppressed finding must carry a SARIF suppression"
-    for text in justifications:
-        assert text == expected
-        # The invariant behind the specific expectations above, stated
-        # independently of them: no field is ever printed twice.
-        parts = [p.strip() for p in text.split(":")]
-        assert len(parts) == len(set(parts)), (
-            f"justification {text!r} repeats a field; one source rendered as two"
-        )
-
-    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
-    skipped = [s.attrib["message"] for s in junit.iter("skipped")]
-    assert skipped, "a suppressed finding must be a skipped JUnit case"
-    for message in skipped:
-        assert message == f"suppressed: {expected}", (
-            "JUnit and SARIF share one justification helper and must not "
-            "phrase it differently"
-        )

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -713,3 +713,175 @@ def test_the_audit_json_validates_against_its_own_published_schema() -> None:
         "an audit must not validate as a compare report — the two documents "
         "mean different things by a null verdict"
     )
+
+
+# ---------------------------------------------------------------------------
+# Suppression provenance: the disposition audit's own record, not a label.
+# ---------------------------------------------------------------------------
+
+
+def _labelled_and_reasoned() -> SuppressionList:
+    """A rule stating BOTH a label and a reason.
+
+    This is the shape that exposed the bug: `SuppressionOutcome.rule_label()`
+    is `label or reason`, so a rule carrying both publishes its label and
+    silently drops the reason. A rule with only one of them cannot detect
+    that, which is why every test here uses both.
+    """
+    return SuppressionList(
+        [
+            Suppression(
+                symbol_pattern=".*",
+                label="audit-waiver-17",
+                reason="temporary vendor debug hook",
+            )
+        ],
+        source_path="waivers.yaml",
+    )
+
+
+@pytest.mark.parametrize(("case", "filename"), _FIXTURES)
+def test_every_suppressed_finding_keeps_its_full_rule_provenance(
+    case: str, filename: str
+) -> None:
+    """ADR-067 D3: a disposition keeps the rule *and the reason* that hid it.
+
+    The audit published `suppression_rule`, which is the display label —
+    `label or reason`, never both — so a reader could not tell why a waiver
+    was written or which file to edit to review it (Codex review, P1).
+
+    The oracle is the run's own disposition ledger, not the report: every
+    field the ledger recorded for the rule that fired must survive into the
+    projection. Asserted over the whole fixture corpus and over every
+    ledger-recorded field, so a projection that carries one field and drops
+    another still fails.
+    """
+    result = _result(case, filename, suppression=_labelled_and_reasoned())
+    doc = compute_no_baseline_document(result)
+    ledger = result.diff.disposition_ledger
+    assert doc.suppressed, "this fixture must have something to suppress"
+
+    body = json.loads(render_no_baseline(result, "json")[0])
+    rows = body["suppressed_findings"]
+    assert len(rows) == len(doc.suppressed)
+
+    for row, finding in zip(rows, doc.suppressed, strict=True):
+        recorded = ledger.rule_for(finding.change)
+        assert recorded is not None, (
+            "the run recorded no ledger entry, so this test would pass "
+            "vacuously against a projection that emits nothing"
+        )
+        assert row["suppression_provenance"] == recorded.to_dict(), (
+            "every field the ledger recorded must reach the report; the "
+            "display label alone collapses label and reason into one string"
+        )
+        # The specific loss the fix closes, stated independently of the
+        # ledger comparison above so it cannot be satisfied by an equality
+        # that happens to compare two equally-lossy values.
+        assert row["suppression_provenance"]["reason"] == (
+            "temporary vendor debug hook"
+        )
+        assert row["suppression_provenance"]["label"] == "audit-waiver-17"
+        assert row["suppression_provenance"]["source_file"] == "waivers.yaml"
+
+
+def test_the_markdown_suppression_table_shows_reason_and_source() -> None:
+    """The same record, in the projection a human actually reads.
+
+    A machine-readable field a person never sees does not close this: the
+    Markdown audit is the "which waivers are still justified?" view, so the
+    reason and the file to edit belong in its table.
+    """
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    text = render_no_baseline(result, "markdown")[0]
+
+    assert "audit-waiver-17" in text
+    assert "temporary vendor debug hook" in text, (
+        "the reason is what tells a reviewer whether the waiver still applies"
+    )
+    assert "waivers.yaml" in text, "and the file is where they would edit it"
+
+
+def test_a_diffresult_without_a_ledger_reports_no_provenance_rather_than_faking_one(
+    tmp_path: Path,
+) -> None:
+    """The complement: absent provenance is `null`, never invented.
+
+    A `DiffResult` rebuilt from JSON carries no disposition ledger. Emitting
+    a row derived from `Change.suppression_rule` there would look like a real
+    ADR-067 record while carrying strictly less, which is worse than saying
+    nothing.
+    """
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    object.__setattr__(result.diff, "disposition_ledger", None)
+    doc = compute_no_baseline_document(result)
+
+    assert doc.suppressed
+    assert all(p is None for p in doc.suppression_provenance)
+    body = json.loads(render_no_baseline(result, "json")[0])
+    assert all(
+        row["suppression_provenance"] is None for row in body["suppressed_findings"]
+    )
+
+
+def test_junit_names_the_axis_that_gated_not_every_axis_that_could_have() -> None:
+    """JUnit must say *which* orthogonal axis fired.
+
+    The suite carried only the total exit code and the contract-coverage
+    contribution, and the failure text listed every axis that might have
+    fired — so a consumer gated by the evidence contract learned nothing
+    (Codex review, P2). JSON, Markdown, oneline and SARIF all name it; JUnit
+    is now held to the same statement.
+
+    The oracle is `doc.exit_axes` — the same resolved mapping the other four
+    projections read — so the formats cannot drift apart, and each axis is
+    checked in both directions: a contributing axis must be named, a cleared
+    one must be published as `0` rather than omitted.
+    """
+    result = run_no_baseline_compare(
+        resolve_no_baseline_candidate(
+            example_catalog.case_dir("case145_audit_unversioned_export")
+            / "snapshot.abi.json"
+        ),
+        contract_evaluation=True,
+        contract_mode="public",
+    )
+    doc = compute_no_baseline_document(result)
+    payload, exit_code = render_no_baseline(result, "junit")
+    assert exit_code != 0, "the gated fixture must actually gate"
+
+    suite = ET.fromstring(payload)
+    props = {p.attrib["name"]: p.attrib["value"] for p in suite.iter("property")}
+    for axis, contribution in doc.exit_axes.items():
+        assert props[f"exit_axis.{axis}"] == str(contribution), (
+            f"axis {axis} must be published with its own contribution; a "
+            "cleared axis is a real '0', not an absent key"
+        )
+
+    failure = suite.find(".//failure")
+    assert failure is not None and failure.text
+    contributing = [a for a, c in doc.exit_axes.items() if c]
+    assert contributing, "this fixture must contribute on some axis"
+    for axis in contributing:
+        assert NO_BASELINE_EXIT_AXIS_LABELS[axis] in failure.text, (
+            f"the failure text must name the contributing axis {axis}"
+        )
+    for axis, contribution in doc.exit_axes.items():
+        if contribution:
+            continue
+        assert NO_BASELINE_EXIT_AXIS_LABELS[axis] not in failure.text, (
+            f"axis {axis} did not fire, so naming it in the failure text is "
+            "the same 'here is every axis that might have' non-answer this "
+            "test exists to forbid"
+        )
+
+    assert doc.coverage_failures, "this fixture gates on the coverage axis"
+    for failed in doc.coverage_failures:
+        assert str(failed["provider"]) in failure.text, (
+            "the coverage axis can name a specific provider; the bare "
+            "contribution number cannot"
+        )

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -42,6 +42,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from abicheck.report.no_baseline import (
+    AUDIT_REPORT_SCHEMA_VERSION,
     NO_BASELINE_EXIT_AXIS_LABELS,
     NO_BASELINE_EXIT_AXIS_NOTICES,
     NO_BASELINE_SUPPORTED_FORMATS,
@@ -705,7 +706,9 @@ def test_the_audit_json_validates_against_its_own_published_schema() -> None:
     assert "report_schema_version" not in doc, (
         "the compare report's identity field must not appear on an audit"
     )
-    assert doc["audit_report_schema_version"], "the audit carries its own version"
+    assert doc["audit_report_schema_version"] == AUDIT_REPORT_SCHEMA_VERSION, (
+        "the emitted version must be the constant, not a literal that can drift from it"
+    )
     compare_errors = list(
         jsonschema.Draft202012Validator(load_compare_report_schema()).iter_errors(doc)
     )
@@ -899,3 +902,34 @@ def test_junit_names_the_axis_that_gated_not_every_axis_that_could_have() -> Non
             "the coverage axis can name a specific provider; the bare "
             "contribution number cannot"
         )
+
+
+def test_the_published_audit_schema_copy_matches_the_packaged_one() -> None:
+    """The two copies of this schema stay byte-identical.
+
+    `scripts/publish_schemas.py` keeps `docs/reference/schemas/v1/` in sync
+    with the packaged copy, and `compare_report.schema.json` has had this
+    guard since its own docs mirror silently drifted (PR #595 -> #611).
+    The audit schema shipped without the equivalent, so its two copies were
+    hand-edited in step and nothing checked that they stayed that way —
+    `jsonschema`'s `additionalProperties` tolerance will not flag a stale
+    published copy, which is exactly how the first drift went unnoticed.
+    """
+    from abicheck.schemas import AUDIT_REPORT_SCHEMA_PATH
+
+    published = (
+        AUDIT_REPORT_SCHEMA_PATH.parent.parent.parent
+        / "docs"
+        / "reference"
+        / "schemas"
+        / "v1"
+        / "audit_report.schema.json"
+    )
+    assert published.is_file(), "the audit schema must be published, not packaged only"
+    assert published.read_text(encoding="utf-8") == AUDIT_REPORT_SCHEMA_PATH.read_text(
+        encoding="utf-8"
+    ), (
+        "the published audit schema has drifted from the packaged one; "
+        "run scripts/publish_schemas.py (or mirror the edit) so a consumer "
+        "reading the documented schema sees what the tool actually emits"
+    )

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -586,11 +586,29 @@ def test_a_coverage_gated_audit_publishes_the_ledger_that_gated_it() -> None:
     assert body["contract_coverage_failures"] == [
         dict(f) for f in doc.coverage_failures
     ]
-    if exit_code:
-        assert body["contract_coverage_failures"], (
-            "a run gated on the coverage axis must list what fell short; "
-            "publishing only the contribution is the defect this closes"
-        )
+    # The half above proves a *closed* domain still publishes the ledger
+    # (`[]`). The gated half needs a fixture that really is short of
+    # evidence -- `case143` closes `public` cleanly, so guarding this on
+    # `if exit_code:` made the assertion unreachable and it never ran
+    # (CodeRabbit review). Assert the gate fires first, then what it must
+    # publish.
+    gated = run_no_baseline_compare(
+        resolve_no_baseline_candidate(
+            example_catalog.case_dir("case145_audit_unversioned_export")
+            / "snapshot.abi.json"
+        ),
+        contract_evaluation=True,
+        contract_mode="public",
+    )
+    gated_payload, gated_exit = render_no_baseline(gated, "json")
+    assert gated_exit != 0, (
+        "case145 under `--contract public` is this suite's gated fixture; "
+        "if it stopped gating, this test proves nothing"
+    )
+    assert json.loads(gated_payload)["contract_coverage_failures"], (
+        "a run gated on the coverage axis must list what fell short; "
+        "publishing only the contribution is the defect this closes"
+    )
 
 
 def test_a_run_without_a_contract_omits_the_ledger_entirely() -> None:

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -577,7 +577,7 @@ def test_a_coverage_gated_audit_publishes_the_ledger_that_gated_it() -> None:
         doc = compute_no_baseline_document(result)
 
     assert doc.contract_selected, "the contract path must actually have run"
-    payload, exit_code = render_no_baseline(result, "json")
+    payload, _exit_code = render_no_baseline(result, "json")
     body = json.loads(payload)
     assert "contract_coverage_failures" in body, (
         "the ledger is emitted whenever a contract domain was selected — `[]` "
@@ -765,8 +765,8 @@ def test_every_suppressed_finding_keeps_its_full_rule_provenance(
     rows = body["suppressed_findings"]
     assert len(rows) == len(doc.suppressed)
 
-    for row, finding in zip(rows, doc.suppressed, strict=True):
-        recorded = ledger.rule_for(finding.change)
+    for row, entry in zip(rows, doc.suppressed, strict=True):
+        recorded = ledger.rule_for(entry.finding.change)
         assert recorded is not None, (
             "the run recorded no ledger entry, so this test would pass "
             "vacuously against a projection that emits nothing"
@@ -804,9 +804,7 @@ def test_the_markdown_suppression_table_shows_reason_and_source() -> None:
     assert "waivers.yaml" in text, "and the file is where they would edit it"
 
 
-def test_a_diffresult_without_a_ledger_reports_no_provenance_rather_than_faking_one(
-    tmp_path: Path,
-) -> None:
+def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -> None:
     """The complement: absent provenance is `null`, never invented.
 
     A `DiffResult` rebuilt from JSON carries no disposition ledger. Emitting
@@ -821,7 +819,7 @@ def test_a_diffresult_without_a_ledger_reports_no_provenance_rather_than_faking_
     doc = compute_no_baseline_document(result)
 
     assert doc.suppressed
-    assert all(p is None for p in doc.suppression_provenance)
+    assert all(entry.provenance is None for entry in doc.suppressed)
     body = json.loads(render_no_baseline(result, "json")[0])
     assert all(
         row["suppression_provenance"] is None for row in body["suppressed_findings"]

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -933,3 +933,73 @@ def test_the_published_audit_schema_copy_matches_the_packaged_one() -> None:
         "run scripts/publish_schemas.py (or mirror the edit) so a consumer "
         "reading the documented schema sees what the tool actually emits"
     )
+
+
+@pytest.mark.parametrize(
+    ("label", "reason", "expected"),
+    [
+        pytest.param(
+            "audit-waiver-17",
+            "temporary vendor debug hook",
+            "audit-waiver-17: temporary vendor debug hook",
+            id="both",
+        ),
+        pytest.param(
+            None,
+            "temporary vendor debug hook",
+            "temporary vendor debug hook",
+            id="reason-only",
+        ),
+        pytest.param("audit-waiver-17", None, "audit-waiver-17", id="label-only"),
+    ],
+)
+def test_a_suppression_justification_never_repeats_one_field_as_two(
+    label: str | None, reason: str | None, expected: str
+) -> None:
+    """`label: reason` only when the rule really states both.
+
+    `Change.suppression_rule` is `label or reason` — one string that does
+    not say which of the two it holds. Reading it as a label whenever
+    provenance had none rendered a reason-only rule as
+    `"<reason>: <reason>"`, presenting the reason as a separate rule label
+    (Codex review, P2). That is the shape
+    `suppression.require_justification` actively encourages, so it is the
+    common case rather than an edge one.
+
+    All three stating combinations are exercised, not just the reported
+    reason-only one: a fix that special-cased equality would still get
+    label-only wrong, and the invariant is "never present one field as
+    two", not "handle this input".
+    """
+    rule = Suppression(symbol_pattern=".*", label=label, reason=reason)
+    result = _result(
+        "case143_audit_accidental_export",
+        suppression=SuppressionList([rule], source_path="waivers.yaml"),
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed, "this fixture must have something to suppress"
+
+    sarif = json.loads(render_no_baseline(result, "sarif")[0])
+    justifications = [
+        r["suppressions"][0]["justification"]
+        for r in sarif["runs"][0]["results"]
+        if r.get("suppressions")
+    ]
+    assert justifications, "a suppressed finding must carry a SARIF suppression"
+    for text in justifications:
+        assert text == expected
+        # The invariant behind the specific expectations above, stated
+        # independently of them: no field is ever printed twice.
+        parts = [p.strip() for p in text.split(":")]
+        assert len(parts) == len(set(parts)), (
+            f"justification {text!r} repeats a field; one source rendered as two"
+        )
+
+    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    skipped = [s.attrib["message"] for s in junit.iter("skipped")]
+    assert skipped, "a suppressed finding must be a skipped JUnit case"
+    for message in skipped:
+        assert message == f"suppressed: {expected}", (
+            "JUnit and SARIF share one justification helper and must not "
+            "phrase it differently"
+        )

--- a/tests/test_no_baseline_report_formats.py
+++ b/tests/test_no_baseline_report_formats.py
@@ -805,3 +805,58 @@ def test_the_published_audit_schema_copy_matches_the_packaged_one() -> None:
         "run scripts/publish_schemas.py (or mirror the edit) so a consumer "
         "reading the documented schema sees what the tool actually emits"
     )
+
+
+#: The audit schema's root ``required`` list, pinned.
+#:
+#: Growing this set is a *narrowing* of the validation contract, not an
+#: addition: a document that validated without the new entry stops
+#: validating. On a published schema version that is a MAJOR bump, or
+#: grounds for leaving the field optional -- MINOR is not available for it
+#: (see `AUDIT_REPORT_SCHEMA_VERSION`'s own note). The rule was prose only
+#: until a review pointed out that `1.1` had quietly grown this list while
+#: the comment beside it called the change "additive" (Codex review, P2);
+#: prose is what let that through, so the rule is executable here instead.
+#:
+#: Updating this set is therefore a deliberate act with a version decision
+#: attached. Do not edit it to make a failure go away.
+#: Read off the schema, not recalled: a first draft of this set was written
+#: from memory, named a `candidate` field the schema does not have, and
+#: omitted three it does. The test caught it, which is the point -- but it
+#: is worth recording that even the pin wanted checking against the source.
+_EXPECTED_AUDIT_ROOT_REQUIRED = frozenset(
+    {
+        "audit_report_schema_version",
+        "changes",
+        "exit_code",
+        "findings",
+        "library",
+        "no_baseline",
+        "old_acquisition_state",
+        "verdict",
+    }
+)
+
+
+def test_the_audit_schemas_required_list_is_pinned() -> None:
+    """A `required` entry may not appear without a version decision.
+
+    Deliberately asserts set *equality*, not `>=`: a one-directional check
+    would catch a removal while letting the tightening this test exists for
+    slip through, which is the direction that actually happened.
+    """
+    schema = json.loads(AUDIT_REPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    actual = frozenset(schema["required"])
+    added = actual - _EXPECTED_AUDIT_ROOT_REQUIRED
+    removed = _EXPECTED_AUDIT_ROOT_REQUIRED - actual
+    assert not added, (
+        f"the audit schema's root `required` list grew by {sorted(added)}. That "
+        "narrows the contract: a document valid without those fields is now "
+        "rejected. If the schema version has been released, this needs a MAJOR "
+        "bump or the field left optional -- see AUDIT_REPORT_SCHEMA_VERSION's "
+        "note. Update this set only with that decision made."
+    )
+    assert not removed, (
+        f"the audit schema's root `required` list lost {sorted(removed)}; a "
+        "removal is a MAJOR change in the other direction"
+    )

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # noqa: S405  # nosec B405 (trusted test data)
 from pathlib import Path
 
 import pytest

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -30,8 +30,14 @@ from abicheck.report.no_baseline import (
     compute_no_baseline_document,
     render_no_baseline,
 )
-from abicheck.report.no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
-from abicheck.report.no_baseline_render import render_no_baseline_junit
+from abicheck.report.no_baseline_document import (
+    NO_BASELINE_EXIT_AXIS_LABELS,
+    SuppressedFinding,
+)
+from abicheck.report.no_baseline_render import (
+    render_no_baseline_junit,
+    render_no_baseline_sarif,
+)
 from abicheck.suppression import Suppression, SuppressionList
 from abicheck.workflows.no_baseline_compare import (
     resolve_no_baseline_candidate,
@@ -82,6 +88,30 @@ _STATING_COMBINATIONS = [
     pytest.param(None, "temporary vendor debug hook", id="reason-only"),
     pytest.param("audit-waiver-17", None, id="label-only"),
 ]
+
+
+def _render_document(doc, fmt: str) -> str:
+    """Project *doc* directly, bypassing `render_no_baseline`'s result input.
+
+    These tests hand-build a document, so they need the projection half on
+    its own rather than the `NoBaselineCompareResult` entry point.
+    """
+    from abicheck.report.no_baseline import (
+        _document_json,
+        render_no_baseline_markdown,
+    )
+
+    if fmt == "json":
+        return json.dumps(_document_json(doc))
+    if fmt == "markdown":
+        return render_no_baseline_markdown(doc)
+    if fmt == "sarif":
+        # Returns the SARIF *document*, not serialized text, unlike its
+        # siblings here -- serialize so every branch answers one type.
+        return json.dumps(render_no_baseline_sarif(doc))
+    if fmt == "junit":
+        return render_no_baseline_junit(doc)
+    raise AssertionError(f"unhandled format {fmt!r}")
 
 
 def _labelled_result(label: str | None, reason: str | None):
@@ -480,3 +510,49 @@ def test_a_suppressed_entry_is_still_a_report_finding() -> None:
     # disposition of findings rather than a separate kind of thing.
     for entry in [*doc.findings, *doc.suppressed]:
         assert isinstance(entry, ReportFinding)
+
+
+@pytest.mark.parametrize("fmt", sorted(NO_BASELINE_SUPPORTED_FORMATS - {"oneline"}))
+def test_a_document_holding_plain_findings_still_renders(fmt: str) -> None:
+    """`suppressed` entries that are not `SuppressedFinding` must not crash.
+
+    `NoBaselineDocument` is an ordinary frozen dataclass, so a caller can
+    build one or `dataclasses.replace` an existing one. A caller written
+    against the pre-pairing shape passes plain `ReportFinding` entries, and
+    every detailed renderer dereferenced `entry.provenance` directly — an
+    `AttributeError` from inside a renderer (Codex review, P2).
+
+    `None` is the right answer for such an entry rather than a papered-over
+    one: a document carrying plain findings genuinely holds no ledger
+    record, so "no provenance recorded" is what it truthfully has to say.
+    That is the same thing the renderers report for a run whose `DiffResult`
+    kept no ledger, and the opposite of inventing a record.
+    """
+    from abicheck.report.finding import ReportFinding
+
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed
+    downgraded = dataclasses.replace(
+        doc,
+        suppressed=tuple(
+            ReportFinding(
+                change=entry.change, verdict=entry.verdict, category=entry.category
+            )
+            for entry in doc.suppressed
+        ),
+    )
+    assert not any(isinstance(e, SuppressedFinding) for e in downgraded.suppressed), (
+        "the point of this test is entries that are NOT the paired type"
+    )
+
+    text = _render_document(downgraded, fmt)
+    assert text, f"{fmt} must still render"
+    # The finding itself is still disclosed -- losing provenance must not
+    # lose the disposition.
+    assert "exported_not_public" in text
+    assert "waivers.yaml" not in text, (
+        "a document with no ledger record must not name a source file"
+    )

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Suppression provenance in the ``--no-baseline`` audit's projections.
+
+Split out of ``test_no_baseline_report_formats.py`` when that module crossed
+1000 lines: these tests share one subject -- ADR-067 D3's rule record, and
+how each renderer states it -- rather than the format-invariant subject the
+parent module owns. Splitting by responsibility is what this repository asks
+for when a file outgrows its cap (``AGENTS.md``: move responsibility out to a
+properly-owned module, never trim to fit).
+
+The subject in one sentence: ``Change.suppression_rule`` is
+``SuppressionOutcome.rule_label()``'s ``label or reason`` collapse -- a single
+string that does not say which of the two it holds -- so every projection
+must read the run's own disposition ledger instead, and none may present one
+field as two.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from abicheck.report.no_baseline import (
+    NO_BASELINE_SUPPORTED_FORMATS,
+    compute_no_baseline_document,
+    render_no_baseline,
+)
+from abicheck.suppression import Suppression, SuppressionList
+from abicheck.workflows.no_baseline_compare import (
+    resolve_no_baseline_candidate,
+    run_no_baseline_compare,
+)
+
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO / "scripts"))
+import example_catalog  # noqa: E402
+
+#: The same G20 audit corpus the parent module gates on, restated here rather
+#: than imported from it: a test module importing another test module for a
+#: constant couples their collection order, and this list is the corpus, not
+#: an implementation detail of either file.
+_FIXTURES = (
+    ("case143_audit_accidental_export", "snapshot.abi.json"),
+    ("case144_audit_private_header_leak", "snapshot.abi.json"),
+    ("case145_audit_unversioned_export", "snapshot.abi.json"),
+    ("case146_audit_rtti_for_internal", "snapshot.abi.json"),
+    ("case147_scan_depth_ladder", "snapshot.abi.json"),
+    ("case148_xcheck_header_build_mismatch", "snapshot.abi.json"),
+    ("case149_xcheck_odr_variant", "snapshot.abi.json"),
+    ("case150_xcheck_export_public_pair", "snapshot.abi.json"),
+    ("case151_xcheck_provider_matrix", "snapshot.abi.json"),
+    ("case151_xcheck_provider_matrix", "thin.abi.json"),
+    ("case181_xcheck_public_to_internal_dependency", "snapshot.abi.json"),
+)
+
+
+def _result(case: str, filename: str = "snapshot.abi.json", *, suppression=None):
+    path = example_catalog.case_dir(case) / filename
+    assert path.is_file(), f"missing committed G20 fixture: {path}"
+    snapshot = resolve_no_baseline_candidate(path)
+    return run_no_baseline_compare(snapshot, suppression=suppression)
+
+
+# ---------------------------------------------------------------------------
+# Suppression provenance: the disposition audit's own record, not a label.
+# ---------------------------------------------------------------------------
+
+
+def _labelled_and_reasoned() -> SuppressionList:
+    """A rule stating BOTH a label and a reason.
+
+    This is the shape that exposed the bug: `SuppressionOutcome.rule_label()`
+    is `label or reason`, so a rule carrying both publishes its label and
+    silently drops the reason. A rule with only one of them cannot detect
+    that, which is why every test here uses both.
+    """
+    return SuppressionList(
+        [
+            Suppression(
+                symbol_pattern=".*",
+                label="audit-waiver-17",
+                reason="temporary vendor debug hook",
+            )
+        ],
+        source_path="waivers.yaml",
+    )
+
+
+@pytest.mark.parametrize(("case", "filename"), _FIXTURES)
+def test_every_suppressed_finding_keeps_its_full_rule_provenance(
+    case: str, filename: str
+) -> None:
+    """ADR-067 D3: a disposition keeps the rule *and the reason* that hid it.
+
+    The audit published `suppression_rule`, which is the display label —
+    `label or reason`, never both — so a reader could not tell why a waiver
+    was written or which file to edit to review it (Codex review, P1).
+
+    The oracle is the run's own disposition ledger, not the report: every
+    field the ledger recorded for the rule that fired must survive into the
+    projection. Asserted over the whole fixture corpus and over every
+    ledger-recorded field, so a projection that carries one field and drops
+    another still fails.
+    """
+    result = _result(case, filename, suppression=_labelled_and_reasoned())
+    doc = compute_no_baseline_document(result)
+    ledger = result.diff.disposition_ledger
+    assert doc.suppressed, "this fixture must have something to suppress"
+
+    body = json.loads(render_no_baseline(result, "json")[0])
+    rows = body["suppressed_findings"]
+    assert len(rows) == len(doc.suppressed)
+
+    for row, entry in zip(rows, doc.suppressed, strict=True):
+        recorded = ledger.rule_for(entry.finding.change)
+        assert recorded is not None, (
+            "the run recorded no ledger entry, so this test would pass "
+            "vacuously against a projection that emits nothing"
+        )
+        assert row["suppression_provenance"] == recorded.to_dict(), (
+            "every field the ledger recorded must reach the report; the "
+            "display label alone collapses label and reason into one string"
+        )
+        # The specific loss the fix closes, stated independently of the
+        # ledger comparison above so it cannot be satisfied by an equality
+        # that happens to compare two equally-lossy values.
+        assert row["suppression_provenance"]["reason"] == (
+            "temporary vendor debug hook"
+        )
+        assert row["suppression_provenance"]["label"] == "audit-waiver-17"
+        assert row["suppression_provenance"]["source_file"] == "waivers.yaml"
+
+
+@pytest.mark.parametrize("fmt", sorted(NO_BASELINE_SUPPORTED_FORMATS - {"oneline"}))
+def test_every_format_carries_the_reason_and_source_not_just_the_label(
+    fmt: str,
+) -> None:
+    """The provenance reaches *every* projection, not the two wired first.
+
+    JSON and Markdown gained it first; SARIF and JUnit kept reading the
+    display label, so a consumer of either structured CI format still could
+    not tell why or where a finding was suppressed (Codex review, P2). A
+    fact one format publishes while its siblings drop it leaves a reader of
+    the quiet format unable to act on the run they were handed.
+
+    Parametrized over the supported set rather than naming today's four, so
+    a format added later is held to this without anyone remembering to.
+    `oneline` is excluded deliberately: it is one sentence by contract and
+    carries no per-finding detail at all.
+    """
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    assert compute_no_baseline_document(result).suppressed
+    text = render_no_baseline(result, fmt)[0]
+
+    assert "audit-waiver-17" in text, f"{fmt} must name the rule"
+    assert "temporary vendor debug hook" in text, (
+        f"{fmt} must carry the reason — it is what tells a reviewer whether "
+        "the waiver still applies, and the display label drops it whenever "
+        "the rule also states a label"
+    )
+    assert "waivers.yaml" in text, (
+        f"{fmt} must carry the source file — it is where a reviewer would "
+        "edit or remove the waiver"
+    )
+
+
+def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -> None:
+    """The complement: absent provenance is `null`, never invented.
+
+    A `DiffResult` rebuilt from JSON carries no disposition ledger. Emitting
+    a row derived from `Change.suppression_rule` there would look like a real
+    ADR-067 record while carrying strictly less, which is worse than saying
+    nothing.
+    """
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    object.__setattr__(result.diff, "disposition_ledger", None)
+    doc = compute_no_baseline_document(result)
+
+    assert doc.suppressed
+    assert all(entry.provenance is None for entry in doc.suppressed)
+    body = json.loads(render_no_baseline(result, "json")[0])
+    assert all(
+        row["suppression_provenance"] is None for row in body["suppressed_findings"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "reason", "expected"),
+    [
+        pytest.param(
+            "audit-waiver-17",
+            "temporary vendor debug hook",
+            "audit-waiver-17: temporary vendor debug hook",
+            id="both",
+        ),
+        pytest.param(
+            None,
+            "temporary vendor debug hook",
+            "temporary vendor debug hook",
+            id="reason-only",
+        ),
+        pytest.param("audit-waiver-17", None, "audit-waiver-17", id="label-only"),
+    ],
+)
+def test_a_suppression_justification_never_repeats_one_field_as_two(
+    label: str | None, reason: str | None, expected: str
+) -> None:
+    """`label: reason` only when the rule really states both.
+
+    `Change.suppression_rule` is `label or reason` — one string that does
+    not say which of the two it holds. Reading it as a label whenever
+    provenance had none rendered a reason-only rule as
+    `"<reason>: <reason>"`, presenting the reason as a separate rule label
+    (Codex review, P2). That is the shape
+    `suppression.require_justification` actively encourages, so it is the
+    common case rather than an edge one.
+
+    All three stating combinations are exercised, not just the reported
+    reason-only one: a fix that special-cased equality would still get
+    label-only wrong, and the invariant is "never present one field as
+    two", not "handle this input".
+    """
+    rule = Suppression(symbol_pattern=".*", label=label, reason=reason)
+    result = _result(
+        "case143_audit_accidental_export",
+        suppression=SuppressionList([rule], source_path="waivers.yaml"),
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed, "this fixture must have something to suppress"
+
+    sarif = json.loads(render_no_baseline(result, "sarif")[0])
+    justifications = [
+        r["suppressions"][0]["justification"]
+        for r in sarif["runs"][0]["results"]
+        if r.get("suppressions")
+    ]
+    assert justifications, "a suppressed finding must carry a SARIF suppression"
+    for text in justifications:
+        assert text == expected
+        # The invariant behind the specific expectations above, stated
+        # independently of them: no field is ever printed twice.
+        parts = [p.strip() for p in text.split(":")]
+        assert len(parts) == len(set(parts)), (
+            f"justification {text!r} repeats a field; one source rendered as two"
+        )
+
+    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    skipped = [s.attrib["message"] for s in junit.iter("skipped")]
+    assert skipped, "a suppressed finding must be a skipped JUnit case"
+    for message in skipped:
+        assert message == f"suppressed: {expected}", (
+            "JUnit and SARIF share one justification helper and must not "
+            "phrase it differently"
+        )

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -616,3 +616,46 @@ def test_a_document_holding_plain_findings_still_renders(fmt: str) -> None:
     assert "waivers.yaml" not in text, (
         "a document with no ledger record must not name a source file"
     )
+
+
+def test_suppressed_finding_equality_is_per_class() -> None:
+    """Equality does not cross the class boundary, and provenance counts.
+
+    Pins a deliberate choice, not an accident. Subclassing `ReportFinding`
+    means the generated `__eq__` requires the same runtime class, so a
+    suppressed entry never equals a bare finding with the same three
+    fields. A review asked for that cross-class equality back (Codex, P2).
+    Declined, and the reason is the assertion below it: restoring it
+    requires a hand-written `__eq__` that ignores provenance, at which
+    point two suppressions under *different waiver rules* compare equal --
+    a recorded field dropped on the way to a consumer, which is the defect
+    this whole class exists to fix. `field(compare=False)` is not an
+    alternative; the class check blocks cross-class equality regardless.
+
+    If someone deliberately changes this, these assertions are where the
+    trade gets re-decided rather than silently made.
+    """
+    from abicheck.report.finding import ReportFinding
+
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed
+    entry = doc.suppressed[0]
+
+    bare = ReportFinding(
+        change=entry.change, verdict=entry.verdict, category=entry.category
+    )
+    assert entry != bare, "a suppressed entry must not equal a bare finding"
+    assert bare != entry, "...and the inequality must be symmetric"
+
+    # Provenance is part of identity: same finding, different waiver.
+    other_rule = dataclasses.replace(entry, provenance={"rule_id": "some-other-rule"})
+    assert entry != other_rule, (
+        "two suppressions under different rules must not compare equal, or "
+        "provenance has stopped counting in equality"
+    )
+    # ...and an identical record still compares equal, so the check above is
+    # about the provenance value rather than object identity.
+    assert entry == dataclasses.replace(entry, provenance=entry.provenance)

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -136,11 +136,34 @@ def _sarif_justifications(result) -> list[str]:
     return texts
 
 
+def _junit_suite(rendered: str) -> ET.Element:
+    """Parse a rendered JUnit suite.
+
+    The one place this module parses XML. Four call sites each called
+    `ET.fromstring` on a string this very process had just rendered, which
+    is not an untrusted document -- but a static analyser cannot know that,
+    so each site was reported as an XML-attack surface, and the count grew
+    with every test that looked at JUnit output. Parsing in one place makes
+    that judgement once, where it can be stated, instead of implying it
+    four times by repetition.
+    """
+    # nosec B314 — not an untrusted document: `rendered` is this process's
+    # own JUnit output, produced by the renderer under test a few lines up.
+    return ET.fromstring(rendered)  # nosec B314  # noqa: S314
+
+
 def _junit_skip_messages(result) -> list[str]:
-    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    junit = _junit_suite(render_no_baseline(result, "junit")[0])
     messages = [s.attrib["message"] for s in junit.iter("skipped")]
     assert messages, "a suppressed finding must be a skipped JUnit case"
     return messages
+
+
+def _junit_gate_failure(doc) -> ET.Element:
+    """The gate testcase's ``<failure>`` for a hand-built document."""
+    failure = _junit_suite(render_no_baseline_junit(doc)).find(".//failure")
+    assert failure is not None and failure.text, "expected a gated JUnit suite"
+    return failure
 
 
 def _assert_no_field_shown_twice(text: str) -> None:
@@ -310,7 +333,7 @@ def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -
         )
         assert suppression["justification"] == "audit-waiver-17"
 
-    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    junit = _junit_suite(render_no_baseline(result, "junit")[0])
     skipped = list(junit.iter("skipped"))
     assert skipped, "a suppressed finding must still be a skipped JUnit case"
     for element in skipped:
@@ -458,8 +481,7 @@ def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
         coverage_failures=(),
     )
 
-    failure = ET.fromstring(render_no_baseline_junit(doc)).find(".//failure")
-    assert failure is not None and failure.text
+    failure = _junit_gate_failure(doc)
 
     assert NO_BASELINE_EXIT_AXIS_LABELS["analysis_assurance"] in failure.text
     assert NO_BASELINE_EXIT_AXIS_LABELS["contract_coverage"] not in failure.text, (
@@ -493,8 +515,7 @@ def test_a_gated_document_with_no_axes_recorded_says_so() -> None:
     base = compute_no_baseline_document(_result("case143_audit_accidental_export"))
     doc = dataclasses.replace(base, exit_code=1, exit_axes={}, coverage_failures=())
 
-    failure = ET.fromstring(render_no_baseline_junit(doc)).find(".//failure")
-    assert failure is not None and failure.text
+    failure = _junit_gate_failure(doc)
     assert "audit exited 1" in failure.attrib["message"]
 
     # It says the breakdown is absent...

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -192,6 +192,79 @@ def test_a_run_without_a_ledger_reports_no_provenance_rather_than_faking_one() -
         row["suppression_provenance"] is None for row in body["suppressed_findings"]
     )
 
+    # Every projection is *rendered*, not just the document inspected. The
+    # first version of this test asserted the document and the JSON row and
+    # stopped there, so the renderers' own no-provenance fallbacks were
+    # never executed — this test claimed the fallback was right while never
+    # running it (found via the patch-coverage report, which flagged exactly
+    # those lines).
+    #
+    # With no ledger the label falls back to the collapsed display field,
+    # which for this rule holds its label; what must NOT appear is a
+    # fabricated structured record.
+    markdown = render_no_baseline(result, "markdown")[0]
+    assert "audit-waiver-17" in markdown, (
+        "with no ledger the collapsed display field is all that is knowable, "
+        "and it is still shown"
+    )
+    assert "waivers.yaml" not in markdown, (
+        "the source file was never recorded for this run, so inventing it "
+        "would be a fabricated ADR-067 record"
+    )
+
+    sarif = json.loads(render_no_baseline(result, "sarif")[0])
+    suppressions = [
+        r["suppressions"][0]
+        for r in sarif["runs"][0]["results"]
+        if r.get("suppressions")
+    ]
+    assert suppressions, "a suppressed finding must still carry a suppression"
+    for suppression in suppressions:
+        assert "properties" not in suppression, (
+            "no ledger entry means no structured record to publish"
+        )
+        assert suppression["justification"] == "audit-waiver-17"
+
+    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    skipped = list(junit.iter("skipped"))
+    assert skipped, "a suppressed finding must still be a skipped JUnit case"
+    for element in skipped:
+        assert element.attrib["message"] == "suppressed: audit-waiver-17"
+        assert "suppression rule:" not in (element.text or ""), (
+            "the structured block belongs only to a run that recorded one"
+        )
+
+
+def test_a_rule_stating_neither_label_nor_reason_still_reads_as_suppressed() -> None:
+    """The last fallback: a rule with nothing to say about itself.
+
+    `--suppress` does not require a label or a reason (only
+    `suppression.require_justification` does), so a bare selector-only rule
+    is legal input. Every projection must still say the finding was
+    suppressed rather than rendering an empty or missing attribution.
+    """
+    result = _result(
+        "case143_audit_accidental_export",
+        suppression=SuppressionList([Suppression(symbol_pattern=".*")]),
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed
+
+    sarif = json.loads(render_no_baseline(result, "sarif")[0])
+    justifications = [
+        r["suppressions"][0]["justification"]
+        for r in sarif["runs"][0]["results"]
+        if r.get("suppressions")
+    ]
+    assert justifications == ["suppressed by an abicheck --suppress rule"] * len(
+        justifications
+    )
+    assert justifications
+
+    markdown = render_no_baseline(result, "markdown")[0]
+    assert "(rule gave no label)" in markdown
+    assert "(none stated)" in markdown
+
 
 @pytest.mark.parametrize(
     ("label", "reason", "expected"),
@@ -283,3 +356,45 @@ def test_a_suppression_justification_never_repeats_one_field_as_two(
             "JUnit and SARIF share one justification helper and must not "
             "phrase it differently"
         )
+
+
+def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
+    """A gate on an axis that names no provider omits the provider block.
+
+    The JUnit failure text has two parts: the contributing axes, and the
+    contract-coverage ledger's per-provider rows. Only the coverage axis can
+    name a provider, so a run gated purely on (say) analysis assurance must
+    state its axis and print no coverage section at all — an empty
+    "contract coverage failures:" heading would imply a ledger that closed
+    with nothing missing, which is a different fact from having no ledger.
+
+    Asserted by projecting a document built for that state rather than by
+    hunting a fixture that happens to gate that way: `render_no_baseline_junit`
+    is a pure function of the document, so the document *is* the input under
+    test, and constructing it directly is what lets the combination be
+    exercised at all.
+    """
+    import dataclasses
+
+    from abicheck.report.no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
+    from abicheck.report.no_baseline_render import render_no_baseline_junit
+
+    base = compute_no_baseline_document(_result("case143_audit_accidental_export"))
+    doc = dataclasses.replace(
+        base,
+        exit_code=1,
+        exit_axes={"analysis_assurance": 1, "contract_coverage": 0},
+        coverage_failures=(),
+    )
+
+    failure = ET.fromstring(render_no_baseline_junit(doc)).find(".//failure")
+    assert failure is not None and failure.text
+
+    assert NO_BASELINE_EXIT_AXIS_LABELS["analysis_assurance"] in failure.text
+    assert NO_BASELINE_EXIT_AXIS_LABELS["contract_coverage"] not in failure.text, (
+        "an axis that contributed 0 must not be named as a cause"
+    )
+    assert "contract coverage failures:" not in failure.text, (
+        "no ledger rows means no section; an empty heading would imply a "
+        "domain that closed cleanly, which is a different fact"
+    )

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -172,7 +172,7 @@ def test_every_suppressed_finding_keeps_its_full_rule_provenance(
     assert len(rows) == len(doc.suppressed)
 
     for row, entry in zip(rows, doc.suppressed, strict=True):
-        recorded = ledger.rule_for(entry.finding.change)
+        recorded = ledger.rule_for(entry.change)
         assert recorded is not None, (
             "the run recorded no ledger entry, so this test would pass "
             "vacuously against a projection that emits nothing"
@@ -439,3 +439,44 @@ def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
         "no ledger rows means no section; an empty heading would imply a "
         "domain that closed cleanly, which is a different fact"
     )
+
+
+def test_a_suppressed_entry_is_still_a_report_finding() -> None:
+    """`doc.suppressed` entries stay usable as ordinary findings.
+
+    `NoBaselineDocument` is reachable from `abicheck.report.no_baseline`, and
+    a consumer iterating `.suppressed` reads `.change`/`.verdict`/`.category`
+    the same way it reads `.findings`. An earlier version of this branch
+    paired the finding with its provenance side by side, which turned every
+    such read into an `AttributeError` — trading one regression for the
+    provenance fix (Codex review, P2).
+
+    Making `SuppressedFinding` *a* `ReportFinding` rather than a wrapper is
+    what keeps both true at once, and this pins it: the attribute reads and
+    the `isinstance` relationship are both asserted, since forwarding
+    properties would satisfy the first alone and still fail a consumer that
+    type-checks.
+    """
+    from abicheck.report.finding import ReportFinding
+
+    result = _result(
+        "case143_audit_accidental_export", suppression=_labelled_and_reasoned()
+    )
+    doc = compute_no_baseline_document(result)
+    assert doc.suppressed
+
+    for entry in doc.suppressed:
+        assert isinstance(entry, ReportFinding)
+        # Read exactly as a `.findings` entry would be.
+        assert entry.change is not None
+        assert entry.verdict is not None
+        assert entry.category is not None
+        # And the provenance rides along rather than replacing any of it.
+        assert entry.provenance is not None
+        assert entry.provenance["reason"] == "temporary vendor debug hook"
+
+    # The two collections are interchangeable to a consumer that does not
+    # care which is which -- the property that makes `.suppressed` a
+    # disposition of findings rather than a separate kind of thing.
+    for entry in [*doc.findings, *doc.suppressed]:
+        assert isinstance(entry, ReportFinding)

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -17,6 +17,7 @@ field as two.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import sys
 import xml.etree.ElementTree as ET
@@ -29,6 +30,8 @@ from abicheck.report.no_baseline import (
     compute_no_baseline_document,
     render_no_baseline,
 )
+from abicheck.report.no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
+from abicheck.report.no_baseline_render import render_no_baseline_junit
 from abicheck.suppression import Suppression, SuppressionList
 from abicheck.workflows.no_baseline_compare import (
     resolve_no_baseline_candidate,
@@ -69,6 +72,58 @@ def _result(case: str, filename: str = "snapshot.abi.json", *, suppression=None)
 # ---------------------------------------------------------------------------
 # Suppression provenance: the disposition audit's own record, not a label.
 # ---------------------------------------------------------------------------
+
+
+#: The three ways a rule can state its identity. A rule stating *both* is
+#: what exposed the original defect, and a fix that special-cased equality
+#: would still get label-only wrong -- so all three are always exercised.
+_STATING_COMBINATIONS = [
+    pytest.param("audit-waiver-17", "temporary vendor debug hook", id="both"),
+    pytest.param(None, "temporary vendor debug hook", id="reason-only"),
+    pytest.param("audit-waiver-17", None, id="label-only"),
+]
+
+
+def _labelled_result(label: str | None, reason: str | None):
+    """An audit whose single finding is suppressed by one rule stating *label*/*reason*."""
+    return _result(
+        "case143_audit_accidental_export",
+        suppression=SuppressionList(
+            [Suppression(symbol_pattern=".*", label=label, reason=reason)],
+            source_path="waivers.yaml",
+        ),
+    )
+
+
+def _sarif_justifications(result) -> list[str]:
+    sarif = json.loads(render_no_baseline(result, "sarif")[0])
+    texts = [
+        r["suppressions"][0]["justification"]
+        for r in sarif["runs"][0]["results"]
+        if r.get("suppressions")
+    ]
+    assert texts, "a suppressed finding must carry a SARIF suppression"
+    return texts
+
+
+def _junit_skip_messages(result) -> list[str]:
+    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
+    messages = [s.attrib["message"] for s in junit.iter("skipped")]
+    assert messages, "a suppressed finding must be a skipped JUnit case"
+    return messages
+
+
+def _assert_no_field_shown_twice(text: str) -> None:
+    """The invariant behind every expected string here, stated separately.
+
+    Checked by splitting the rendered text and comparing part counts, never
+    by re-running the helper that produced it -- an oracle that shares the
+    implementation's logic cannot falsify it.
+    """
+    parts = [p.strip() for p in text.split(":")]
+    assert len(parts) == len(set(parts)), (
+        f"justification {text!r} repeats a field; one source rendered as two"
+    )
 
 
 def _labelled_and_reasoned() -> SuppressionList:
@@ -302,35 +357,36 @@ def test_a_suppression_justification_never_repeats_one_field_as_two(
     label-only wrong, and the invariant is "never present one field as
     two", not "handle this input".
     """
-    rule = Suppression(symbol_pattern=".*", label=label, reason=reason)
-    result = _result(
-        "case143_audit_accidental_export",
-        suppression=SuppressionList([rule], source_path="waivers.yaml"),
+    result = _labelled_result(label, reason)
+    assert compute_no_baseline_document(result).suppressed, (
+        "this fixture must have something to suppress"
     )
-    doc = compute_no_baseline_document(result)
-    assert doc.suppressed, "this fixture must have something to suppress"
 
-    sarif = json.loads(render_no_baseline(result, "sarif")[0])
-    justifications = [
-        r["suppressions"][0]["justification"]
-        for r in sarif["runs"][0]["results"]
-        if r.get("suppressions")
-    ]
-    assert justifications, "a suppressed finding must carry a SARIF suppression"
-    for text in justifications:
+    # The single-string projections. Both go through one helper, so they are
+    # checked together -- if they ever diverge, that is itself the bug.
+    for text in _sarif_justifications(result):
         assert text == expected
-        # The invariant behind the specific expectations above, stated
-        # independently of them: no field is ever printed twice.
-        parts = [p.strip() for p in text.split(":")]
-        assert len(parts) == len(set(parts)), (
-            f"justification {text!r} repeats a field; one source rendered as two"
+        _assert_no_field_shown_twice(text)
+    for message in _junit_skip_messages(result):
+        assert message == f"suppressed: {expected}", (
+            "JUnit and SARIF share one justification helper and must not "
+            "phrase it differently"
         )
 
-    # Markdown shows the label in its own column beside the reason, so it
-    # needs the same rule applied at a *different* shape -- and it was the
-    # site the first fix missed, printing a reason-only rule's reason under
-    # both headings (Codex review, P2, the second time). Asserted on the
-    # rendered row, so the two columns really differ.
+
+@pytest.mark.parametrize(("label", "reason"), _STATING_COMBINATIONS)
+def test_the_markdown_columns_never_show_one_field_as_two(
+    label: str | None, reason: str | None
+) -> None:
+    """The same rule at Markdown's shape: two columns, not one string.
+
+    Split from the single-string test above rather than folded into it,
+    because this is where the defect recurred: Markdown shows the label and
+    the reason in *separate columns*, so a test written only against the
+    helper's one-string shape could not have caught it (Codex review, P2,
+    the second time).
+    """
+    result = _labelled_result(label, reason)
     markdown = render_no_baseline(result, "markdown")[0]
     rows = [
         line
@@ -340,22 +396,12 @@ def test_a_suppression_justification_never_repeats_one_field_as_two(
     assert rows, "the suppressed finding must appear in the Markdown table"
     for row in rows:
         cells = [c.strip() for c in row.strip("|").split("|")]
-        label_cell, reason_cell = cells[3], cells[4]
-        assert label_cell != reason_cell, (
+        assert cells[3] != cells[4], (
             f"Markdown row {row!r} prints the same text as both the rule "
             "label and the reason; one field shown as two"
         )
-        assert label_cell == (label or "(rule gave no label)")
-        assert reason_cell == (reason or "(none stated)")
-
-    junit = ET.fromstring(render_no_baseline(result, "junit")[0])
-    skipped = [s.attrib["message"] for s in junit.iter("skipped")]
-    assert skipped, "a suppressed finding must be a skipped JUnit case"
-    for message in skipped:
-        assert message == f"suppressed: {expected}", (
-            "JUnit and SARIF share one justification helper and must not "
-            "phrase it differently"
-        )
+        assert cells[3] == (label or "(rule gave no label)")
+        assert cells[4] == (reason or "(none stated)")
 
 
 def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
@@ -374,11 +420,6 @@ def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
     test, and constructing it directly is what lets the combination be
     exercised at all.
     """
-    import dataclasses
-
-    from abicheck.report.no_baseline_document import NO_BASELINE_EXIT_AXIS_LABELS
-    from abicheck.report.no_baseline_render import render_no_baseline_junit
-
     base = compute_no_baseline_document(_result("case143_audit_accidental_export"))
     doc = dataclasses.replace(
         base,

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -253,6 +253,28 @@ def test_a_suppression_justification_never_repeats_one_field_as_two(
             f"justification {text!r} repeats a field; one source rendered as two"
         )
 
+    # Markdown shows the label in its own column beside the reason, so it
+    # needs the same rule applied at a *different* shape -- and it was the
+    # site the first fix missed, printing a reason-only rule's reason under
+    # both headings (Codex review, P2, the second time). Asserted on the
+    # rendered row, so the two columns really differ.
+    markdown = render_no_baseline(result, "markdown")[0]
+    rows = [
+        line
+        for line in markdown.splitlines()
+        if line.startswith("| `exported_not_public`")
+    ]
+    assert rows, "the suppressed finding must appear in the Markdown table"
+    for row in rows:
+        cells = [c.strip() for c in row.strip("|").split("|")]
+        label_cell, reason_cell = cells[3], cells[4]
+        assert label_cell != reason_cell, (
+            f"Markdown row {row!r} prints the same text as both the rule "
+            "label and the reason; one field shown as two"
+        )
+        assert label_cell == (label or "(rule gave no label)")
+        assert reason_cell == (reason or "(none stated)")
+
     junit = ET.fromstring(render_no_baseline(result, "junit")[0])
     skipped = [s.attrib["message"] for s in junit.iter("skipped")]
     assert skipped, "a suppressed finding must be a skipped JUnit case"

--- a/tests/test_no_baseline_suppression_provenance.py
+++ b/tests/test_no_baseline_suppression_provenance.py
@@ -471,6 +471,45 @@ def test_a_non_coverage_gate_names_its_axis_without_a_coverage_block() -> None:
     )
 
 
+def test_a_gated_document_with_no_axes_recorded_says_so() -> None:
+    """A gated suite whose document carries no per-axis breakdown must say
+    the record is missing, not fall silent.
+
+    Unreachable for a document this package builds -- `exit_code` is
+    `max(exit_axes.values())`, so a nonzero one always has a nonzero axis
+    behind it. Reachable for a *hand-built* one, because `exit_axes`
+    defaults to empty and `NoBaselineDocument` is an ordinary frozen
+    dataclass a caller may construct or `replace` (the same tolerance the
+    plain-`ReportFinding` test above pins). Codecov found this as the one
+    partial branch in the fix: the sibling `if contributing:` was exercised
+    only in the direction that had something to list.
+
+    The assertion is about what the renderer *must not* do in that state:
+    not crash, not name an axis it has no record of, and not print the
+    "contributing axes:" heading with nothing under it -- an empty heading
+    reads as "measured, nothing contributed", which for a suite that
+    demonstrably gated is a false statement rather than a missing one.
+    """
+    base = compute_no_baseline_document(_result("case143_audit_accidental_export"))
+    doc = dataclasses.replace(base, exit_code=1, exit_axes={}, coverage_failures=())
+
+    failure = ET.fromstring(render_no_baseline_junit(doc)).find(".//failure")
+    assert failure is not None and failure.text
+    assert "audit exited 1" in failure.attrib["message"]
+
+    # It says the breakdown is absent...
+    assert "none recorded" in failure.text
+    # ...and names no axis, since it has the record for none of them.
+    for label in NO_BASELINE_EXIT_AXIS_LABELS.values():
+        assert label not in failure.text, (
+            f"named {label!r} as a cause with no per-axis record to support it"
+        )
+    # The bare heading its sibling branch prints must not appear alone: a
+    # consumer reading "contributing axes:" with no rows concludes every
+    # axis was measured and cleared, which contradicts the exit code.
+    assert "contributing axes:\n" not in failure.text
+
+
 def test_a_suppressed_entry_is_still_a_report_finding() -> None:
     """`doc.suppressed` entries stay usable as ordinary findings.
 

--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -663,3 +663,121 @@ def test_agent_skills_drift_gate_runs_in_ci():
     """ADR-058's generated trees are committed; without a CI-reachable drift
     gate, a stale publication tree merges silently."""
     assert "agent-skills-generated" in _ci_only_step_names()
+
+
+# --- ci.yml's unit-tests job budget ---------------------------------------
+
+
+class TestUnitTestsPerPlatformTimeout:
+    """The `unit-tests` matrix job's `timeout-minutes` must be resolved *per
+    leg*, not shared as one number.
+
+    Bug class this closes: a single job-level budget makes every matrix leg
+    pay the slowest platform's needs, or -- the direction that actually bit
+    -- forces the slowest leg to live inside a budget sized for the fast
+    ones. ci.yml's own comment history records the same drift three times
+    (15 -> 20 -> 30 for the canonical Linux leg, then -> 45 once Windows
+    reached it), each time by raising the shared number, which loosens the
+    gate on legs that already fit. On 2026-09-09 the Windows leg measured
+    40m24s and 41m18s on consecutive `main` runs against that shared 45,
+    and on 2026-09-10 run 34435814307 -- `main` itself, no pull request in
+    flight -- was cancelled at 45m14s, while the canonical Linux leg on the
+    same runs finished in 31m30s and macOS in 18m.
+
+    These assertions are structural: they enumerate the matrix legs ci.yml
+    actually declares and check that each one resolves to a budget, and that
+    the leg the expression singles out is the one that gets *more*. That
+    catches a leg added to the matrix with no budget of its own, and catches
+    the two branches being transposed -- neither of which a hardcoded
+    ``timeout-minutes: 45`` assertion could see.
+    """
+
+    _TERNARY = re.compile(
+        r"^\$\{\{\s*matrix\.os\s*==\s*'(?P<os>[^']+)'\s*"
+        r"&&\s*(?P<then>\d+)\s*\|\|\s*(?P<otherwise>\d+)\s*\}\}$"
+    )
+
+    @staticmethod
+    def _unit_tests_job() -> dict[str, Any]:
+        yaml = pytest.importorskip("yaml")
+        data = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text())
+        return dict(data["jobs"]["unit-tests"])
+
+    @classmethod
+    def _matrix_operating_systems(cls) -> set[str]:
+        """Every OS the matrix really runs, base rows plus `include:` rows."""
+        matrix = cls._unit_tests_job()["strategy"]["matrix"]
+        systems = set(matrix["os"])
+        for extra in matrix.get("include", []):
+            systems.add(extra["os"])
+        return systems
+
+    def test_the_budget_is_an_os_keyed_expression(self) -> None:
+        budget = self._unit_tests_job()["timeout-minutes"]
+        assert isinstance(budget, str), (
+            "unit-tests' timeout-minutes is a bare number again, so every "
+            f"matrix leg shares one budget: {budget!r}"
+        )
+        assert self._TERNARY.match(budget.strip()), (
+            f"could not read a per-OS budget out of {budget!r}"
+        )
+
+    def test_the_singled_out_os_is_one_the_matrix_runs(self) -> None:
+        """A budget keyed on an OS absent from the matrix is dead
+        configuration: every leg would silently take the fallback."""
+        match = self._TERNARY.match(
+            str(self._unit_tests_job()["timeout-minutes"]).strip()
+        )
+        assert match
+        assert match.group("os") in self._matrix_operating_systems()
+
+    def test_every_matrix_leg_resolves_to_a_positive_budget(self) -> None:
+        """Enumerate the real legs rather than asserting two literals -- an
+        OS added to the matrix must still land on a budget."""
+        match = self._TERNARY.match(
+            str(self._unit_tests_job()["timeout-minutes"]).strip()
+        )
+        assert match
+        singled_out, then, otherwise = (
+            match.group("os"),
+            int(match.group("then")),
+            int(match.group("otherwise")),
+        )
+        resolved = {
+            operating_system: then if operating_system == singled_out else otherwise
+            for operating_system in self._matrix_operating_systems()
+        }
+        assert resolved, "the unit-tests matrix declares no operating system"
+        assert all(minutes > 0 for minutes in resolved.values()), resolved
+
+    def test_the_singled_out_leg_gets_strictly_more_headroom(self) -> None:
+        """The whole point of splitting the budget. If the two branches are
+        ever transposed, the slow leg gets the fast legs' budget -- exactly
+        the failure being fixed, now silent."""
+        match = self._TERNARY.match(
+            str(self._unit_tests_job()["timeout-minutes"]).strip()
+        )
+        assert match
+        assert int(match.group("then")) > int(match.group("otherwise")), (
+            "the OS singled out for its own budget must get more minutes than "
+            "the fallback, not fewer"
+        )
+
+    def test_the_slow_legs_budget_clears_the_observed_cost_on_main(self) -> None:
+        """Oracle independent of the workflow: the wall-clock figures below
+        were read off `main`'s own completed runs (see this class's
+        docstring), not derived from the budget the workflow declares."""
+        observed_windows_minutes_on_main = (40.4, 41.3, 45.2)
+        match = self._TERNARY.match(
+            str(self._unit_tests_job()["timeout-minutes"]).strip()
+        )
+        assert match
+        assert match.group("os") == "windows-latest", (
+            "the observations below are Windows measurements; if another leg "
+            "is now the singled-out one, re-measure rather than reusing these"
+        )
+        assert int(match.group("then")) > max(observed_windows_minutes_on_main), (
+            "the Windows budget must exceed every cost already observed on "
+            f"main ({observed_windows_minutes_on_main}), or it will keep "
+            "cancelling healthy runs"
+        )


### PR DESCRIPTION
## Summary

Four post-merge review findings on `compare --no-baseline` (PR #1185), plus the documentation and test-quality corrections that came with them — and one CI fix the branch's own red check turned up, which turned out to be a defect on `main`.

## Motivation

#1185 merged while two Codex findings and several CodeRabbit findings were still outstanding, and two more Codex findings arrived against its final commit. None can be addressed on that PR — it is merged — so this is a follow-up branch restarted from `main`.

Three of the four are the same failure in different places: a value that exists in the run is dropped on the way to the reader, or is applied by one path and not its sibling.

## Changes

**Suppression acceptance rules were ignored by the audit** (Codex P1). `.abicheck.yml`'s `suppression.require_justification` and `suppression.strict` decide whether a suppression *document* may be used at all. The audit resolved the project config but read neither, so a reasonless or long-expired rule that ordinary `compare` rejects was accepted here, hid the finding, and exited `0` — the worst direction for the failure to run in. Both settings are now carried on the resolved invocation and applied by the real run *and* by `--dry-run`'s validation load.

**A saved ABICC Perl dump was held to the `--depth` floor** (Codex P2). `--depth build`/`--depth source` is a floor for live extraction, not a ceiling for a description someone already wrote down, but the carve-out recognized only `.abi.json` and `ProjectSnapshot` packages — so `--depth source` exited `7` on a saved ABICC dump and `0` on the equivalent `.abi.json`. The line is now "an already-serialized ABI description" vs "raw evidence a description is derived from", which keeps `Module.symvers` and bare BTF/CTF blobs held to the floor. Shared with two-sided `compare` through the same predicate.

**A suppressed finding lost its ADR-067 provenance** (Codex P1). The audit published `suppression_rule`, which is `SuppressionOutcome.rule_label()`'s deliberate `label or reason` collapse — so a waiver stating both showed its label and silently dropped the reason it was written for and the file it lives in, which is exactly what a reviewer needs to decide whether it still applies. Every projection now carries the run's own disposition-ledger record (rule id, source file, reason, label, expiry) as `suppression_provenance`, joined by object identity through the same `DispositionLedger.rule_for` lookup `reporter.py`'s two-sided suppression block already uses. The Markdown table gains reason/source/expiry columns. `suppression_rule` is unchanged for existing consumers; `null` provenance is the honest answer for a `DiffResult` rebuilt from JSON, which keeps no ledger.

**A gated JUnit suite could not say which axis fired** (Codex P2). It carried only the total exit code and the contract-coverage contribution, and its failure text listed every axis that *might* have gated. Each orthogonal axis is now its own `exit_axis.<name>` property with its own contribution (a cleared axis publishes a real `0`, not an absent key), the failure text names only the axes that actually contributed, and the coverage ledger's per-provider rows are included.

**`unit-tests`' job budget was one number for a matrix whose legs cost 18 to 45 minutes.** The Windows leg reached that ceiling, and the cancellation is not this branch's: run [34435814307](https://github.com/abicheck/abicheck/actions/runs/34435814307) — `main` itself, no PR in flight — was cancelled at 45m14s, after two `main` runs measured 41m18s and 42m12s against `timeout-minutes: 45`. `ci.yml`'s own comment already records this drift three times (15 → 20 → 30 as the canonical Linux leg grew, then → 45 once Windows reached it) and already names the lesson, that a budget sized tight against today's measurement expires in days — but every one of those bumps moved the *same shared number*, which loosens the gate on the legs that already fit. The budget is now per leg: Windows 75, every other leg exactly the 45 it fits inside (canonical Linux 31m30s, macOS 18m). A budget, not a fix — why this suite costs 41 minutes on Windows and 20 on Linux under coverage stays the separate unowned investigation that comment names. A job-level timeout reports `cancelled`, which reads as a superseded run rather than a failure, and that is why this went a day undiagnosed on `main`.

Also, from CodeRabbit:

- `old_acquisition_state` is emitted unconditionally, so it joins the audit report schema's root `required` list (runtime and published copies).
- **Two gated-run assertions were unreachable.** Both used `case143`, which closes the `public` contract domain cleanly, behind `if exit_code:`. They now use `case145` and assert the gate fires *before* asserting what it must publish.
- `--variant`'s rejection reason was stale after package directories became acceptable. The rejection stands; its reason is now "this path performs no variant selection".
- `NoBaselineDocument`'s docstring no longer implies deep immutability. The deep-freeze itself is declined with a stated reason: it would fork the shared `ReportFinding`/`Change` shape for one command.
- The report bug-class entry drops its unearned `cli` surface claim and its unexercised `comparison-scope-table` renderer axis, recording the latter as a known gap.
- The changelog fragment no longer lists `--config` as unsupported while also saying it is honored; the plan's F-5 row and its overstated "agree *exactly*" parity claim are corrected (the harness proves a directional statement, not equality).
- The G20 case READMEs no longer say the audit's verdict is `COMPATIBLE` — an audit reports no verdict at all (ADR-068 D2).

## Bug-fix test contract

- Bug class: `report.finding_entry_builder_parity` (`tests/regressions/manifest_report.py`) — extended, not restated, since both new Codex findings are the shape it already names: a sibling builder omitting a field another computes. Widened to cover parity *between formats* of one report. The CI budget fix adds a second class, `ci.shared_budget_over_heterogeneous_matrix` (`tests/regressions/manifest_tool_surface.py`), genuinely new to this registry.
- Publicly observable failure: `compare --no-baseline snap.json --suppress reasonless.yaml` exits `0` and hides the finding where `compare snap.json snap.json --suppress reasonless.yaml` exits `1`; a suppressed row's `suppression_provenance` is absent so the waiver's reason and source file are unrecoverable; a JUnit consumer gated on the evidence contract cannot tell which axis fired. For the CI class: `unit-tests (windows-latest, 3.13)` is cancelled at its 45-minute job budget on `main` itself.
- Regression test fails on base: yes — verified by mutation, not by assumption. Reverting `_provenance_row` to the collapsed label and deleting the `exit_axis.*` properties fails 10 tests across the corpus; restoring both passes 112. The CI class's tests were checked against three wrong workflows rather than only the fixed one: the bare shared budget (5 of 5 fail), the two branches transposed (2 fail), and a budget keyed on a leg that is not the slow one (1 fail).
- Negative control: `test_a_diffresult_without_a_ledger_reports_no_provenance_rather_than_faking_one` (absent provenance must be `null`, never invented) and the JUnit test's reverse assertion (an axis that did *not* fire must not be named in the failure text — the "here is every axis that might have" non-answer this fix removes).
- Public-surface test: yes — `test_a_configs_suppression_acceptance_rules_bind_the_audit_too` runs through Click (`invoke_cli`) on both the audit and two-sided `compare`.
- Axes covered: both suppression settings × real run and `--dry-run`; the provenance invariant over all eleven G20 fixtures × JSON and Markdown; the depth-floor predicate over `symvers` / unknown-text (live) and `.abi.json` / `ProjectSnapshot` package / Perl dump (exempt).
- Malicious fixture + side-effect absence: the workflow change is one expression — `timeout-minutes: ${{ matrix.os == 'windows-latest' && 75 || 45 }}` — in a numeric job field, not in a `run:` script. It interpolates exactly one value, `matrix.os`, a literal list in the same file that no PR-controlled input can reach, so there is no untrusted value to build a hostile fixture from and no shell for one to escape into. The gate's real concern is a text assertion standing in for execution, and I want this fix's limit stated rather than glossed: `test_the_singled_out_os_is_one_the_matrix_runs` resolves the interpolated operand against the matrix `ci.yml` actually declares, so an operand naming something the workflow does not define fails — but an Actions expression can only be *evaluated* by a real runner, so no test here proves how Actions resolves it. The proof is the run: the Windows leg completing inside a 75-minute budget while every other leg stays at 45. I will confirm that from this PR's own run rather than assert it in advance.
- General invariant: a projection of a shared record carries every field the run recorded for it, and every consumer of a gate can name the axis that fired. For the CI class: a budget a job declares once must resolve per matrix leg whenever the legs' costs differ by more than its headroom. The oracles are independent of the implementation — the two-sided command's own exit code, the run's own `disposition_ledger`, `doc.exit_axes`, and wall-clock figures read off `main`'s completed runs — never the same helper the projection uses.
- Known unsupported cases: the CI class's quantitative half is not executable here — whether a leg's budget still clears its real cost needs run durations this repository does not ingest, so the seed test pins hand-read figures and nothing detects the same decay recurring at 75. And the fix is scoped to `unit-tests`, the one job observed cancelling; the other matrix jobs were not audited for the same shape. Both are recorded as `KnownGap`s on the registry entry.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed
- [x] `ruff`, `mypy` (735 files), `check_architecture` (0 errors), `mkdocs --strict` clean
- [x] No new `mypy` or `ruff` errors introduced

Note: `check_ai_readiness` reports 3 pre-existing `adr-status-sync` errors in this environment — commit `40f0063` is on `main` but unreachable from `origin/main` in a shallow clone. Those ADR files are not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6zMEckhE5ni5tTLNtUXJF

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6zMEckhE5ni5tTLNtUXJF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `compare --no-baseline` now honors suppression acceptance rules during audits and dry runs.
  * Suppressed findings include rule provenance—reason, source, label, and expiration—in JSON, Markdown, SARIF, and JUnit reports.
  * JUnit reports now identify contributing exit axes and coverage failures.
  * Saved ABICC Perl dumps are recognized as prebuilt ABI descriptions and exempt from depth restrictions.

* **Bug Fixes**
  * Single-build audits consistently report no compatibility verdict (`null`).

* **Documentation**
  * Updated audit report schema to version 1.1 and refreshed no-baseline guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->