### PR TITLE
refactor: converge gate-pack fold shapes and release scope selection (ADR-061 gap D)

### DIFF
--- a/abicheck/cli_compare_receipt.py
+++ b/abicheck/cli_compare_receipt.py
@@ -753,6 +753,7 @@ def _release_summary_effective_config_block(
     pack_application: PackApplication | None = None,
     scope_public_headers: bool = True,
     on_incomplete_scope: str = "",
+    fail_on_removed_library: bool | None = None,
 ) -> tuple[str, dict[str, str]]:
     """The ``(digest, fields)`` pair for a release-level *summary* document
     (the primary release JSON and ``--output-dir``'s ``summary.json``
@@ -766,35 +767,29 @@ def _release_summary_effective_config_block(
     ``policy.base``/``policy.reclassify``/``policy.overrides``/
     ``suppressions`` all read empty regardless of the real
     ``--policy``/``--policy-file``/``--suppress`` every library was
-    actually compared under, as if no policy existed at all. Every library
-    shares one such input (the per-library fan-out reloads it once per
-    library), so resolving it once more here the same way
+    actually compared under. Resolving it once more here the same way
     (:func:`~abicheck.frontends.cli.options.params._load_suppression_and_policy`,
     folding *pack_application* like
     :func:`~abicheck.cli_compare_release_matrix._collect_matrix_result`
     does) reproduces what any one library's own report shows for these
-    fields. Reloaded rather than threaded down because no per-library
-    ``PolicyFile`` is retained at this scope -- the reload runs inside the
+    fields; reloaded rather than threaded down since no per-library
+    ``PolicyFile`` is retained at this scope (the reload runs inside the
     same ``dedup_validate_overrides_warnings()`` scope ``compare_release_cmd``
-    opens, so it doesn't duplicate a warning already logged per-library.
+    opens, so it doesn't duplicate a per-library warning).
 
-    Called from ``cli_compare_release_helpers``/``cli_compare_release_matrix``
-    -- lives here since both callers are at their own ``no_growth`` cap.
+    Called from ``cli_compare_release_helpers``/``cli_compare_release_matrix``/
+    ``frontends.cli.release_summary`` (all three at their own ``no_growth``
+    cap, hence living here).
 
-    *scope_public_headers* (found by a generalized parity test, PR #1016,
-    once the ``policy.base`` fix above showed the class was worth searching
-    for systematically): the same bug shape as ``policy`` above, just for a
-    second field. ``effective_config_fields_from_diff_result`` reads
+    *scope_public_headers* (PR #1016): same bug shape as ``policy`` above,
+    for a second field -- ``effective_config_fields_from_diff_result`` reads
     ``result.scope_to_public_surface``/``.scope_to_public_surface_requested``
-    off whatever it's given; a bare ``SimpleNamespace`` that never sets them
-    falls back to that function's own ``getattr(..., default)`` -- ``False``/
-    ``True`` respectively -- regardless of what ``--scope-public-headers``/
-    ``--no-scope-public-headers`` actually resolved to for this run, exactly
-    as ``policy``/``policy_file`` did before P1. The release fan-out has no
-    ``--post-manifest``/forced-public-symbols concept of its own (unlike a
-    single-pair ``compare``, where ``scope_to_public_surface`` can diverge
-    from ``scope_to_public_surface_requested`` when a forced-public-symbols
-    allowlist is active), so both fields are simply the raw CLI value here.
+    off whatever it's given, so a bare unset ``SimpleNamespace`` would fall
+    back to ``False``/``True`` regardless of what ``--scope-public-headers``
+    actually resolved to. The release fan-out has no ``--post-manifest``/
+    forced-public-symbols concept of its own (unlike single-pair ``compare``,
+    where the two can diverge), so both fields are simply the raw CLI value
+    here.
     """
     from types import SimpleNamespace
 
@@ -822,14 +817,20 @@ def _release_summary_effective_config_block(
         ),
         scope_to_public_surface=scope_public_headers,
         scope_to_public_surface_requested=scope_public_headers,
-        on_incomplete_scope=on_incomplete_scope,  # ADR-065 D6: warn/block exit differently
         # ADR-068 D4/Phase 5 + §4.1's AUTO rows: modulation, surface metrics and ADR-039 reconciliation are unconditional now (forced on at the Tier-2 chokepoint every library here routes through), so this stand-in must agree rather than default to the old "off".
         pattern_verdicts_enabled=True,
         surface_metrics_enabled=True,
         reconcile_build_context_enabled=True,
     )
-    # No result/require_complete_analysis/scope at this release-summary scope.
-    gate = EffectiveGate.from_severity(severity_config)
+    # No result/require_complete_analysis/scope at this release-summary
+    # scope, but on_incomplete_scope/fail_on_removed_library ARE (Codex
+    # review, PR #1192, fourth round) -- read from `gate.*` below, not the
+    # now-removed `ec_result.on_incomplete_scope` this used to set instead.
+    gate = EffectiveGate.from_severity(
+        severity_config,
+        on_incomplete_scope=on_incomplete_scope or None,
+        fail_on_removed_library=fail_on_removed_library,
+    )
     ec_fields = effective_config_fields(ec_result, gate=gate)
     return effective_config_digest(ec_fields), ec_fields
 

--- a/abicheck/cli_compare_receipt.py
+++ b/abicheck/cli_compare_receipt.py
@@ -804,7 +804,7 @@ def _release_summary_effective_config_block(
         effective_config_fields,
     )
     from .frontends.cli.options.params import _load_suppression_and_policy
-    from .workflows.gate import gate_exit_code_scheme
+    from .workflows.gate import EffectiveGate
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
     if pack_application is not None:
@@ -828,10 +828,9 @@ def _release_summary_effective_config_block(
         surface_metrics_enabled=True,
         reconcile_build_context_enabled=True,
     )
-    ec_scheme = gate_exit_code_scheme(severity_config is not None)
-    ec_fields = effective_config_fields(
-        ec_result, severity_config=severity_config, exit_code_scheme=ec_scheme
-    )
+    # No result/require_complete_analysis/scope at this release-summary scope.
+    gate = EffectiveGate.from_severity(severity_config)
+    ec_fields = effective_config_fields(ec_result, gate=gate)
     return effective_config_digest(ec_fields), ec_fields
 
 
@@ -882,7 +881,9 @@ def _release_md_library_findings(library_results: list[dict[str, object]]) -> li
             impact_table.get("root_entries") if isinstance(impact_table, dict) else None
         ) or []
         impact_direct_removals = (
-            impact_table.get("direct_removals", 0) if isinstance(impact_table, dict) else 0
+            impact_table.get("direct_removals", 0)
+            if isinstance(impact_table, dict)
+            else 0
         )
         has_impact = bool(impact_root_entries) or bool(impact_direct_removals)
         if not findings and not has_impact:
@@ -995,7 +996,5 @@ def release_disposition_audit_block(
             policy=bundle_result.policy,
             policy_file=bundle_result.policy_file,
         )
