### PR TITLE
fix: raise windows-latest unit-tests job timeout to 65m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,19 @@ jobs:
     # budget on a required check, for a cost this comment's own evidence
     # only ever measured on Windows. The other legs keep the 45m this
     # comment's prior bumps established.
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 65 || 45 }}
+    #
+    # 65 turned out to be too tight on its own first re-run: PR #1197's
+    # own windows-latest/3.13 job (run 34458364910, job 102810016338)
+    # was killed at exactly 65m14s -- 14 seconds past the just-raised
+    # budget, with every test up to that point (99% of the suite) still
+    # passing. A ~1.5x multiplier that worked for three prior bumps
+    # (20->30, 45->65 from ~29m/~49m observed) left essentially zero
+    # headroom this time, since normal runner-to-runner variance on
+    # Windows is itself worth several minutes. 90 restores real margin
+    # (not just matching-the-multiplier margin) over the ~65m14s+
+    # observed here -- the run was still executing when killed, so the
+    # true completion time is unknown and at least this high.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 90 || 45 }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,14 @@ jobs:
     # otherwise-green run, not a real test failure. 65 restores headroom
     # over the ~49m21s observed here, matching the ~1.5x-of-observed
     # pattern each prior bump in this comment already followed.
-    timeout-minutes: 65
+    #
+    # Scoped to the windows-latest leg only (Codex review, PR #1197):
+    # `timeout-minutes` is a job-level setting, so a flat 65 would also
+    # hand every ubuntu/macos matrix cell 20 extra minutes of runaway-hang
+    # budget on a required check, for a cost this comment's own evidence
+    # only ever measured on Windows. The other legs keep the 45m this
+    # comment's prior bumps established.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 65 || 45 }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,19 @@ jobs:
     # 29m19s with 99% of the suite passed. 45 restores headroom over that
     # 27-29m; the per-platform cost of the stored-package path is a
     # separate, unowned investigation, not something a test budget fixes.
-    timeout-minutes: 45
+    #
+    # The drift repeated on the *Windows* leg again: on 2026-09-10, run
+    # 11381's windows-latest/3.13 job (github.com/abicheck/abicheck/actions/
+    # runs/34435814307/job/102752838266) was killed by the job-level
+    # timeout at 49m21s -- past the 45m budget above -- with every test
+    # that had run so far passing and the suite at 99% completion (mid
+    # tests/test_cli_compare_release_project_snapshot_package.py, the same
+    # stored-package test module PR #1079's own overrun was in). Same
+    # class of failure as 2026-09-05's: a job-level timeout racing an
+    # otherwise-green run, not a real test failure. 65 restores headroom
+    # over the ~49m21s observed here, matching the ~1.5x-of-observed
+    # pattern each prior bump in this comment already followed.
+    timeout-minutes: 65
     permissions:
       contents: read
       id-token: write

--- a/tests/test_compare_no_baseline_cli.py
+++ b/tests/test_compare_no_baseline_cli.py
@@ -44,6 +44,35 @@ def invoke_cli(*args: str):
     return CliRunner().invoke(abicheck_main, list(args))
 
 
+def _native_library_with_exports() -> Path | None:
+    """A real, already-built native binary that exports symbols.
+
+    ``compare``'s live-artifact path requires an export table (a "DLL", in
+    its own error wording) -- a plain executable copied in under a ``.so``
+    name reads its file *content*, not its name, so it fails that check
+    regardless of extension. ``shutil.which("true")`` used to stand in for
+    "any native binary" on every platform, which holds on Linux/macOS
+    (a dynamically-linked ELF/Mach-O executable there still carries a real
+    dynamic symbol table) but not on Windows: Git for Windows' ``true.exe``
+    is a plain PE executable with no export directory at all, so the copy
+    fails abicheck's own "has no exports ... Verify the file is a valid
+    DLL" check every time -- reproduced on windows-latest CI (previously
+    masked by an unrelated job timeout that cancelled the run before this
+    test's turn in the suite). A real system DLL is the Windows-correct
+    stand-in; every supported Windows image ships one at this path.
+    """
+    import shutil
+
+    if sys.platform == "win32":
+        import os
+
+        system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+        dll = system_root / "System32" / "kernel32.dll"
+        return dll if dll.is_file() else None
+    which = shutil.which("true")
+    return Path(which) if which is not None else None
+
+
 @pytest.fixture
 def candidate() -> Path:
     """A committed G20 audit fixture that reports exactly one finding."""
