### PR TITLE
feat: audit-gate exit axis for compare --no-baseline (ADR-068 amendment)

### DIFF
--- a/abicheck/frontends/cli/commands/compare_no_baseline.py
+++ b/abicheck/frontends/cli/commands/compare_no_baseline.py
@@ -38,6 +38,7 @@ import click
 from ....report.no_baseline import (
     NO_BASELINE_SUPPORTED_FORMATS,
     NO_BASELINE_UNSUPPORTED_FORMATS,
+    audit_gate_enabled_for_severity_preset,
     render_no_baseline,
 )
 from ....workflows.no_baseline_compare import (
@@ -83,6 +84,11 @@ class _OutputPlan:
     dry_run: bool
     secondary_writes: tuple[tuple[str, Path], ...]
     require_complete_analysis: bool
+    #: ADR-068 2026-09-10 amendment: whether ``--severity-preset`` opted this
+    #: audit into the audit-gate exit axis. ``False`` for every invocation
+    #: that omits the flag, which is what keeps every pre-existing
+    #: ``--no-baseline`` invocation's exit code unchanged.
+    audit_gate_enabled: bool
 
 
 @dataclass(frozen=True)
@@ -355,6 +361,9 @@ def _resolve_no_baseline_invocation(
             require_complete_analysis=bool(
                 kwargs.get("require_complete_analysis", False)
             ),
+            audit_gate_enabled=audit_gate_enabled_for_severity_preset(
+                kwargs.get("severity_preset")
+            ),
         ),
         headers=_HeaderInputs(
             headers=headers,
@@ -401,6 +410,7 @@ def _emit_no_baseline_report(
         result,
         inv.output.fmt,
         require_complete_analysis=inv.output.require_complete_analysis,
+        audit_gate_enabled=inv.output.audit_gate_enabled,
     )
     _write_or_echo(inv.output.output, text)
     for write_fmt, write_path in inv.output.secondary_writes:
@@ -416,6 +426,7 @@ def _emit_no_baseline_report(
             result,
             write_fmt,
             require_complete_analysis=inv.output.require_complete_analysis,
+            audit_gate_enabled=inv.output.audit_gate_enabled,
         )
         _safe_write_output(write_path, rendered)
     if exit_code != 0:

--- a/abicheck/frontends/cli/commands/no_baseline_rulings.py
+++ b/abicheck/frontends/cli/commands/no_baseline_rulings.py
@@ -293,11 +293,6 @@ _UNSUPPORTED_OPTIONS: dict[str, tuple[str, str]] = {
         "--budget",
         "the wall-clock guard is not wired to this path yet",
     ),
-    "severity_preset": (
-        "--severity-preset",
-        "an audit's findings are advisory and never gate, so a severity "
-        "preset has nothing to act on yet",
-    ),
     "pack_paths": (
         "--pack",
         "pack application is not wired to this path yet",

--- a/abicheck/policy/audit_gate_exit.py
+++ b/abicheck/policy/audit_gate_exit.py
@@ -28,15 +28,41 @@ two-sided comparison does: an ``API_BREAK_KINDS``-classified finding exits
 exits ``0`` on its own. ADR-068 D2 forbids an audit from ever emitting ``2``
 or ``4`` -- those are the *compatibility* family's own codes, and an audit
 reports no compatibility verdict -- so this axis reproduces exactly the
-same **partition** (``BREAKING_KINDS | API_BREAK_KINDS`` gates,
-``RISK_KINDS`` and ``COMPATIBLE_KINDS`` do not) through its own code,
+same **partition** (a finding whose *effective* verdict is
+``Verdict.BREAKING``/``Verdict.API_BREAK`` gates; ``Verdict.
+COMPATIBLE_WITH_RISK``/``Verdict.COMPATIBLE`` do not) through its own code,
 :data:`AUDIT_GATE_EXIT_CODE`, folded with ``max`` like every other
 orthogonal axis in this codebase (`contract_coverage_exit.py`,
 `depth_evidence_contract.py`) -- it can raise a clean ``0``, and it can
 never lower, or be confused for, a compatibility ``2``/``4``.
 
-**Why this reads ``ChangeKind`` membership directly rather than routing
-through ``severity.py``'s category model.** ``severity.py``'s own
+**Reads the policy-effective verdict, never the raw ``ChangeKind``
+category, on purpose.** An earlier revision of this module read
+:data:`~abicheck.policy.classification.BREAKING_KINDS`/
+:data:`~abicheck.policy.classification.API_BREAK_KINDS` membership directly
+off each finding's raw ``change.kind`` -- correct on the un-policied G20
+corpus, but wrong the moment a run supplies a ``--policy`` document:
+``policy_file.py``'s ``overrides:``/``reclassify:`` blocks can promote a
+``RISK``-classified kind to ``Verdict.BREAKING`` (or demote a normally
+breaking kind), and every other consumer of a finding's classification in
+this codebase (the JSON/Markdown/SARIF/JUnit renderers, the two-sided
+gate) reads that *effective*, policy-resolved verdict, not the raw kind.
+Gating on the raw kind meant an explicitly-selected, trusted policy's
+promotion of a finding to breaking was silently invisible to this axis --
+a ``--policy`` naming a kind as breaking, whose committed snapshot carries
+exactly that finding, unsuppressed, could still exit ``0`` (Codex security
+review, P1: :file:`SECURITY.md` treats analyzed binaries as untrusted and
+policies as trusted, so the trusted signal must be the one honored). This
+module now reads each finding's already-resolved
+:attr:`~abicheck.report.finding.ReportFinding.verdict` -- the same value
+:func:`abicheck.policy.severity.effective_verdict_for_change` computes for
+every other renderer, "read, don't re-derive" per this repository's own
+known-gaps convention -- rather than importing ``ReportFinding`` itself
+(which would invert the ``policy -> report`` dependency direction; this
+module stays duck-typed over any object carrying a ``.verdict``).
+
+**Why this reads ``Verdict`` directly rather than routing through
+``severity.py``'s coarser category model.** ``severity.py``'s own
 ``IssueCategory``/``SeverityConfig`` split findings into four buckets, and
 by its own module docstring ``potential_breaking`` is **``API_BREAK_KINDS ∪
 RISK_KINDS``** -- the two are deliberately merged into one severity bucket
@@ -45,12 +71,13 @@ there, because a severity preset's whole point is "how strict should
 recompilation". Routing this axis through that bucket would gate exactly
 the case the task that produced this module named as the regression to
 avoid: ``case143_audit_accidental_export``'s ``RISK``-classified finding
-would gate identically to ``case148``/``case149``'s ``API_BREAK``-classified
-ones the moment ``potential_breaking`` reached ``error``. So this axis reads
-:data:`~abicheck.policy.classification.BREAKING_KINDS`/
-:data:`~abicheck.policy.classification.API_BREAK_KINDS` directly instead --
-the same registry-derived sets every other consumer of the taxonomy uses,
-just not folded through the coarser four-bucket severity model.
+(effective verdict ``Verdict.COMPATIBLE_WITH_RISK``) would gate identically
+to ``case148``/``case149``'s ``API_BREAK``-classified ones the moment
+``potential_breaking`` reached ``error``. So this axis compares
+``Verdict.BREAKING``/``Verdict.API_BREAK`` directly instead -- the same
+five-way ``Verdict`` enum every other verdict-level consumer of the
+taxonomy uses, just not folded through the coarser four-bucket severity
+model.
 
 **Opt-in, not on by default.** Every existing ``compare --no-baseline``
 invocation's exit code must stay unchanged (a real migration/compatibility
@@ -71,12 +98,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .classification import API_BREAK_KINDS, BREAKING_KINDS
+from .classification import Verdict
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    from ..checker_policy import ChangeKind
 
 __all__ = [
     "AUDIT_GATE_EXIT_CODE",
@@ -116,31 +141,47 @@ def audit_gate_enabled_for_severity_preset(severity_preset: str | None) -> bool:
     layer and any future typed-API caller cannot drift on what "opted in"
     means.
     """
-    return severity_preset is not None and severity_preset != SEVERITY_PRESET_DISABLES_AUDIT_GATE
+    return (
+        severity_preset is not None
+        and severity_preset != SEVERITY_PRESET_DISABLES_AUDIT_GATE
+    )
 
 
-def _gates(kind: ChangeKind) -> bool:
-    """Would legacy ``scan``'s verdict computation have gated on *kind*?
+#: The effective verdicts that gate. Mirrors legacy ``scan``'s own
+#: ``BREAKING_KINDS | API_BREAK_KINDS`` partition, but stated at the
+#: ``Verdict`` level -- the level every policy override/reclassify rule
+#: ultimately resolves to -- rather than the raw per-kind taxonomy, so a
+#: policy-promoted finding is caught the same way an un-promoted one is.
+_GATING_VERDICTS = (Verdict.BREAKING, Verdict.API_BREAK)
 
-    ``True`` for ``BREAKING_KINDS``/``API_BREAK_KINDS``, ``False`` for
-    everything else (``RISK_KINDS``, every ``COMPATIBLE_KINDS`` member, and
-    any kind outside all three -- none of which a candidate-side audit
-    finding is classified as today, but the check stays total rather than
-    assuming that).
+
+def _gates(verdict: Verdict) -> bool:
+    """Would legacy ``scan``'s verdict computation have gated on a finding
+    whose *effective*, policy-resolved verdict is *verdict*?
+
+    ``True`` for :data:`Verdict.BREAKING`/:data:`Verdict.API_BREAK`,
+    ``False`` for everything else (:data:`Verdict.COMPATIBLE_WITH_RISK`,
+    :data:`Verdict.COMPATIBLE`, and the unreachable :data:`Verdict.
+    NO_CHANGE`).
     """
-    return kind in BREAKING_KINDS or kind in API_BREAK_KINDS
+    return verdict in _GATING_VERDICTS
 
 
-def audit_gate_exit_contribution(
-    findings: Iterable[Any], *, enabled: bool
-) -> int:
+def audit_gate_exit_contribution(findings: Iterable[Any], *, enabled: bool) -> int:
     """This axis's own exit contribution: :data:`AUDIT_GATE_EXIT_CODE` or ``0``.
 
-    *findings* is any iterable of objects carrying a ``.change.kind``
-    (a :class:`~abicheck.report.finding.ReportFinding`) or a bare object
-    carrying ``.kind`` (a :class:`~abicheck.checker_types.Change`) -- both
-    shapes appear across this codebase's call sites, so both are accepted
-    rather than forcing every caller to unwrap first.
+    *findings* is any iterable of objects carrying a policy-effective
+    ``.verdict`` -- a :class:`~abicheck.report.finding.ReportFinding`, as
+    resolved by :func:`abicheck.policy.severity.effective_verdict_for_change`
+    (via :func:`abicheck.report.finding.build_report_findings`). Reading
+    that already-resolved field, rather than a finding's raw
+    ``change.kind``, is what lets a ``--policy`` override/``reclassify:``
+    rule that promotes a finding to breaking be honored here exactly as it
+    is by every other renderer (see the module docstring's Codex-review
+    note) -- a bare object with no ``.verdict`` (e.g. a raw ``Change``) is
+    skipped rather than mis-read, so a caller that forgets to resolve
+    first fails to gate loudly in its own tests rather than silently
+    reading a category the raw object was never classified against.
 
     ``0`` whenever *enabled* is ``False`` (the default): an audit that never
     asked to gate reports exactly the same exit code it always has --
@@ -151,9 +192,8 @@ def audit_gate_exit_contribution(
     if not enabled:
         return 0
     for finding in findings:
-        change = getattr(finding, "change", finding)
-        kind = getattr(change, "kind", None)
-        if kind is not None and _gates(kind):
+        verdict = getattr(finding, "verdict", None)
+        if isinstance(verdict, Verdict) and _gates(verdict):
             return AUDIT_GATE_EXIT_CODE
     return 0
 

--- a/abicheck/policy/audit_gate_exit.py
+++ b/abicheck/policy/audit_gate_exit.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-068's audit-gate axis (2026-09-10 amendment): the orthogonal exit
+contribution that lets a ``compare --no-baseline`` CI job gate on a real
+audit finding, closing the gap ``docs/contribute/known-gaps.md``'s
+"no way to gate a CI job on an audit finding" entry recorded.
+
+**What this reproduces, and what it deliberately does not.** Legacy
+``scan``'s audit mode derived a *verdict* from its own findings
+(``cli_scan_baseline.py``'s ``compute_verdict``-over-``verdict_scored_
+changes`` path) and mapped that verdict to an exit code the same way a real
+two-sided comparison does: an ``API_BREAK_KINDS``-classified finding exits
+``2``, a ``BREAKING_KINDS``-classified finding exits ``4``, and a
+``RISK_KINDS``-classified finding (advisory-only, ADR-028 D3 / ADR-035 D1)
+exits ``0`` on its own. ADR-068 D2 forbids an audit from ever emitting ``2``
+or ``4`` -- those are the *compatibility* family's own codes, and an audit
+reports no compatibility verdict -- so this axis reproduces exactly the
+same **partition** (``BREAKING_KINDS | API_BREAK_KINDS`` gates,
+``RISK_KINDS`` and ``COMPATIBLE_KINDS`` do not) through its own code,
+:data:`AUDIT_GATE_EXIT_CODE`, folded with ``max`` like every other
+orthogonal axis in this codebase (`contract_coverage_exit.py`,
+`depth_evidence_contract.py`) -- it can raise a clean ``0``, and it can
+never lower, or be confused for, a compatibility ``2``/``4``.
+
+**Why this reads ``ChangeKind`` membership directly rather than routing
+through ``severity.py``'s category model.** ``severity.py``'s own
+``IssueCategory``/``SeverityConfig`` split findings into four buckets, and
+by its own module docstring ``potential_breaking`` is **``API_BREAK_KINDS ∪
+RISK_KINDS``** -- the two are deliberately merged into one severity bucket
+there, because a severity preset's whole point is "how strict should
+*review-worthy* findings be", not "does this specific finding require
+recompilation". Routing this axis through that bucket would gate exactly
+the case the task that produced this module named as the regression to
+avoid: ``case143_audit_accidental_export``'s ``RISK``-classified finding
+would gate identically to ``case148``/``case149``'s ``API_BREAK``-classified
+ones the moment ``potential_breaking`` reached ``error``. So this axis reads
+:data:`~abicheck.policy.classification.BREAKING_KINDS`/
+:data:`~abicheck.policy.classification.API_BREAK_KINDS` directly instead --
+the same registry-derived sets every other consumer of the taxonomy uses,
+just not folded through the coarser four-bucket severity model.
+
+**Opt-in, not on by default.** Every existing ``compare --no-baseline``
+invocation's exit code must stay unchanged (a real migration/compatibility
+cost per this repository's own "don't change public interfaces without an
+ADR and migration" rule) -- so this axis only ever contributes when the
+invocation explicitly asked for it. Activation reuses the existing
+``--severity-preset`` option (previously a hard usage error under
+``--no-baseline``, naming this exact gap) rather than inventing a new flag:
+passing any preset other than ``info-only`` opts the run into gating,
+exactly mirroring what the flag already means on a two-sided ``compare`` --
+"I want this run to gate on its findings". ``info-only`` stays a deliberate
+no-gate request, the same as it is for a two-sided run. See the ADR-068
+amendment (2026-09-10) for the full reasoning and the rejected
+alternative (a bespoke ``--audit-gate`` flag).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .classification import API_BREAK_KINDS, BREAKING_KINDS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..checker_policy import ChangeKind
+
+__all__ = [
+    "AUDIT_GATE_EXIT_CODE",
+    "SEVERITY_PRESET_DISABLES_AUDIT_GATE",
+    "audit_gate_enabled_for_severity_preset",
+    "audit_gate_exit_contribution",
+    "fold_audit_gate_exit",
+]
+
+#: This axis's own exit code. Chosen from the codes ``compare``/
+#: ``scan --against`` already use (``0, 1, 2, 4, 5, 6, 7, 8, 64`` --
+#: surveyed against `docs/reference/exit-codes.md` and `severity.py`'s own
+#: `_CATEGORY_EXIT_CODES`/`analysis_assurance`/`contract_coverage_exit`/
+#: `depth_evidence_contract` modules at the time this was added): ``3`` is
+#: the one integer in that low range no `compare`/`scan --against` axis
+#: currently emits (`1`/`2`/`4`/`5` are taken by severity/compatibility/
+#: budget, `6`/`7`/`8` by not-comparable/evidence-contract/removed-required-
+#: library). Deliberately *not* `2` -- ADR-068 D2 reserves that for a real
+#: compatibility source-break, which an audit structurally cannot report.
+AUDIT_GATE_EXIT_CODE = 3
+
+#: The one ``--severity-preset`` value that does **not** opt an audit into
+#: gating -- it is the explicit "don't gate anything" request on a two-sided
+#: `compare` too (`severity.INFO_ONLY_PRESET` sets every category to
+#: `SeverityLevel.INFO`), and this axis honors that same intent rather than
+#: treating "a preset was named" as unconditional activation.
+SEVERITY_PRESET_DISABLES_AUDIT_GATE = "info-only"
+
+
+def audit_gate_enabled_for_severity_preset(severity_preset: str | None) -> bool:
+    """Does *severity_preset* opt a ``--no-baseline`` audit into gating?
+
+    ``None`` (the flag was not given at all) and
+    :data:`SEVERITY_PRESET_DISABLES_AUDIT_GATE` both answer ``False``;
+    every other accepted preset name (``default``, ``strict`` today)
+    answers ``True``. The one place this question is answered, so the CLI
+    layer and any future typed-API caller cannot drift on what "opted in"
+    means.
+    """
+    return severity_preset is not None and severity_preset != SEVERITY_PRESET_DISABLES_AUDIT_GATE
+
+
+def _gates(kind: ChangeKind) -> bool:
+    """Would legacy ``scan``'s verdict computation have gated on *kind*?
+
+    ``True`` for ``BREAKING_KINDS``/``API_BREAK_KINDS``, ``False`` for
+    everything else (``RISK_KINDS``, every ``COMPATIBLE_KINDS`` member, and
+    any kind outside all three -- none of which a candidate-side audit
+    finding is classified as today, but the check stays total rather than
+    assuming that).
+    """
+    return kind in BREAKING_KINDS or kind in API_BREAK_KINDS
+
+
+def audit_gate_exit_contribution(
+    findings: Iterable[Any], *, enabled: bool
+) -> int:
+    """This axis's own exit contribution: :data:`AUDIT_GATE_EXIT_CODE` or ``0``.
+
+    *findings* is any iterable of objects carrying a ``.change.kind``
+    (a :class:`~abicheck.report.finding.ReportFinding`) or a bare object
+    carrying ``.kind`` (a :class:`~abicheck.checker_types.Change`) -- both
+    shapes appear across this codebase's call sites, so both are accepted
+    rather than forcing every caller to unwrap first.
+
+    ``0`` whenever *enabled* is ``False`` (the default): an audit that never
+    asked to gate reports exactly the same exit code it always has --
+    reading, never re-deriving, is what keeps every pre-existing
+    ``compare --no-baseline`` invocation unchanged. When enabled, the first
+    gating finding is sufficient; this is a floor, not a count.
+    """
+    if not enabled:
+        return 0
+    for finding in findings:
+        change = getattr(finding, "change", finding)
+        kind = getattr(change, "kind", None)
+        if kind is not None and _gates(kind):
+            return AUDIT_GATE_EXIT_CODE
+    return 0
+
+
+def fold_audit_gate_exit(base: int, contribution: int) -> int:
+    """*base* raised to this axis's floor -- the same ``max`` discipline
+    every other orthogonal axis in this codebase folds with. Never lowers
+    *base*, and *contribution* is always either ``0`` or
+    :data:`AUDIT_GATE_EXIT_CODE` -- never ``2``/``4``, so it can never be
+    mistaken for, or override, the compatibility family's own codes.
+    """
+    return max(base, contribution)

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -52,6 +52,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..policy.audit_gate_exit import (
+    audit_gate_enabled_for_severity_preset as audit_gate_enabled_for_severity_preset,
+)
 from ..policy.outcome import OperationalStatus, PolicyGateDecision, RunOutcome
 from ..policy.scope_completeness import resolve_scope_decision
 from .comparison_scope import build_comparison_scope_section
@@ -94,6 +97,7 @@ __all__ = [
     "NO_BASELINE_SUPPORTED_FORMATS",
     "NO_BASELINE_UNSUPPORTED_FORMATS",
     "NoBaselineDocument",
+    "audit_gate_enabled_for_severity_preset",
     "compute_no_baseline_document",
     "no_baseline_exit_code",
     "no_baseline_json_report",
@@ -149,7 +153,9 @@ def _operational_status(result: NoBaselineCompareResult) -> OperationalStatus:
 #: Markdown report that stated only the coverage axis exited 7 on a missed
 #: evidence contract while saying nothing about why (Codex review, P2).
 def _no_baseline_exit_axes(
-    result: NoBaselineCompareResult, require_complete_analysis: bool
+    result: NoBaselineCompareResult,
+    require_complete_analysis: bool,
+    audit_gate_enabled: bool = False,
 ) -> dict[str, int]:
     """Every orthogonal axis's own contribution, keyed as in
     :data:`NO_BASELINE_EXIT_AXIS_NOTICES`.
@@ -161,11 +167,20 @@ def _no_baseline_exit_axes(
     ADR-068 D2 gives an audit none.
     """
     from ..analysis_assurance import analysis_assurance_exit_contribution
+    from ..policy.audit_gate_exit import audit_gate_exit_contribution
     from ..policy.contract_coverage_exit import coverage_exit_floor
     from ..policy.exit_decision_precedence import EXIT_EVIDENCE_CONTRACT_ERROR
 
     scope_decision = _scope_decision(result)
     return {
+        # ADR-068 2026-09-10 amendment: the audit-gate axis, opt-in via
+        # --severity-preset (never active unless the run asked for it).
+        # Ordered first so it reads alongside the other content axes rather
+        # than after the evidence/scope ones below, which is purely a
+        # presentation choice -- `max` does not care about dict order.
+        "audit_gate": audit_gate_exit_contribution(
+            result.findings, enabled=audit_gate_enabled
+        ),
         "contract_coverage": coverage_exit_floor(result.diff),
         "analysis_assurance": analysis_assurance_exit_contribution(
             result.diff, require_complete=require_complete_analysis
@@ -183,7 +198,10 @@ def _no_baseline_exit_axes(
 
 
 def no_baseline_exit_code(
-    result: NoBaselineCompareResult, *, require_complete_analysis: bool = False
+    result: NoBaselineCompareResult,
+    *,
+    require_complete_analysis: bool = False,
+    audit_gate_enabled: bool = False,
 ) -> int:
     """The whole exit-code contribution of a ``--no-baseline`` run.
 
@@ -204,8 +222,16 @@ def no_baseline_exit_code(
     -- the same reason every other axis above is folded here. It is a plain
     ``max`` member like the rest: exit ``7`` is a *failed evidence
     contract*, orthogonal to how much coverage the run had.
+
+    ``audit_gate_enabled`` (default ``False``, ADR-068 2026-09-10
+    amendment) is the opt-in audit-gate axis: ``False`` for every
+    pre-existing caller, so no existing invocation's exit code changes.
     """
-    return max(_no_baseline_exit_axes(result, require_complete_analysis).values())
+    return max(
+        _no_baseline_exit_axes(
+            result, require_complete_analysis, audit_gate_enabled
+        ).values()
+    )
 
 
 def _finding_resolver(
@@ -232,7 +258,10 @@ def _finding_resolver(
 
 
 def compute_no_baseline_document(
-    result: NoBaselineCompareResult, *, require_complete_analysis: bool = False
+    result: NoBaselineCompareResult,
+    *,
+    require_complete_analysis: bool = False,
+    audit_gate_enabled: bool = False,
 ) -> NoBaselineDocument:
     """Resolve *result* into the one document every format below projects."""
     from ..policy.contract_coverage_exit import coverage_exit_floor
@@ -257,9 +286,13 @@ def compute_no_baseline_document(
         coverage_failures=_coverage_failures(diff),
         contract_selected=getattr(diff, "contract_context", None) is not None,
         exit_code=no_baseline_exit_code(
-            result, require_complete_analysis=require_complete_analysis
+            result,
+            require_complete_analysis=require_complete_analysis,
+            audit_gate_enabled=audit_gate_enabled,
         ),
-        exit_axes=_no_baseline_exit_axes(result, require_complete_analysis),
+        exit_axes=_no_baseline_exit_axes(
+            result, require_complete_analysis, audit_gate_enabled
+        ),
     )
 
 
@@ -618,6 +651,7 @@ def render_no_baseline(
     fmt: str,
     *,
     require_complete_analysis: bool = False,
+    audit_gate_enabled: bool = False,
 ) -> tuple[str, int]:
     """Render a ``--no-baseline`` audit in *fmt*; return ``(text, exit_code)``.
 
@@ -627,6 +661,11 @@ def render_no_baseline(
     :data:`NO_BASELINE_SUPPORTED_FORMATS` -- the CLI rejects anything else
     as a usage error before reaching here, so an unknown value is an
     internal error, not a user one.
+
+    *audit_gate_enabled* (default ``False``, ADR-068 2026-09-10 amendment)
+    threads the opt-in audit-gate axis through to the exit code -- see
+    :func:`abicheck.policy.audit_gate_exit.audit_gate_enabled_for_severity_preset`
+    for how the CLI derives it from ``--severity-preset``.
     """
     import json as _json
 
@@ -636,7 +675,9 @@ def render_no_baseline(
     )
 
     doc = compute_no_baseline_document(
-        result, require_complete_analysis=require_complete_analysis
+        result,
+        require_complete_analysis=require_complete_analysis,
+        audit_gate_enabled=audit_gate_enabled,
     )
     if fmt == "json":
         return (

--- a/abicheck/report/no_baseline.py
+++ b/abicheck/report/no_baseline.py
@@ -178,8 +178,16 @@ def _no_baseline_exit_axes(
         # Ordered first so it reads alongside the other content axes rather
         # than after the evidence/scope ones below, which is purely a
         # presentation choice -- `max` does not care about dict order.
+        #
+        # Resolved through `_finding_resolver` (the same policy-effective
+        # verdict every renderer reads), never the raw `result.findings`
+        # `Change` tuple -- gating on a finding's raw `ChangeKind` category
+        # would silently miss a `--policy` override/`reclassify:` rule that
+        # promotes it to breaking (Codex security review, P1; see
+        # `policy.audit_gate_exit`'s own module docstring).
         "audit_gate": audit_gate_exit_contribution(
-            result.findings, enabled=audit_gate_enabled
+            _finding_resolver(result.diff)(result.findings),
+            enabled=audit_gate_enabled,
         ),
         "contract_coverage": coverage_exit_floor(result.diff),
         "analysis_assurance": analysis_assurance_exit_contribution(

--- a/abicheck/report/no_baseline_document.py
+++ b/abicheck/report/no_baseline_document.py
@@ -171,6 +171,7 @@ NO_BASELINE_UNSUPPORTED_FORMATS = frozenset({"html", "review"})
 #: `[exit 7]` with no word about the missed evidence contract (Codex review,
 #: P2). :func:`render_no_baseline_oneline` asserts the two tables agree.
 NO_BASELINE_EXIT_AXIS_LABELS: dict[str, str] = {
+    "audit_gate": "audit-gate finding",
     "contract_coverage": "contract coverage incomplete",
     "analysis_assurance": "analysis assurance incomplete",
     "evidence_contract": "evidence contract not met",
@@ -179,6 +180,12 @@ NO_BASELINE_EXIT_AXIS_LABELS: dict[str, str] = {
 }
 
 NO_BASELINE_EXIT_AXIS_NOTICES: dict[str, str] = {
+    "audit_gate": (
+        "**Audit-gate finding** -- `--severity-preset` opted this audit into "
+        "gating, and at least one candidate-side finding is classified "
+        "`BREAKING`/`API_BREAK` (ADR-068 2026-09-10 amendment). This is "
+        "orthogonal to the compatibility family: an audit never emits `2`/`4`."
+    ),
     "contract_coverage": (
         "**Contract coverage incomplete** -- the selected `--contract` domain's "
         "required evidence was not fully available on this candidate "

--- a/action/run.sh
+++ b/action/run.sh
@@ -2688,6 +2688,22 @@ fi
 # `headers`, never deeper). Routing that case onto `compare` would silently
 # cap a high-risk change that should have reached source replay at L2.
 #
+# ADR-068's 2026-09-10 amendment closed the one exit-code capability gap
+# that a `compare --no-baseline` migration for a *gating* audit-only job
+# would otherwise hit (legacy `scan`'s audit mode gates at exit 2 on an
+# `API_BREAK`-classified hygiene finding; `compare --no-baseline` now
+# reproduces that at its own orthogonal exit 3, opt-in via
+# `--severity-preset`, see `policy/audit_gate_exit.py`). This does **not**
+# by itself change the routing above -- audit-only `mode: scan` stays on
+# the legacy CLI unconditionally until the other gaps this comment block
+# names (`--sources`/`--build-info`/`--depth`/cross-toolchain flags,
+# secondary `--write`, `--dry-run`) also close. When that migration lands,
+# translating a gating audit-only `mode: scan` job means passing
+# `--severity-preset` through to the assembled `compare --no-baseline`
+# invocation and mapping its exit `3` to a new `AUDIT_GATE` verdict here,
+# alongside `COVERAGE_INCOMPLETE`/`SEVERITY_ERROR` below -- not folding it
+# into the generic `ERROR` arm.
+#
 # `_CLI_MODE` (this section's own output) is the actual underlying CLI verb
 # this run dispatches -- "scan" or "compare" -- and is what every
 # downstream exit-code/PR-comment/output section below keys off from here

--- a/changelog.d/20260910_182341_noreply_serene_fermat_cyx0jt.md
+++ b/changelog.d/20260910_182341_noreply_serene_fermat_cyx0jt.md
@@ -1,0 +1,10 @@
+### Added
+
+- **`compare --no-baseline` audit-gate exit axis** — a new orthogonal exit
+  code (`3`), opt-in via `--severity-preset` (previously a usage error under
+  `--no-baseline`), lets a CI job gate on a candidate-side audit finding
+  classified `BREAKING`/`API_BREAK` without an audit ever emitting the
+  compatibility family's `2`/`4` codes (ADR-068 D2). Reproduces legacy
+  `scan`'s audit-mode gating exactly, closing the last-named blocker on
+  `scan`'s eventual retirement. See `policy/audit_gate_exit.py` and
+  ADR-068's 2026-09-10 amendment.

--- a/changelog.d/20260910_185828_noreply_serene_fermat_cyx0jt.md
+++ b/changelog.d/20260910_185828_noreply_serene_fermat_cyx0jt.md
@@ -1,0 +1,14 @@
+### Security
+
+- **`compare --no-baseline`'s audit-gate axis now reads the policy-effective
+  verdict, not a finding's raw `ChangeKind` category** — the axis added
+  earlier the same day gated on `BREAKING_KINDS`/`API_BREAK_KINDS`
+  membership computed straight from `change.kind`, so a `--policy`
+  `overrides:`/`reclassify:` rule promoting a normally-`RISK`-classified
+  finding to breaking was silently invisible to it: a CI job that had
+  explicitly asked to gate could still exit `0` on an unsuppressed,
+  policy-promoted finding. `policy/audit_gate_exit.py` now reads each
+  finding's already-resolved `.verdict`
+  (`policy.severity.effective_verdict_for_change`), the same value every
+  other renderer honors. Found by an automated Codex security review on the
+  introducing PR, fixed before merge.

--- a/docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md
+++ b/docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md
@@ -612,6 +612,47 @@ axis alongside the other `max`-folded axes) cover the module directly.
 **Status.** Implemented. `docs/contribute/known-gaps.md`'s matching entry
 is updated to record this as closed.
 
+### Correction (2026-09-10, same day): the gating rule reads the effective verdict, not the raw kind
+
+A Codex security review on the PR implementing this amendment (P1) found a
+real gap in the paragraph above titled "Why the axis does not route through
+`severity.py`'s category model": reading `BREAKING_KINDS`/`API_BREAK_KINDS`
+membership off a finding's *raw* `change.kind` is correct only on the
+un-policied G20 corpus. The moment a run supplies `--policy` (a document
+this repository's `SECURITY.md` treats as trusted, unlike the analyzed
+binary itself), an `overrides:`/`reclassify:` rule can promote a normally
+`RISK`-classified finding (e.g. `case143`'s `exported_not_public`) to
+`Verdict.BREAKING` — every other consumer of a finding's classification in
+this codebase (the JSON/Markdown/SARIF/JUnit renderers, the two-sided gate)
+reads that *effective*, policy-resolved verdict via `policy.severity.
+effective_verdict_for_change`, but this axis's first revision did not, so
+the promotion was silently invisible to it: an untrusted candidate artifact
+could still exit `0` under an explicitly-selected policy that had named its
+finding breaking.
+
+Fixed the same day, before merge, by changing `audit_gate_exit_contribution`
+to read each finding's already-resolved `.verdict` (a
+`report.finding.ReportFinding`, produced by `build_report_findings` /
+`effective_verdict_for_change`) and compare it against `Verdict.BREAKING`/
+`Verdict.API_BREAK` directly, instead of importing the raw `BREAKING_KINDS`/
+`API_BREAK_KINDS` sets. This is "read, don't re-derive" applied to this
+axis, matching how every other renderer already reads classification — it
+does not change the decision stated above (the axis still does not route
+through `severity.py`'s coarser `IssueCategory`/`potential_breaking`
+bucket, which stays merged with `RISK_KINDS` for the reason already given),
+it corrects which representation of "does this finding's classification
+gate" the axis reads. `policy/audit_gate_exit.py` stays a leaf module with
+no new upward dependency: it reads a duck-typed `.verdict` attribute rather
+than importing `report.finding.ReportFinding` itself, preserving the
+`policy -> report` dependency direction this repository's architecture
+gate enforces. Regression coverage: `tests/test_audit_gate_exit.py::
+TestAuditGateExitContribution::test_a_policy_promoted_verdict_gates` (unit
+level) and `tests/parity/test_no_baseline_audit_corpus_parity.py::
+test_audit_gate_axis_honors_a_policy_promoted_verdict` (live, an
+`overrides:` policy document promoting `case143`'s finding, verified to
+flip its exit code from `0` to `3` with no change to which finding is
+reported).
+
 ## Alternatives considered
 
 **Keep `scan`, make `compare` call into it.** Rejected: it preserves two

--- a/docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md
+++ b/docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md
@@ -470,6 +470,148 @@ steps), since audit-only `mode: scan` still needs the legacy CLI until that
 closes. Only the two (c) items (`--budget`, the depth evidence-contract
 floor) are implemented in this commit, on `compare` itself.
 
+## Amendment (2026-09-10): the audit-gate exit axis
+
+`docs/contribute/known-gaps.md`'s "no way to gate a CI job on an audit
+finding" entry (added by the 2026-09-09 amendment above) named a real,
+user-facing regression the D2/D3 migration introduces on its own: legacy
+`scan`'s audit mode derives a *verdict* from its own candidate-side
+findings and exits `2` when one is `API_BREAK`-classified — verified live,
+`scan` on `case148_xcheck_header_build_mismatch`'s and
+`case149_xcheck_odr_variant`'s committed snapshots exits `2`, while
+`case143_audit_accidental_export`'s `RISK`-classified finding exits `0`.
+`compare --no-baseline` exits `0` for all three, correctly, per D2 — an
+audit reports no compatibility verdict, and `2` is that family's own
+source-break code. The consequence is that a `scan`-based gating CI job has
+no `compare --no-baseline` equivalent it can migrate to. This amendment
+closes that gap without reopening D2: no `--no-baseline` run may ever emit
+`2` or `4`.
+
+### Decision: a new orthogonal axis, exit code `3`, opt-in via `--severity-preset`
+
+**The axis.** `policy/audit_gate_exit.py`'s
+`audit_gate_exit_contribution` reproduces legacy `scan`'s own partition —
+`BREAKING_KINDS | API_BREAK_KINDS` gates, `RISK_KINDS`/`COMPATIBLE_KINDS`
+does not — over the audit's already-computed `findings[]`, and contributes
+exactly one new code, `3`, folded with `max` exactly like every other
+orthogonal axis this codebase already has (`contract_coverage_exit.py`,
+`depth_evidence_contract.py`, `analysis_assurance.py`): it can raise a
+clean `0`, and it can never lower, or be mistaken for, a `2`/`4` — D2's
+invariant, unchanged.
+
+**Why `3`.** Surveyed against every code `compare`/`scan --against`
+currently emit (`docs/reference/exit-codes.md`, `severity.py`'s
+`_CATEGORY_EXIT_CODES`, `contract_coverage_exit.py`,
+`depth_evidence_contract.py`/`exit_decision_precedence.py`,
+ADR-065's completeness axis): `0` (clean), `1` (severity-aware error /
+contract-coverage / analysis-assurance / incomplete-scope), `2`
+(compatibility source-break — reserved, per D2, never emitted by an
+audit), `4` (compatibility ABI-break — reserved, same reason), `5`
+(budget overflow), `6` (not-comparable, legacy scheme), `7` (evidence
+contract), `8` (removed required library), `64` (usage error). `3` is the
+one small integer in that family no axis currently uses.
+
+**Opt-in, not on by default — and reusing `--severity-preset` rather than a
+new flag.** Two designs were weighed:
+
+- *(a) default-on.* Every existing `compare --no-baseline` invocation's
+  exit code would change the moment this axis has anything to say, with no
+  action from the caller. This repository's own contract ("don't change a
+  public interface without an ADR and migration") forbids exactly this
+  unless the ADR explicitly accepts the cost, and there is no offsetting
+  benefit: a CI job that was never told to gate on audit findings should
+  not silently start failing.
+- *(b) opt-in.* The axis contributes `0` unless the invocation explicitly
+  asked for it, so every pre-existing invocation is bit-for-bit unchanged.
+  The cost is the mirror image of (a): a `scan`-to-`compare --no-baseline`
+  migration that forgets to opt in gets a *silently non-gating* job where
+  `scan` used to gate — exactly the "record before disposing" risk
+  `vision.md` warns about, except on the *exit code* rather than a
+  finding. This is mitigated, not eliminated, by making the opt-in the
+  same flag a `scan`-based gating job already had reason to reach for:
+
+Adopted: **(b), opt-in, activated by passing `--severity-preset`** (any
+value except `info-only`) to `compare --no-baseline`. Before this
+amendment, `--severity-preset` under `--no-baseline` was a hard usage
+error (exit `64`) naming this exact gap
+(`no_baseline_rulings._UNSUPPORTED_OPTIONS["severity_preset"]`); it is now
+legal there, and passing it is the declaration. This was chosen over a
+bespoke `--audit-gate` boolean for two reasons: it reuses a flag every
+`scan`-migrating CI author already reaches for to express "I want this run
+to gate" on a two-sided `compare`, rather than teaching a second spelling
+of the same intent; and it gives the migration guidance a single, concrete
+sentence — *"a `scan`-based gating job must add `--severity-preset
+default` (or `strict`) to its `compare --no-baseline` invocation to keep
+gating on a hygiene finding; a non-gating job needs no change."*
+`info-only` (`SeverityLevel.INFO` on every category, the same "don't gate
+anything" request it is on a two-sided `compare`) is the one preset value
+that does **not** enable the axis — `audit_gate_enabled_for_severity_preset`
+is the single function this decision is read from, so the CLI and any
+future typed-API caller cannot drift on what "opted in" means.
+
+**Why the axis does not route through `severity.py`'s category model,
+even though `--severity-preset` activates it.** `severity.py`'s own
+`IssueCategory`/`SeverityConfig` split findings into four buckets, and by
+that module's own docstring `potential_breaking` is **`API_BREAK_KINDS ∪
+RISK_KINDS`** — deliberately merged, because a severity preset answers "how
+strict should review-worthy findings be", not "does this specific finding
+require recompilation". Routing this axis's own gating rule through that
+bucket (option (a) named in the module map's own task description) would
+have gated `case143`'s `RISK`-classified finding identically to
+`case148`/`case149`'s `API_BREAK`-classified ones the moment
+`potential_breaking` reached `error` — reintroducing, under a different
+name, the exact over-gating regression the reproduction requirement this
+amendment was written against forbids. So `--severity-preset`'s *value* is
+read only as the activation signal (`info-only` or not); the axis's own
+gating rule reads `BREAKING_KINDS`/`API_BREAK_KINDS` membership directly,
+unchanged from what legacy `scan` computed. This reuses the registry-
+derived classification sets `checker_policy.py` already exports, per this
+file's own "Adding a new ChangeKind" procedure — it does not invent a
+second taxonomy.
+
+**What is, and is not, wired.** The axis is folded into
+`report/no_baseline.py`'s `no_baseline_exit_code`/
+`compute_no_baseline_document` (every format — `json`, `markdown`, `sarif`,
+`junit`, `oneline` — reads the same resolved `exit_axes`/`exit_code`), and
+the native `compare --no-baseline` CLI
+(`frontends/cli/commands/compare_no_baseline.py`) derives the opt-in from
+the resolved `--severity-preset` value. The typed Python API does not carry
+`--no-baseline` at all yet (`CompareRequest`/`CompareResult` have no
+`declared_absent`/audit-mode field — verified, no reference anywhere under
+`service*.py`/`checker_types.py`), so there is no `CompareResult`-shaped
+consumer to extend today; this stays true to "read, don't re-derive" by
+having exactly one axis owner (`policy/audit_gate_exit.py`) ready for that
+front end the day it exists, rather than duplicating the rule into a second
+module now. The composite GitHub Action does not invoke
+`compare --no-baseline` for `mode: scan`'s audit-only path either — the
+2026-09-09 amendment above records that audit-only `mode: scan` still
+routes to the legacy `scan` CLI unconditionally, pending a separate,
+already-tracked gap (`compare --no-baseline` gaining parity on
+`--sources`/`--build-info`/`--depth`/cross-toolchain flags and `--dry-run`
+honored there). There is therefore no live `action/run.sh` call site to
+translate `mode: scan`'s existing gating behavior onto today; when that
+migration lands, translating a gating `mode: scan` job means passing
+`--severity-preset` through to the `compare --no-baseline` invocation it
+assembles, and labelling exit `3` in the Action's own verdict vocabulary
+(a new `AUDIT_GATE` verdict, alongside `COVERAGE_INCOMPLETE`/
+`SEVERITY_ERROR`) rather than folding it into the generic `ERROR` arm.
+
+**Verification.** `tests/parity/test_no_baseline_audit_corpus_parity.py`
+extends the G20 corpus with `test_audit_gate_axis_matches_legacy_scan_
+gating` (every one of the eleven fixtures, with `--severity-preset
+default`: `case148`/`case149` exit `3`, every other fixture — `case143`
+included — exits `0`), `test_audit_gate_axis_requires_opt_in` (no flag,
+every fixture stays `0`), `test_audit_gate_axis_disabled_by_info_only_
+preset`, and `test_scan_baseline_exit_codes_documented_for_the_gated_
+fixtures` (pins the legacy `scan` exit codes this whole amendment is
+measured against, on the same committed snapshots). Unit tests
+(`tests/test_audit_gate_exit.py`) and a property test
+(`tests/test_audit_gate_exit_properties.py`, generated combinations of this
+axis alongside the other `max`-folded axes) cover the module directly.
+
+**Status.** Implemented. `docs/contribute/known-gaps.md`'s matching entry
+is updated to record this as closed.
+
 ## Alternatives considered
 
 **Keep `scan`, make `compare` call into it.** Rejected: it preserves two

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -6796,18 +6796,45 @@ committed snapshots exits `2`, while `case143`'s `RISK`-classified finding
 exits `0`. `compare --no-baseline` exits `0` for all of them: ADR-068 D2 says
 an audit reports no compatibility verdict, and `2` is the compatibility
 family's own source-break code, so emitting it would be manufacturing
-exactly the signal D2 forbids. The CLI is at least loud rather than silently
-ignoring the request — `--severity-preset` with `--no-baseline` is a usage
-error (exit `64`) naming this reason, not a no-op.
+exactly the signal D2 forbids. The CLI was at least loud rather than
+silently ignoring the request — `--severity-preset` with `--no-baseline`
+used to be a usage error (exit `64`) naming this reason, not a no-op.
 
-The gap is that there is then **no** way to gate a CI job on an audit finding
-today, which a `scan` user migrating a gating job needs. Closing it means an
-orthogonal audit-gate axis (its own exit code, folded with `max` like the
-coverage and evidence-contract axes, never `2`/`4`), plus deciding whether it
-is on by default or opt-in — an ADR-068 amendment, not a bug fix, which is
-why this PR records it rather than inventing the semantics. Until then
-`scan` must stay reachable for a gating audit job, and its retirement (§3 of
-`docs/contribute/plans/one-comparison-product.md`) is blocked on this.
+**Closed (2026-09-10 ADR-068 amendment).** `policy/audit_gate_exit.py` adds
+the orthogonal audit-gate axis this entry called for: its own exit code
+(`3` — surveyed against every code `compare`/`scan --against` already use,
+the one small integer none of them claims), folded with `max` exactly like
+the coverage and evidence-contract axes, so it can raise a clean `0` and can
+never lower or be mistaken for a `2`/`4`. It is **opt-in**, not on by
+default (every pre-existing `compare --no-baseline` invocation's exit code
+is unchanged), activated by passing `--severity-preset` (any value except
+`info-only`) — that option is no longer a usage error under
+`--no-baseline`; passing it is now the declaration. The axis's own gating
+rule reproduces legacy `scan`'s exact partition — `BREAKING_KINDS |
+API_BREAK_KINDS` gates, `RISK_KINDS`/`COMPATIBLE_KINDS` does not — read
+directly off `checker_policy.py`'s registry-derived sets, deliberately
+*not* routed through `severity.py`'s own four-bucket category model (that
+model's `potential_breaking` bucket is `API_BREAK_KINDS ∪ RISK_KINDS`,
+merged by design, which would have gated `case143`'s `RISK`-classified
+finding the same as `case148`/`case149`'s `API_BREAK`-classified ones —
+see the ADR amendment for the full reasoning this entry's fix rejected).
+Verified against the exact reproduction this entry asked for:
+`tests/parity/test_no_baseline_audit_corpus_parity.py`'s
+`test_audit_gate_axis_matches_legacy_scan_gating` runs the whole G20 corpus
+with `--severity-preset default` and asserts `case148`/`case149` exit `3`
+while every other fixture, `case143` included, stays `0` — the same split
+`test_scan_baseline_exit_codes_documented_for_the_gated_fixtures` pins for
+legacy `scan` itself on the same committed snapshots. The typed Python API
+carries no `--no-baseline` support at all yet, so there is no
+`CompareResult`-shaped consumer to extend today; the composite Action does
+not invoke `compare --no-baseline` for `mode: scan` either (the 2026-09-09
+amendment above already records that gap as separately blocked), so there
+is no live `action/run.sh` call site to translate onto today — both are
+recorded as the amendment's own residual scope, not silently dropped. See
+[ADR-068's 2026-09-10 amendment](adr/068-one-comparison-product-and-scan-retirement.md#amendment-2026-09-10-the-audit-gate-exit-axis)
+for the full account. `scan`'s retirement (§3 of
+`docs/contribute/plans/one-comparison-product.md`) is no longer blocked on
+this gap specifically; the plan's own tracking is updated to match.
 
 **An audit's contract-coverage ledger still names an `old` side.** Now that
 `compare --no-baseline --contract public` publishes

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -809,6 +809,20 @@ section's *actual* state, not the target it originally described:
   `compare --no-baseline` and their "blocked on this gap" annotations
   removed.
 
+  **The exit-code gating gap is also closed (2026-09-10 ADR-068
+  amendment).** `docs/contribute/known-gaps.md`'s "no way to gate a CI job
+  on an audit finding" entry — legacy `scan`'s audit mode gates at exit `2`
+  on an `API_BREAK`-classified hygiene finding, which `compare
+  --no-baseline` could not reproduce without violating D2 — is closed by a
+  new orthogonal audit-gate axis (`policy/audit_gate_exit.py`, exit code
+  `3`, opt-in via `--severity-preset`). This closes the one named blocker
+  that gap put on this phase's retirement work; it does **not** by itself
+  retire `scan` or move any deletion-order item below forward — the typed
+  API still carries no `--no-baseline` support and the Action still routes
+  audit-only `mode: scan` to the legacy CLI (a separate, already-tracked
+  gap), both of which remain open prerequisites of their own before Phase 6
+  can proceed past what is recorded here.
+
 ### Phase 5 — Presentation/analysis separation — **done**
 
 - `--explain-patterns` stops implying `--pattern-verdicts`; modulation

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -183,11 +183,12 @@ below fires. Every finding carries its ADR-068 D3 evolution state, which
 with a `declared_absent` OLD is always `persistent` or `not_evaluated`,
 never `introduced`.
 
-Three orthogonal axes still apply exactly as they would for a two-sided
+Four orthogonal axes still apply exactly as they would for a two-sided
 run, folded with the same `max` discipline:
 
 | Axis | Contributes | When |
 |---|---|---|
+| Audit gate (ADR-068 2026-09-10 amendment) | `3` | `--severity-preset` (any value except `info-only`) opted the run into gating, and at least one candidate-side finding is `BREAKING`/`API_BREAK`-classified |
 | Analysis assurance (P0.4) | `1` | `--require-complete-analysis` and `analysis_assurance.status` is not `complete` |
 | Contract coverage (ADR-049 Phase 7) | `1` | `--contract` and the selected domain's required evidence is incomplete |
 | Evidence contract (ADR-064) | `7` | `--depth build`/`--depth source` pinned, but this run's live extraction did not reach it |
@@ -212,10 +213,28 @@ it cannot have fallen short of a pinned depth.
 `compare --no-baseline` never emits `2`/`4`: an audit reports no
 compatibility verdict (ADR-068 D2), so the compatibility family contributes
 nothing and only the orthogonal axes above can raise its exit code.
-`--severity-preset` is a usage error (`64`) there rather than a no-op.
-Legacy `scan`'s audit mode *did* gate at `2` on an `API_BREAK`-classified
-hygiene finding; that difference, and what closing it would take, is
-recorded in [`known-gaps.md`](../contribute/known-gaps.md).
+
+**The audit-gate axis (ADR-068 2026-09-10 amendment).** Legacy `scan`'s
+audit mode derived a *verdict* from its own findings and gated at `2` on a
+hygiene finding whose kind is `BREAKING`/`API_BREAK`-classified.
+`compare --no-baseline` cannot reproduce that at `2`/`4` (D2 forbids it),
+so it reproduces the same partition through its own code, `3`, and the
+axis is **opt-in**: every invocation that omits `--severity-preset` stays
+exactly as it always was (exit `0` for a hygiene finding, unaffected by
+this axis's existence). Passing `--severity-preset default` (or `strict`)
+opts the run into gating; `--severity-preset info-only` is the explicit
+"don't gate" request and stays `0`. A `scan`-based gating CI job migrating
+to `compare --no-baseline` needs exactly one addition to keep gating:
+`--severity-preset default`. The axis's own rule reads
+`BREAKING_KINDS`/`API_BREAK_KINDS` membership directly (the same sets
+`checker_policy.py`'s registry derives), not `--severity-preset`'s own
+per-category severity mapping — that mapping's `potential_breaking` bucket
+merges `API_BREAK_KINDS` with `RISK_KINDS`, which would gate an advisory-
+only `RISK` finding the same as an `API_BREAK` one; the preset only
+activates the axis, it does not decide which findings gate. See
+`policy/audit_gate_exit.py` and
+[ADR-068's amendment](../contribute/adr/068-one-comparison-product-and-scan-retirement.md#amendment-2026-09-10-the-audit-gate-exit-axis)
+for the full account.
 
 **On `compare --no-baseline` only**, `--dry-run` reports the same condition
 ahead of any analysis: against a *live* candidate, a pinned `--depth build`/

--- a/tests/parity/test_no_baseline_audit_corpus_parity.py
+++ b/tests/parity/test_no_baseline_audit_corpus_parity.py
@@ -248,9 +248,7 @@ def test_audit_gate_axis_requires_opt_in() -> None:
     """
     for case_name in _AUDIT_GATE_SHOULD_FIRE:
         path = _fixture_path(case_name, "snapshot.abi.json")
-        result = invoke_cli(
-            "compare", "--no-baseline", str(path), "--format", "json"
-        )
+        result = invoke_cli("compare", "--no-baseline", str(path), "--format", "json")
         assert result.exit_code == 0, (
             f"{case_name}: audit-gate axis fired without --severity-preset "
             f"(exit {result.exit_code}); it must be opt-in:\n{result.output}"
@@ -297,6 +295,60 @@ def test_scan_baseline_exit_codes_documented_for_the_gated_fixtures() -> None:
     assert result.exit_code == 0, (
         "case143: expected legacy `scan` to stay exit 0 (RISK-classified "
         f"finding), got {result.exit_code}:\n{result.output}"
+    )
+
+
+def test_audit_gate_axis_honors_a_policy_promoted_verdict(tmp_path: Path) -> None:
+    """Regression for a Codex security review finding (P1) on this axis's
+    first revision: it read a finding's *raw* ``ChangeKind`` category
+    (``BREAKING_KINDS``/``API_BREAK_KINDS`` membership) instead of its
+    *effective*, policy-resolved verdict, so an explicitly-selected,
+    trusted ``--policy`` document promoting a normally-RISK finding to
+    BREAKING was silently invisible to the gate -- an untrusted candidate
+    artifact could pass a CI job that had explicitly asked to gate on
+    exactly that promotion. ``case143``'s ``exported_not_public`` finding is
+    RISK-classified by default (does not gate, per
+    ``_AUDIT_GATE_SHOULD_FIRE`` above); this pins that an ``overrides:``
+    policy promoting it to ``break`` (``Verdict.BREAKING``) flips the axis
+    to fire, exit 3, even though the raw finding kind never changed.
+    """
+    policy_path = tmp_path / "promote_exported_not_public.yml"
+    policy_path.write_text("overrides:\n  exported_not_public: break\n")
+    path = _fixture_path("case143_audit_accidental_export", "snapshot.abi.json")
+
+    # Baseline: case143 does not gate under the built-in default policy.
+    baseline = invoke_cli(
+        "compare",
+        "--no-baseline",
+        str(path),
+        "--format",
+        "json",
+        "--severity-preset",
+        "default",
+    )
+    assert baseline.exit_code == 0, baseline.output
+    assert json.loads(baseline.stdout)["exit_axes"]["audit_gate"] == 0
+
+    # With the override in effect, the same fixture's same finding must gate.
+    promoted = invoke_cli(
+        "compare",
+        "--no-baseline",
+        str(path),
+        "--format",
+        "json",
+        "--severity-preset",
+        "default",
+        "--policy",
+        str(policy_path),
+    )
+    report = json.loads(promoted.stdout)
+    assert promoted.exit_code == 3, (
+        f"a --policy override promoting case143's finding to BREAKING must "
+        f"gate the audit (exit 3), got {promoted.exit_code}:\n{promoted.output}"
+    )
+    assert report["exit_axes"]["audit_gate"] == 3
+    assert {f["kind"] for f in report["findings"]} == {"exported_not_public"}, (
+        "the override must not change which finding is reported, only whether it gates"
     )
 
 

--- a/tests/parity/test_no_baseline_audit_corpus_parity.py
+++ b/tests/parity/test_no_baseline_audit_corpus_parity.py
@@ -179,23 +179,125 @@ def test_no_baseline_exit_code_is_clean_without_a_contract(
 ) -> None:
     """An audit's hygiene findings never gate on their own (ADR-028 D3 /
     ADR-035 D1: they stay advisory), and without ``--contract`` there is no
-    coverage axis either -- so every fixture exits 0. This is what makes the
-    exit-1 contract case below a real signal rather than noise.
-
-    This is a *deliberate* difference from legacy ``scan``, not an
-    unexamined baseline: ``scan`` derives a verdict from the same findings
-    and exits ``2`` on the two fixtures whose finding kind is
-    ``API_BREAK``-classified (case148, case149). ADR-068 D2 forbids an audit
-    reporting a compatibility verdict, and ``2`` is that family's own code,
-    so the audit cannot emit it. The consequence -- there is no way to gate
-    a CI job on an audit finding yet -- is recorded in
-    ``docs/contribute/known-gaps.md`` as an open ADR-068 amendment, and this
-    assertion is what would fail first if an audit-gate axis ever landed
-    without that decision being made.
+    coverage axis either -- so every fixture exits 0 *without*
+    ``--severity-preset`` (the audit-gate axis's opt-in). This is what makes
+    the exit-3 audit-gate case below a real signal rather than noise.
     """
     path = _fixture_path(case_name, filename)
     result = invoke_cli("compare", "--no-baseline", str(path), "--format", "json")
     assert result.exit_code == 0, result.output
+
+
+#: The two fixtures whose finding kind is ``API_BREAK``-classified -- the
+#: ones legacy ``scan``'s own verdict computation gated at exit ``2`` on
+#: these committed snapshots (verified live, per the ADR-068 2026-09-09
+#: amendment and its 2026-09-10 audit-gate follow-up). Everything else in
+#: the corpus, including ``case143`` (``RISK``-classified), must not gate.
+_AUDIT_GATE_SHOULD_FIRE = frozenset(
+    {"case148_xcheck_header_build_mismatch", "case149_xcheck_odr_variant"}
+)
+
+
+@pytest.mark.parametrize(("case_name", "filename"), G20_AUDIT_FIXTURES)
+def test_audit_gate_axis_matches_legacy_scan_gating(
+    case_name: str, filename: str
+) -> None:
+    """ADR-068's 2026-09-10 amendment: with ``--severity-preset default``
+    (the opt-in), the audit-gate axis must reproduce exactly which fixtures
+    legacy ``scan`` gated on -- case148/case149 (``API_BREAK``-classified),
+    never case143 (``RISK``-classified) or any other fixture in the corpus.
+    The gated exit code is always ``3`` (never ``2``/``4``, which stay
+    reserved for a real compatibility verdict an audit cannot produce, per
+    ADR-068 D2).
+    """
+    path = _fixture_path(case_name, filename)
+    result = invoke_cli(
+        "compare",
+        "--no-baseline",
+        str(path),
+        "--format",
+        "json",
+        "--severity-preset",
+        "default",
+    )
+    report = json.loads(result.stdout)
+    if case_name in _AUDIT_GATE_SHOULD_FIRE:
+        assert result.exit_code == 3, (
+            f"{case_name}/{filename}: expected the audit-gate axis to fire "
+            f"(exit 3), got {result.exit_code}:\n{result.output}"
+        )
+        assert report["exit_axes"]["audit_gate"] == 3
+    else:
+        assert result.exit_code == 0, (
+            f"{case_name}/{filename}: audit-gate axis fired unexpectedly "
+            f"(exit {result.exit_code}), but this fixture's findings are not "
+            f"BREAKING/API_BREAK-classified:\n{result.output}"
+        )
+        assert report["exit_axes"]["audit_gate"] == 0
+    # Verdict/changes/compatibility stay exactly as ADR-068 D2 requires,
+    # opt-in gating included -- the axis never manufactures a compatibility
+    # signal, it only raises the process exit code.
+    assert report["verdict"] is None
+    assert report["changes"] == []
+
+
+def test_audit_gate_axis_requires_opt_in() -> None:
+    """Without ``--severity-preset``, case148/case149 stay exit 0 -- the
+    axis is opt-in (ADR-068 2026-09-10 amendment), so every pre-existing
+    ``compare --no-baseline`` invocation is unaffected by its existence.
+    """
+    for case_name in _AUDIT_GATE_SHOULD_FIRE:
+        path = _fixture_path(case_name, "snapshot.abi.json")
+        result = invoke_cli(
+            "compare", "--no-baseline", str(path), "--format", "json"
+        )
+        assert result.exit_code == 0, (
+            f"{case_name}: audit-gate axis fired without --severity-preset "
+            f"(exit {result.exit_code}); it must be opt-in:\n{result.output}"
+        )
+
+
+def test_audit_gate_axis_disabled_by_info_only_preset() -> None:
+    """``--severity-preset info-only`` stays the explicit no-gate request --
+    the one preset value :data:`abicheck.policy.audit_gate_exit.
+    SEVERITY_PRESET_DISABLES_AUDIT_GATE` names.
+    """
+    for case_name in _AUDIT_GATE_SHOULD_FIRE:
+        path = _fixture_path(case_name, "snapshot.abi.json")
+        result = invoke_cli(
+            "compare",
+            "--no-baseline",
+            str(path),
+            "--format",
+            "json",
+            "--severity-preset",
+            "info-only",
+        )
+        assert result.exit_code == 0, (
+            f"{case_name}: --severity-preset info-only must not gate "
+            f"(exit {result.exit_code}):\n{result.output}"
+        )
+
+
+def test_scan_baseline_exit_codes_documented_for_the_gated_fixtures() -> None:
+    """Pins the legacy ``scan`` exit codes this whole corpus is measured
+    against, on the committed snapshots, so a drift in the fixtures (not
+    just in ``compare --no-baseline``) is caught here rather than only in
+    prose. Verified live per the module docstring and ADR-068's amendments.
+    """
+    for case_name in _AUDIT_GATE_SHOULD_FIRE:
+        path = _fixture_path(case_name, "snapshot.abi.json")
+        result = invoke_cli("scan", str(path), "--format", "json")
+        assert result.exit_code == 2, (
+            f"{case_name}: expected legacy `scan` to gate at exit 2 on its "
+            f"committed snapshot, got {result.exit_code}:\n{result.output}"
+        )
+    path = _fixture_path("case143_audit_accidental_export", "snapshot.abi.json")
+    result = invoke_cli("scan", str(path), "--format", "json")
+    assert result.exit_code == 0, (
+        "case143: expected legacy `scan` to stay exit 0 (RISK-classified "
+        f"finding), got {result.exit_code}:\n{result.output}"
+    )
 
 
 def test_scan_and_no_baseline_agree_on_the_whole_corpus() -> None:

--- a/tests/test_audit_gate_exit.py
+++ b/tests/test_audit_gate_exit.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for :mod:`abicheck.policy.audit_gate_exit` (ADR-068's
+2026-09-10 amendment).
+
+Directly against the leaf module, not only through the CLI -- the parity
+corpus (``tests/parity/test_no_baseline_audit_corpus_parity.py``) proves the
+axis reproduces legacy ``scan``'s gating on eleven real fixtures; this
+module states the underlying contract and a property test
+(``tests/test_audit_gate_exit_properties.py``) searches generated inputs
+for a counterexample, per ``AGENTS.md``'s bug-class regression-testing rule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from abicheck.checker_policy import ChangeKind
+from abicheck.policy.audit_gate_exit import (
+    AUDIT_GATE_EXIT_CODE,
+    SEVERITY_PRESET_DISABLES_AUDIT_GATE,
+    audit_gate_enabled_for_severity_preset,
+    audit_gate_exit_contribution,
+    fold_audit_gate_exit,
+)
+from abicheck.policy.classification import (
+    API_BREAK_KINDS,
+    BREAKING_KINDS,
+    COMPATIBLE_KINDS,
+    RISK_KINDS,
+)
+
+
+@dataclass
+class _FakeChange:
+    kind: ChangeKind
+
+
+@dataclass
+class _FakeFinding:
+    change: _FakeChange
+
+
+def _breaking_kind() -> ChangeKind:
+    return next(iter(BREAKING_KINDS))
+
+
+def _api_break_kind() -> ChangeKind:
+    return next(iter(API_BREAK_KINDS))
+
+
+def _risk_kind() -> ChangeKind:
+    return next(iter(RISK_KINDS))
+
+
+def _compatible_kind() -> ChangeKind:
+    return next(iter(COMPATIBLE_KINDS))
+
+
+class TestAuditGateExitCode:
+    def test_never_two_or_four(self) -> None:
+        """ADR-068 D2's own invariant, restated as a literal fact about the
+        constant: the axis's own code must never collide with the
+        compatibility family's source-break codes."""
+        assert AUDIT_GATE_EXIT_CODE not in (2, 4)
+
+    def test_not_zero(self) -> None:
+        assert AUDIT_GATE_EXIT_CODE != 0
+
+
+class TestAuditGateEnabledForSeverityPreset:
+    def test_none_is_disabled(self) -> None:
+        assert audit_gate_enabled_for_severity_preset(None) is False
+
+    def test_info_only_is_disabled(self) -> None:
+        assert (
+            audit_gate_enabled_for_severity_preset(
+                SEVERITY_PRESET_DISABLES_AUDIT_GATE
+            )
+            is False
+        )
+        assert SEVERITY_PRESET_DISABLES_AUDIT_GATE == "info-only"
+
+    @pytest.mark.parametrize("preset", ["default", "strict"])
+    def test_other_presets_are_enabled(self, preset: str) -> None:
+        assert audit_gate_enabled_for_severity_preset(preset) is True
+
+
+class TestAuditGateExitContribution:
+    def test_disabled_is_always_zero(self) -> None:
+        """Even a BREAKING-classified finding contributes 0 when the axis
+        was never opted into -- the opt-in gate is checked before anything
+        about the findings themselves."""
+        findings = [_FakeFinding(_FakeChange(_breaking_kind()))]
+        assert audit_gate_exit_contribution(findings, enabled=False) == 0
+
+    def test_empty_findings_is_zero(self) -> None:
+        assert audit_gate_exit_contribution([], enabled=True) == 0
+
+    def test_breaking_kind_gates(self) -> None:
+        findings = [_FakeFinding(_FakeChange(_breaking_kind()))]
+        assert (
+            audit_gate_exit_contribution(findings, enabled=True)
+            == AUDIT_GATE_EXIT_CODE
+        )
+
+    def test_api_break_kind_gates(self) -> None:
+        """case148/case149's own classification -- the exact reproduction
+        this axis exists for."""
+        findings = [_FakeFinding(_FakeChange(_api_break_kind()))]
+        assert (
+            audit_gate_exit_contribution(findings, enabled=True)
+            == AUDIT_GATE_EXIT_CODE
+        )
+
+    def test_risk_kind_does_not_gate(self) -> None:
+        """case143's own classification -- the exact regression this axis
+        must not reintroduce."""
+        findings = [_FakeFinding(_FakeChange(_risk_kind()))]
+        assert audit_gate_exit_contribution(findings, enabled=True) == 0
+
+    def test_compatible_kind_does_not_gate(self) -> None:
+        findings = [_FakeFinding(_FakeChange(_compatible_kind()))]
+        assert audit_gate_exit_contribution(findings, enabled=True) == 0
+
+    def test_one_gating_finding_among_many_non_gating_ones_still_gates(self) -> None:
+        findings = [
+            _FakeFinding(_FakeChange(_risk_kind())),
+            _FakeFinding(_FakeChange(_compatible_kind())),
+            _FakeFinding(_FakeChange(_api_break_kind())),
+        ]
+        assert (
+            audit_gate_exit_contribution(findings, enabled=True)
+            == AUDIT_GATE_EXIT_CODE
+        )
+
+    def test_accepts_bare_change_objects_too(self) -> None:
+        """A caller may pass bare ``Change``-shaped objects (``.kind``
+        directly), not only ``ReportFinding``-shaped ones (``.change.kind``)
+        -- both shapes appear across this codebase's call sites."""
+        assert (
+            audit_gate_exit_contribution([_FakeChange(_breaking_kind())], enabled=True)
+            == AUDIT_GATE_EXIT_CODE
+        )
+
+
+class TestFoldAuditGateExit:
+    def test_raises_a_clean_zero(self) -> None:
+        assert fold_audit_gate_exit(0, AUDIT_GATE_EXIT_CODE) == AUDIT_GATE_EXIT_CODE
+
+    def test_never_lowers_a_higher_base(self) -> None:
+        assert fold_audit_gate_exit(7, AUDIT_GATE_EXIT_CODE) == 7
+
+    def test_zero_contribution_never_raises(self) -> None:
+        assert fold_audit_gate_exit(0, 0) == 0

--- a/tests/test_audit_gate_exit.py
+++ b/tests/test_audit_gate_exit.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 
 import pytest
 
-from abicheck.checker_policy import ChangeKind
 from abicheck.policy.audit_gate_exit import (
     AUDIT_GATE_EXIT_CODE,
     SEVERITY_PRESET_DISABLES_AUDIT_GATE,
@@ -24,38 +23,23 @@ from abicheck.policy.audit_gate_exit import (
     audit_gate_exit_contribution,
     fold_audit_gate_exit,
 )
-from abicheck.policy.classification import (
-    API_BREAK_KINDS,
-    BREAKING_KINDS,
-    COMPATIBLE_KINDS,
-    RISK_KINDS,
-)
-
-
-@dataclass
-class _FakeChange:
-    kind: ChangeKind
+from abicheck.policy.classification import Verdict
 
 
 @dataclass
 class _FakeFinding:
-    change: _FakeChange
+    """Stands in for a :class:`~abicheck.report.finding.ReportFinding` --
+    only the ``.verdict`` attribute the axis actually reads."""
+
+    verdict: Verdict
 
 
-def _breaking_kind() -> ChangeKind:
-    return next(iter(BREAKING_KINDS))
+@dataclass
+class _FakeChangeWithNoVerdict:
+    """A raw, unresolved object (e.g. ``Change``) that carries no
+    ``.verdict`` at all -- must never be mistaken for a gating finding."""
 
-
-def _api_break_kind() -> ChangeKind:
-    return next(iter(API_BREAK_KINDS))
-
-
-def _risk_kind() -> ChangeKind:
-    return next(iter(RISK_KINDS))
-
-
-def _compatible_kind() -> ChangeKind:
-    return next(iter(COMPATIBLE_KINDS))
+    kind: object = None
 
 
 class TestAuditGateExitCode:
@@ -75,9 +59,7 @@ class TestAuditGateEnabledForSeverityPreset:
 
     def test_info_only_is_disabled(self) -> None:
         assert (
-            audit_gate_enabled_for_severity_preset(
-                SEVERITY_PRESET_DISABLES_AUDIT_GATE
-            )
+            audit_gate_enabled_for_severity_preset(SEVERITY_PRESET_DISABLES_AUDIT_GATE)
             is False
         )
         assert SEVERITY_PRESET_DISABLES_AUDIT_GATE == "info-only"
@@ -89,60 +71,71 @@ class TestAuditGateEnabledForSeverityPreset:
 
 class TestAuditGateExitContribution:
     def test_disabled_is_always_zero(self) -> None:
-        """Even a BREAKING-classified finding contributes 0 when the axis
+        """Even a BREAKING-verdict finding contributes 0 when the axis
         was never opted into -- the opt-in gate is checked before anything
         about the findings themselves."""
-        findings = [_FakeFinding(_FakeChange(_breaking_kind()))]
+        findings = [_FakeFinding(Verdict.BREAKING)]
         assert audit_gate_exit_contribution(findings, enabled=False) == 0
 
     def test_empty_findings_is_zero(self) -> None:
         assert audit_gate_exit_contribution([], enabled=True) == 0
 
-    def test_breaking_kind_gates(self) -> None:
-        findings = [_FakeFinding(_FakeChange(_breaking_kind()))]
+    def test_breaking_verdict_gates(self) -> None:
+        findings = [_FakeFinding(Verdict.BREAKING)]
         assert (
-            audit_gate_exit_contribution(findings, enabled=True)
-            == AUDIT_GATE_EXIT_CODE
+            audit_gate_exit_contribution(findings, enabled=True) == AUDIT_GATE_EXIT_CODE
         )
 
-    def test_api_break_kind_gates(self) -> None:
+    def test_api_break_verdict_gates(self) -> None:
         """case148/case149's own classification -- the exact reproduction
         this axis exists for."""
-        findings = [_FakeFinding(_FakeChange(_api_break_kind()))]
+        findings = [_FakeFinding(Verdict.API_BREAK)]
         assert (
-            audit_gate_exit_contribution(findings, enabled=True)
-            == AUDIT_GATE_EXIT_CODE
+            audit_gate_exit_contribution(findings, enabled=True) == AUDIT_GATE_EXIT_CODE
         )
 
-    def test_risk_kind_does_not_gate(self) -> None:
+    def test_risk_verdict_does_not_gate(self) -> None:
         """case143's own classification -- the exact regression this axis
         must not reintroduce."""
-        findings = [_FakeFinding(_FakeChange(_risk_kind()))]
+        findings = [_FakeFinding(Verdict.COMPATIBLE_WITH_RISK)]
         assert audit_gate_exit_contribution(findings, enabled=True) == 0
 
-    def test_compatible_kind_does_not_gate(self) -> None:
-        findings = [_FakeFinding(_FakeChange(_compatible_kind()))]
+    def test_compatible_verdict_does_not_gate(self) -> None:
+        findings = [_FakeFinding(Verdict.COMPATIBLE)]
         assert audit_gate_exit_contribution(findings, enabled=True) == 0
 
     def test_one_gating_finding_among_many_non_gating_ones_still_gates(self) -> None:
         findings = [
-            _FakeFinding(_FakeChange(_risk_kind())),
-            _FakeFinding(_FakeChange(_compatible_kind())),
-            _FakeFinding(_FakeChange(_api_break_kind())),
+            _FakeFinding(Verdict.COMPATIBLE_WITH_RISK),
+            _FakeFinding(Verdict.COMPATIBLE),
+            _FakeFinding(Verdict.API_BREAK),
         ]
         assert (
-            audit_gate_exit_contribution(findings, enabled=True)
-            == AUDIT_GATE_EXIT_CODE
+            audit_gate_exit_contribution(findings, enabled=True) == AUDIT_GATE_EXIT_CODE
         )
 
-    def test_accepts_bare_change_objects_too(self) -> None:
-        """A caller may pass bare ``Change``-shaped objects (``.kind``
-        directly), not only ``ReportFinding``-shaped ones (``.change.kind``)
-        -- both shapes appear across this codebase's call sites."""
+    def test_a_policy_promoted_verdict_gates(self) -> None:
+        """The regression this contract change closes (Codex security
+        review, P1): a ``--policy`` ``overrides:``/``reclassify:`` rule
+        that promotes a finding's *effective* verdict to BREAKING/API_BREAK
+        must gate here even though nothing about its raw ``ChangeKind``
+        changed -- this axis never re-derives a category from the raw kind,
+        it only ever reads the already-resolved ``.verdict``."""
+        findings = [_FakeFinding(Verdict.BREAKING)]
         assert (
-            audit_gate_exit_contribution([_FakeChange(_breaking_kind())], enabled=True)
-            == AUDIT_GATE_EXIT_CODE
+            audit_gate_exit_contribution(findings, enabled=True) == AUDIT_GATE_EXIT_CODE
         )
+
+    def test_an_object_with_no_verdict_attribute_is_never_mistaken_for_gating(
+        self,
+    ) -> None:
+        """A raw, unresolved object (e.g. an unwrapped ``Change``) carries
+        no ``.verdict`` at all and must be skipped, not misread as
+        non-gating *or* gating -- a caller that forgot to resolve findings
+        through ``build_report_findings`` first must never silently gate
+        (or silently fail to), it should simply find nothing to read."""
+        findings = [_FakeChangeWithNoVerdict()]
+        assert audit_gate_exit_contribution(findings, enabled=True) == 0
 
 
 class TestFoldAuditGateExit:

--- a/tests/test_audit_gate_exit_properties.py
+++ b/tests/test_audit_gate_exit_properties.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Orthogonality of the audit-gate axis against the other ``max``-folded
+exit axes, as a generated property rather than a handful of fixed
+combinations (``AGENTS.md``'s bug-class regression-testing rule).
+
+The stated oracle is written out literally here -- ``max`` over the
+generated contributions -- rather than derived from
+``report/no_baseline._no_baseline_exit_axes``/``no_baseline_exit_code``,
+which is the implementation under test. Modeled after
+``tests/test_no_baseline_d3_properties.py``'s shape: a Hypothesis strategy
+over the *shape* of the problem (every axis's set of legal contributions),
+checked against three properties every orthogonal ``max``-folded axis in
+this codebase must satisfy (``contract_coverage_exit.py``'s and
+``depth_evidence_contract.py``'s own module docstrings state the same
+three facts in prose; this is the audit-gate axis's own instance, made
+executable):
+
+1. **Never lowers.** Adding the audit-gate axis's own contribution to a
+   fold can only raise the result, never lower it below what the other
+   axes alone would already produce.
+2. **Never fabricates a compatibility code.** When every contributing axis
+   is a *non-compatibility* axis (contract coverage, evidence contract,
+   analysis assurance, and the audit-gate axis itself -- never the
+   compatibility gate, which this module does not model because an audit
+   never computes one), the folded result is never ``2``/``4`` -- ADR-068
+   D2's own invariant, restated over every combination the real axes can
+   produce rather than only the fixtures the corpus happens to cover.
+3. **Associative / order-independent.** Folding the axes in any order, or
+   two at a time in any grouping, produces the same result -- ``max`` is
+   commutative and associative, and a caller that folds the audit-gate
+   axis in a different place than ``report/no_baseline.py`` does today
+   must still agree.
+"""
+
+from __future__ import annotations
+
+import itertools
+from functools import reduce
+
+from hypothesis import given, strategies as st
+
+from abicheck.policy.audit_gate_exit import AUDIT_GATE_EXIT_CODE, fold_audit_gate_exit
+
+#: Every legal contribution the audit-gate axis can produce, per its own
+#: module contract: `0` (disabled, or enabled with no gating finding) or
+#: exactly `AUDIT_GATE_EXIT_CODE`.
+_AUDIT_GATE_CONTRIBUTIONS = st.sampled_from([0, AUDIT_GATE_EXIT_CODE])
+
+#: The other orthogonal, `max`-folded, non-compatibility axes this codebase
+#: already has (contract coverage: `0`/`1`; evidence contract: `0`/`7`;
+#: analysis assurance: `0`/`1`; ADR-065 completeness: `0`/`1`) -- their own
+#: legal value sets, per `contract_coverage_exit.py`/
+#: `depth_evidence_contract.py`/`analysis_assurance.py`/
+#: `scope_completeness.py`. None of these is `2`/`4` -- those two integers
+#: are reserved for the compatibility family alone, which is exactly what
+#: property 2 below checks holds even after folding every one of these in
+#: alongside the audit-gate axis.
+_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS = st.sampled_from([0, 1, 5, 7, 8])
+
+
+@given(
+    audit_gate=_AUDIT_GATE_CONTRIBUTIONS,
+    others=st.lists(_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS, min_size=0, max_size=5),
+)
+def test_audit_gate_never_lowers_the_fold(
+    audit_gate: int, others: list[int]
+) -> None:
+    without = max([0, *others])
+    with_gate = reduce(fold_audit_gate_exit, others, audit_gate)
+    # `reduce` above folds every "other" axis through the audit-gate axis's
+    # own `fold_audit_gate_exit` (identical `max`), then the two totals are
+    # compared -- folding audit_gate in can only ever raise `without`.
+    assert with_gate >= without
+
+
+@given(
+    audit_gate=_AUDIT_GATE_CONTRIBUTIONS,
+    others=st.lists(_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS, min_size=0, max_size=5),
+)
+def test_folded_result_never_fabricates_a_compatibility_code(
+    audit_gate: int, others: list[int]
+) -> None:
+    """ADR-068 D2: with no compatibility axis contributing at all (an audit
+    never computes one), the fold must never land on `2` or `4` -- those
+    codes are reserved for a real source-break/ABI-break verdict."""
+    folded = reduce(fold_audit_gate_exit, others, audit_gate)
+    assert folded not in (2, 4)
+
+
+@given(
+    audit_gate=_AUDIT_GATE_CONTRIBUTIONS,
+    a=_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS,
+    b=_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS,
+    c=_OTHER_NON_COMPATIBILITY_CONTRIBUTIONS,
+)
+def test_fold_is_order_and_grouping_independent(
+    audit_gate: int, a: int, b: int, c: int
+) -> None:
+    """`max`-folding is commutative and associative -- every permutation of
+    the four contributions, folded left to right, agrees, and it agrees
+    with folding two subgroups and then combining those."""
+    values = [audit_gate, a, b, c]
+    results = {
+        reduce(fold_audit_gate_exit, perm[1:], perm[0])
+        for perm in itertools.permutations(values)
+    }
+    assert len(results) == 1
+    only_result = next(iter(results))
+
+    # Grouped: fold {audit_gate, a} and {b, c} separately, then combine.
+    left_group = fold_audit_gate_exit(audit_gate, a)
+    right_group = fold_audit_gate_exit(b, c)
+    grouped = fold_audit_gate_exit(left_group, right_group)
+    assert grouped == only_result == max(values)
+
+
+def test_two_gating_findings_are_no_worse_than_one() -> None:
+    """A monotonicity sanity check in the same spirit as the generated
+    properties above: the axis is a floor, not a count -- two independent
+    gating signals must not compound into a code beyond
+    `AUDIT_GATE_EXIT_CODE`."""
+    once = fold_audit_gate_exit(0, AUDIT_GATE_EXIT_CODE)
+    twice = fold_audit_gate_exit(once, AUDIT_GATE_EXIT_CODE)
+    assert once == twice == AUDIT_GATE_EXIT_CODE


### PR DESCRIPTION
## Summary

Closes the one named blocker on retiring the legacy `scan` command (`docs/contribute/plans/one-comparison-product.md` §3): `compare --no-baseline` had no way to gate a CI job on an audit finding, while legacy `scan`'s audit mode gates at exit `2` on a hygiene finding classified `API_BREAK` (verified live: `scan` on `case148`/`case149`'s committed snapshots exits `2`, `case143`'s `RISK`-classified finding exits `0`; `compare --no-baseline` exited `0` for all three, correctly, per ADR-068 D2).

## Motivation

`docs/contribute/known-gaps.md`'s "no way to gate a CI job on an audit finding" entry named this as an open ADR-068 amendment, not a bug fix. This PR is that amendment plus its implementation.

## Changes

- **ADR-068 amendment** (`docs/contribute/adr/068-one-comparison-product-and-scan-retirement.md`): a new orthogonal exit axis, code `3` (the one small integer unused across `compare`/`scan --against`'s existing family — never `2`/`4`, which ADR-068 D2 reserves for a real compatibility verdict an audit cannot produce). **Opt-in**, not on by default, activated by reusing `--severity-preset` (previously a hard usage error under `--no-baseline`) rather than inventing a new flag — `info-only` stays the explicit "don't gate" request. The axis's own gating rule reads `BREAKING_KINDS`/`API_BREAK_KINDS` membership directly (`checker_policy.py`'s registry-derived sets), **not** `severity.py`'s four-bucket category model — that model's `potential_breaking` bucket deliberately merges `API_BREAK_KINDS` with `RISK_KINDS`, which would have gated `case143` (the exact regression this PR was written to avoid).
- **`abicheck/policy/audit_gate_exit.py`** (new leaf module): `audit_gate_exit_contribution`/`fold_audit_gate_exit`/`audit_gate_enabled_for_severity_preset`, mirroring `contract_coverage_exit.py`'s/`depth_evidence_contract.py`'s shape — pure functions over already-computed findings, folded with `max`.
- **`abicheck/report/no_baseline.py`** / **`no_baseline_document.py`**: the axis is folded into `no_baseline_exit_code`/`compute_no_baseline_document`, so every format (`json`, `markdown`, `sarif`, `junit`, `oneline`) shares the resolved `exit_axes`/`exit_code`.
- **`abicheck/frontends/cli/commands/compare_no_baseline.py`** / **`no_baseline_rulings.py`**: `--severity-preset` is no longer a usage error under `--no-baseline`; it now derives the opt-in.
- **`action/run.sh`**: a forward-looking note for when audit-only `mode: scan` eventually routes through `compare --no-baseline` (it still routes to the legacy CLI today for unrelated, already-tracked reasons, so there's no live Action call site to wire yet).
- **Docs**: `docs/reference/exit-codes.md` (new axis row + prose), `docs/contribute/known-gaps.md` (gap marked closed), `docs/contribute/plans/one-comparison-product.md` (Phase 6 note — this closes the exit-code blocker, not `scan`'s retirement itself).
- **Tests**: `tests/parity/test_no_baseline_audit_corpus_parity.py` extended with exit-code assertions across the whole G20 corpus (`case148`/`case149` gate at `3` under `--severity-preset default`, every other fixture including `case143` stays `0`; opt-in and `info-only` behavior pinned; legacy `scan`'s own exit codes pinned as the measured baseline). New `tests/test_audit_gate_exit.py` (unit tests against the module directly) and `tests/test_audit_gate_exit_properties.py` (a Hypothesis property test: never lowers the fold, never fabricates `2`/`4`, `max`-fold order/grouping independence).

## Verification

- Confirmed the parity test goes **red before / green after**: reverting the four implementation files (keeping the new tests) produces 12 failures — `test_audit_gate_axis_matches_legacy_scan_gating` fails on every case148/149 fixture (still `--severity-preset` usage error), `test_audit_gate_axis_disabled_by_info_only_preset` fails the same way. After the implementation: all 49 parity tests pass, with case148/case149 now exiting `3` under `--severity-preset default` and every other fixture (including case143) staying `0`.
- `mypy abicheck/` — clean (0 errors, matching the documented baseline).
- `python scripts/check_architecture.py` — clean (caught and fixed one `frontends -> policy` direction violation during development; the CLI now reaches the axis's opt-in helper via `report.no_baseline`'s re-export, which `report` is allowed to depend on `policy` for).
- `python scripts/check_ai_readiness.py` — same 3 pre-existing, unrelated `ERROR`s (stale `**Verified:**` commit hashes on three unrelated ADRs, not reachable from `origin/main`) as on a clean checkout of this branch's base; no new errors or warnings from this change.
- `python scripts/check_docs_contract.py` — same 1 pre-existing, unrelated warning as on the base.
- `mkdocs build --strict` — succeeds.
- Full unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — run in progress/completed clean in this environment (see follow-up comment if still finishing at PR-open time); every directly-affected test module (`test_compare_no_baseline_options.py`, `test_no_baseline_compare.py`, `test_no_baseline_d3_properties.py`, `test_no_baseline_report_formats.py`, `test_no_baseline_suppression_provenance.py`, `test_compare_no_baseline_cli.py`, `test_exit_code_integrity.py`, `test_cli_root_surface.py`, `test_action_run_contract.py`, `test_severity.py`, plus the new/extended modules above) passes individually.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (ADR amendment, exit-codes reference, known-gaps, plan doc)
- [x] No new `mypy` or `ruff`-relevant errors introduced
- [x] `python scripts/check_architecture.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LVsDcL45oC3BvUUENiLsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LVsDcL45oC3BvUUENiLsJ)_