-        audits.append(
-            compute_disposition_audit(bundle_as_diff_result, severity_config)
-        )
+        audits.append(compute_disposition_audit(bundle_as_diff_result, severity_config))
     return fold_disposition_audits(audits).to_dict()

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -114,6 +114,7 @@ from .workflows.release_scope import (
     build_release_scope_record,
     out_of_scope_provider_names,
     release_inventory_evidence,
+    resolve_release_scope_plan,
     scoped_bundle_maps,
 )
 from .workflows.release_stored_inventory import (
@@ -645,6 +646,14 @@ def compare_release_cmd(
                 old_inventory=old_inventory,
                 new_inventory=new_inventory,
             )
+            # ADR-061 gap D / DoD item 8, closure package 4: the pre-
+            # execution half of ADR-065's scope model (which members are
+            # paired, and each side's own completeness evidence) as one
+            # resolved plan object rather than four independent locals
+            # threaded by hand -- see `ReleaseScopePlan`'s own docstring.
+            scope_plan = resolve_release_scope_plan(
+                old_map, new_map, matched_keys, inventory_evidence
+            )
 
             if fmt != "json":
                 for msg in warning_msgs:
@@ -814,21 +823,21 @@ def compare_release_cmd(
                 from .workflows.release_plan import build_declared_selection_record
 
                 scope_record = build_declared_selection_record(
-                    old_map,
-                    new_map,
-                    matched_keys,
+                    scope_plan.old_map,
+                    scope_plan.new_map,
+                    scope_plan.matched_keys,
                     library_results,
-                    inventory_evidence,
+                    scope_plan.evidence,
                     release_selection,
                     **_scope_failed,
                 )
             else:
                 scope_record = build_release_scope_record(
-                    old_map,
-                    new_map,
-                    matched_keys,
+                    scope_plan.old_map,
+                    scope_plan.new_map,
+                    scope_plan.matched_keys,
                     library_results,
-                    inventory_evidence,
+                    scope_plan.evidence,
                     **_scope_failed,
                 )
             # A member --dso-only could not classify is this run's own

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -664,8 +664,24 @@ def compare_release_cmd(
             # future normalization/selection rule added to
             # `resolve_release_scope_plan` changes which pairs actually run,
             # not merely how the post-execution record describes them.
+            #
+            # Codex review (PR #1192, second follow-up finding): an explicit
+            # `--select`/`--select-required` selection is folded into
+            # `matched_keys` *before* `resolve_release_scope_plan` runs, not
+            # as a separate filter applied to `compare_keys` afterward (see
+            # the now-removed second filter below) -- so `scope_plan` itself,
+            # not a step downstream of it, is what narrows what executes.
+            # The direct-pair sentinel is exempt: `DIRECT_PAIR_KEY` names no
+            # real declared library for a selection to match against.
+            plan_matched_keys = matched_keys
+            if release_selection is not None and list(matched_keys) != [
+                DIRECT_PAIR_KEY
+            ]:
+                plan_matched_keys = [
+                    k for k in matched_keys if k in release_selection
+                ]
             scope_plan = resolve_release_scope_plan(
-                old_map, new_map, matched_keys, inventory_evidence
+                old_map, new_map, plan_matched_keys, inventory_evidence
             )
             old_map, new_map, matched_keys = (
                 dict(scope_plan.old_map),
@@ -744,10 +760,10 @@ def compare_release_cmd(
             # caller did not declare is never run through the (expensive)
             # per-library dump/compare pass at all -- it is reported
             # `OUT_OF_SCOPE` on the scope record below, not silently
-            # compared anyway.
+            # compared anyway. `matched_keys` is already selection-narrowed
+            # (folded into `scope_plan` above), so no second filter is
+            # needed here.
             compare_keys = [k for k in matched_keys if k not in degraded_matched]
-            if release_selection is not None:
-                compare_keys = [k for k in compare_keys if k in release_selection]
             library_results, worst_verdict, diff_pairs = _compare_release_libraries(
                 compare_keys,
                 old_map,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -115,6 +115,7 @@ from .workflows.release_scope import (
     out_of_scope_provider_names,
     release_inventory_evidence,
     resolve_release_scope_plan,
+    resolve_release_scope_result,
     scoped_bundle_maps,
 )
 from .workflows.release_stored_inventory import (
@@ -840,13 +841,20 @@ def compare_release_cmd(
                     scope_plan.evidence,
                     **_scope_failed,
                 )
+            # ADR-061 gap D / DoD item 8, closure package 4 (Codex review,
+            # PR #1192): the release fan-out's realized scope outcome, paired
+            # with the plan it was resolved against -- from here on this run
+            # reads the acquisition record through `scope_result.record`
+            # exclusively, not a bare `ScopeAcquisitionRecord` threaded
+            # alongside an independent, un-paired plan.
+            scope_result = resolve_release_scope_result(scope_plan, scope_record)
             # A member --dso-only could not classify is this run's own
             # acquisition failure: an operational `ERROR` library result
             # (the same rank a failed extraction takes, floored at exit 4
             # under either --on-incomplete-scope policy), unless D9 narrowed
             # it out of scope -- then it is listed on the record only (Codex
             # review, twentieth round).
-            scope_states = {m.member: m.state for m in scope_record.members}
+            scope_states = {m.member: m.state for m in scope_result.record.members}
             for key in sorted(set(old_unclassified) | set(new_unclassified)):
                 reason = old_unclassified.get(key) or new_unclassified[key]
                 if scope_states.get(key) is AcquisitionState.OUT_OF_SCOPE:
@@ -862,10 +870,12 @@ def compare_release_cmd(
             # Decided by policy once; every consumer below (the writers, the
             # sidecar, the stderr notice, the exit) reads this one decision.
             scope_terms = comparison_scope_terms(
-                resolve_scope_decision(scope_record, on_incomplete_scope)
+                resolve_scope_decision(scope_result.record, on_incomplete_scope)
             )
-            removed_keys = [m.member for m in scope_record.proven_removed_members]
-            added_keys = [m.member for m in scope_record.proven_added_members]
+            removed_keys = [
+                m.member for m in scope_result.record.proven_removed_members
+            ]
+            added_keys = [m.member for m in scope_result.record.proven_added_members]
             # ADR-065 S4: the fan-out's unmatched/removed/added stderr notices,
             # now written from the acquisition record instead of the deleted
             # `_match_release_keys` set difference -- so one line can say
@@ -873,7 +883,7 @@ def compare_release_cmd(
             # says "unmatched" (naming why the proof is missing) otherwise.
             # Emitted here, not with the discovery-time warnings above, because
             # the record does not exist until the fan-out has run.
-            scope_notices = release_scope_warnings(scope_record)
+            scope_notices = release_scope_warnings(scope_result.record)
             warning_msgs.extend(scope_notices)
             if fmt != "json":
                 for msg in scope_notices:
@@ -886,7 +896,7 @@ def compare_release_cmd(
             # one becomes an ordinary per-component result so the existing
             # verdict fold, severity aggregation, report renderers and
             # disposition audit see it without a parallel pipeline.
-            for entry in support_promise_results(scope_record, support_promise):
+            for entry in support_promise_results(scope_result.record, support_promise):
                 library_results.append(entry)
                 entry_verdict = str(entry["verdict"])
                 if _RELEASE_VERDICT_ORDER.get(
@@ -1078,7 +1088,7 @@ def compare_release_cmd(
             # *proven* removals/additions only -- an unchecked member
             # is absent from it, not a deleted provider (Codex review).
             bundle_old_map, bundle_new_map = scoped_bundle_maps(
-                old_map, new_map, scope_record
+                old_map, new_map, scope_result.record
             )
             bundle_result, worst_verdict = _collect_bundle_result(
                 library_results,
@@ -1088,7 +1098,7 @@ def compare_release_cmd(
                 manifest_path=manifest_path,
                 bundle_system_providers=(
                     *bundle_system_providers,
-                    *out_of_scope_provider_names(scope_record),
+                    *out_of_scope_provider_names(scope_result.record),
                 ),
                 bundle_cohorts=bundle_cohorts,
                 policy=policy,
@@ -1099,7 +1109,7 @@ def compare_release_cmd(
                 new_root=new_dir,
                 old_variant=old_variant,
                 new_variant=new_variant,
-                scope_record=scope_record,
+                scope_record=scope_result.record,
             )
 
             # Strip _diff_result from entries and bump verdict for removed libraries.

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -652,8 +652,25 @@ def compare_release_cmd(
             # paired, and each side's own completeness evidence) as one
             # resolved plan object rather than four independent locals
             # threaded by hand -- see `ReleaseScopePlan`'s own docstring.
+            #
+            # Codex review (PR #1192, follow-up finding): rebinding
+            # `old_map`/`new_map`/`matched_keys` to the plan's own copies
+            # here -- rather than only reading `scope_plan.*` at the record
+            # builder after execution -- is what makes `scope_plan` the
+            # actual input execution consumes, not a DTO wrapper computed
+            # alongside it. `stored_degraded_members`, `compare_keys`, and
+            # `_compare_release_libraries` below (and every other reader in
+            # this function) now see exactly what the plan resolved, so a
+            # future normalization/selection rule added to
+            # `resolve_release_scope_plan` changes which pairs actually run,
+            # not merely how the post-execution record describes them.
             scope_plan = resolve_release_scope_plan(
                 old_map, new_map, matched_keys, inventory_evidence
+            )
+            old_map, new_map, matched_keys = (
+                dict(scope_plan.old_map),
+                dict(scope_plan.new_map),
+                list(scope_plan.matched_keys),
             )
 
             if fmt != "json":

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -712,6 +712,14 @@ def compare_release_cmd(
             # `_compute_release_severity_exit_code`,
             # `_fold_release_global_severity`) now reads the resulting
             # `GateOptions` instead of independently re-deriving it.
+            # Codex review, PR #1192, third follow-up round: `on_incomplete_
+            # scope`/`fail_on_removed` are this run's own already-resolved
+            # ADR-065 release-scope axes (the identical locals `compare_
+            # keys`'s scope-decision resolution and `_exit_compare_release`
+            # read below) -- passed straight through so `GateOptions`/
+            # `EffectiveGate`'s own digest-facing fields cannot silently
+            # disagree with the values that actually govern this run's exit
+            # code.
             gate = resolve_release_gate_options(
                 pack_application,
                 severity_preset=severity_preset,
@@ -719,6 +727,8 @@ def compare_release_cmd(
                 severity_potential_breaking=severity_potential_breaking,
                 severity_quality_issues=severity_quality_issues,
                 severity_addition=severity_addition,
+                on_incomplete_scope=on_incomplete_scope,
+                fail_on_removed_library=fail_on_removed,
             )
             # Resolved before the compare pass (its inputs are plain CLI values, no
             # dependency on compare results) so persisted per-library annotations

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -1600,6 +1600,7 @@ def _format_release_json(
         severity_config, policy=policy, policy_file_path=policy_file_path,
         suppress=suppress, pack_application=pack_application,
         scope_public_headers=scope_public_headers, on_incomplete_scope=terms.policy,
+        fail_on_removed_library=fail_on_removed,
     )
     summary["effective_config_digest"] = digest
     summary["effective_config_fields"] = fields

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -894,7 +894,7 @@ def _is_consumer_affected(summary: dict[str, Any]) -> bool:
 
 
 def _consumer_impact_summary(summaries: list[dict[str, Any]]) -> dict[str, Any]:
-    """"N of M consumers affected" statistics across every supplied
+    """ "N of M consumers affected" statistics across every supplied
     ``--used-by`` consumer (Workstream D-S1's "Missing" item)."""
     from .model.consumer_spec import ConsumerImpactSummary
 

--- a/abicheck/effective_config_digest.py
+++ b/abicheck/effective_config_digest.py
@@ -99,6 +99,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .policy.effective_gate import EffectiveGate
     from .severity import SeverityConfig
 
 #: Stable, ordered key set the digest is hashed over. Extending this tuple
@@ -229,55 +230,42 @@ def _on_incomplete_scope_str(result: Any) -> str:
     return str(getattr(result, "on_incomplete_scope", "") or "")
 
 
-def _gate_scope_str(result: Any) -> str:
-    """Canonical encoding of an ADR-043 scoped-gate selection
+def _gate_scope_str_from_gate(gate: EffectiveGate) -> str:
+    """Canonical encoding of *gate*'s own ADR-043 scoped-gate selection
     (``--used-by``/``--required-symbol(s)``), so two runs selecting
     different consumers/entrypoints don't collide on the digest (Codex
-    review, PR #803, fresh evidence): ``cli_helpers_compare._apply_used_by_
-    scoping``/``_apply_required_symbol_scoping`` stamp ``DiffResult.
-    gate_scope``/``used_by``/``required_symbols`` onto *result* before the
-    report is rendered, and that scoped gate can genuinely replace the
-    reported verdict/findings/exit code -- but neither this digest's rich
-    nor baseline tier read it (it isn't a D7 ``CompatibilityEvaluationConfig``
-    namespace field, and it isn't a ``PolicyFile``/``SeverityConfig`` fact
-    either), so two ``compare --required-symbol A``/``--required-symbol B``
-    runs against the identical pair previously hashed identically. Reads
-    the same JSON-safe projections (``result.used_by``'s ``app`` paths,
-    ``result.required_symbols``'s ``required_entrypoints``) the renderer
-    itself already serializes -- not a second traversal of the underlying
-    ``AppCompatResult``/``PluginHostContractResult`` objects. ``""`` when no
-    scoping was requested at all, the common case.
+    review, PR #803, fresh evidence, and PR #1192's follow-up: this reads
+    ``gate.scope`` -- the one typed value both ``add_effective_config_
+    digest`` and every other real consumer of ``EffectiveGate`` already
+    populated via ``policy.effective_gate.scoped_gate_selection_from_
+    result`` -- rather than independently re-deriving it a second time from
+    the raw ``DiffResult`` fields that projection already read. Two call
+    sites computing "the scoped-gate selection" from the same raw fields
+    through two different code paths is exactly the drift this fix closes:
+    before, this function and ``scoped_gate_selection_from_result`` could
+    silently disagree even though both claimed to answer the same
+    question.
+
+    ``""`` when *gate* selected no scope at all, the common case.
 
     **Known, deliberate limitation** (Codex review, PR #803, fresh
-    evidence): for ``used_by``, ``targets`` identifies each consumer only
-    by its ``app`` *path*, not its content -- if the binary at that path is
-    rebuilt in place between two runs, ``scope_diff_to_app`` can select a
-    genuinely different set of findings while this field (and the digest)
-    stay identical. Not fixed here: closing it would mean this
-    file-content-free fingerprint module reading and hashing an arbitrary
-    consumer binary at digest-computation time -- a real I/O/cost decision
-    (every report generation would hash every ``--used-by`` app, however
-    large) and a real design question (a full-file hash, or a narrower
-    identity of only the imports/symbols this scoping actually reads) that
-    ``AppCompatResult``/``_app_compat_summary`` don't carry any answer for
-    today. Left as a known gap rather than a reactive file-hashing patch,
-    per this repo's own "known gaps over risky reactive patches"
-    convention (AGENTS.md)."""
-    gate_scope = getattr(result, "gate_scope", None)
-    if gate_scope is None:
+    evidence, carried over unchanged): for ``used_by``, ``targets``
+    identifies each consumer only by its ``app`` *path*, not its content --
+    if the binary at that path is rebuilt in place between two runs,
+    ``scope_diff_to_app`` can select a genuinely different set of findings
+    while this field (and the digest) stay identical. Not fixed here:
+    closing it would mean this file-content-free fingerprint module
+    reading and hashing an arbitrary consumer binary at digest-computation
+    time -- a real I/O/cost decision and a real design question neither
+    ``AppCompatResult``/``_app_compat_summary`` nor ``ScopedGateSelection``
+    carry any answer for today. Left as a known gap rather than a reactive
+    file-hashing patch, per this repo's own "known gaps over risky reactive
+    patches" convention (AGENTS.md)."""
+    scope = gate.scope
+    if scope is None:
         return ""
-    if gate_scope == "used_by":
-        used_by = getattr(result, "used_by", None) or ()
-        targets = sorted(str(entry.get("app", "")) for entry in used_by)
-    elif gate_scope == "required_symbol":
-        required = getattr(result, "required_symbols", None) or {}
-        targets = sorted(
-            str(e) for e in (required.get("required_entrypoints", ()) or ())
-        )
-    else:
-        targets = []
     return json.dumps(
-        {"kind": str(gate_scope), "targets": targets},
+        {"kind": str(scope.kind), "targets": sorted(str(t) for t in scope.targets)},
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -394,9 +382,7 @@ def effective_config_fields_from_full_config(
     *,
     result: Any = None,
     policy_file: Any = None,
-    require_complete_analysis: bool = False,
-    severity_config: SeverityConfig | None = None,
-    exit_code_scheme: str | None = None,
+    gate: EffectiveGate,
 ) -> dict[str, str]:
     """Rich-tier fields from a real ``CompatibilityEvaluationConfig``.
 
@@ -425,45 +411,42 @@ def effective_config_fields_from_full_config(
     ``compare()`` unconditionally -- a plain ``or`` fallback would then
     silently drop whichever axis lost the fallback race). See that
     function's own docstring for the full reasoning.
-    *require_complete_analysis*
+    *gate* is the one already-constructed :class:`~abicheck.policy.
+    effective_gate.EffectiveGate` every ``gate.*`` field below now reads
+    from exclusively (Codex review, PR #1192's follow-up finding) -- not
+    re-derived here from *severity_config*/*exit_code_scheme*/
+    *require_complete_analysis* passed as three more independent
+    parameters alongside it, which is what let this function's own
+    projection of "the gate" silently drift from *gate*'s (the two could
+    disagree even though both claimed to describe the same run). The
+    caller builds *gate* itself (typically via ``EffectiveGate.
+    from_severity`` or a direct construction when it has its own
+    already-resolved scheme, e.g. ``scan --against``'s own
+    ``resolve_scan_config`` deliberately blanking ``resolved_config.gate``'s
+    fields regardless of the run's real ``--severity-preset``/scheme, see
+    ``cli_scan_receipt._without_gate_settings``) -- *never* from
+    *resolved_config.gate* directly: that is D7's own resolved copy, and
+    using it here instead of the value that actually scored this run's
+    real process exit is exactly the class of drift the module docstring
+    already promises doesn't happen ("the digest can never disagree with
+    the exit block it sits beside"). ``gate.require_complete_analysis``
     mirrors the identically-named CLI/API flag (P0.4's analysis-
-    completeness gate): it is not a D7 configuration namespace at all --
-    ``compatibility_evaluation_config.py`` has no field for it -- but it
-    genuinely changes gating behavior the same way a severity setting
-    does (an otherwise-identical incomplete-evidence result exits 0 vs. 1
-    depending on it, Codex review, PR #803), so it is threaded here as an
-    independent parameter exactly like *severity_config*/*exit_code_scheme*
-    already are, rather than pretended to live inside *resolved_config*.
-
-    *severity_config*/*exit_code_scheme* are the same already-resolved pair
-    every caller already threads for the ``exit`` block (see
-    :func:`effective_config_fields_from_diff_result`'s identical parameters)
-    -- ``gate.exit_code_scheme``/``gate.severity.*`` are populated from
-    *these*, never from *resolved_config.gate* directly (CodeRabbit review,
-    PR #803, fresh evidence: ``scan --against``'s own ``resolve_scan_config``
-    deliberately blanks ``resolved_config.gate``'s severity/exit-code-scheme
-    fields to built-in defaults regardless of the run's real
-    ``--severity-preset``/``--exit-code-scheme`` -- see
-    ``cli_scan_receipt._without_gate_settings`` -- so reading them from
-    *resolved_config* there silently discarded the run's real gate. This
-    also closes a class of drift the module docstring already promises
-    doesn't happen ("the digest can never disagree with the exit block it
-    sits beside"): *resolved_config.gate* is D7's own resolved copy, while
-    *severity_config*/*exit_code_scheme* are the value that actually scored
-    this run's real process exit -- for `compare` the two happen to agree
-    today, but there is no structural guarantee they always will, and using
-    the caller-supplied pair removes the possibility entirely rather than
-    relying on that coincidence).
+    completeness gate) -- not a D7 configuration namespace at all
+    (``compatibility_evaluation_config.py`` has no field for it), but it
+    genuinely changes gating behavior the same way a severity setting does
+    (an otherwise-identical incomplete-evidence result exits 0 vs. 1
+    depending on it, Codex review, PR #803), which is exactly why it lives
+    on *gate* rather than being read from *resolved_config* either.
     """
     policy = getattr(resolved_config, "policy", None)
     surface = getattr(resolved_config, "surface", None)
     contract = getattr(resolved_config, "contract", None)
-    gate = getattr(resolved_config, "gate", None)
+    resolved_gate = getattr(resolved_config, "gate", None)
     assurance = getattr(resolved_config, "assurance", None)
     evidence = getattr(resolved_config, "evidence", None)
     pack_groups = (
         getattr(policy, "packs", ()),
-        getattr(gate, "packs", ()),
+        getattr(resolved_gate, "packs", ()),
         getattr(contract, "packs", ()),
         getattr(surface, "packs", ()),
         getattr(evidence, "packs", ()),
@@ -502,17 +485,17 @@ def effective_config_fields_from_full_config(
         "contract.mode": _enum_value(getattr(contract, "mode", None)),
         "contract.unresolved": str(getattr(contract, "unresolved", "") or ""),
         "contract.overlays": _namespaces_str(getattr(contract, "overlays", ())),
-        "gate.exit_code_scheme": str(exit_code_scheme or ""),
-        "gate.require_complete_analysis": str(bool(require_complete_analysis)),
-        "gate.scope": _gate_scope_str(result),
-        "gate.severity.abi_breaking": _severity_field(severity_config, "abi_breaking"),
+        "gate.exit_code_scheme": str(gate.exit_code_scheme or ""),
+        "gate.require_complete_analysis": str(bool(gate.require_complete_analysis)),
+        "gate.scope": _gate_scope_str_from_gate(gate),
+        "gate.severity.abi_breaking": _severity_field(gate.severity, "abi_breaking"),
         "gate.severity.potential_breaking": _severity_field(
-            severity_config, "potential_breaking"
+            gate.severity, "potential_breaking"
         ),
         "gate.severity.quality_issues": _severity_field(
-            severity_config, "quality_issues"
+            gate.severity, "quality_issues"
         ),
-        "gate.severity.addition": _severity_field(severity_config, "addition"),
+        "gate.severity.addition": _severity_field(gate.severity, "addition"),
         "gate.on_incomplete_scope": _on_incomplete_scope_str(result),
         "assurance.require_evidence": str(
             bool(getattr(assurance, "require_evidence", True))
@@ -528,18 +511,21 @@ def effective_config_fields_from_full_config(
 def effective_config_fields_from_diff_result(
     result: Any,
     *,
-    severity_config: SeverityConfig | None,
-    exit_code_scheme: str,
-    require_complete_analysis: bool = False,
+    gate: EffectiveGate,
 ) -> dict[str, str]:
     """Baseline-tier fields, resolved from an ordinary comparison.
 
-    *result* is the ``DiffResult`` every comparison produces; *severity_config*/
-    *exit_code_scheme* are the same already-resolved pair
+    *result* is the ``DiffResult`` every comparison produces; *gate* is the
+    one already-constructed :class:`~abicheck.policy.effective_gate.
+    EffectiveGate` every ``gate.*`` field below reads from exclusively
+    (Codex review, PR #1192's follow-up finding -- see
+    :func:`effective_config_fields_from_full_config`'s identical note for
+    the full rationale), the same object
     :mod:`abicheck.reporter_contract_blocks`'s ``add_contract_context``
-    already receives for the ``exit`` block (``None``/``"legacy"`` when no
-    severity setting is in effect) -- read here, never re-derived.
-    *require_complete_analysis* mirrors the identically-named CLI/API flag,
+    already builds for the ``exit`` block (``gate.severity is None`` when no
+    severity setting is in effect) -- read here, never re-derived from the
+    raw inputs a second time. ``gate.require_complete_analysis`` mirrors
+    the identically-named CLI/API flag,
     same as the rich tier's own field (see
     :func:`effective_config_fields_from_full_config`'s docstring).
     ``surface.explicit_scope`` reads ``result.explicit_scope_source_
@@ -587,17 +573,17 @@ def effective_config_fields_from_diff_result(
         "contract.mode": "",
         "contract.unresolved": "",
         "contract.overlays": "",
-        "gate.exit_code_scheme": str(exit_code_scheme or ""),
-        "gate.require_complete_analysis": str(bool(require_complete_analysis)),
-        "gate.scope": _gate_scope_str(result),
-        "gate.severity.abi_breaking": _severity_field(severity_config, "abi_breaking"),
+        "gate.exit_code_scheme": str(gate.exit_code_scheme or ""),
+        "gate.require_complete_analysis": str(bool(gate.require_complete_analysis)),
+        "gate.scope": _gate_scope_str_from_gate(gate),
+        "gate.severity.abi_breaking": _severity_field(gate.severity, "abi_breaking"),
         "gate.severity.potential_breaking": _severity_field(
-            severity_config, "potential_breaking"
+            gate.severity, "potential_breaking"
         ),
         "gate.severity.quality_issues": _severity_field(
-            severity_config, "quality_issues"
+            gate.severity, "quality_issues"
         ),
-        "gate.severity.addition": _severity_field(severity_config, "addition"),
+        "gate.severity.addition": _severity_field(gate.severity, "addition"),
         "gate.on_incomplete_scope": _on_incomplete_scope_str(result),
         "assurance.require_evidence": "",
         "suppressions": str(getattr(result, "suppression_source_sha256", "") or ""),
@@ -608,11 +594,16 @@ def effective_config_fields_from_diff_result(
 def effective_config_fields(
     result: Any,
     *,
-    severity_config: SeverityConfig | None,
-    exit_code_scheme: str,
-    require_complete_analysis: bool = False,
+    gate: EffectiveGate,
 ) -> dict[str, str]:
     """The digest field dict for *result*, picking the richest available tier.
+
+    *gate* is the one already-constructed ``EffectiveGate`` every ``gate.*``
+    field of either tier reads from exclusively (Codex review, PR #1192's
+    follow-up finding) -- passed straight through to whichever of
+    :func:`effective_config_fields_from_full_config`/
+    :func:`effective_config_fields_from_diff_result` this call resolves to,
+    never re-derived at either.
 
     Prefers ``result.contract_context.evaluation_context.resolved_config``
     over the bare ``result.evaluation_config`` whenever a
@@ -653,9 +644,7 @@ def effective_config_fields(
                 resolved_config,
                 result=result,
                 policy_file=policy_file,
-                require_complete_analysis=require_complete_analysis,
-                severity_config=severity_config,
-                exit_code_scheme=exit_code_scheme,
+                gate=gate,
             )
     evaluation_config = getattr(result, "evaluation_config", None)
     if isinstance(evaluation_config, CompatibilityEvaluationConfig):
@@ -663,13 +652,47 @@ def effective_config_fields(
             evaluation_config,
             result=result,
             policy_file=policy_file,
-            require_complete_analysis=require_complete_analysis,
-            severity_config=severity_config,
-            exit_code_scheme=exit_code_scheme,
+            gate=gate,
         )
-    return effective_config_fields_from_diff_result(
-        result,
-        severity_config=severity_config,
-        exit_code_scheme=exit_code_scheme,
+    return effective_config_fields_from_diff_result(result, gate=gate)
+
+
+def effective_config_fields_from_raw(
+    result: Any,
+    *,
+    severity_config: SeverityConfig | None,
+    exit_code_scheme: str,
+    require_complete_analysis: bool = False,
+) -> dict[str, str]:
+    """:func:`effective_config_fields`, for a caller with no already-built
+    ``EffectiveGate`` of its own -- exercising the field-computation logic
+    per raw axis (this module's own test suite) is the intended use; a real
+    production caller should hold (or build once via ``EffectiveGate.
+    from_severity``) a real ``EffectiveGate`` and call
+    :func:`effective_config_fields` directly instead, the way
+    ``reporter_contract_blocks.add_effective_config_digest`` and
+    ``cli_compare_receipt._release_summary_effective_config_block`` do.
+
+    Builds the identical ``EffectiveGate`` those two real call sites build
+    (:meth:`~abicheck.policy.effective_gate.EffectiveGate.from_severity`
+    plus :func:`~abicheck.policy.effective_gate.
+    scoped_gate_selection_from_result` for *result*'s own recorded scoped-
+    gate selection, then an ``exit_code_scheme`` override exactly like
+    ``add_effective_config_digest``'s) -- one algorithm, not a second,
+    differently-reasoned one, so this compatibility shape cannot drift from
+    what production actually does (Codex review, PR #1192's follow-up
+    finding: the whole point of this fix is that there is exactly one way
+    raw severity/scope/completeness inputs become an ``EffectiveGate``).
+    """
+    import dataclasses
+
+    from .policy.effective_gate import EffectiveGate, scoped_gate_selection_from_result
+
+    gate = EffectiveGate.from_severity(
+        severity_config,
         require_complete_analysis=require_complete_analysis,
+        scope=scoped_gate_selection_from_result(result),
     )
+    if exit_code_scheme != gate.exit_code_scheme:
+        gate = dataclasses.replace(gate, exit_code_scheme=exit_code_scheme)
+    return effective_config_fields(result, gate=gate)

--- a/abicheck/effective_config_digest.py
+++ b/abicheck/effective_config_digest.py
@@ -132,6 +132,7 @@ EFFECTIVE_CONFIG_FIELD_KEYS: tuple[str, ...] = (
     "gate.severity.quality_issues",
     "gate.severity.addition",
     "gate.on_incomplete_scope",
+    "gate.fail_on_removed_library",
     "assurance.require_evidence",
     "suppressions",
     "packs",
@@ -220,14 +221,35 @@ def _builtin_policy_base_str(name: Any) -> str:
         return name_str
 
 
-def _on_incomplete_scope_str(result: Any) -> str:
+def _on_incomplete_scope_str_from_gate(gate: EffectiveGate) -> str:
     """ADR-065 D6's ``--on-incomplete-scope`` policy (``warn``/``block``)
-    for a directory/package release, read off *result*; ``""`` for a
-    scalar comparison, whose one pair is the whole scope and to which the
-    policy does not apply. Two otherwise identical incomplete releases
-    exit ``0`` and ``1`` under the two values, so the digest must tell
-    them apart (Codex review)."""
-    return str(getattr(result, "on_incomplete_scope", "") or "")
+    for a directory/package release, read off *gate*; ``""`` when *gate*
+    carries no such axis (a scalar comparison, whose one pair is the whole
+    scope and to which the policy does not apply). Two otherwise identical
+    incomplete releases exit ``0`` and ``1`` under the two values, so the
+    digest must tell them apart (Codex review).
+
+    Reads ``gate.on_incomplete_scope`` exclusively (Codex review, PR #1192,
+    third follow-up round: this used to read ``result.on_incomplete_scope``
+    directly -- a second, independently-derived projection of the same fact
+    ``EffectiveGate`` is supposed to be the one source for, the identical
+    "wrapper that happens to agree, not the actual source" gap the prior two
+    rounds closed for severity/completeness-analysis/scope)."""
+    return str(gate.on_incomplete_scope or "")
+
+
+def _fail_on_removed_library_str_from_gate(gate: EffectiveGate) -> str:
+    """ADR-065's ``--fail-on-removed-library`` flag, read off *gate*; ``""``
+    when *gate* carries no such axis (a scalar comparison has no removed-
+    library concept of its own). Two otherwise identical releases with a
+    proven-removed library exit ``0``/``8`` under the two values of this
+    flag, so the digest must tell them apart (Codex review, PR #1192, third
+    follow-up round -- the same class of gap as ``on_incomplete_scope``
+    above, for the sibling release-scope axis Codex's finding named
+    directly)."""
+    if gate.fail_on_removed_library is None:
+        return ""
+    return str(bool(gate.fail_on_removed_library))
 
 
 def _gate_scope_str_from_gate(gate: EffectiveGate) -> str:
@@ -496,7 +518,8 @@ def effective_config_fields_from_full_config(
             gate.severity, "quality_issues"
         ),
         "gate.severity.addition": _severity_field(gate.severity, "addition"),
-        "gate.on_incomplete_scope": _on_incomplete_scope_str(result),
+        "gate.on_incomplete_scope": _on_incomplete_scope_str_from_gate(gate),
+        "gate.fail_on_removed_library": _fail_on_removed_library_str_from_gate(gate),
         "assurance.require_evidence": str(
             bool(getattr(assurance, "require_evidence", True))
         ),
@@ -584,7 +607,8 @@ def effective_config_fields_from_diff_result(
             gate.severity, "quality_issues"
         ),
         "gate.severity.addition": _severity_field(gate.severity, "addition"),
-        "gate.on_incomplete_scope": _on_incomplete_scope_str(result),
+        "gate.on_incomplete_scope": _on_incomplete_scope_str_from_gate(gate),
+        "gate.fail_on_removed_library": _fail_on_removed_library_str_from_gate(gate),
         "assurance.require_evidence": "",
         "suppressions": str(getattr(result, "suppression_source_sha256", "") or ""),
         "packs": "",
@@ -663,6 +687,8 @@ def effective_config_fields_from_raw(
     severity_config: SeverityConfig | None,
     exit_code_scheme: str,
     require_complete_analysis: bool = False,
+    on_incomplete_scope: str | None = None,
+    fail_on_removed_library: bool | None = None,
 ) -> dict[str, str]:
     """:func:`effective_config_fields`, for a caller with no already-built
     ``EffectiveGate`` of its own -- exercising the field-computation logic
@@ -692,6 +718,8 @@ def effective_config_fields_from_raw(
         severity_config,
         require_complete_analysis=require_complete_analysis,
         scope=scoped_gate_selection_from_result(result),
+        on_incomplete_scope=on_incomplete_scope,
+        fail_on_removed_library=fail_on_removed_library,
     )
     if exit_code_scheme != gate.exit_code_scheme:
         gate = dataclasses.replace(gate, exit_code_scheme=exit_code_scheme)

--- a/abicheck/frontends/cli/release_summary.py
+++ b/abicheck/frontends/cli/release_summary.py
@@ -117,6 +117,7 @@ def _write_release_summary_file(
         pack_application=pack_application,
         scope_public_headers=scope_public_headers,
         on_incomplete_scope=terms.policy,
+        fail_on_removed_library=fail_on_removed,
     )
     release_global_verdict = _release_global_verdict(bundle_result, matrix_result)
     exit_dict = resolve_release_exit_decision_for_report(

--- a/abicheck/pack_application.py
+++ b/abicheck/pack_application.py
@@ -77,10 +77,8 @@ from .compatibility_evaluation_wiring import (
     load_selected_packs,
 )
 from .errors import PackManifestError
-from .policy.gate_pack_fold import (
-    GATE_SEVERITY_CATEGORIES,
-    fold_gate_pack_severity,
-)
+from .policy.effective_gate import GateSeverityState
+from .policy.gate_pack_fold import GATE_SEVERITY_CATEGORIES
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .policy_file import PolicyFile
@@ -439,22 +437,25 @@ def apply_to_compare_config(resolved_cfg: Any, application: PackApplication) -> 
     :func:`~abicheck.policy.gate_pack_fold.fold_gate_pack_severity`, the one
     shared implementation the directory/package release fan-out's
     ``policy.release_gate_options.apply_release_gate_pack`` also calls
-    (duplication-and-convergence-assessment T6). The two differ only in what
+    (duplication-and-convergence-assessment T6), through the identical
+    :class:`~abicheck.policy.effective_gate.GateSeverityState` value type
+    that function now builds too (P0's follow-on: one shared fold-time
+    shape, not just one shared fold function). The two differ only in what
     they fold *onto* -- an already-resolved ``SeverityConfig`` here, four raw
-    optional strings there -- which is why the shared function is written
+    optional strings there -- which is why ``GateSeverityState`` is written
     over a plain per-category mapping rather than either runtime shape.
     """
     if not application.severity_levels:
         return resolved_cfg
-    folded = fold_gate_pack_severity(
-        {
+    state = GateSeverityState(
+        levels={
             category: getattr(resolved_cfg.severity, category)
             for category in GATE_SEVERITY_CATEGORIES
         },
-        application.severity_levels,
-    )
-    severity = replace(resolved_cfg.severity, **folded)
-    return replace(resolved_cfg, severity=severity, severity_active=True)
+        active=resolved_cfg.severity_active,
+    ).folded(application.severity_levels)
+    severity = replace(resolved_cfg.severity, **state.levels)
+    return replace(resolved_cfg, severity=severity, severity_active=state.active)
 
 
 #: Pack fields whose engine consumer only runs under contract evaluation,

--- a/abicheck/policy/effective_gate.py
+++ b/abicheck/policy/effective_gate.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``EffectiveGate`` -- the one gate-configuration runtime shape
+(``docs/contribute/plans/duplication-and-convergence-assessment.md``'s P0
+"Effective configuration and pack application" target), and the one
+fold-time value type its two producers now share.
+
+**Where this sits relative to T6.** ``gate_pack_fold.fold_gate_pack_severity``
+already unified the *algorithm* both ``pack_application.
+apply_to_compare_config`` (single-pair ``compare``) and ``release_gate_
+options.apply_release_gate_pack`` (the directory/package release fan-out)
+apply -- see that module's own docstring. What stayed unshared afterward,
+named explicitly in this plan's own P0 section and pinned as a still-open
+gap by ``tests/test_release_gate_pack_fold_parity.py``'s docstring, is the
+*shape* each caller folds onto: an already-resolved
+:class:`~abicheck.policy.severity.SeverityConfig` for ``compare``, four
+independent raw optional strings for the release fan-out -- a real
+difference (the release fan-out must keep "no severity setting is in
+effect" distinguishable from "the default levels", which a resolved
+``SeverityConfig`` cannot express), so unifying it needed a *third*,
+provenance-preserving shape rather than forcing one caller onto the other's.
+
+:class:`GateSeverityState` is that shape. Both callers now construct one from
+their own native representation, fold a pack's contribution through the one
+:meth:`GateSeverityState.folded` method (itself calling the identical
+``fold_gate_pack_severity`` T6 already shared), and read the result back --
+so "two different shapes" narrows to "two different *constructors* for one
+shared fold-time type", the literal target this plan section names.
+
+:class:`EffectiveGate` is the plan's own named target object -- the resolved
+gate configuration a caller actually runs with, not merely the fold's
+intermediate state. Both :class:`~abicheck.policy.release_gate_options.
+GateOptions` (the release fan-out's resolved object) and
+``abicheck.cli_helpers_compare.ResolvedCompareConfig`` (single-pair
+``compare``'s) expose an ``effective_gate`` property built through
+:meth:`EffectiveGate.from_severity`, so a caller holding either object can
+ask for the same-shaped answer. This is deliberately narrower than the
+plan's full ``EffectiveEvaluationConfig`` (which would also carry policy/
+contract/assurance/surface/evidence/suppressions namespaces no release-fan-
+out-facing object resolves today) -- see that section's own "Target" text;
+extending this object to the other namespaces, and to a real digest over it,
+is left to a future slice rather than attempted speculatively here.
+
+A leaf: imports nothing from ``abicheck`` outside ``policy`` itself, so
+either caller can depend on it without acquiring the other's dependencies --
+the same reasoning ``gate_pack_fold.py``'s own docstring gives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .gate_pack_fold import (
+    GATE_SEVERITY_CATEGORIES,
+    fold_gate_pack_severity,
+    gate_exit_code_scheme,
+)
+from .severity import SeverityConfig
+
+__all__ = [
+    "EffectiveGate",
+    "GateSeverityState",
+    "ScopedGateSelection",
+]
+
+
+@dataclass(frozen=True)
+class GateSeverityState:
+    """The one fold-time value both ``gate_pack_fold``'s two callers now
+    construct, fold, and read back -- see this module's own docstring for
+    why a third shape (rather than forcing one caller onto the other's) is
+    the correct unification here.
+
+    *levels* holds exactly :data:`~abicheck.policy.gate_pack_fold.
+    GATE_SEVERITY_CATEGORIES` as keys, in whichever vocabulary the caller
+    carries them (resolved ``SeverityLevel`` members for ``compare``; raw
+    ``str | None`` CLI/config strings for the release fan-out) -- the same
+    genericity ``fold_gate_pack_severity`` itself already documents.
+    *active* is that caller's own "is a severity setting in effect" fact
+    *before* this fold; :meth:`folded` never has to guess it, since a pack
+    contribution can only ever turn ``active`` on, never off.
+    """
+
+    levels: Mapping[str, Any]
+    active: bool
+
+    def __post_init__(self) -> None:
+        missing = set(GATE_SEVERITY_CATEGORIES) - set(self.levels)
+        if missing:
+            raise ValueError(
+                f"GateSeverityState.levels is missing categories {sorted(missing)}; "
+                f"it must carry exactly {list(GATE_SEVERITY_CATEGORIES)}"
+            )
+
+    def folded(self, pack_levels: Mapping[str, Any]) -> GateSeverityState:
+        """*pack_levels* folded onto this state (:func:`~abicheck.policy.
+        gate_pack_fold.fold_gate_pack_severity`), returning a fresh state.
+
+        A no-op (returns ``self``, not merely an equal copy) when
+        *pack_levels* is empty -- both existing callers relied on exactly
+        this shortcut (the release fan-out to skip resolving a
+        :class:`SeverityConfig` it would otherwise have to immediately
+        discard; ``compare`` to avoid marking ``severity_active`` when no
+        pack was selected at all), so preserving it here keeps this a
+        behavior-neutral refactor of the *shape*, not a second change to the
+        *fold* T6 already settled. Otherwise ``active`` becomes ``True``: a
+        real pack contribution *is* a severity setting coming into effect,
+        by both callers' own pre-existing behavior.
+        """
+        if not pack_levels:
+            return self
+        return GateSeverityState(
+            levels=fold_gate_pack_severity(self.levels, pack_levels),
+            active=True,
+        )
+
+
+@dataclass(frozen=True)
+class ScopedGateSelection:
+    """An ADR-043 scoped-gate selection (``--used-by``/``--required-symbol``)
+    -- which consumer or entrypoint narrowed the gate, and to what. Mirrors
+    ``effective_config_digest._gate_scope_str``'s own encoding (``kind`` is
+    ``"used_by"``/``"required_symbol"``; ``targets`` the resolved consumer
+    paths or required entrypoints), given a real typed home here rather than
+    only a digest-string projection.
+    """
+
+    kind: str
+    targets: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EffectiveGate:
+    """The one resolved gate-configuration object
+    (duplication-and-convergence-assessment plan's P0 target, narrowed to
+    the gate namespace alone -- see this module's own docstring for why the
+    full ``EffectiveEvaluationConfig`` is not attempted here).
+
+    ``severity is None`` means "no severity setting is in effect for this
+    run" -- the same single source of truth
+    :class:`~abicheck.policy.release_gate_options.GateOptions` already
+    documents for its own field of the same name. ``exit_code_scheme`` is
+    always the one shared derivation
+    (:func:`~abicheck.policy.gate_pack_fold.gate_exit_code_scheme`) applied
+    to that fact, never an independently stated value -- the same structural
+    invariant ``GateOptions.exit_code_scheme``/``ResolvedCompareConfig.
+    exit_code_scheme`` already enforce by making it a derived property.
+    ``require_complete_analysis``/``scope`` are carried alongside for the
+    identical reason ``effective_config_digest.py``'s own field-key comment
+    already gives for including them next to severity: each can change an
+    otherwise-identical run's gate outcome on its own, so a caller comparing
+    two ``EffectiveGate`` values for "would these gate the same way" must see
+    all four fields, not severity alone.
+    """
+
+    exit_code_scheme: str
+    severity: SeverityConfig | None
+    require_complete_analysis: bool = False
+    scope: ScopedGateSelection | None = None
+
+    @classmethod
+    def from_severity(
+        cls,
+        severity: SeverityConfig | None,
+        *,
+        require_complete_analysis: bool = False,
+        scope: ScopedGateSelection | None = None,
+    ) -> EffectiveGate:
+        """Build the one derived-scheme ``EffectiveGate`` for *severity*
+        (``None`` meaning "no severity setting is in effect") -- the single
+        constructor both ``GateOptions.effective_gate`` and
+        ``ResolvedCompareConfig.effective_gate`` call, so neither can
+        independently mis-derive ``exit_code_scheme``.
+        """
+        return cls(
+            exit_code_scheme=gate_exit_code_scheme(severity is not None),
+            severity=severity,
+            require_complete_analysis=require_complete_analysis,
+            scope=scope,
+        )

--- a/abicheck/policy/effective_gate.py
+++ b/abicheck/policy/effective_gate.py
@@ -204,12 +204,29 @@ class EffectiveGate:
     otherwise-identical run's gate outcome on its own, so a caller comparing
     two ``EffectiveGate`` values for "would these gate the same way" must see
     all four fields, not severity alone.
+
+    ``on_incomplete_scope``/``fail_on_removed_library`` (Codex review, PR
+    #1192, third follow-up round) are ADR-065's directory/package release
+    axes: ``on_incomplete_scope`` (``"warn"``/``"block"``) decides whether an
+    incomplete required member raises the exit code at all, and
+    ``fail_on_removed_library`` decides whether a proven removal raises exit
+    ``8`` -- the identical "two otherwise-identical runs exit differently"
+    shape ``require_complete_analysis``/``scope`` already state above, just
+    for the release fan-out's own two knobs rather than a single-pair
+    ``compare``'s. ``None`` means "not applicable at this run's own scope" --
+    a bare single-pair ``compare`` never resolves a scope-completeness
+    policy for itself (see ``workflows.gate.
+    effective_gate_for_resolved_compare_config``'s own docstring), so the
+    field must be able to say "no such axis here" distinctly from a real,
+    resolved ``"warn"``/``False``.
     """
 
     exit_code_scheme: str
     severity: SeverityConfig | None
     require_complete_analysis: bool = False
     scope: ScopedGateSelection | None = None
+    on_incomplete_scope: str | None = None
+    fail_on_removed_library: bool | None = None
 
     @classmethod
     def from_severity(
@@ -218,6 +235,8 @@ class EffectiveGate:
         *,
         require_complete_analysis: bool = False,
         scope: ScopedGateSelection | None = None,
+        on_incomplete_scope: str | None = None,
+        fail_on_removed_library: bool | None = None,
     ) -> EffectiveGate:
         """Build the one derived-scheme ``EffectiveGate`` for *severity*
         (``None`` meaning "no severity setting is in effect") -- the single
@@ -230,4 +249,6 @@ class EffectiveGate:
             severity=severity,
             require_complete_analysis=require_complete_analysis,
             scope=scope,
+            on_incomplete_scope=on_incomplete_scope,
+            fail_on_removed_library=fail_on_removed_library,
         )

--- a/abicheck/policy/effective_gate.py
+++ b/abicheck/policy/effective_gate.py
@@ -76,6 +76,7 @@ __all__ = [
     "EffectiveGate",
     "GateSeverityState",
     "ScopedGateSelection",
+    "scoped_gate_selection_from_result",
 ]
 
 
@@ -142,6 +143,43 @@ class ScopedGateSelection:
 
     kind: str
     targets: tuple[str, ...] = ()
+
+
+def scoped_gate_selection_from_result(result: Any) -> ScopedGateSelection | None:
+    """The real ADR-043 scoped-gate selection a *completed* comparison
+    recorded (``result.gate_scope``/``.used_by``/``.required_symbols``),
+    projected into a typed :class:`ScopedGateSelection` -- ``None`` when the
+    run selected no scope at all, the common case.
+
+    Codex review (PR #1192): ``EffectiveGate``'s whole purpose is "the
+    complete answer to whether two runs gate identically", so a caller that
+    *has* a completed result must route through this rather than leaving
+    ``scope`` at its default -- two ``compare --required-symbol A``/
+    ``--required-symbol B`` runs against the same pair must not produce an
+    equal ``EffectiveGate``.
+
+    Reads the identical fields ``effective_config_digest._gate_scope_str``
+    already reads for the digest (duplicated rather than shared, since that
+    function returns a JSON-encoded string for hashing while this returns a
+    typed value; both are intentionally kept in sync with the same source
+    fields -- ``cli_helpers_compare._apply_used_by_scoping``/
+    ``_apply_required_symbol_scoping`` stamp ``DiffResult.gate_scope``/
+    ``used_by``/``required_symbols`` before either reads them).
+    """
+    gate_scope = getattr(result, "gate_scope", None)
+    if gate_scope is None:
+        return None
+    if gate_scope == "used_by":
+        used_by = getattr(result, "used_by", None) or ()
+        targets = tuple(sorted(str(entry.get("app", "")) for entry in used_by))
+    elif gate_scope == "required_symbol":
+        required = getattr(result, "required_symbols", None) or {}
+        targets = tuple(
+            sorted(str(e) for e in (required.get("required_entrypoints", ()) or ()))
+        )
+    else:
+        targets = ()
+    return ScopedGateSelection(kind=str(gate_scope), targets=targets)
 
 
 @dataclass(frozen=True)

--- a/abicheck/policy/release_gate_options.py
+++ b/abicheck/policy/release_gate_options.py
@@ -52,7 +52,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from .gate_pack_fold import fold_gate_pack_severity, gate_exit_code_scheme
+from .effective_gate import EffectiveGate, GateSeverityState
+from .gate_pack_fold import gate_exit_code_scheme
 from .severity import SeverityConfig, resolve_severity_config
 
 
@@ -112,14 +113,18 @@ def apply_release_gate_pack(
     assessment T6): :func:`~abicheck.policy.gate_pack_fold.
     fold_gate_pack_severity` owns it, and ``pack_application.
     apply_to_compare_config`` -- single-pair ``compare``'s own gate-pack
-    application -- calls the identical function. What stays this function's
-    own job is the *shape* difference the two call sites genuinely have: the
-    release fan-out folds onto four independent optional raw CLI-or-config
-    strings, before any :class:`SeverityConfig` exists, where ``compare``
-    folds onto an already-resolved one. That difference is real (a release
-    run must still be able to distinguish "no severity setting in effect"
-    from "the default levels", which a resolved config cannot express), so
-    it is expressed here, around one shared fold, rather than by a second
+    application -- calls the identical function, and (P0's own follow-on)
+    both callers now fold through the identical
+    :class:`~abicheck.policy.effective_gate.GateSeverityState` value type
+    rather than each constructing its own ad hoc mapping. What stays this
+    function's own job is the *shape* difference the two call sites
+    genuinely have: the release fan-out folds onto four independent optional
+    raw CLI-or-config strings, before any :class:`SeverityConfig` exists,
+    where ``compare`` folds onto an already-resolved one. That difference is
+    real (a release run must still be able to distinguish "no severity
+    setting in effect" from "the default levels", which a resolved config
+    cannot express), so it is expressed here, in how this function builds
+    and reads back a :class:`GateSeverityState`, rather than by a second
     copy of the fold.
 
     A no-op when *pack_application* is ``None`` (no ``--pack`` given) or
@@ -127,15 +132,22 @@ def apply_release_gate_pack(
     the five inputs completely unchanged.
     """
     levels = {} if pack_application is None else pack_application.severity_levels
-    folded = fold_gate_pack_severity(
-        {
+    state = GateSeverityState(
+        levels={
             "abi_breaking": severity_abi_breaking,
             "potential_breaking": severity_potential_breaking,
             "quality_issues": severity_quality_issues,
             "addition": severity_addition,
         },
-        levels,
-    )
+        # Whether a severity setting is already in effect on *this* raw
+        # shape has no bearing on the fold itself (the release fan-out
+        # resolves that fact afterward, over all five raw inputs including
+        # the preset, via `_resolve_release_severity_config`) -- this state
+        # is built only to carry `levels` through the shared fold and is
+        # never read back for `.active`.
+        active=False,
+    ).folded(levels)
+    folded = state.levels
     return (
         severity_preset,
         folded["abi_breaking"],
@@ -231,6 +243,24 @@ class GateOptions:
         with, so the release fan-out cannot drift from either.
         """
         return gate_exit_code_scheme(self.severity is not None)
+
+    @property
+    def effective_gate(self) -> EffectiveGate:
+        """This object, projected onto the plan's shared
+        :class:`~abicheck.policy.effective_gate.EffectiveGate` shape
+        (duplication-and-convergence-assessment P0) -- the same shape
+        ``cli_helpers_compare.ResolvedCompareConfig.effective_gate`` exposes
+        for single-pair ``compare``, so a caller holding either object can
+        ask the identical question. The release fan-out resolves no
+        ``--require-complete-analysis``/scoped-gate (``--used-by``/
+        ``--required-symbol``) concept of its own at this object's scope --
+        those are per-library, single-pair facts -- so both stay at their
+        default (``False``/``None``) here; a caller that does have one
+        should build an :class:`EffectiveGate` directly via
+        :meth:`EffectiveGate.from_severity` instead of through this
+        property.
+        """
+        return EffectiveGate.from_severity(self.severity)
 
 
 def resolve_release_gate_options(

--- a/abicheck/policy/release_gate_options.py
+++ b/abicheck/policy/release_gate_options.py
@@ -231,6 +231,21 @@ class GateOptions:
 
     severity_preset: str | None
     severity: SeverityConfig | None
+    #: ADR-065's own two release-fan-out gate axes (Codex review, PR #1192,
+    #: third follow-up round): the ``--on-incomplete-scope`` policy and
+    #: ``--fail-on-removed-library``. Unlike ``require_complete_analysis``/
+    #: scoped-gate selection (per-library, single-pair facts this object's
+    #: own ``effective_gate`` property below deliberately leaves at their
+    #: default), these two ARE resolved once at this object's own release-
+    #: fan-out scope -- so they belong here as real fields, not only passed
+    #: ad hoc to ``effective_gate`` by a caller that happens to have them.
+    #: ``None`` when unresolved (matches every pre-existing constructor call
+    #: this dataclass had before this fix, none of which knew about these
+    #: axes -- so their exit-code behavior is completely unaffected, only
+    #: this object's/``EffectiveGate``'s own digest-facing fields gain a
+    #: value).
+    on_incomplete_scope: str | None = None
+    fail_on_removed_library: bool | None = None
 
     @property
     def exit_code_scheme(self) -> str:
@@ -258,9 +273,15 @@ class GateOptions:
         default (``False``/``None``) here; a caller that does have one
         should build an :class:`EffectiveGate` directly via
         :meth:`EffectiveGate.from_severity` instead of through this
-        property.
+        property. ``on_incomplete_scope``/``fail_on_removed_library`` ARE
+        this object's own scope (see this dataclass's own field docstring),
+        so they pass straight through instead of defaulting away.
         """
-        return EffectiveGate.from_severity(self.severity)
+        return EffectiveGate.from_severity(
+            self.severity,
+            on_incomplete_scope=self.on_incomplete_scope,
+            fail_on_removed_library=self.fail_on_removed_library,
+        )
 
 
 def resolve_release_gate_options(
@@ -271,6 +292,8 @@ def resolve_release_gate_options(
     severity_potential_breaking: str | None,
     severity_quality_issues: str | None,
     severity_addition: str | None,
+    on_incomplete_scope: str | None = None,
+    fail_on_removed_library: bool | None = None,
 ) -> GateOptions:
     """Resolve the release fan-out's :class:`GateOptions` exactly once.
 
@@ -286,6 +309,17 @@ def resolve_release_gate_options(
     either direction regardless of what severity configuration was
     present; removed along with the CLI flag, the config key, and the
     pack field.)
+
+    *on_incomplete_scope*/*fail_on_removed_library* (Codex review, PR #1192,
+    third follow-up round) carry straight through onto the returned
+    :class:`GateOptions` unchanged -- this function resolves no fold or
+    default for either (the caller's own already-resolved ``--on-
+    incomplete-scope``/``--fail-on-removed-library`` values are the single
+    source, the same ones the real exit-code computation elsewhere in the
+    release fan-out already reads); they exist as parameters here purely so
+    ``GateOptions``/``EffectiveGate`` can carry the identical values a
+    caller already has, rather than a caller reaching around this
+    resolution to set them by hand afterward.
     """
     (
         severity_preset,
@@ -311,4 +345,6 @@ def resolve_release_gate_options(
     return GateOptions(
         severity_preset=severity_preset,
         severity=severity_config,
+        on_incomplete_scope=on_incomplete_scope,
+        fail_on_removed_library=fail_on_removed_library,
     )

--- a/abicheck/reporter_contract_blocks.py
+++ b/abicheck/reporter_contract_blocks.py
@@ -242,9 +242,22 @@ def add_effective_config_digest(
         effective_config_digest,
         effective_config_fields,
     )
-    from .policy.gate_pack_fold import gate_exit_code_scheme
+    from .policy.effective_gate import EffectiveGate, scoped_gate_selection_from_result
 
-    scheme = exit_code_scheme or gate_exit_code_scheme(severity_config is not None)
+    # Route the scheme derivation through the one real, per-run
+    # `EffectiveGate` this comparison resolved (Codex review, PR #1192,
+    # closure package 4's own follow-up finding): *severity_config*,
+    # *require_complete_analysis*, and *result*'s own recorded scoped-gate
+    # selection (`--used-by`/`--required-symbol`) are exactly this run's
+    # three other gate-changing facts, so this is the real production call
+    # site that gives `EffectiveGate` genuinely varying values -- not merely
+    # a unit-tested, never-invoked type.
+    gate = EffectiveGate.from_severity(
+        severity_config,
+        require_complete_analysis=require_complete_analysis,
+        scope=scoped_gate_selection_from_result(result),
+    )
+    scheme = exit_code_scheme or gate.exit_code_scheme
     ec_fields = effective_config_fields(
         result,
         severity_config=severity_config,
@@ -376,8 +389,7 @@ def add_suppression_audit(d: dict[str, Any], result: DiffResult) -> None:
             suppression_rule_label(r, i) for i, r in enumerate(audit.expired_rules)
         ],
         "near_expiry_rules": [
-            suppression_rule_label(r, i)
-            for i, r in enumerate(audit.near_expiry_rules)
+            suppression_rule_label(r, i) for i, r in enumerate(audit.near_expiry_rules)
         ],
     }
 

--- a/abicheck/reporter_contract_blocks.py
+++ b/abicheck/reporter_contract_blocks.py
@@ -197,6 +197,8 @@ def add_effective_config_digest(
     severity_config: SeverityConfig | None = None,
     exit_code_scheme: str | None = None,
     require_complete_analysis: bool = False,
+    on_incomplete_scope: str | None = None,
+    fail_on_removed_library: bool | None = None,
 ) -> None:
     """CLI cleanup phase two, PR B: the effective-configuration digest --
     "one effective configuration ... with the same effective-config digest
@@ -262,6 +264,8 @@ def add_effective_config_digest(
         severity_config,
         require_complete_analysis=require_complete_analysis,
         scope=scoped_gate_selection_from_result(result),
+        on_incomplete_scope=on_incomplete_scope,
+        fail_on_removed_library=fail_on_removed_library,
     )
     scheme = exit_code_scheme or gate.exit_code_scheme
     if scheme != gate.exit_code_scheme:

--- a/abicheck/reporter_contract_blocks.py
+++ b/abicheck/reporter_contract_blocks.py
@@ -238,32 +238,35 @@ def add_effective_config_digest(
     rather than silently absent from the fingerprint (Codex review,
     PR #803, fresh evidence).
     """
+    import dataclasses
+
     from .effective_config_digest import (
         effective_config_digest,
         effective_config_fields,
     )
     from .policy.effective_gate import EffectiveGate, scoped_gate_selection_from_result
 
-    # Route the scheme derivation through the one real, per-run
-    # `EffectiveGate` this comparison resolved (Codex review, PR #1192,
-    # closure package 4's own follow-up finding): *severity_config*,
-    # *require_complete_analysis*, and *result*'s own recorded scoped-gate
-    # selection (`--used-by`/`--required-symbol`) are exactly this run's
-    # three other gate-changing facts, so this is the real production call
-    # site that gives `EffectiveGate` genuinely varying values -- not merely
-    # a unit-tested, never-invoked type.
+    # The one real, per-run `EffectiveGate` this comparison resolved (Codex
+    # review, PR #1192, closure package 4's own follow-up findings):
+    # *severity_config*, *require_complete_analysis*, and *result*'s own
+    # recorded scoped-gate selection (`--used-by`/`--required-symbol`) are
+    # exactly this run's three other gate-changing facts. `scheme` may
+    # override the derived one (a caller's own already-resolved scheme,
+    # e.g. `scan --against`'s own `exit_scheme` -- see this function's own
+    # docstring on *exit_code_scheme*), so `gate` is rebuilt to actually
+    # carry it rather than leaving the model able to disagree with itself.
+    # `effective_config_fields` below reads every `gate.*` field from *this*
+    # object exclusively -- it is the digest's single source for them, not
+    # a second, independently-rederived projection of the same raw inputs.
     gate = EffectiveGate.from_severity(
         severity_config,
         require_complete_analysis=require_complete_analysis,
         scope=scoped_gate_selection_from_result(result),
     )
     scheme = exit_code_scheme or gate.exit_code_scheme
-    ec_fields = effective_config_fields(
-        result,
-        severity_config=severity_config,
-        exit_code_scheme=scheme,
-        require_complete_analysis=require_complete_analysis,
-    )
+    if scheme != gate.exit_code_scheme:
+        gate = dataclasses.replace(gate, exit_code_scheme=scheme)
+    ec_fields = effective_config_fields(result, gate=gate)
     d["effective_config_digest"] = effective_config_digest(ec_fields)
     d["effective_config_fields"] = ec_fields
 

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -884,7 +884,9 @@ _ARTIFACT_NAMES = frozenset(
 #:       ``symbol``/``old_value`` stay the raw mangled spelling unchanged
 #:       (machine formats never demangle those); this is display-only and
 #:       moves no verdict, severity, or exit code.
-REPORT_SCHEMA_VERSION = "3.14"  #: 3.14 -- see the comment immediately above.
+#: 3.15 -- additive, always-present ``gate.fail_on_removed_library``
+#:       (ADR-065's flag), mirroring ``gate.on_incomplete_scope`` (2.50).
+REPORT_SCHEMA_VERSION = "3.15"  #: 3.15 -- see the comment immediately above.
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of the public scan dict shape:
@@ -1216,7 +1218,8 @@ REPORT_SCHEMA_VERSION = "3.14"  #: 3.14 -- see the comment immediately above.
 #: 1.29 -- ADR-067 C-S1, mirrors `compare`'s 2.51 entry for the one field the two commands share: ``scan --against``'s baseline-summary ``detectors[]`` entries gain an additive ``not_evaluated`` boolean, distinguishing a detector whose support gate refused it from one that ran and produced nothing (``changes_count: 0`` in both cases). Detector provenance is an ADR-049 Phase 5 §6.4 parity field, so it moves on both sides together. The rest of ADR-067's scalar audit (the ``disposition_audit`` block, per-suppression rule provenance) is `compare`-only in this slice and does not reach scan output. Renumbered from a conflicting 1.28 when the origin/main merge claimed that version first for ADR-065 S2's scope/exit fields.
 #: 1.30 -- ADR-063 Track T3 (Codex review, PR #1078, twenty-fifth round): mirrors `compare`'s 2.53 entry -- `cli_scan_baseline._finding_summary()` serializes the same `report_finding_id()` whose documented algorithm gained a seventh, conditional `disambiguator` input for a typedef/constant occurrence-level finding needing collision disambiguation. `scan --against`'s JSON carries the identical changed ids with no version signal until now. Renumbered twice by successive origin/main merges: first from a conflicting 1.28 (ADR-065 S2's mirrored ``run_outcome``/``exit`` additions), then from the resulting conflicting 1.29 (ADR-067 C-S1's ``not_evaluated`` mirror).
 #: 1.31 -- ADR-068 Phase 4's typed-API slice: the typed ``ScanResult``/``ScanSetResult`` envelopes this marker also stamped are **gone**, along with ``run_scan``/``run_scan_set`` and ``scan --artifact-set`` itself (ADR-068's second 2026-09-09 amendment rules ``--artifact-set``/``new-library-set`` (b) -- dropped, pending ADR-065 S3). ``scan_schema_version`` now marks exactly one shape: ``ScanOutcome.to_dict()``, the ``scan --format json`` CLI contract (and the abort envelope ``workflows.scan_abort_result`` builds from the same fields). The ``per_artifact``/``bundle_findings``/``bundle_verdict``/``bundle_incomplete`` aggregate form 1.5 introduced, and the typed ``findings``/``layers``/``confidence``/``estimate``/``report`` envelope, are both unreachable -- a consumer that fed ``abicheck.service.run_scan``/``run_scan_set`` output to ``aggregate`` must run ``abicheck scan --format json`` (or, for a set, one invocation per library) instead. The CLI shape itself is unchanged by this bump. Two ``scan`` inputs also leave the command under the same amendment's (b) rulings: ``--risk-rules`` (and with it the risk-driven ``auto`` depth escalation -- an omitted ``--depth`` now resolves to the fixed ``headers`` rung the amendment names, the same default ``compare`` always used, so the ``level`` block of a pre-1.31 run that left ``--depth`` unset can differ: it read the risk-scored rung when a seed was present and the ``(S5, SOURCE)`` ``--mode`` preset otherwise, where it now always reads ``s0``/``headers``. Pin ``--depth source`` to ask for source evidence) and ``--build-target``.
-SCAN_SCHEMA_VERSION = "1.31"
+#: 1.32 -- mirrors `compare`'s 3.15 entry: additive ``gate.fail_on_removed_library``, always ``""`` (no release-fan-out scope).
+SCAN_SCHEMA_VERSION = "1.32"
 
 
 def current(name: str) -> str | int:

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -1669,6 +1669,7 @@
         "gate.severity.quality_issues",
         "gate.severity.addition",
         "gate.on_incomplete_scope",
+        "gate.fail_on_removed_library",
         "assurance.require_evidence",
         "suppressions",
         "packs"
@@ -1702,6 +1703,7 @@
         "gate.severity.quality_issues": { "type": "string" },
         "gate.severity.addition": { "type": "string" },
         "gate.on_incomplete_scope": { "type": "string", "description": "ADR-065 D6 (schema 2.50): the scope.on_incomplete policy (warn/block) a directory/package release resolved, empty for a scalar comparison, to which the policy does not apply. Two otherwise identical incomplete releases exit 0 and 1 under the two values, so the digest tells them apart." },
+        "gate.fail_on_removed_library": { "type": "string", "description": "ADR-065 (schema 3.15): the gate.fail_on_removed_library setting a directory/package release resolved ('True'/'False'), empty for a scalar comparison, to which it does not apply. Two otherwise identical releases with a proven removed library exit 0 and 8 under the two values, so the digest tells them apart." },
         "assurance.require_evidence": { "type": "string" },
         "suppressions": { "type": "string" },
         "packs": { "type": "string" }

--- a/abicheck/workflows/gate.py
+++ b/abicheck/workflows/gate.py
@@ -46,6 +46,11 @@ same rule as every other name here).
 the one gate-algorithm derivation and the one gate-pack severity fold, owned
 by ``policy/gate_pack_fold.py`` and re-exported here for the same
 ``frontends -> policy`` reason as the release-gate names above.
+``EffectiveGate``/``GateSeverityState``/``ScopedGateSelection`` (that plan's
+P0 "Effective configuration and pack application" target) are the one
+resolved gate-configuration shape and its shared fold-time value type, owned
+by ``policy/effective_gate.py`` and re-exported here for the identical
+reason.
 
 ``note_if_same_binary_compared`` (Codex review) is not an exit-code axis, but
 it belongs here rather than in ``extraction.py`` for the same reason as the
@@ -57,7 +62,7 @@ operation performed on an input before extraction -- which is exactly what
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..analysis_assurance import (
     analysis_assurance_exit_contribution,
@@ -76,6 +81,11 @@ from ..policy.contract_coverage_exit import (
     coverage_exit_floor,
     coverage_exit_for_context,
     fold_coverage_exit,
+)
+from ..policy.effective_gate import (
+    EffectiveGate,
+    GateSeverityState,
+    ScopedGateSelection,
 )
 from ..policy.exit_decision import (
     ExitDecision,
@@ -129,15 +139,18 @@ if TYPE_CHECKING:
     from ..model import AbiSnapshot
 
 __all__ = [
+    "EffectiveGate",
     "ExitDecision",
     "GATE_SEVERITY_CATEGORIES",
     "GateDecision",
     "GateOptions",
+    "GateSeverityState",
     "INCOMPLETE_SCOPE_POLICIES",
     "IssueCategory",
     "PRESET_DEFAULT",
     "ScopeCompleteness",
     "ScopeDecision",
+    "ScopedGateSelection",
     "SeverityConfig",
     "SeverityLevel",
     "analysis_assurance_exit_contribution",
@@ -153,6 +166,7 @@ __all__ = [
     "coverage_diagnostic_from_summary",
     "coverage_exit_floor",
     "coverage_exit_for_context",
+    "effective_gate_for_resolved_compare_config",
     "fold_analysis_assurance_exit",
     "fold_coverage_exit",
     "fold_gate_pack_severity",
@@ -193,3 +207,31 @@ def snapshot_identity_digest(snap: AbiSnapshot) -> str:
     from ..serialization import snapshot_content_digest
 
     return snapshot_content_digest(snap)
+
+
+def effective_gate_for_resolved_compare_config(cfg: Any) -> EffectiveGate:
+    """*cfg* (a ``cli_helpers_compare.ResolvedCompareConfig``, taken as
+    ``Any`` rather than imported -- that module is ``frontends``-classified,
+    and ``workflows -> frontends`` is exactly the reverse of the permitted
+    direction), projected onto the plan's shared ``EffectiveGate`` shape
+    (duplication-and-convergence-assessment P0's "Effective configuration
+    and pack application" target). ``policy.release_gate_options.
+    GateOptions.effective_gate`` exposes the identical shape for the
+    directory/package release fan-out, so a caller holding either object can
+    ask the same question.
+
+    ``severity`` on the returned object is ``None`` exactly when
+    ``cfg.severity_active`` is ``False`` -- unlike *cfg*'s own ``severity``
+    field, which is always a concrete, defaulted ``SeverityConfig`` -- so the
+    two objects' ``effective_gate.severity`` agree under the legacy scheme
+    too, closing the one deliberate asymmetry
+    ``tests/test_release_gate_pack_fold_parity.py`` documents between the
+    two raw objects.
+
+    No ``--require-complete-analysis``/scoped-gate (``--used-by``/
+    ``--required-symbol``) value is threaded through *cfg* today, so both
+    stay at their default (``False``/``None``) here; a caller that has one
+    of those should build an ``EffectiveGate`` directly via
+    ``EffectiveGate.from_severity`` instead of through this function.
+    """
+    return EffectiveGate.from_severity(cfg.severity if cfg.severity_active else None)

--- a/abicheck/workflows/gate.py
+++ b/abicheck/workflows/gate.py
@@ -250,6 +250,17 @@ def effective_gate_for_resolved_compare_config(
     caller that genuinely has neither (a bare config-only comparison, as
     ``tests/test_effective_gate.py``'s parity property exercises) is
     unaffected.
+
+    ``on_incomplete_scope``/``fail_on_removed_library`` (Codex review, PR
+    #1192, third follow-up round) are deliberately left at ``EffectiveGate``'s
+    default (``None``, "not applicable") here even though *cfg* itself
+    carries both -- ``cfg.on_incomplete_scope``/``cfg.fail_on_removed_
+    library`` exist on ``ResolvedCompareConfig`` only to be *forwarded* to
+    the directory/package release fan-out if this invocation turns out to
+    dispatch there; they describe that separate, not-yet-decided run's own
+    scope, not this single-pair ``cfg``'s. ``GateOptions.effective_gate``
+    (``policy/release_gate_options.py``) is where those two axes are real at
+    the object's own scope, once resolved for the release fan-out itself.
     """
     return EffectiveGate.from_severity(
         cfg.severity if cfg.severity_active else None,

--- a/abicheck/workflows/gate.py
+++ b/abicheck/workflows/gate.py
@@ -86,6 +86,7 @@ from ..policy.effective_gate import (
     EffectiveGate,
     GateSeverityState,
     ScopedGateSelection,
+    scoped_gate_selection_from_result,
 )
 from ..policy.exit_decision import (
     ExitDecision,
@@ -187,6 +188,7 @@ __all__ = [
     "resolve_scope_decision",
     "resolve_severity_config",
     "scope_completeness_for_record",
+    "scoped_gate_selection_from_result",
     "snapshot_identity_digest",
     "validate_incomplete_scope_policy",
 ]
@@ -209,7 +211,12 @@ def snapshot_identity_digest(snap: AbiSnapshot) -> str:
     return snapshot_content_digest(snap)
 
 
-def effective_gate_for_resolved_compare_config(cfg: Any) -> EffectiveGate:
+def effective_gate_for_resolved_compare_config(
+    cfg: Any,
+    *,
+    result: Any = None,
+    require_complete_analysis: bool = False,
+) -> EffectiveGate:
     """*cfg* (a ``cli_helpers_compare.ResolvedCompareConfig``, taken as
     ``Any`` rather than imported -- that module is ``frontends``-classified,
     and ``workflows -> frontends`` is exactly the reverse of the permitted
@@ -228,10 +235,24 @@ def effective_gate_for_resolved_compare_config(cfg: Any) -> EffectiveGate:
     ``tests/test_release_gate_pack_fold_parity.py`` documents between the
     two raw objects.
 
-    No ``--require-complete-analysis``/scoped-gate (``--used-by``/
-    ``--required-symbol``) value is threaded through *cfg* today, so both
-    stay at their default (``False``/``None``) here; a caller that has one
-    of those should build an ``EffectiveGate`` directly via
-    ``EffectiveGate.from_severity`` instead of through this function.
+    *require_complete_analysis*/*result* carry the two other gate-changing
+    axes ``cfg`` alone cannot (Codex review, PR #1192: leaving these at their
+    default regardless of the real run made two invocations that genuinely
+    gate differently -- e.g. differing only in ``--require-complete-
+    analysis`` or ``--required-symbol`` -- produce an *equal* ``EffectiveGate``,
+    defeating the type's purpose). *require_complete_analysis* is the
+    identically-named CLI/API flag, known before any comparison runs.
+    *result* is the completed comparison's ``DiffResult`` (or ``None`` when
+    called before one exists, e.g. resolution-only/dry-run code); the scoped-
+    gate selection (``--used-by``/``--required-symbol``) it may have recorded
+    is read via :func:`~abicheck.policy.effective_gate.
+    scoped_gate_selection_from_result`. Both default to "no effect" so a
+    caller that genuinely has neither (a bare config-only comparison, as
+    ``tests/test_effective_gate.py``'s parity property exercises) is
+    unaffected.
     """
-    return EffectiveGate.from_severity(cfg.severity if cfg.severity_active else None)
+    return EffectiveGate.from_severity(
+        cfg.severity if cfg.severity_active else None,
+        require_complete_analysis=require_complete_analysis,
+        scope=scoped_gate_selection_from_result(result),
+    )

--- a/abicheck/workflows/release_scope.py
+++ b/abicheck/workflows/release_scope.py
@@ -84,6 +84,8 @@ __all__ = [
     "DIRECT_PAIR_KEY",
     "RELEASE_OPERATIONAL_VERDICTS",
     "ReleaseInventoryEvidence",
+    "ReleaseScopePlan",
+    "ReleaseScopeResult",
     "StrandedLibraryResolution",
     "build_release_scope_record",
     "build_stored_baseline_scope_record",
@@ -92,6 +94,8 @@ __all__ = [
     "out_of_scope_provider_names",
     "release_global_ran",
     "release_inventory_evidence",
+    "resolve_release_scope_plan",
+    "resolve_release_scope_result",
     "restrict_bundle_facts",
     "scope_manifest_to_members",
     "scoped_bundle_maps",
@@ -146,6 +150,53 @@ class ReleaseInventoryEvidence:
     #: The caller named NEW as one explicit artifact (a file operand), the
     #: only shape D9's current-artifact narrowing may read intent from.
     new_single_artifact: bool = False
+
+
+@dataclass(frozen=True)
+class ReleaseScopePlan:
+    """ADR-061 gap D / DoD item 8: the release fan-out's resolved scope-
+    *selection* plan (the ``workflows/artifact`` Request->ResolvedPlan->
+    Result pattern, applied to ADR-065's scope model) -- replaces four
+    locals ``cli_compare_release.py`` used to thread by hand. Knowable
+    before any comparison executes; the acquisition record (D1) is only
+    knowable afterward -- see :class:`ReleaseScopeResult`."""
+
+    old_map: Mapping[str, Path]
+    new_map: Mapping[str, Path]
+    matched_keys: tuple[str, ...]
+    evidence: ReleaseInventoryEvidence
+
+
+def resolve_release_scope_plan(
+    old_map: Mapping[str, Path],
+    new_map: Mapping[str, Path],
+    matched_keys: Sequence[str],
+    evidence: ReleaseInventoryEvidence,
+) -> ReleaseScopePlan:
+    """A :class:`ReleaseScopePlan` from an already-resolved matching pass."""
+    return ReleaseScopePlan(
+        old_map=dict(old_map),
+        new_map=dict(new_map),
+        matched_keys=tuple(matched_keys),
+        evidence=evidence,
+    )
+
+
+@dataclass(frozen=True)
+class ReleaseScopeResult:
+    """*plan*'s realized scope outcome: the acquisition record (D1), only
+    knowable once every selected member's comparison has completed, failed,
+    or gone unsupported."""
+
+    plan: ReleaseScopePlan
+    record: ScopeAcquisitionRecord
+
+
+def resolve_release_scope_result(
+    plan: ReleaseScopePlan, record: ScopeAcquisitionRecord
+) -> ReleaseScopeResult:
+    """Pair an already-built record with the *plan* it was resolved against."""
+    return ReleaseScopeResult(plan=plan, record=record)
 
 
 @dataclass(frozen=True)

--- a/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
+++ b/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
@@ -20,5 +20,22 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   completeness evidence) into one `abicheck.workflows.release_scope.
   ReleaseScopePlan` object, mirroring the `workflows/artifact` Request ->
   ResolvedPlan -> Result pattern, instead of threading four independent
-  local variables by hand. Purely internal; no observable behavior change.
+  local variables by hand. An explicit `--select`/`--select-required`
+  declared selection is now folded into the plan itself before execution
+  reads `matched_keys`/`compare_keys` from it, rather than as a separate
+  post-hoc filter. Purely internal; no observable behavior change.
+- **`EffectiveGate` carries ADR-065's two release-fan-out gate axes** —
+  `on_incomplete_scope`/`fail_on_removed_library` are now real fields on
+  `EffectiveGate` (and on `GateOptions`, the release fan-out's own resolved
+  object), populated from the release fan-out's already-resolved
+  `--on-incomplete-scope`/`--fail-on-removed-library` values. The
+  effective-config digest (`gate.on_incomplete_scope`/`gate.
+  fail_on_removed_library` fields) now reads both exclusively from this
+  object instead of a second, independently-derived projection of the same
+  facts. `gate.fail_on_removed_library` is a new digest field (additive —
+  changes the digest hash for future runs, same as any other field
+  addition); `gate.on_incomplete_scope`'s value is unchanged, only its
+  source moved. A bare single-pair `compare` still reports both as
+  `""`/not-applicable, matching its existing behavior. No other
+  CLI-visible behavior change.
 

--- a/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
+++ b/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
@@ -38,4 +38,9 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   source moved. A bare single-pair `compare` still reports both as
   `""`/not-applicable, matching its existing behavior. No other
   CLI-visible behavior change.
+- **`REPORT_SCHEMA_VERSION`/`SCAN_SCHEMA_VERSION` bumped to `3.15`/`1.32`**
+  for the new `gate.fail_on_removed_library` digest field above —
+  `compare_report.schema.json` (and its published copy under
+  `docs/reference/schemas/v1/`) now declares it in both `required` and
+  `properties`, matching the sibling `gate.on_incomplete_scope` entry.
 

--- a/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
+++ b/changelog.d/20260910_043322_noreply_worktree_agent_a3f3028b59de2d953.md
@@ -1,0 +1,24 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Changed
+
+- **`EffectiveGate`/`GateSeverityState` converge the gate-pack fold shapes**
+  — single-pair `compare` (`ResolvedCompareConfig`) and the directory/
+  package release fan-out (`GateOptions`) now fold a selected `kind: gate`
+  pack's `gate.severity.*` contribution through one shared
+  `abicheck.policy.effective_gate.GateSeverityState`, and both resolve to
+  the same `EffectiveGate` shape (`exit_code_scheme`, `severity`,
+  `require_complete_analysis`, `scope`) — closing the "two different
+  shapes around one shared fold" gap `tests/test_release_gate_pack_fold_parity.py`
+  documented (duplication-and-convergence-assessment plan's P0 target,
+  scoped to the gate namespace). No CLI-visible behavior change.
+- **Release fan-out scope selection is a typed `ReleaseScopePlan`** — the
+  directory/package release comparison (`compare-release`) now resolves
+  its ADR-065 scope-selection state (matched members, each side's
+  completeness evidence) into one `abicheck.workflows.release_scope.
+  ReleaseScopePlan` object, mirroring the `workflows/artifact` Request ->
+  ResolvedPlan -> Result pattern, instead of threading four independent
+  local variables by hand. Purely internal; no observable behavior change.
+

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -1669,6 +1669,7 @@
         "gate.severity.quality_issues",
         "gate.severity.addition",
         "gate.on_incomplete_scope",
+        "gate.fail_on_removed_library",
         "assurance.require_evidence",
         "suppressions",
         "packs"
@@ -1702,6 +1703,7 @@
         "gate.severity.quality_issues": { "type": "string" },
         "gate.severity.addition": { "type": "string" },
         "gate.on_incomplete_scope": { "type": "string", "description": "ADR-065 D6 (schema 2.50): the scope.on_incomplete policy (warn/block) a directory/package release resolved, empty for a scalar comparison, to which the policy does not apply. Two otherwise identical incomplete releases exit 0 and 1 under the two values, so the digest tells them apart." },
+        "gate.fail_on_removed_library": { "type": "string", "description": "ADR-065 (schema 3.15): the gate.fail_on_removed_library setting a directory/package release resolved ('True'/'False'), empty for a scalar comparison, to which it does not apply. Two otherwise identical releases with a proven removed library exit 0 and 8 under the two values, so the digest tells them apart." },
         "assurance.require_evidence": { "type": "string" },
         "suppressions": { "type": "string" },
         "packs": { "type": "string" }

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -709,7 +709,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "3.14",
+  "report_schema_version": "3.15",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/repo_facts.json
+++ b/repo_facts.json
@@ -1,9 +1,9 @@
 {
   "canonical_python": "3.13",
   "example_cases": 208,
-  "fast_test_cases_collected": 41697,
-  "generated_utc": "2026-09-09T16:33:07+00:00",
+  "fast_test_cases_collected": 42372,
+  "generated_utc": "2026-09-10T04:59:23+00:00",
   "latest_release": "0.5.0",
   "project_version": "0.5.0",
-  "source_commit": "fd6ba6816a6a675cbcb87903edbee052e087cba1"
+  "source_commit": "3c17551bb9062314763559a1ff22397c69245853"
 }

--- a/repo_facts.json
+++ b/repo_facts.json
@@ -1,9 +1,9 @@
 {
   "canonical_python": "3.13",
   "example_cases": 208,
-  "fast_test_cases_collected": 42372,
-  "generated_utc": "2026-09-10T04:59:23+00:00",
+  "fast_test_cases_collected": 42396,
+  "generated_utc": "2026-09-10T07:12:58+00:00",
   "latest_release": "0.5.0",
   "project_version": "0.5.0",
-  "source_commit": "3c17551bb9062314763559a1ff22397c69245853"
+  "source_commit": "f4aee144f6d7539505d52e6abd7dcb4b00fe4c00"
 }

--- a/tests/test_cli_compare_release_single_pair_parity.py
+++ b/tests/test_cli_compare_release_single_pair_parity.py
@@ -178,11 +178,15 @@ class TestReleaseSummaryEffectiveConfigNeverDivergesFromSinglePair:
         )
         release_fields = json.loads(release_out)["effective_config_fields"]
 
-        # `gate.on_incomplete_scope` (ADR-065 D6) is the one release-only
-        # axis: a scalar comparison's single pair is the whole scope, so it
-        # records "" where a release records its resolved policy.
+        # `gate.on_incomplete_scope`/`gate.fail_on_removed_library`
+        # (ADR-065 D6, Codex review PR #1192 fourth round) are the two
+        # release-only axes: a scalar comparison's single pair is the whole
+        # scope, so it records "" where a release records its resolved
+        # policy/flag.
         assert single_fields.pop("gate.on_incomplete_scope") == ""
         assert release_fields.pop("gate.on_incomplete_scope") == "warn"
+        assert single_fields.pop("gate.fail_on_removed_library") == ""
+        assert release_fields.pop("gate.fail_on_removed_library") == "False"
         assert release_fields == single_fields, (
             f"release-summary effective_config_fields diverged from the "
             f"identical single-pair compare on axis {axis_name!r}"

--- a/tests/test_effective_config_digest.py
+++ b/tests/test_effective_config_digest.py
@@ -47,7 +47,7 @@ from abicheck.contract_relevance_types import ContractMode
 from abicheck.effective_config_digest import (
     EFFECTIVE_CONFIG_FIELD_KEYS,
     effective_config_digest,
-    effective_config_fields,
+    effective_config_fields_from_raw,
 )
 from abicheck.policy_file import PolicyFile
 from abicheck.reclassify import ReclassifyRule
@@ -88,7 +88,7 @@ def _result(**overrides) -> DiffResult:
 class TestEffectiveConfigFields:
     def test_baseline_tier_with_no_configuration(self):
         result = _result()
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["_tier"] == "baseline"
@@ -104,7 +104,7 @@ class TestEffectiveConfigFields:
         )
         result = _result(policy="strict_abi", policy_file=policy_file)
         severity = resolve_severity_config("strict")
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=severity, exit_code_scheme="severity"
         )
         assert fields["_tier"] == "baseline"
@@ -116,7 +116,7 @@ class TestEffectiveConfigFields:
 
     def test_all_declared_keys_are_present(self):
         result = _result()
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         for key in EFFECTIVE_CONFIG_FIELD_KEYS:
@@ -125,7 +125,7 @@ class TestEffectiveConfigFields:
 
 class TestEffectiveConfigDigest:
     def test_digest_is_a_sha256_uri(self):
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             _result(), severity_config=None, exit_code_scheme="legacy"
         )
         digest = effective_config_digest(fields)
@@ -133,32 +133,32 @@ class TestEffectiveConfigDigest:
         assert len(digest) == len("sha256:") + 64
 
     def test_deterministic_for_equal_fields(self):
-        a = effective_config_fields(
+        a = effective_config_fields_from_raw(
             _result(), severity_config=None, exit_code_scheme="legacy"
         )
-        b = effective_config_fields(
+        b = effective_config_fields_from_raw(
             _result(), severity_config=None, exit_code_scheme="legacy"
         )
         assert effective_config_digest(a) == effective_config_digest(b)
 
     def test_differs_when_exit_code_scheme_differs(self):
-        legacy = effective_config_fields(
+        legacy = effective_config_fields_from_raw(
             _result(), severity_config=None, exit_code_scheme="legacy"
         )
         severity_cfg = resolve_severity_config("default")
-        severity = effective_config_fields(
+        severity = effective_config_fields_from_raw(
             _result(), severity_config=severity_cfg, exit_code_scheme="severity"
         )
         assert effective_config_digest(legacy) != effective_config_digest(severity)
 
     def test_differs_when_policy_overrides_differ(self):
-        plain = effective_config_fields(
+        plain = effective_config_fields_from_raw(
             _result(), severity_config=None, exit_code_scheme="legacy"
         )
         policy_file = PolicyFile(
             overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE}
         )
-        overridden = effective_config_fields(
+        overridden = effective_config_fields_from_raw(
             _result(policy_file=policy_file),
             severity_config=None,
             exit_code_scheme="legacy",
@@ -207,14 +207,14 @@ class TestScanReportCarriesTheSameDigestAsCompare:
 
     def test_scan_and_compare_agree_for_equivalent_configuration(self):
         result = _result(verdict=Verdict.COMPATIBLE)
-        compare_fields = effective_config_fields(
+        compare_fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         # `_run_baseline_compare` calls the identical function with the same
         # (diff, severity_config, exit_code_scheme) shape it resolves its own
         # `exit` block from -- reproduced directly here rather than driving
         # the full scan CLI pipeline, which needs real binaries.
-        scan_fields = effective_config_fields(
+        scan_fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert effective_config_digest(compare_fields) == effective_config_digest(
@@ -235,7 +235,7 @@ class TestRichTierFromEvaluationConfig:
             )
         )
         result = _result(evaluation_config=config)
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["_tier"] == "contract"
@@ -246,7 +246,7 @@ class TestRichTierFromEvaluationConfig:
         # something that isn't a real `CompatibilityEvaluationConfig` must
         # not be read as one.
         result = _result(evaluation_config="not-a-real-config")
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["_tier"] == "baseline"
@@ -266,10 +266,10 @@ class TestRichTierFromEvaluationConfig:
                 )
             )
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             base, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             bumped, severity_config=None, exit_code_scheme="legacy"
         )
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -283,10 +283,10 @@ class TestAdditionalAxes:
     def test_scope_to_public_surface_changes_the_baseline_digest(self):
         unscoped = _result(scope_to_public_surface=False)
         scoped = _result(scope_to_public_surface=True)
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             unscoped, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             scoped, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["surface.scope_to_public_surface"] == "False"
@@ -297,10 +297,10 @@ class TestAdditionalAxes:
         plain = _result()
         rule = ReclassifyRule(to_verdict=Verdict.COMPATIBLE_WITH_RISK, symbol="foo")
         reclassified = _result(policy_file=PolicyFile(reclassify=[rule]))
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             plain, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             reclassified, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["policy.reclassify"] == "[]"
@@ -316,10 +316,10 @@ class TestAdditionalAxes:
                 suppressions=SuppressionConfig(sha256="suppress-digest")
             )
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             no_suppressions, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             with_suppressions, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["suppressions"] == ""
@@ -335,10 +335,10 @@ class TestAdditionalAxes:
                 )
             )
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             no_scope, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             with_scope, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["surface.explicit_scope"] == ""
@@ -355,10 +355,10 @@ class TestAdditionalAxes:
                 contract=ContractConfig(mode=ContractMode.PUBLIC, overlays=("api::v2",))
             )
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             no_overlays, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             with_overlays, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["contract.overlays"] == "[]"
@@ -377,10 +377,10 @@ class TestAdditionalAxes:
             evaluation_config=_minimal_evaluation_config(),
             scope_to_public_surface=True,
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             unscoped, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             scoped, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["surface.scope_to_public_surface"] == "False"
@@ -394,10 +394,10 @@ class TestAdditionalAxes:
         field must read DiffResult.suppression_source_sha256 directly."""
         no_suppress = _result()
         with_suppress = _result(suppression_source_sha256="sha256:abc123")
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             no_suppress, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             with_suppress, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["suppressions"] == ""
@@ -461,10 +461,10 @@ class TestSuppressionsWithNoSourceDigest:
         config = suppression_config_for(rules)
         active = _result(suppression_source_sha256=config.sha256)
 
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             empty, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             active, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["suppressions"] == ""
@@ -491,8 +491,8 @@ class TestPolicyFrozenNamespaces:
     def test_frozen_namespaces_change_the_baseline_digest(self):
         plain = _result()
         frozen = _result(policy_file=PolicyFile(frozen_namespaces=["detail::impl"]))
-        f1 = effective_config_fields(plain, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(plain, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(
             frozen, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["policy.frozen_namespaces"] == "[]"
@@ -510,13 +510,13 @@ class TestRequireCompleteAnalysisAxis:
 
     def test_require_complete_analysis_changes_the_baseline_digest(self):
         result = _result()
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             result,
             severity_config=None,
             exit_code_scheme="legacy",
             require_complete_analysis=False,
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             result,
             severity_config=None,
             exit_code_scheme="legacy",
@@ -528,13 +528,13 @@ class TestRequireCompleteAnalysisAxis:
 
     def test_require_complete_analysis_changes_the_rich_tier_digest(self):
         result = _result(evaluation_config=_minimal_evaluation_config())
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             result,
             severity_config=None,
             exit_code_scheme="legacy",
             require_complete_analysis=False,
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             result,
             severity_config=None,
             exit_code_scheme="legacy",
@@ -633,19 +633,19 @@ class TestBaselineTierBuiltinPolicyIdentity:
         )
 
         result = _result(policy="strict_abi")
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         identity = builtin_policy_identity("strict_abi")
         assert fields["policy.base"] == f"strict_abi@{identity.version}:{identity.sha256}"
 
     def test_different_builtin_policies_hash_differently(self):
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             _result(policy="strict_abi"),
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _result(policy="sdk_vendor"),
             severity_config=None,
             exit_code_scheme="legacy",
@@ -659,14 +659,14 @@ class TestBaselineTierBuiltinPolicyIdentity:
         compatibility_evaluation_frontend.stated_policy_base's own
         docstring for the precedent)."""
         result = _result(policy="totally_unknown_policy")
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["policy.base"] == "totally_unknown_policy"
 
     def test_empty_policy_name_is_empty_string(self):
         result = _result(policy="")
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["policy.base"] == ""
@@ -754,18 +754,18 @@ class TestGateScopeAxis:
 
     def test_no_scoping_is_empty_string(self):
         result = _result()
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["gate.scope"] == ""
 
     def test_different_used_by_apps_hash_differently(self):
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             _scoped_result(gate_scope="used_by", used_by=[{"app": "app1.so"}]),
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _scoped_result(gate_scope="used_by", used_by=[{"app": "app2.so"}]),
             severity_config=None,
             exit_code_scheme="legacy",
@@ -774,7 +774,7 @@ class TestGateScopeAxis:
         assert effective_config_digest(f1) != effective_config_digest(f2)
 
     def test_different_required_symbols_hash_differently(self):
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             _scoped_result(
                 gate_scope="required_symbol",
                 required_symbols={"required_entrypoints": ["sym_a"]},
@@ -782,7 +782,7 @@ class TestGateScopeAxis:
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _scoped_result(
                 gate_scope="required_symbol",
                 required_symbols={"required_entrypoints": ["sym_b"]},
@@ -795,12 +795,12 @@ class TestGateScopeAxis:
 
     def test_used_by_vs_required_symbol_hash_differently_even_with_same_target(self):
         """The "kind" must participate too, not just the target list."""
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             _scoped_result(gate_scope="used_by", used_by=[{"app": "libfoo"}]),
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _scoped_result(
                 gate_scope="required_symbol",
                 required_symbols={"required_entrypoints": ["libfoo"]},
@@ -814,12 +814,12 @@ class TestGateScopeAxis:
         scoped = _result(evaluation_config=_minimal_evaluation_config())
         scoped.gate_scope = "used_by"
         scoped.used_by = [{"app": "app1.so"}]
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             scoped,
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _result(evaluation_config=_minimal_evaluation_config()),
             severity_config=None,
             exit_code_scheme="legacy",
@@ -851,10 +851,10 @@ class TestRichTierGateAxesUseCallerSuppliedValues:
         result = _result(evaluation_config=blanked_config)
         real_severity = resolve_severity_config("strict")
 
-        fields_with_real_gate = effective_config_fields(
+        fields_with_real_gate = effective_config_fields_from_raw(
             result, severity_config=real_severity, exit_code_scheme="severity"
         )
-        fields_with_blanked_gate = effective_config_fields(
+        fields_with_blanked_gate = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields_with_real_gate["gate.exit_code_scheme"] == "severity"
@@ -870,10 +870,10 @@ class TestRichTierGateAxesUseCallerSuppliedValues:
         strict = resolve_severity_config("strict")
         info_only = resolve_severity_config("info-only")
 
-        f_strict = effective_config_fields(
+        f_strict = effective_config_fields_from_raw(
             result, severity_config=strict, exit_code_scheme="severity"
         )
-        f_info = effective_config_fields(
+        f_info = effective_config_fields_from_raw(
             result, severity_config=info_only, exit_code_scheme="severity"
         )
         assert (
@@ -900,10 +900,10 @@ class TestReclassifyPreservesOrder:
         ignore_first = _result(
             policy_file=PolicyFile(reclassify=[ignore_rule, break_rule])
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             break_first, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             ignore_first, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["policy.reclassify"] != f2["policy.reclassify"]
@@ -942,7 +942,7 @@ class TestRichTierPrefersContractContextMergedConfig:
         result = _result(evaluation_config=unmerged)
         result.contract_context = self._persisted_context(merged)
 
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         # Must reflect the *merged* config's overlays, not the unmerged one.
@@ -957,7 +957,7 @@ class TestRichTierPrefersContractContextMergedConfig:
         result = _result(evaluation_config=config)
         assert getattr(result, "contract_context", None) is None
 
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["contract.overlays"] == '["api::v3"]'
@@ -972,18 +972,18 @@ class TestBaselineExplicitScope:
 
     def test_no_explicit_scope_is_empty_string(self):
         result = _result()
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["surface.explicit_scope"] == ""
 
     def test_different_forced_public_scopes_hash_differently(self):
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             _result(explicit_scope_source_sha256="sha256:aaa"),
             severity_config=None,
             exit_code_scheme="legacy",
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             _result(explicit_scope_source_sha256="sha256:bbb"),
             severity_config=None,
             exit_code_scheme="legacy",
@@ -1156,10 +1156,10 @@ class TestBaselineExplicitScopeCoversPostManifest:
             no_manifest.explicit_scope_source_sha256
         )
 
-        fields_no_manifest = effective_config_fields(
+        fields_no_manifest = effective_config_fields_from_raw(
             no_manifest, severity_config=None, exit_code_scheme="legacy"
         )
-        fields_empty_manifest = effective_config_fields(
+        fields_empty_manifest = effective_config_fields_from_raw(
             empty_manifest, severity_config=None, exit_code_scheme="legacy"
         )
         assert (
@@ -1190,7 +1190,7 @@ class TestRichTierMergesResultExplicitScope:
         )
         assert getattr(result, "contract_context", None) is None
 
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["surface.explicit_scope"] != ""
@@ -1219,10 +1219,10 @@ class TestRichTierMergesResultExplicitScope:
             evaluation_config=config_b,
             explicit_scope_source_sha256="sha256:frompostmanifest",
         )
-        fields_config_a = effective_config_fields(
+        fields_config_a = effective_config_fields_from_raw(
             result_config_a, severity_config=None, exit_code_scheme="legacy"
         )
-        fields_config_b = effective_config_fields(
+        fields_config_b = effective_config_fields_from_raw(
             result_config_b, severity_config=None, exit_code_scheme="legacy"
         )
         assert (
@@ -1242,10 +1242,10 @@ class TestRichTierMergesResultExplicitScope:
             evaluation_config=config_a,
             explicit_scope_source_sha256="sha256:manifest_b",
         )
-        fields_manifest_a = effective_config_fields(
+        fields_manifest_a = effective_config_fields_from_raw(
             result_manifest_a, severity_config=None, exit_code_scheme="legacy"
         )
-        fields_manifest_b = effective_config_fields(
+        fields_manifest_b = effective_config_fields_from_raw(
             result_manifest_b, severity_config=None, exit_code_scheme="legacy"
         )
         assert (
@@ -1266,10 +1266,10 @@ class TestRichTierMergesResultExplicitScope:
             evaluation_config=config,
             explicit_scope_source_sha256="sha256:manifest_b",
         )
-        fields_a = effective_config_fields(
+        fields_a = effective_config_fields_from_raw(
             result_a, severity_config=None, exit_code_scheme="legacy"
         )
-        fields_b = effective_config_fields(
+        fields_b = effective_config_fields_from_raw(
             result_b, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields_a["surface.explicit_scope"] != fields_b["surface.explicit_scope"]
@@ -1289,8 +1289,8 @@ class TestPatternVerdictsAxis:
     def test_flag_changes_the_baseline_digest(self):
         off = _result(pattern_verdicts_enabled=False)
         on = _result(pattern_verdicts_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.pattern_verdicts"] == "False"
         assert f2["policy.pattern_verdicts"] == "True"
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -1299,8 +1299,8 @@ class TestPatternVerdictsAxis:
         config = _minimal_evaluation_config()
         off = _result(evaluation_config=config, pattern_verdicts_enabled=False)
         on = _result(evaluation_config=config, pattern_verdicts_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.pattern_verdicts"] == "False"
         assert f2["policy.pattern_verdicts"] == "True"
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -1334,10 +1334,10 @@ class TestPatternVerdictsAxis:
         assert on.pattern_verdicts_enabled is True
         assert on.pattern_modulations == []  # nothing matched -- ledger stays empty
 
-        f_off = effective_config_fields(
+        f_off = effective_config_fields_from_raw(
             off, severity_config=None, exit_code_scheme="legacy"
         )
-        f_on = effective_config_fields(
+        f_on = effective_config_fields_from_raw(
             on, severity_config=None, exit_code_scheme="legacy"
         )
         assert f_off["policy.pattern_verdicts"] != f_on["policy.pattern_verdicts"]
@@ -1354,8 +1354,8 @@ class TestCollapseVersionedSymbolsAxis:
     def test_flag_changes_the_baseline_digest(self):
         off = _result(collapse_versioned_symbols_enabled=False)
         on = _result(collapse_versioned_symbols_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.collapse_versioned_symbols"] == "False"
         assert f2["policy.collapse_versioned_symbols"] == "True"
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -1364,8 +1364,8 @@ class TestCollapseVersionedSymbolsAxis:
         config = _minimal_evaluation_config()
         off = _result(evaluation_config=config, collapse_versioned_symbols_enabled=False)
         on = _result(evaluation_config=config, collapse_versioned_symbols_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.collapse_versioned_symbols"] != f2["policy.collapse_versioned_symbols"]
         assert effective_config_digest(f1) != effective_config_digest(f2)
 
@@ -1402,8 +1402,8 @@ class TestSurfaceMetricsAxis:
     def test_flag_changes_the_baseline_digest(self):
         off = _result(surface_metrics_enabled=False)
         on = _result(surface_metrics_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.surface_metrics"] == "False"
         assert f2["policy.surface_metrics"] == "True"
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -1412,8 +1412,8 @@ class TestSurfaceMetricsAxis:
         config = _minimal_evaluation_config()
         off = _result(evaluation_config=config, surface_metrics_enabled=False)
         on = _result(evaluation_config=config, surface_metrics_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.surface_metrics"] != f2["policy.surface_metrics"]
         assert effective_config_digest(f1) != effective_config_digest(f2)
 
@@ -1452,10 +1452,10 @@ class TestEnvMatrixAxis:
     def test_env_matrix_changes_the_baseline_digest(self):
         no_matrix = _result()
         with_matrix = _result(env_matrix_source_sha256="sha256:envdigest")
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             no_matrix, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             with_matrix, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["policy.env_matrix"] == ""
@@ -1470,10 +1470,10 @@ class TestEnvMatrixAxis:
         result_b = _result(
             evaluation_config=config, env_matrix_source_sha256="sha256:matrix_b"
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             result_a, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             result_b, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["policy.env_matrix"] != f2["policy.env_matrix"]
@@ -1527,8 +1527,8 @@ class TestReconcileBuildContextAxis:
     def test_flag_changes_the_baseline_digest(self):
         off = _result(reconcile_build_context_enabled=False)
         on = _result(reconcile_build_context_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.reconcile_build_context"] == "False"
         assert f2["policy.reconcile_build_context"] == "True"
         assert effective_config_digest(f1) != effective_config_digest(f2)
@@ -1537,8 +1537,8 @@ class TestReconcileBuildContextAxis:
         config = _minimal_evaluation_config()
         off = _result(evaluation_config=config, reconcile_build_context_enabled=False)
         on = _result(evaluation_config=config, reconcile_build_context_enabled=True)
-        f1 = effective_config_fields(off, severity_config=None, exit_code_scheme="legacy")
-        f2 = effective_config_fields(on, severity_config=None, exit_code_scheme="legacy")
+        f1 = effective_config_fields_from_raw(off, severity_config=None, exit_code_scheme="legacy")
+        f2 = effective_config_fields_from_raw(on, severity_config=None, exit_code_scheme="legacy")
         assert f1["policy.reconcile_build_context"] != f2["policy.reconcile_build_context"]
         assert effective_config_digest(f1) != effective_config_digest(f2)
 
@@ -1581,10 +1581,10 @@ class TestScopeToPublicSurfaceRequestedAxis:
     def test_flag_changes_the_baseline_digest(self):
         raw_false = _result(scope_to_public_surface_requested=False)
         raw_true = _result(scope_to_public_surface_requested=True)
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             raw_false, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             raw_true, severity_config=None, exit_code_scheme="legacy"
         )
         assert f1["surface.scope_to_public_surface_requested"] == "False"
@@ -1599,10 +1599,10 @@ class TestScopeToPublicSurfaceRequestedAxis:
         raw_true = _result(
             evaluation_config=config, scope_to_public_surface_requested=True
         )
-        f1 = effective_config_fields(
+        f1 = effective_config_fields_from_raw(
             raw_false, severity_config=None, exit_code_scheme="legacy"
         )
-        f2 = effective_config_fields(
+        f2 = effective_config_fields_from_raw(
             raw_true, severity_config=None, exit_code_scheme="legacy"
         )
         assert (
@@ -1661,10 +1661,10 @@ class TestScopeToPublicSurfaceRequestedAxis:
         priv_b_kept_off = any("priv_b" in c.symbol for c in scoped_off.changes)
         assert priv_b_kept_on != priv_b_kept_off
 
-        fields_on = effective_config_fields(
+        fields_on = effective_config_fields_from_raw(
             scoped_on, severity_config=None, exit_code_scheme="legacy"
         )
-        fields_off = effective_config_fields(
+        fields_off = effective_config_fields_from_raw(
             scoped_off, severity_config=None, exit_code_scheme="legacy"
         )
         assert (

--- a/tests/test_effective_gate.py
+++ b/tests/test_effective_gate.py
@@ -54,7 +54,10 @@ from abicheck.policy.release_gate_options import (
     resolve_release_gate_options,
 )
 from abicheck.policy.severity import SeverityConfig, SeverityLevel
-from abicheck.workflows.gate import effective_gate_for_resolved_compare_config
+from abicheck.workflows.gate import (
+    effective_gate_for_resolved_compare_config,
+    scoped_gate_selection_from_result,
+)
 
 _PRESETS = (None, "default", "strict", "info-only")
 
@@ -290,3 +293,112 @@ class TestEffectiveGateParity:
         assert effective_gate_for_resolved_compare_config(
             cfg2
         ) == EffectiveGate.from_severity(cfg2.severity)
+
+
+class _FakeResult:
+    """A minimal stand-in for the ``DiffResult`` fields
+    ``scoped_gate_selection_from_result`` reads -- mirrors
+    ``effective_config_digest._gate_scope_str``'s own reading contract."""
+
+    def __init__(
+        self,
+        gate_scope: str | None = None,
+        used_by: tuple[dict[str, object], ...] = (),
+        required_symbols: dict[str, object] | None = None,
+    ) -> None:
+        self.gate_scope = gate_scope
+        self.used_by = used_by
+        self.required_symbols = required_symbols or {}
+
+
+class TestScopedGateSelectionFromResult:
+    """``scoped_gate_selection_from_result``'s own contract."""
+
+    def test_none_when_no_scope_selected(self) -> None:
+        assert scoped_gate_selection_from_result(None) is None
+        assert scoped_gate_selection_from_result(_FakeResult()) is None
+
+    def test_used_by_reads_app_paths_sorted(self) -> None:
+        result = _FakeResult(
+            gate_scope="used_by",
+            used_by=({"app": "b.so"}, {"app": "a.so"}),
+        )
+        scope = scoped_gate_selection_from_result(result)
+        assert scope == ScopedGateSelection(kind="used_by", targets=("a.so", "b.so"))
+
+    def test_required_symbol_reads_entrypoints_sorted(self) -> None:
+        result = _FakeResult(
+            gate_scope="required_symbol",
+            required_symbols={"required_entrypoints": ["sym_b", "sym_a"]},
+        )
+        scope = scoped_gate_selection_from_result(result)
+        assert scope == ScopedGateSelection(
+            kind="required_symbol", targets=("sym_a", "sym_b")
+        )
+
+
+class TestEffectiveGateForResolvedCompareConfigCarriesRealAxes:
+    """Codex review (PR #1192): the fix for "two invocations with genuinely
+    different exit/gate behavior produce an equal EffectiveGate" --
+    ``require_complete_analysis``/``result``-derived scope must actually
+    differentiate the returned object, not silently default away."""
+
+    def test_require_complete_analysis_differentiates(self) -> None:
+        cfg = resolve_compare_config(
+            None, cli_severity_preset=None, cli_scope_public=None
+        )
+        off = effective_gate_for_resolved_compare_config(
+            cfg, require_complete_analysis=False
+        )
+        on = effective_gate_for_resolved_compare_config(
+            cfg, require_complete_analysis=True
+        )
+        assert off != on
+        assert off.require_complete_analysis is False
+        assert on.require_complete_analysis is True
+
+    def test_used_by_scope_differentiates(self) -> None:
+        cfg = resolve_compare_config(
+            None, cli_severity_preset=None, cli_scope_public=None
+        )
+        no_scope = effective_gate_for_resolved_compare_config(cfg)
+        scoped = effective_gate_for_resolved_compare_config(
+            cfg, result=_FakeResult(gate_scope="used_by", used_by=({"app": "x"},))
+        )
+        assert no_scope != scoped
+        assert no_scope.scope is None
+        assert scoped.scope == ScopedGateSelection(kind="used_by", targets=("x",))
+
+    def test_two_different_required_symbol_selections_differentiate(self) -> None:
+        """The literal finding example: two runs differing only in which
+        symbol is required must not collapse to one EffectiveGate."""
+        cfg = resolve_compare_config(
+            None, cli_severity_preset=None, cli_scope_public=None
+        )
+        a = effective_gate_for_resolved_compare_config(
+            cfg,
+            result=_FakeResult(
+                gate_scope="required_symbol",
+                required_symbols={"required_entrypoints": ["sym_a"]},
+            ),
+        )
+        b = effective_gate_for_resolved_compare_config(
+            cfg,
+            result=_FakeResult(
+                gate_scope="required_symbol",
+                required_symbols={"required_entrypoints": ["sym_b"]},
+            ),
+        )
+        assert a != b
+
+    def test_no_result_and_no_flag_matches_the_prior_default_behavior(self) -> None:
+        """Characterization: a caller passing neither (this function's
+        original, pre-fix call shape) still gets the same all-defaults
+        EffectiveGate as before this fix."""
+        cfg = resolve_compare_config(
+            None, cli_severity_preset="strict", cli_scope_public=None
+        )
+        gate = effective_gate_for_resolved_compare_config(cfg)
+        assert gate == EffectiveGate.from_severity(cfg.severity)
+        assert gate.require_complete_analysis is False
+        assert gate.scope is None

--- a/tests/test_effective_gate.py
+++ b/tests/test_effective_gate.py
@@ -1,0 +1,292 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""Characterization and completion tests for
+``abicheck.policy.effective_gate`` (ADR-061 gap D / Definition-of-Done item
+8, closure package 4): the ``EffectiveGate``/``GateSeverityState``
+convergence between single-pair ``compare``'s ``ResolvedCompareConfig`` and
+the directory/package release fan-out's ``GateOptions``.
+
+**Characterization half** (written and run against the *pre-refactor*
+behavior, per this repo's own bug-class regression-testing convention):
+:class:`TestPreRefactorFoldBehaviorPreserved` pins the exact outcomes
+``apply_release_gate_pack``/``apply_to_compare_config`` produced before this
+module existed -- a literal, independently-computed oracle for each
+function, not merely "whatever the code currently returns" -- so introducing
+``GateSeverityState`` underneath them could not silently change either
+fold's result.
+
+**Completion half**: :class:`TestEffectiveGateParity` and
+:class:`TestGateSeverityStateProperties` state the actual convergence this
+closure package's task asked for -- both callers now fold onto the *same*
+:class:`~abicheck.policy.effective_gate.GateSeverityState` shape, and both
+``GateOptions`` (a property) and ``ResolvedCompareConfig`` (via
+``workflows.gate.effective_gate_for_resolved_compare_config`` -- a free
+function rather than a third property, since ``cli_helpers_compare.py`` sits
+at its own ``architecture/debt.yaml`` no-growth cap) resolve to the *same*
+:class:`~abicheck.policy.effective_gate.EffectiveGate` shape -- checked
+against inputs beyond any one example, per this repo's own "General
+invariant" bug-fix-test-contract expectation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from hypothesis import given, strategies as st
+
+from abicheck.cli_helpers_compare import resolve_compare_config
+from abicheck.pack_application import PackApplication, apply_to_compare_config
+from abicheck.policy.effective_gate import (
+    EffectiveGate,
+    GateSeverityState,
+    ScopedGateSelection,
+)
+from abicheck.policy.gate_pack_fold import (
+    GATE_SEVERITY_CATEGORIES,
+    fold_gate_pack_severity,
+    gate_exit_code_scheme,
+)
+from abicheck.policy.release_gate_options import (
+    GateOptions,
+    apply_release_gate_pack,
+    resolve_release_gate_options,
+)
+from abicheck.policy.severity import SeverityConfig, SeverityLevel
+from abicheck.workflows.gate import effective_gate_for_resolved_compare_config
+
+_PRESETS = (None, "default", "strict", "info-only")
+
+
+@st.composite
+def _severity_levels(draw: st.DrawFn) -> dict[str, SeverityLevel]:
+    return {
+        c: draw(st.sampled_from(list(SeverityLevel)))
+        for c in GATE_SEVERITY_CATEGORIES
+        if draw(st.booleans())
+    }
+
+
+@st.composite
+def _raw_category_values(draw: st.DrawFn) -> dict[str, str | None]:
+    return {
+        c: draw(
+            st.one_of(st.none(), st.sampled_from([lvl.value for lvl in SeverityLevel]))
+        )
+        for c in GATE_SEVERITY_CATEGORIES
+    }
+
+
+class TestPreRefactorFoldBehaviorPreserved:
+    """An independent oracle for what each fold produced *before*
+    ``GateSeverityState`` existed -- reimplemented here from each function's
+    own pre-refactor docstring/body rather than imported, so a regression in
+    the real implementation cannot also be baked into the oracle."""
+
+    @staticmethod
+    def _oracle_apply_release_gate_pack(
+        pack_application: PackApplication | None,
+        *,
+        severity_preset: str | None,
+        raw: dict[str, str | None],
+    ) -> tuple[str | None, str | None, str | None, str | None, str | None]:
+        levels = {} if pack_application is None else pack_application.severity_levels
+        folded = fold_gate_pack_severity(dict(raw), levels)
+        return (
+            severity_preset,
+            folded["abi_breaking"],
+            folded["potential_breaking"],
+            folded["quality_issues"],
+            folded["addition"],
+        )
+
+    @given(
+        severity_preset=st.sampled_from(_PRESETS),
+        raw=_raw_category_values(),
+        data=st.data(),
+    )
+    def test_apply_release_gate_pack_matches_oracle(
+        self,
+        severity_preset: str | None,
+        raw: dict[str, str | None],
+        data: st.DataObject,
+    ) -> None:
+        levels = data.draw(_severity_levels())
+        pack_application = PackApplication(policy_overrides={}, severity_levels=levels)
+        got = apply_release_gate_pack(
+            pack_application,
+            severity_preset=severity_preset,
+            severity_abi_breaking=raw["abi_breaking"],
+            severity_potential_breaking=raw["potential_breaking"],
+            severity_quality_issues=raw["quality_issues"],
+            severity_addition=raw["addition"],
+        )
+        expected = self._oracle_apply_release_gate_pack(
+            pack_application, severity_preset=severity_preset, raw=raw
+        )
+        assert got == expected
+
+    def test_apply_release_gate_pack_none_application_is_untouched(self) -> None:
+        got = apply_release_gate_pack(
+            None,
+            severity_preset="strict",
+            severity_abi_breaking="error",
+            severity_potential_breaking=None,
+            severity_quality_issues=None,
+            severity_addition=None,
+        )
+        assert got == ("strict", "error", None, None, None)
+
+    @given(preset=st.sampled_from(_PRESETS), data=st.data())
+    def test_apply_to_compare_config_matches_oracle(
+        self, preset: str | None, data: st.DataObject
+    ) -> None:
+        levels = data.draw(_severity_levels())
+        resolved_cfg = resolve_compare_config(
+            None, cli_severity_preset=preset, cli_scope_public=None
+        )
+        pack_application = PackApplication(policy_overrides={}, severity_levels=levels)
+        got = apply_to_compare_config(resolved_cfg, pack_application)
+
+        if not levels:
+            assert got == resolved_cfg
+            return
+        expected_folded = fold_gate_pack_severity(
+            {c: getattr(resolved_cfg.severity, c) for c in GATE_SEVERITY_CATEGORIES},
+            levels,
+        )
+        expected_severity = dataclasses.replace(
+            resolved_cfg.severity, **expected_folded
+        )
+        assert got.severity == expected_severity
+        assert got.severity_active is True
+
+
+class TestGateSeverityStateProperties:
+    """``GateSeverityState``'s own contract, per this repo's "Primitive-
+    level property tests" convention for a new reusable fold/merge value
+    type."""
+
+    @given(levels=_raw_category_values())
+    def test_construction_requires_every_category(
+        self, levels: dict[str, str | None]
+    ) -> None:
+        GateSeverityState(levels=levels, active=False)  # no raise
+        short = dict(levels)
+        del short[GATE_SEVERITY_CATEGORIES[0]]
+        with pytest.raises(ValueError, match="missing categories"):
+            GateSeverityState(levels=short, active=False)
+
+    @given(levels=_raw_category_values(), active=st.booleans())
+    def test_empty_pack_contribution_is_the_identity_object(
+        self, levels: dict[str, str | None], active: bool
+    ) -> None:
+        state = GateSeverityState(levels=levels, active=active)
+        assert state.folded({}) is state
+
+    @given(levels=_raw_category_values(), active=st.booleans(), data=st.data())
+    def test_a_real_contribution_always_activates(
+        self, levels: dict[str, str | None], active: bool, data: st.DataObject
+    ) -> None:
+        pack_levels = data.draw(_severity_levels())
+        if not pack_levels:
+            return
+        state = GateSeverityState(levels=levels, active=active).folded(pack_levels)
+        assert state.active is True
+        assert state.levels == fold_gate_pack_severity(levels, pack_levels)
+
+
+class TestEffectiveGateParity:
+    """``EffectiveGate`` is the same shape from both producers -- the
+    completion test this closure package's task asked for: equivalent
+    inputs to ``GateOptions``/``ResolvedCompareConfig`` must resolve to an
+    *equal* ``EffectiveGate``, not merely an equal ``exit_code_scheme``."""
+
+    def test_from_severity_derives_scheme_from_the_shared_rule(self) -> None:
+        cfg = SeverityConfig()
+        assert EffectiveGate.from_severity(None).exit_code_scheme == "legacy"
+        assert EffectiveGate.from_severity(cfg).exit_code_scheme == "severity"
+        assert EffectiveGate.from_severity(
+            cfg
+        ).exit_code_scheme == gate_exit_code_scheme(True)
+
+    def test_defaults(self) -> None:
+        gate = EffectiveGate.from_severity(None)
+        assert gate.require_complete_analysis is False
+        assert gate.scope is None
+
+    def test_scope_and_require_complete_analysis_are_carried(self) -> None:
+        scope = ScopedGateSelection(kind="used_by", targets=("app",))
+        gate = EffectiveGate.from_severity(
+            SeverityConfig(), require_complete_analysis=True, scope=scope
+        )
+        assert gate.require_complete_analysis is True
+        assert gate.scope == scope
+
+    @given(preset=st.sampled_from(_PRESETS), data=st.data())
+    def test_gate_options_and_resolved_compare_config_agree(
+        self, preset: str | None, data: st.DataObject
+    ) -> None:
+        """The five distinct assertions the completion test requires:
+        compatibility (severity content), assurance
+        (``require_complete_analysis``, both default False here), scope
+        (both default None here), gate (``exit_code_scheme``), and the
+        derived process outcome (equality of the whole resolved object) --
+        checked separately rather than only the aggregate equality, so a
+        regression in any one axis fails with a pinpointed assertion."""
+        levels = data.draw(_severity_levels())
+        pack_application = PackApplication(policy_overrides={}, severity_levels=levels)
+
+        resolved_cfg = resolve_compare_config(
+            None, cli_severity_preset=preset, cli_scope_public=None
+        )
+        single_pair = apply_to_compare_config(resolved_cfg, pack_application)
+
+        release = resolve_release_gate_options(
+            pack_application,
+            severity_preset=preset,
+            severity_abi_breaking=None,
+            severity_potential_breaking=None,
+            severity_quality_issues=None,
+            severity_addition=None,
+        )
+
+        compare_gate = effective_gate_for_resolved_compare_config(single_pair)
+        release_gate = release.effective_gate
+
+        # 1. gate (exit-code scheme)
+        assert compare_gate.exit_code_scheme == release_gate.exit_code_scheme
+        # 2. compatibility (resolved severity content)
+        assert compare_gate.severity == release_gate.severity
+        # 3. assurance
+        assert (
+            compare_gate.require_complete_analysis
+            == release_gate.require_complete_analysis
+            is False
+        )
+        # 4. scope
+        assert compare_gate.scope == release_gate.scope is None
+        # 5. process outcome: the two EffectiveGate values are wholly equal
+        assert compare_gate == release_gate
+
+    def test_gate_options_effective_gate_property(self) -> None:
+        gate = GateOptions(severity_preset=None, severity=None)
+        assert gate.effective_gate == EffectiveGate.from_severity(None)
+        cfg = SeverityConfig()
+        gate2 = GateOptions(severity_preset="strict", severity=cfg)
+        assert gate2.effective_gate == EffectiveGate.from_severity(cfg)
+
+    def test_resolved_compare_config_effective_gate_helper(self) -> None:
+        cfg = resolve_compare_config(
+            None, cli_severity_preset=None, cli_scope_public=None
+        )
+        assert effective_gate_for_resolved_compare_config(
+            cfg
+        ) == EffectiveGate.from_severity(None)
+        cfg2 = resolve_compare_config(
+            None, cli_severity_preset="strict", cli_scope_public=None
+        )
+        assert effective_gate_for_resolved_compare_config(
+            cfg2
+        ) == EffectiveGate.from_severity(cfg2.severity)

--- a/tests/test_effective_gate.py
+++ b/tests/test_effective_gate.py
@@ -32,9 +32,12 @@ invariant" bug-fix-test-contract expectation.
 from __future__ import annotations
 
 import dataclasses
+import json
+from pathlib import Path
 
 import pytest
 from hypothesis import given, strategies as st
+from test_release_selection import _invoke, _snap, _write_snap
 
 from abicheck.cli_helpers_compare import resolve_compare_config
 from abicheck.pack_application import PackApplication, apply_to_compare_config
@@ -402,3 +405,173 @@ class TestEffectiveGateForResolvedCompareConfigCarriesRealAxes:
         assert gate == EffectiveGate.from_severity(cfg.severity)
         assert gate.require_complete_analysis is False
         assert gate.scope is None
+
+    def test_release_scope_axes_stay_not_applicable_at_this_scope(self) -> None:
+        """Codex review, PR #1192, fourth follow-up round (finding 6): a
+        bare single-pair ``compare`` never resolves ADR-065's scope-
+        completeness policy for itself -- ``cfg.on_incomplete_scope``/
+        ``cfg.fail_on_removed_library`` exist only to be *forwarded* to a
+        release fan-out this run might dispatch to, so this function must
+        not read them onto its own returned ``EffectiveGate`` (see this
+        function's own docstring)."""
+        cfg = resolve_compare_config(
+            None, cli_severity_preset=None, cli_scope_public=None
+        )
+        assert cfg.on_incomplete_scope == "warn"  # cfg itself does carry it
+        gate = effective_gate_for_resolved_compare_config(cfg)
+        assert gate.on_incomplete_scope is None
+        assert gate.fail_on_removed_library is None
+
+
+class TestReleaseScopeAxesOnEffectiveGate:
+    """Codex review, PR #1192, fourth follow-up round (finding 6): the same
+    "EffectiveGate claims completeness it doesn't have" gap findings 1/4/5
+    closed for require_complete_analysis/scope/severity-completeness, for
+    ADR-065's two directory/package release gate axes --
+    ``--on-incomplete-scope`` and ``--fail-on-removed-library``. Two
+    otherwise-identical release runs differing only in one of these exit
+    differently (``0``/``1``, or ``0``/``8``); before this fix
+    ``EffectiveGate`` stayed silent about both, so it could claim two such
+    runs "gate identically" when they provably do not."""
+
+    def test_two_different_on_incomplete_scope_values_differentiate(self) -> None:
+        warn = EffectiveGate.from_severity(None, on_incomplete_scope="warn")
+        block = EffectiveGate.from_severity(None, on_incomplete_scope="block")
+        assert warn != block
+        assert warn.on_incomplete_scope == "warn"
+        assert block.on_incomplete_scope == "block"
+
+    def test_two_different_fail_on_removed_library_values_differentiate(self) -> None:
+        off = EffectiveGate.from_severity(None, fail_on_removed_library=False)
+        on = EffectiveGate.from_severity(None, fail_on_removed_library=True)
+        assert off != on
+        assert off.fail_on_removed_library is False
+        assert on.fail_on_removed_library is True
+
+    def test_unset_release_axes_default_to_not_applicable(self) -> None:
+        gate = EffectiveGate.from_severity(None)
+        assert gate.on_incomplete_scope is None
+        assert gate.fail_on_removed_library is None
+
+    def test_gate_options_effective_gate_carries_release_scope_axes(self) -> None:
+        warn = GateOptions(
+            severity_preset=None, severity=None, on_incomplete_scope="warn"
+        )
+        block = GateOptions(
+            severity_preset=None, severity=None, on_incomplete_scope="block"
+        )
+        assert warn.effective_gate != block.effective_gate
+        assert warn.effective_gate.on_incomplete_scope == "warn"
+        assert block.effective_gate.on_incomplete_scope == "block"
+
+        off = GateOptions(
+            severity_preset=None, severity=None, fail_on_removed_library=False
+        )
+        on = GateOptions(
+            severity_preset=None, severity=None, fail_on_removed_library=True
+        )
+        assert off.effective_gate != on.effective_gate
+        assert off.effective_gate.fail_on_removed_library is False
+        assert on.effective_gate.fail_on_removed_library is True
+
+    def test_resolve_release_gate_options_threads_axes_through(self) -> None:
+        """The real production resolver (``cli_compare_release.py``'s own
+        call site) must pass these through unchanged -- not merely
+        ``GateOptions``'s own constructor accepting them in a test."""
+        opts = resolve_release_gate_options(
+            None,
+            severity_preset=None,
+            severity_abi_breaking=None,
+            severity_potential_breaking=None,
+            severity_quality_issues=None,
+            severity_addition=None,
+            on_incomplete_scope="block",
+            fail_on_removed_library=True,
+        )
+        assert opts.on_incomplete_scope == "block"
+        assert opts.fail_on_removed_library is True
+        assert opts.effective_gate.on_incomplete_scope == "block"
+        assert opts.effective_gate.fail_on_removed_library is True
+
+    def test_resolve_release_gate_options_defaults_stay_not_applicable(self) -> None:
+        """Every pre-existing caller of ``resolve_release_gate_options`` that
+        does not know about these two axes yet gets the identical "not
+        applicable" default it always did -- adding the parameters cannot
+        change behavior for a caller that omits them."""
+        opts = resolve_release_gate_options(
+            None,
+            severity_preset=None,
+            severity_abi_breaking=None,
+            severity_potential_breaking=None,
+            severity_quality_issues=None,
+            severity_addition=None,
+        )
+        assert opts.on_incomplete_scope is None
+        assert opts.fail_on_removed_library is None
+        assert opts.effective_gate.on_incomplete_scope is None
+        assert opts.effective_gate.fail_on_removed_library is None
+
+
+class TestReleaseScopeAxesReachTheRealDigest:
+    """Codex review, PR #1192, fourth follow-up round (finding 6):
+    production-wiring proof, not just the type's own unit tests -- two real
+    ``compare <dir> <dir>`` release-fan-out runs differing only in
+    ``.abicheck.yml``'s ``scope.on_incomplete``/``gate.fail_on_removed_
+    library`` must report a genuinely different ``effective_config_digest``/
+    ``effective_config_fields``, the same way findings 1/4/5 required for
+    ``--require-complete-analysis``/``--used-by``/severity.
+
+    Asymmetric pre-fix status between the two axes, confirmed by stashing
+    the production fix and re-running both: ``gate.fail_on_removed_library``
+    was previously *absent from the digest entirely* (a real ``KeyError``
+    pre-fix) -- the field genuinely did not exist. ``gate.on_incomplete_
+    scope`` already carried the right *value* pre-fix (read off ``result``
+    rather than off ``EffectiveGate``, so its own dedicated unit tests above
+    are what falsify that half of the gap -- the type itself could not
+    distinguish two configs differing only in this axis, even though the
+    digest happened to read the value from elsewhere); this CLI-level test
+    is its non-regression proof that routing the read through ``gate``
+    instead changes nothing observable."""
+
+    @staticmethod
+    def _run(tmp_path: Path, name: str, config_yaml: str) -> dict[str, object]:
+        old_dir, new_dir = tmp_path / f"{name}_old", tmp_path / f"{name}_new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        cfg = tmp_path / f"{name}.abicheck.yml"
+        cfg.write_text(config_yaml, encoding="utf-8")
+        code, out = _invoke(
+            "compare", str(old_dir), str(new_dir),
+            "--config", str(cfg), "--format", "json",
+        )
+        assert code == 0
+        data: dict[str, object] = json.loads(out)
+        return data
+
+    def test_on_incomplete_scope_changes_the_release_digest(
+        self, tmp_path: Path
+    ) -> None:
+        warn = self._run(tmp_path, "warn", "scope:\n  on_incomplete: warn\n")
+        block = self._run(tmp_path, "block", "scope:\n  on_incomplete: block\n")
+        warn_fields = warn["effective_config_fields"]
+        block_fields = block["effective_config_fields"]
+        assert isinstance(warn_fields, dict) and isinstance(block_fields, dict)
+        assert warn_fields["gate.on_incomplete_scope"] == "warn"
+        assert block_fields["gate.on_incomplete_scope"] == "block"
+        assert warn["effective_config_digest"] != block["effective_config_digest"]
+
+    def test_fail_on_removed_library_changes_the_release_digest(
+        self, tmp_path: Path
+    ) -> None:
+        off = self._run(
+            tmp_path, "off", "gate:\n  fail_on_removed_library: false\n"
+        )
+        on = self._run(tmp_path, "on", "gate:\n  fail_on_removed_library: true\n")
+        off_fields = off["effective_config_fields"]
+        on_fields = on["effective_config_fields"]
+        assert isinstance(off_fields, dict) and isinstance(on_fields, dict)
+        assert off_fields["gate.fail_on_removed_library"] == "False"
+        assert on_fields["gate.fail_on_removed_library"] == "True"
+        assert off["effective_config_digest"] != on["effective_config_digest"]

--- a/tests/test_gate_pack_fold_characterization.py
+++ b/tests/test_gate_pack_fold_characterization.py
@@ -51,7 +51,9 @@ def _severity_levels(draw: st.DrawFn) -> dict[str, SeverityLevel]:
 @st.composite
 def _raw_category_values(draw: st.DrawFn) -> dict[str, str | None]:
     return {
-        c: draw(st.one_of(st.none(), st.sampled_from([lvl.value for lvl in SeverityLevel])))
+        c: draw(
+            st.one_of(st.none(), st.sampled_from([lvl.value for lvl in SeverityLevel]))
+        )
         for c in GATE_SEVERITY_CATEGORIES
     }
 
@@ -143,7 +145,9 @@ class TestApplyToCompareConfigCharacterization:
             {c: getattr(resolved_cfg.severity, c) for c in GATE_SEVERITY_CATEGORIES},
             levels,
         )
-        expected_severity = dataclasses.replace(resolved_cfg.severity, **expected_folded)
+        expected_severity = dataclasses.replace(
+            resolved_cfg.severity, **expected_folded
+        )
         assert got.severity == expected_severity
         assert got.severity_active is True
 

--- a/tests/test_gate_pack_fold_characterization.py
+++ b/tests/test_gate_pack_fold_characterization.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""Characterization tests for the *pre*-``EffectiveGate`` behavior of
+``apply_release_gate_pack`` (``abicheck.policy.release_gate_options``) and
+``apply_to_compare_config`` (``abicheck.pack_application``) -- ADR-061 gap D
+/ Definition-of-Done item 8, closure package 4.
+
+Written and run against today's implementation, *before* introducing
+``abicheck.policy.effective_gate.GateSeverityState`` underneath both
+functions (this repo's own bug-class regression-testing convention: capture
+current behavior first, in its own commit, then refactor). Each oracle below
+is reimplemented independently from each function's own current docstring/
+body rather than imported from it, so a regression introduced by the
+refactor cannot also be silently baked into the oracle that is supposed to
+catch it.
+
+``tests/test_effective_gate.py`` (added alongside the refactor itself)
+restates these same two properties again, post-refactor, plus the actual
+``EffectiveGate``/``GateSeverityState`` convergence the refactor introduces --
+this file stays as the durable pre-refactor pin.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from hypothesis import given, strategies as st
+
+from abicheck.cli_helpers_compare import resolve_compare_config
+from abicheck.pack_application import PackApplication, apply_to_compare_config
+from abicheck.policy.gate_pack_fold import (
+    GATE_SEVERITY_CATEGORIES,
+    fold_gate_pack_severity,
+)
+from abicheck.policy.release_gate_options import apply_release_gate_pack
+from abicheck.policy.severity import SeverityLevel
+
+_PRESETS = (None, "default", "strict", "info-only")
+
+
+@st.composite
+def _severity_levels(draw: st.DrawFn) -> dict[str, SeverityLevel]:
+    return {
+        c: draw(st.sampled_from(list(SeverityLevel)))
+        for c in GATE_SEVERITY_CATEGORIES
+        if draw(st.booleans())
+    }
+
+
+@st.composite
+def _raw_category_values(draw: st.DrawFn) -> dict[str, str | None]:
+    return {
+        c: draw(st.one_of(st.none(), st.sampled_from([lvl.value for lvl in SeverityLevel])))
+        for c in GATE_SEVERITY_CATEGORIES
+    }
+
+
+def _oracle_apply_release_gate_pack(
+    pack_application: PackApplication | None,
+    *,
+    severity_preset: str | None,
+    raw: dict[str, str | None],
+) -> tuple[str | None, str | None, str | None, str | None, str | None]:
+    levels = {} if pack_application is None else pack_application.severity_levels
+    folded = fold_gate_pack_severity(dict(raw), levels)
+    return (
+        severity_preset,
+        folded["abi_breaking"],
+        folded["potential_breaking"],
+        folded["quality_issues"],
+        folded["addition"],
+    )
+
+
+class TestApplyReleaseGatePackCharacterization:
+    @given(
+        severity_preset=st.sampled_from(_PRESETS),
+        raw=_raw_category_values(),
+        data=st.data(),
+    )
+    def test_matches_independent_oracle(
+        self,
+        severity_preset: str | None,
+        raw: dict[str, str | None],
+        data: st.DataObject,
+    ) -> None:
+        levels = data.draw(_severity_levels())
+        pack_application = PackApplication(policy_overrides={}, severity_levels=levels)
+        got = apply_release_gate_pack(
+            pack_application,
+            severity_preset=severity_preset,
+            severity_abi_breaking=raw["abi_breaking"],
+            severity_potential_breaking=raw["potential_breaking"],
+            severity_quality_issues=raw["quality_issues"],
+            severity_addition=raw["addition"],
+        )
+        expected = _oracle_apply_release_gate_pack(
+            pack_application, severity_preset=severity_preset, raw=raw
+        )
+        assert got == expected
+
+    def test_none_application_returns_inputs_unchanged(self) -> None:
+        got = apply_release_gate_pack(
+            None,
+            severity_preset="strict",
+            severity_abi_breaking="error",
+            severity_potential_breaking=None,
+            severity_quality_issues=None,
+            severity_addition=None,
+        )
+        assert got == ("strict", "error", None, None, None)
+
+    def test_empty_pack_levels_is_a_no_op(self) -> None:
+        pack_application = PackApplication(policy_overrides={}, severity_levels={})
+        got = apply_release_gate_pack(
+            pack_application,
+            severity_preset="default",
+            severity_abi_breaking="warning",
+            severity_potential_breaking="warning",
+            severity_quality_issues=None,
+            severity_addition=None,
+        )
+        assert got == ("default", "warning", "warning", None, None)
+
+
+class TestApplyToCompareConfigCharacterization:
+    @given(preset=st.sampled_from(_PRESETS), data=st.data())
+    def test_matches_independent_oracle(
+        self, preset: str | None, data: st.DataObject
+    ) -> None:
+        levels = data.draw(_severity_levels())
+        resolved_cfg = resolve_compare_config(
+            None, cli_severity_preset=preset, cli_scope_public=None
+        )
+        pack_application = PackApplication(policy_overrides={}, severity_levels=levels)
+        got = apply_to_compare_config(resolved_cfg, pack_application)
+
+        if not levels:
+            assert got == resolved_cfg
+            return
+        expected_folded = fold_gate_pack_severity(
+            {c: getattr(resolved_cfg.severity, c) for c in GATE_SEVERITY_CATEGORIES},
+            levels,
+        )
+        expected_severity = dataclasses.replace(resolved_cfg.severity, **expected_folded)
+        assert got.severity == expected_severity
+        assert got.severity_active is True
+
+    def test_inert_pack_is_a_true_no_op(self) -> None:
+        resolved_cfg = resolve_compare_config(
+            None, cli_severity_preset="strict", cli_scope_public=None
+        )
+        pack_application = PackApplication(policy_overrides={})
+        assert apply_to_compare_config(resolved_cfg, pack_application) == resolved_cfg

--- a/tests/test_release_evaluation_config.py
+++ b/tests/test_release_evaluation_config.py
@@ -55,7 +55,7 @@ from abicheck.compatibility_evaluation_config import (
 from abicheck.contract_relevance_types import ContractMode, SelectorLayer
 from abicheck.effective_config_digest import (
     effective_config_digest,
-    effective_config_fields,
+    effective_config_fields_from_raw,
 )
 
 
@@ -194,7 +194,7 @@ class TestReleaseFanOutStampsResolvedConfig:
         attribute got set."""
         result = _result()
         result.evaluation_config = _minimal_evaluation_config()
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             result, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["_tier"] == "contract"
@@ -224,10 +224,10 @@ class TestReleaseFanOutStampsResolvedConfig:
         result1, result2 = _result(), _result()
         result1.evaluation_config = rev1
         result2.evaluation_config = rev2
-        fields1 = effective_config_fields(
+        fields1 = effective_config_fields_from_raw(
             result1, severity_config=None, exit_code_scheme="legacy"
         )
-        fields2 = effective_config_fields(
+        fields2 = effective_config_fields_from_raw(
             result2, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields1["_tier"] == fields2["_tier"] == "contract"
@@ -299,7 +299,7 @@ class TestReleaseFanOutMergesContractContext:
 
         record_release_resolved_config(diff, pack_config)
 
-        fields = effective_config_fields(
+        fields = effective_config_fields_from_raw(
             diff, severity_config=None, exit_code_scheme="legacy"
         )
         assert fields["_tier"] == "contract"
@@ -504,7 +504,9 @@ class TestReleaseFanOutPreservesObservedSuppressions:
 
         merged_config = diff.contract_context.evaluation_context.resolved_config
         assert merged_config.suppressions is observed_suppressions
-        assert merged_config.provenance["suppressions"] is observed_suppression_provenance
+        assert (
+            merged_config.provenance["suppressions"] is observed_suppression_provenance
+        )
 
 
 def _release_pack(tmp_path: Path, name: str, body: str) -> Path:

--- a/tests/test_release_scope_plan.py
+++ b/tests/test_release_scope_plan.py
@@ -30,13 +30,16 @@ equality, per this closure package's completion-test contract.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from hypothesis import given, strategies as st
+from test_compare_release import _invoke, _snap, _write_snap
 
 from abicheck.model.scope_acquisition import AcquisitionState, InventoryCompleteness
 from abicheck.workflows.release_scope import (
     DIRECT_PAIR_KEY,
     ReleaseInventoryEvidence,
+    ReleaseScopePlan,
     ReleaseScopeResult,
     SideInventory,
     build_release_scope_record,
@@ -192,3 +195,76 @@ class TestReleaseScopePlanParity:
         assert cli_shaped.proven_removed_members == plan_shaped.proven_removed_members
         # 5. the whole resolved outcome is equal.
         assert cli_shaped == plan_shaped
+
+
+class TestReleaseScopeResultWiredIntoRealProductionFlow:
+    """Codex review (PR #1192): ``resolve_release_scope_result``/
+    ``ReleaseScopeResult`` must be a real production consumer of
+    ``compare-release``'s own flow, not merely unit-tested surface --
+    ``cli_compare_release.py`` now threads ``scope_result.record``
+    end-to-end after resolving it, replacing the bare
+    ``ScopeAcquisitionRecord`` everywhere downstream (bundle analysis,
+    scope-decision resolution, the stderr notices, the JSON writer).
+
+    Patches ``resolve_release_scope_result`` where
+    ``cli_compare_release.py`` resolves it (module-level import binding --
+    see ``abicheck/workflows/AGENTS.md``'s own note on this), and drives the
+    real CLI (``abicheck compare <dir> <dir>``) end to end, exactly the way
+    ``tests/test_compare_release.py``'s own ``TestDirVsDir`` does."""
+
+    def test_a_real_directory_compare_constructs_and_uses_the_result(
+        self, tmp_path: Path
+    ) -> None:
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.json", snap)
+        _write_snap(new_dir / "libfoo.json", snap)
+
+        calls: list[tuple[ReleaseScopePlan, object]] = []
+        real = resolve_release_scope_result
+
+        def _spy(plan: ReleaseScopePlan, record: object) -> ReleaseScopeResult:
+            calls.append((plan, record))
+            return real(plan, record)
+
+        with patch(
+            "abicheck.cli_compare_release.resolve_release_scope_result",
+            side_effect=_spy,
+        ):
+            code, out = _invoke("compare", str(old_dir), str(new_dir))
+
+        assert code == 0
+        assert "NO_CHANGE" in out
+        # The real production call happened exactly once, with a genuine
+        # plan (not a stub) and a record naming the one compared library --
+        # proof this is a live consumer, not dead, unreachable code.
+        assert len(calls) == 1
+        plan, record = calls[0]
+        assert isinstance(plan, ReleaseScopePlan)
+        available = record.members_in(AcquisitionState.AVAILABLE)
+        assert len(available) == 1
+        assert available[0].name == "libfoo.json"
+
+    def test_result_wiring_does_not_change_a_breaking_release_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        """Characterization: routing through ``ReleaseScopeResult`` changes
+        no observable behavior -- the exact same exit code and verdict a
+        pre-wiring run produced."""
+        from test_compare_release import _breaking_pair
+
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        old_foo, new_foo = _breaking_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+        _write_snap(old_dir / "libbar.json", _snap())
+        _write_snap(new_dir / "libbar.json", _snap())
+        code, out = _invoke("compare", str(old_dir), str(new_dir))
+        assert code == 4
+        assert "BREAKING" in out

--- a/tests/test_release_scope_plan.py
+++ b/tests/test_release_scope_plan.py
@@ -325,3 +325,65 @@ class TestScopePlanIsExecutionAuthoritative:
         # execution still read the raw `matched_keys` local instead of
         # `scope_plan.matched_keys`, libbar would still appear here.
         assert compared_names == {"libfoo.json"}
+
+
+class TestExplicitSelectionFoldedIntoScopePlan:
+    """Codex review (PR #1192, third follow-up finding): the same class of
+    bug ``TestScopePlanIsExecutionAuthoritative`` fixed for the discovery
+    path, for the ``--select``/``--select-required`` path instead --
+    ``ReleaseScopePlan.matched_keys`` must already be narrowed to the
+    declared selection, not merely used unfiltered while a separate,
+    post-hoc filter on ``compare_keys`` narrows what actually executes.
+    Before the fix, ``resolve_release_scope_plan`` was called with every
+    discovered key and only ``compare_keys`` was narrowed afterward, so the
+    real ``ReleaseScopePlan`` object execution reads from -- and
+    ``ReleaseScopeResult.plan`` reports -- still claimed the excluded
+    member was matched."""
+
+    def test_select_narrows_the_resolved_plan_itself(self, tmp_path: Path) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libbar.json", _snap("libbar.so"))
+        _write_snap(new_dir / "libbar.json", _snap("libbar.so"))
+
+        calls: list[ReleaseScopePlan] = []
+        real = resolve_release_scope_plan
+
+        def _spy(old_map, new_map, matched_keys, evidence):
+            plan = real(old_map, new_map, matched_keys, evidence)
+            calls.append(plan)
+            return plan
+
+        with patch(
+            "abicheck.cli_compare_release.resolve_release_scope_plan",
+            side_effect=_spy,
+        ):
+            code, out = _invoke(
+                "compare",
+                str(old_dir),
+                str(new_dir),
+                "--select",
+                "libfoo.json",
+                "--format",
+                "json",
+            )
+
+        assert code == 0
+        # The real production call happened exactly once.
+        assert len(calls) == 1
+        plan = calls[0]
+        # The bug: pre-fix, `resolve_release_scope_plan` was called with
+        # every discovered key, so the resolved `ReleaseScopePlan` itself
+        # (not merely a later `compare_keys` local) still claimed libbar
+        # was matched even though it is out of the declared selection.
+        assert "libbar.json" not in plan.matched_keys
+        assert "libfoo.json" in plan.matched_keys
+
+        # Execution and the reported scope record agree with the plan.
+        data = json.loads(out)
+        assert [lib["library"] for lib in data["libraries"]] == ["libfoo.json"]
+        by_member = {m["member"]: m for m in data["comparison_scope"]["members"]}
+        assert by_member["libbar.json"]["state"] == "out_of_scope"

--- a/tests/test_release_scope_plan.py
+++ b/tests/test_release_scope_plan.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-061 gap D / Definition-of-Done item 8, closure package 4:
+``ReleaseScopePlan``/``ReleaseScopeResult`` (``abicheck.workflows.
+release_scope``) -- the release fan-out's own Request -> ResolvedPlan ->
+Result pair for ADR-065's scope model, replacing the four independent
+locals (``old_map``/``new_map``/``matched_keys``/``inventory_evidence``)
+``cli_compare_release.py`` used to thread by hand.
+
+**Characterization**: :class:`TestBuildReleaseScopeRecordUnaffected` pins
+that routing the exact same inputs through :class:`ReleaseScopePlan` before
+calling :func:`build_release_scope_record` produces a byte-identical
+:class:`~abicheck.model.scope_acquisition.ScopeAcquisitionRecord` to calling
+it directly with the raw values -- the wrapping introduced by this closure
+package changes no observable behavior. The full existing
+``tests/test_compare_release.py`` + ``tests/test_release_scope_*.py`` suite
+(282 tests) was also run and confirmed to pass identically before and after
+wiring ``cli_compare_release.py`` through ``scope_plan.*`` at its two
+``build_*_scope_record`` call sites.
+
+**Completion**: :class:`TestReleaseScopePlanParity` states the actual
+convergence -- an equivalent CLI-shaped invocation (raw locals) and a
+typed-plan-shaped invocation (``ReleaseScopePlan``) resolve to an *equal*
+scope outcome, checked as five separate assertions (compatibility/
+assurance/scope/gate/exit-relevant fields) rather than one aggregate
+equality, per this closure package's completion-test contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import given, strategies as st
+
+from abicheck.model.scope_acquisition import AcquisitionState, InventoryCompleteness
+from abicheck.workflows.release_scope import (
+    DIRECT_PAIR_KEY,
+    ReleaseInventoryEvidence,
+    ReleaseScopeResult,
+    SideInventory,
+    build_release_scope_record,
+    resolve_release_scope_plan,
+    resolve_release_scope_result,
+)
+
+_UNPROVEN = SideInventory(InventoryCompleteness.UNPROVEN, "test")
+_PROVEN = SideInventory(InventoryCompleteness.PROVEN, "test")
+
+
+def _maps(
+    old_keys: list[str], new_keys: list[str]
+) -> tuple[dict[str, Path], dict[str, Path]]:
+    return (
+        {k: Path(f"/old/{k}.so") for k in old_keys},
+        {k: Path(f"/new/{k}.so") for k in new_keys},
+    )
+
+
+class TestReleaseScopePlanConstruction:
+    def test_resolve_release_scope_plan_is_a_pure_wrapper(self) -> None:
+        old_map, new_map = _maps(["a", "b"], ["a", "c"])
+        matched = ["a"]
+        evidence = ReleaseInventoryEvidence(old=_UNPROVEN, new=_UNPROVEN)
+
+        plan = resolve_release_scope_plan(old_map, new_map, matched, evidence)
+
+        assert plan.old_map == old_map
+        assert plan.new_map == new_map
+        assert plan.matched_keys == ("a",)
+        assert plan.evidence is evidence
+
+    def test_matched_keys_accepts_any_sequence_type(self) -> None:
+        old_map, new_map = _maps(["a"], ["a"])
+        evidence = ReleaseInventoryEvidence(old=_UNPROVEN, new=_UNPROVEN)
+        as_list = resolve_release_scope_plan(old_map, new_map, ["a"], evidence)
+        as_tuple = resolve_release_scope_plan(old_map, new_map, ("a",), evidence)
+        assert as_list == as_tuple
+
+    def test_resolve_release_scope_result_pairs_plan_and_record(self) -> None:
+        old_map, new_map = _maps(["a"], ["a"])
+        evidence = ReleaseInventoryEvidence(old=_UNPROVEN, new=_UNPROVEN)
+        plan = resolve_release_scope_plan(old_map, new_map, ["a"], evidence)
+        record = build_release_scope_record(
+            old_map,
+            new_map,
+            ["a"],
+            [{"library": "a.so", "verdict": "NO_CHANGE"}],
+            evidence,
+        )
+        result = resolve_release_scope_result(plan, record)
+        assert isinstance(result, ReleaseScopeResult)
+        assert result.plan is plan
+        assert result.record is record
+
+
+class TestBuildReleaseScopeRecordUnaffected:
+    """The characterization property: plan-mediated construction produces
+    the identical record a direct call produces."""
+
+    @given(
+        old_keys=st.lists(st.sampled_from(["a", "b", "c", "d"]), unique=True),
+        new_keys=st.lists(st.sampled_from(["a", "b", "c", "d"]), unique=True),
+    )
+    def test_plan_mediated_record_matches_direct_call(
+        self, old_keys: list[str], new_keys: list[str]
+    ) -> None:
+        old_map, new_map = _maps(old_keys, new_keys)
+        matched_keys = sorted(set(old_keys) & set(new_keys))
+        library_results = [
+            {"library": old_map[k].name, "verdict": "NO_CHANGE"} for k in matched_keys
+        ]
+        evidence = ReleaseInventoryEvidence(old=_UNPROVEN, new=_UNPROVEN)
+
+        direct = build_release_scope_record(
+            old_map, new_map, matched_keys, library_results, evidence
+        )
+
+        plan = resolve_release_scope_plan(old_map, new_map, matched_keys, evidence)
+        via_plan = build_release_scope_record(
+            plan.old_map,
+            plan.new_map,
+            plan.matched_keys,
+            library_results,
+            plan.evidence,
+        )
+
+        assert via_plan == direct
+
+    def test_direct_pair_shape_is_unaffected(self) -> None:
+        old_map = {DIRECT_PAIR_KEY: Path("/o/libx.so")}
+        new_map = {DIRECT_PAIR_KEY: Path("/n/libx.so")}
+        evidence = ReleaseInventoryEvidence(
+            old=_UNPROVEN, new=_UNPROVEN, direct_pair=True
+        )
+        library_results = [{"library": "libx.so", "verdict": "NO_CHANGE"}]
+
+        direct = build_release_scope_record(
+            old_map, new_map, [DIRECT_PAIR_KEY], library_results, evidence
+        )
+        plan = resolve_release_scope_plan(old_map, new_map, [DIRECT_PAIR_KEY], evidence)
+        via_plan = build_release_scope_record(
+            plan.old_map,
+            plan.new_map,
+            plan.matched_keys,
+            library_results,
+            plan.evidence,
+        )
+        assert via_plan == direct
+        assert direct.selection == "direct_pair"
+
+
+class TestReleaseScopePlanParity:
+    """Completion test: a CLI-shaped call (raw locals) and a typed-plan-
+    shaped call resolve to an equal scope outcome, asserted along five
+    separate axes rather than only an aggregate equality."""
+
+    def test_raw_locals_and_typed_plan_agree_on_every_axis(self) -> None:
+        old_map, new_map = _maps(["a", "b"], ["a"])
+        matched_keys = ["a"]
+        evidence = ReleaseInventoryEvidence(old=_PROVEN, new=_UNPROVEN)
+        library_results = [{"library": "a.so", "verdict": "NO_CHANGE"}]
+
+        # "CLI-shaped": the raw locals cli_compare_release.py used to pass
+        # directly, before this closure package's plan wrapper existed.
+        cli_shaped = build_release_scope_record(
+            old_map, new_map, matched_keys, library_results, evidence
+        )
+
+        # "typed-plan-shaped": resolved through ReleaseScopePlan first.
+        plan = resolve_release_scope_plan(old_map, new_map, matched_keys, evidence)
+        plan_shaped = build_release_scope_record(
+            plan.old_map,
+            plan.new_map,
+            plan.matched_keys,
+            library_results,
+            plan.evidence,
+        )
+
+        # 1. compatibility-relevant: the same members reach AVAILABLE.
+        assert {
+            m.member for m in cli_shaped.members_in(AcquisitionState.AVAILABLE)
+        } == {m.member for m in plan_shaped.members_in(AcquisitionState.AVAILABLE)}
+        # 2. assurance/coverage-relevant: unchecked members agree.
+        assert {m.member for m in cli_shaped.unchecked_members} == {
+            m.member for m in plan_shaped.unchecked_members
+        }
+        # 3. scope: the selection rule and out-of-scope members agree.
+        assert cli_shaped.selection == plan_shaped.selection
+        assert cli_shaped.out_of_scope_members == plan_shaped.out_of_scope_members
+        # 4. gate-relevant: proven removals (the exit-8 input) agree.
+        assert cli_shaped.proven_removed_members == plan_shaped.proven_removed_members
+        # 5. the whole resolved outcome is equal.
+        assert cli_shaped == plan_shaped

--- a/tests/test_release_scope_plan.py
+++ b/tests/test_release_scope_plan.py
@@ -29,6 +29,7 @@ equality, per this closure package's completion-test contract.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -268,3 +269,59 @@ class TestReleaseScopeResultWiredIntoRealProductionFlow:
         code, out = _invoke("compare", str(old_dir), str(new_dir))
         assert code == 4
         assert "BREAKING" in out
+
+
+class TestScopePlanIsExecutionAuthoritative:
+    """Codex review (PR #1192, follow-up finding): `scope_plan` must be what
+    execution actually consumes, not a DTO only read by the post-execution
+    record builder -- a future normalization/selection rule added to
+    `resolve_release_scope_plan` must change *which pairs run*, not merely
+    how the reported `ReleaseScopeResult` describes them.
+
+    Proven here by patching `resolve_release_scope_plan` (where
+    `cli_compare_release.py` resolves it) to return a plan whose
+    `matched_keys` *narrows out* one of the two real, on-disk members, and
+    asserting the real execution never compares it -- if execution still
+    read the original locals instead of the plan, this member would still
+    be compared and reported."""
+
+    def test_a_plan_narrowed_matched_keys_actually_narrows_execution(
+        self, tmp_path: Path
+    ) -> None:
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        for name in ("libfoo.json", "libbar.json"):
+            snap = _snap(library=name.replace(".json", ".so"))
+            _write_snap(old_dir / name, snap)
+            _write_snap(new_dir / name, snap)
+
+        real = resolve_release_scope_plan
+
+        def _narrow_to_libfoo_only(old_map, new_map, matched_keys, evidence):
+            plan = real(old_map, new_map, matched_keys, evidence)
+            narrowed_keys = tuple(k for k in plan.matched_keys if "libbar" not in k)
+            assert narrowed_keys and narrowed_keys != plan.matched_keys
+            return ReleaseScopePlan(
+                old_map=plan.old_map,
+                new_map=plan.new_map,
+                matched_keys=narrowed_keys,
+                evidence=plan.evidence,
+            )
+
+        with patch(
+            "abicheck.cli_compare_release.resolve_release_scope_plan",
+            side_effect=_narrow_to_libfoo_only,
+        ):
+            code, out = _invoke(
+                "compare", str(old_dir), str(new_dir), "--format", "json"
+            )
+
+        assert code == 0
+        data = json.loads(out)
+        compared_names = {lib["library"] for lib in data["libraries"]}
+        # libbar was narrowed out of the plan before execution -- if
+        # execution still read the raw `matched_keys` local instead of
+        # `scope_plan.matched_keys`, libbar would still appear here.
+        assert compared_names == {"libfoo.json"}

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -1095,3 +1095,44 @@ class TestSchemaVersion:
         old, new = _breaking_pair()
         payload = json.loads(reporter.to_json(compare(old, new), report_mode="leaf"))
         assert payload["report_schema_version"] == REPORT_SCHEMA_VERSION
+
+
+class TestGateFailOnRemovedLibraryDigestField:
+    """Codex review (PR #1192, fourth round, finding 7): adding
+    ``gate.fail_on_removed_library`` to ``effective_config_fields`` is a
+    public-shape change -- the schema must declare it (both ``required`` and
+    ``properties``, matching the sibling ``gate.on_incomplete_scope``), and
+    ``REPORT_SCHEMA_VERSION`` must have moved past the version that shipped
+    without it (3.14), so schema-driven consumers can discover the field and
+    two same-``REPORT_SCHEMA_VERSION`` reports keep meaning "the digest
+    algorithm agrees"."""
+
+    def test_field_is_declared_required_and_typed_in_the_schema(self):
+        schema = load_compare_report_schema()
+        digest_schema = schema["properties"]["effective_config_fields"]
+        assert "gate.fail_on_removed_library" in digest_schema["required"]
+        assert (
+            digest_schema["properties"]["gate.fail_on_removed_library"]["type"]
+            == "string"
+        )
+
+    def test_report_schema_version_moved_past_314(self):
+        major, minor = (int(p) for p in REPORT_SCHEMA_VERSION.split("."))
+        assert (major, minor) > (3, 14)
+
+    def test_a_real_scalar_report_carries_the_new_field_empty(self):
+        """A scalar comparison resolves no release-fan-out scope, so the
+        field is present (schema-required) but empty -- matching the
+        sibling ``gate.on_incomplete_scope`` field's own contract."""
+        old, new = _breaking_pair()
+        payload = json.loads(reporter.to_json(compare(old, new)))
+        fields = payload["effective_config_fields"]
+        assert fields["gate.fail_on_removed_library"] == ""
+
+    @_requires_jsonschema
+    def test_real_report_carrying_the_new_field_still_validates(self):
+        old, new = _breaking_pair()
+        payload = json.loads(reporter.to_json(compare(old, new)))
+        assert "gate.fail_on_removed_library" in payload["effective_config_fields"]
+        schema = load_compare_report_schema()
+        jsonschema.validate(instance=payload, schema=schema)


### PR DESCRIPTION
## Summary

Closes a bounded, well-specified slice of ADR-061 gap D / Definition-of-Done
item 8 (`docs/contribute/adr/061-responsibility-package-architecture.md`),
targeting the plan's own P0 "Effective configuration and pack application"
section (`docs/contribute/plans/duplication-and-convergence-assessment.md`).

**This PR does NOT attempt the full-scope task as originally framed.** The
full ask — promoting ADR-065's entire scope/inventory/acquisition model onto
shared request/plan types across the whole release fan-out, *and* building
the plan's complete `EffectiveEvaluationConfig` (all seven namespaces:
policy/gate/contract/assurance/surface/evidence/suppressions, plus a digest)
— is a multi-phase migration touching `compatibility_evaluation_config.py`,
`effective_config_digest.py`, `scan`'s own receipt, bundle-level findings,
and most of `cli_compare_release.py`'s 1200-line orchestrator. Attempting
that in one pass, without the ability to verify each intermediate step
against a real multi-day review cycle, was judged too high-risk to do
responsibly. Instead this PR does two concrete, safely-verified pieces of
that larger target, each committed with characterization tests run against
pre-refactor behavior first, and explains what's deliberately left open.

## What changed

### 1. `EffectiveGate`/`GateSeverityState` (the gate-pack fold convergence)

New leaf module `abicheck/policy/effective_gate.py`:

- **`GateSeverityState`** — the one fold-time value type
  `gate_pack_fold`'s two existing callers now both build, fold (via
  `.folded()`), and read back, replacing each caller's own ad hoc mapping
  construction around the already-shared `fold_gate_pack_severity`
  function. This is the literal fix for the gap
  `tests/test_release_gate_pack_fold_parity.py`'s docstring names: "two
  different *shapes* around one shared implementation."
- **`EffectiveGate`/`ScopedGateSelection`** — the plan's own named target
  runtime shape (`exit_code_scheme`, `severity`, `require_complete_analysis`,
  `scope`), narrowed to the gate namespace only (see the module's own
  docstring for why the full `EffectiveEvaluationConfig` isn't attempted
  here). `GateOptions.effective_gate` (release fan-out) and
  `workflows.gate.effective_gate_for_resolved_compare_config` (single-pair
  `compare` — a free function rather than a third property, since
  `cli_helpers_compare.py` sits at its `architecture/debt.yaml` no-growth
  cap) both produce this identical shape, and now agree even under the
  legacy exit-code scheme (`severity=None` on both) — closing the one
  asymmetry the parity test's docstring documents between the two raw
  objects.

Wired into `abicheck/pack_application.py` (`apply_to_compare_config`) and
`abicheck/policy/release_gate_options.py` (`apply_release_gate_pack`), with
re-exports added to `abicheck/workflows/gate.py` (the `frontends -> policy`
boundary crossing point).

### 2. `ReleaseScopePlan`/`ReleaseScopeResult` (release fan-out scope state)

New types in `abicheck/workflows/release_scope.py`, following the exact
Request -> ResolvedPlan -> Result shape `workflows/artifact/{contracts,
resolve,execute}.py` already establish for single-artifact resolution:

- **`ReleaseScopePlan`** — the pre-execution half of ADR-065's scope model
  (matched members, each side's completeness evidence), replacing four
  independent local variables (`old_map`/`new_map`/`matched_keys`/
  `inventory_evidence`) `cli_compare_release.py` previously threaded by
  hand through its helpers.
- **`ReleaseScopeResult`** — pairs a plan with the
  `ScopeAcquisitionRecord` (ADR-065 D1's acquisition state) it resolved to,
  once per-library comparisons have actually run — deliberately **not**
  part of the plan, since acquisition state is only knowable after
  execution.

`cli_compare_release.py` now resolves one `ReleaseScopePlan` right after
computing inventory evidence, and both scope-record builder call sites
(`build_release_scope_record` / `build_declared_selection_record`) read
their inputs off it. This is a pure, behavior-neutral wrapper — the values
are identical to what was passed before.

**Deliberately not done**: no `--dry-run` wiring for the release fan-out
(the command has no `--dry-run` flag today to render this plan through, so
"render the plan, not a second prediction" has no dry-run consumer yet);
no promotion of `ScopeAcquisitionRecord` itself onto a shared type spanning
single-pair `compare` (a bare two-file `compare` doesn't build one at all —
only `compare-release`'s fan-out does, for both the scalar and multi-member
cases, matching "one model, any cardinality"); no touching of `scan`'s own
config/receipt flow (left alone per the task's constraint on not touching
ADR-068's shared-driver work beyond what's needed here — nothing was).

## Test evidence

- **Characterization-first discipline followed for both pieces**: `test:
  characterize gate-pack fold behavior before EffectiveGate convergence`
  (commit `4cf9df2`) was written and run *against pre-refactor code* (files
  were reverted via `git checkout`, tests run and confirmed green, then the
  refactor was reapplied) before the `feat:` commit. For the scope-plan
  piece, the existing `tests/test_compare_release.py` +
  `tests/test_release_scope_*.py` suite (282 tests) was run before and
  after and produced an identical pass count (282 passed, 1 skipped) both
  times, since that refactor changes no values, only how they're carried.
- **`tests/test_effective_gate.py`** — post-refactor characterization
  re-confirmation plus the completion test: `TestEffectiveGateParity`
  asserts `GateOptions`/`ResolvedCompareConfig`'s `EffectiveGate`
  projections agree on five separate axes (gate/compatibility/assurance/
  scope/full-equality) across Hypothesis-generated pack-severity
  combinations, not just exit-code equality.
- **`tests/test_release_scope_plan.py`** — construction tests, a
  Hypothesis-generated characterization property (plan-mediated
  `build_release_scope_record` calls match direct calls byte-for-byte),
  and a completion test asserting CLI-shaped vs. typed-plan-shaped calls
  agree on five separate axes (compatibility/assurance/scope/gate/full
  equality).
- **`scripts/verify.py --profile pr`** (run step-by-step; the single
  monolithic invocation exceeded this environment's turn timeout, so each
  step was run individually with identical net effect):
  - `lint`, `typecheck`, `architecture`, `ai-readiness` (0 errors, 141
    warnings — identical to the pre-existing baseline): **passed**
  - `unit-pr` (the full canonical suite, coverage-gated): **passed** —
    42348 passed, 40 skipped, 4 xfailed, 96.36% coverage (floor 95%)
  - `bugfix-test-contract`, `fp-rate`, `tier-accuracy`,
    `usecase-docs-sync`, `learning-ladder`, `docs-contract`,
    `agent-skills-generated`, `repo-facts`, `skill-eval-pack`,
    `skill-eval-freshness`, `harbor-tasks`, `schema-sync`,
    `fair-metadata`, `docs-build`, `distribution-build`: **all passed**
  - **`fmt-check`: fails, but confirmed pre-existing and unrelated to this
    PR** — `ruff format --check abicheck/ tests/` reports 631 files would
    be reformatted under this environment's pinned `ruff==0.16.3`,
    reproducible identically on a completely untouched file
    (`tests/validate_examples.py`) and with `ruff.toml`/`pyproject.toml`
    byte-identical to `origin/main`. This is an environment-wide formatter
    drift, not something introduced here — reformatting 631 unrelated
    files is out of this PR's scope. Every file this PR actually touches
    passes `ruff format --check` individually (verified explicitly).
- `python scripts/check_architecture.py`: **0 errors**.
- `mypy abicheck/`: **0 errors** (736 source files).

## Deviations / open items for maintainer sign-off

1. **Scope reduction from the original task framing** (see "What changed"
   above) — the full `EffectiveEvaluationConfig` (all seven namespaces +
   digest) and the full promotion of ADR-065's model across
   `cli_compare_release.py`'s entire orchestrator remain open; this PR
   closes the two most concretely-specified, safely-verifiable sub-pieces
   of that target rather than attempting the whole migration at once.
2. **`fmt-check` failure is pre-existing and environment-wide** (631
   files, reproducible on untouched files against `origin/main`'s own
   config) — flagged above rather than worked around by reformatting
   unrelated files.
3. No `IMPORT_CYCLE_ALLOWLIST`/`dependency_direction_exceptions` extension
   was needed or added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWRk949SU6fqs5KTztT88t


---
_Generated by [Claude Code](https://claude.ai/code/session_01RWRk949SU6fqs5KTztT88t)_