@@ -457,13 +486,11 @@ def test_a_candidate_version_label_is_honoured(candidate: Path, tmp_path: Path) 
     recorded version on both the one- and two-sided paths -- asserting on the
     snapshot would pass whether or not the option was wired.
     """
-    import shutil
-
-    src = shutil.which("true")
-    if src is None:  # pragma: no cover - every supported CI image has it
-        pytest.skip("no native binary available to label")
+    src = _native_library_with_exports()
+    if src is None:  # pragma: no cover - every supported CI image has one
+        pytest.skip("no native library with exports available to label")
     binary = tmp_path / "libfoo.so"
-    binary.write_bytes(Path(src).read_bytes())
+    binary.write_bytes(src.read_bytes())
     result = invoke_cli(
         "compare",
         "--no-baseline",


### PR DESCRIPTION
## Summary

Raise the `unit-tests` job's `timeout-minutes` for the `windows-latest` leg (scoped per-matrix; ubuntu/macos keep 45) — now 90m, after 65m also proved too tight. Also ports a fix (from #1198) for a real test bug the timeout fix uncovered.

## Motivation

Investigating CI on `main`, I found the `windows-latest, 3.13` `unit-tests` job in run [11381](https://github.com/abicheck/abicheck/actions/runs/34435814307/job/102752838266) was killed by the job-level timeout at 49m21s — past the then-current 45m budget — while the suite was at 99% completion with every test that had run so far passing. This is the same class of failure the inline comment above `timeout-minutes` already documents happening three times before (15→20→30→45m, most recently 2026-09-05): the stored-`ProjectSnapshot`-package test suite is expensive on Windows and the fixed budget keeps re-drifting to zero as the suite grows.

Once a first bump to 65m let the Windows suite actually run to completion, a second, real, reproducible failure surfaced: `test_a_candidate_version_label_is_honoured` — previously masked because the suite never got far enough to reach it. Root-caused and fixed in #1198 (a real test-fixture bug, unrelated to CI config: `shutil.which("true")` on Windows resolves to a plain `.exe` with no PE export table). Ported that fix here (commit 1f0a5c35).

Then, on the very next CI run with both fixes applied, the 65m budget itself proved too tight: the job was cancelled at exactly 65m14s — 14 seconds over — with 99% of the suite again passing. Normal Windows runner-to-runner variance alone accounts for several minutes, so the ~1.5x-of-observed multiplier that worked for three earlier bumps left essentially no real margin this time. Bumped to 90m (commit c9055c12) for genuine headroom rather than just matching the prior ratio.

## Changes

- `.github/workflows/ci.yml`: `unit-tests` job `timeout-minutes` scoped per-matrix — `windows-latest` now 90 (was 65, was 45), ubuntu/macos keep the existing 45 — with inline comments documenting each overrun's evidence, following the same pattern as the prior bumps already recorded there. (First pushed as a flat 65 for the whole job; Codex review flagged that as handing every matrix leg the extra budget, fixed in commit 1756580; then 65→90 after the near-miss above.)
- `tests/test_compare_no_baseline_cli.py`: ported from #1198 — uses a real system DLL on Windows instead of a bare `.exe` for the "native binary with exports" test fixture.

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: CI job-level timeout budget racing an otherwise-green Windows test run, not an application code bug — the fifth recurrence of the documented pattern in this same file (15→20→30→45→65→90m). (The ported commit's own bug class — a Windows-incorrect test fixture assumption — is documented in full in #1198's own PR body/contract; not restated here to avoid drift between the two.)
- Publicly observable failure: `windows-latest, 3.13` `unit-tests` job cancelled with "The operation was canceled" — first at 49m21s (45m budget, run 11381/job 102752838266), then at 65m14s (65m budget, run 34458364910/job 102810016338) — both times with every test that had run so far passing.
- Regression test fails on base: N/A — this is a CI resource-budget configuration value, not application logic; there is no unit-testable code path to regress-test. `git blame`/the inline comment history is the evidence trail for this class of drift.
- Negative control: None — documented as a known gap. The per-platform cost of the stored-package test path itself remains a separate, unowned investigation (per the existing comment), and no code change closes that; this PR only restores timeout headroom, the same mitigation used for every prior recurrence.
- Public-surface test: None — documented as a known gap; no public API or CLI surface changed.
- Axes covered: None — documented as a known gap; single scalar config value change.
- General invariant: None — documented as a known gap. There is no generalizable code-level invariant to state for a CI timeout budget; the actual fix for the underlying cost driver (Windows stored-package compare test runtime) is explicitly out of scope per the pre-existing comment in this file.
- Known unsupported cases: This is a budget bump, not a fix to the underlying cost driver — if the Windows-leg stored-`ProjectSnapshot`-package test runtime keeps growing (as it now has four times: 15→20→30→45→65→90m), this same job will eventually exceed 90m again and need another bump, or the real fix (reducing that path's Windows-specific cost, or splitting/parallelizing the slow module) which remains unowned per the pre-existing comment. This PR does not attempt that fix.
- Malicious fixture + side-effect absence: Not applicable — this diff touches `.github/workflows/ci.yml` (the trust boundary) but only changes a scalar `timeout-minutes:` value (now per-matrix) on an existing job; it adds no new logic, no new input parsing, and no new execution path that could process a hostile fixture. GitHub Actions' own timeout enforcement (unchanged mechanism) is what's being given a larger budget on one matrix leg.

## Checklist

- [x] Tests added / updated for new behaviour — N/A for the timeout change; the ported commit updates a test (see #1198)
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — N/A, doesn't touch `abicheck/**/*.py`
- [ ] Docs updated if user-visible behaviour changed — N/A
- [x] `pre-commit run --all-files` passes locally — N/A (no pre-commit hooks apply to this file beyond YAML validity, verified by inspection)
- [x] No new `mypy` or `ruff` errors introduced — N/A, no Python changed by the timeout fix; the ported test fix is `ruff`-clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nMSZvqQiUbm6vLpxFXayw

---
_Generated by [Claude Code](https://claude.ai/code/session_014nMSZvqQiUbm6vLpxFXayw)_