### PR TITLE
fix: stop labeling closure coordinate-shift as declaration_renamed

### DIFF
--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -395,12 +395,9 @@ def _classify_outcome(
 ) -> str:
     old_qn = old_identity.qualified_name
     new_qn = new_identity.qualified_name
-    # source_relative encodes file#scope#name — compare just the file prefix
-    # (before the first separator) to ask "did the declaring file change",
-    # after normalizing each side's path (see _project_relative_path).
-    # Falls back to the SOURCE_DECLARES-edge-derived declaring file (see
-    # _declaring_files) when the node carries no def_file/file attr of its
-    # own.
+    # source_relative is file#scope#name; the file prefix says "did the
+    # declaring file change" (falls back to _declaring_files' edge-derived
+    # file when the node carries none of its own).
     old_file = (
         _project_relative_path(old_identity.source_relative.split("\x1f", 1)[0])
         or old_declaring_file
@@ -409,24 +406,9 @@ def _classify_outcome(
         _project_relative_path(new_identity.source_relative.split("\x1f", 1)[0])
         or new_declaring_file
     )
-    # A closure/anonymous-tag's qualified-name spelling embeds its own
-    # source coordinates (`(lambda:foo.h:4:37)`) -- an unrelated edit
-    # elsewhere in the same header shifts an otherwise-unchanged closure to
-    # a new line, which literal `old_qn != new_qn` alone reads as a genuine
-    # rename. Comparing the coordinate-free form instead asks the actual
-    # question this outcome cares about: did anything *other* than the
-    # closure's incidental position change? A real declaring-file move is
-    # still caught below via `old_file`/`new_file`, which never derives from
-    # this marker text -- see `closure_location_free_identity`'s own
-    # docstring for why dropping the discriminator here is safe (this pair
-    # was already matched by canonical-id/alias/structural-context evidence
-    # that never consults this comparison; no new merge rides on it).
-    renamed = (
-        bool(old_qn)
-        and bool(new_qn)
-        and closure_location_free_identity(old_qn)
-        != closure_location_free_identity(new_qn)
-    )
+    old_key = closure_location_free_identity(old_qn)
+    new_key = closure_location_free_identity(new_qn)
+    renamed = bool(old_qn) and bool(new_qn) and old_key != new_key
     moved = bool(old_file) and bool(new_file) and old_file != new_file
     if renamed and not moved:
         return OUTCOME_RENAMED

--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -104,6 +104,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from ..model.graph_identity import closure_location_free_identity
 from .entity_identity import (
     IDENTITY_TIER_CANONICAL,
     CanonicalIdentity,
@@ -408,7 +409,24 @@ def _classify_outcome(
         _project_relative_path(new_identity.source_relative.split("\x1f", 1)[0])
         or new_declaring_file
     )
-    renamed = bool(old_qn) and bool(new_qn) and old_qn != new_qn
+    # A closure/anonymous-tag's qualified-name spelling embeds its own
+    # source coordinates (`(lambda:foo.h:4:37)`) -- an unrelated edit
+    # elsewhere in the same header shifts an otherwise-unchanged closure to
+    # a new line, which literal `old_qn != new_qn` alone reads as a genuine
+    # rename. Comparing the coordinate-free form instead asks the actual
+    # question this outcome cares about: did anything *other* than the
+    # closure's incidental position change? A real declaring-file move is
+    # still caught below via `old_file`/`new_file`, which never derives from
+    # this marker text -- see `closure_location_free_identity`'s own
+    # docstring for why dropping the discriminator here is safe (this pair
+    # was already matched by canonical-id/alias/structural-context evidence
+    # that never consults this comparison; no new merge rides on it).
+    renamed = (
+        bool(old_qn)
+        and bool(new_qn)
+        and closure_location_free_identity(old_qn)
+        != closure_location_free_identity(new_qn)
+    )
     moved = bool(old_file) and bool(new_file) and old_file != new_file
     if renamed and not moved:
         return OUTCOME_RENAMED

--- a/abicheck/model/graph_identity.py
+++ b/abicheck/model/graph_identity.py
@@ -329,3 +329,69 @@ def _decl_node_id(identity: str) -> str:
 
 def _type_node_id(identity: str) -> str:
     return f"type://{_normalize_graph_identity(identity)}"
+
+
+#: Matches the ``<marker>:<basename>:<line>:<col>`` shape
+#: :func:`_normalize_graph_identity` already produces (both the
+#: parenthesized and bare closure/anonymous-tag spellings converge on this
+#: one form once normalized -- see its own docstring), capturing just the
+#: marker so a substitution can drop the trailing basename/coordinates
+#: entirely rather than merely relocating them. Deliberately runs on
+#: *already-normalized* text rather than duplicating the quote/timestamp-
+#: aware machinery `_normalize_graph_identity`'s own regexes already carry.
+_NORMALIZED_CLOSURE_DISCRIMINATOR_RE = re.compile(
+    r"\b(lambda|unnamed\s+\w+|anonymous\s+\w+):[^():\"]*:\d+:\d+\b"
+)
+
+
+def closure_location_free_identity(identity: str) -> str:
+    """*identity*, with every closure/anonymous-tag marker's basename and
+    ``:<line>:<col>`` discriminator dropped entirely, leaving just the bare
+    marker (``"(lambda at /a/foo.h:4:37)"`` /
+    ``"lambda at /a/foo.h:4:37"`` -> ``"(lambda)"`` / ``"lambda"``).
+
+    :func:`_normalize_graph_identity` (used for a node's own id/label, and
+    for identity ATTRS a rename/move candidate is matched *against*)
+    deliberately *keeps* the basename+``:line:col`` discriminator --
+    dropping it there would let two unrelated lambdas declared in the same
+    header collide onto one node id, silently merging two distinct
+    declarations (see that function's own docstring, and
+    ``strip_anonymous_type_location``'s: "there is no location-based
+    discriminator that is simultaneously stable under unrelated line
+    movement AND distinguishing between two declarations in one header").
+
+    This function is for a *different*, narrower job where that collision
+    risk does not apply: :func:`~abicheck.buildsource.graph_reconcile.
+    _classify_outcome` decides whether an *already-matched* pair (matched
+    by :mod:`~abicheck.buildsource.graph_reconcile`'s canonical-id/alias/
+    structural-context tiers -- none of which use this function, so no new
+    merge is ever made on its evidence) should be labeled a genuine
+    "rename" or not. A pure coordinate shift on an otherwise-identical
+    closure/anonymous-tag spelling -- the common case when an unrelated
+    edit elsewhere in the same header moves an unchanged lambda to a new
+    line -- is not, in any user-meaningful sense, a "declaration renamed":
+    it is source churn the closure's own identity has no way to be stable
+    against (a lambda has no user-given name to begin with). Reporting it
+    as ``declaration_renamed`` anyway is misleading noise, observed at real
+    scale in a template/lambda-heavy corpus (oneTBB) where an unrelated
+    header edit shifts dozens of otherwise-unchanged closures at once.
+
+    Dropping the basename here too (not just ``:line:col``) is deliberate
+    and still safe: a lambda that genuinely moved to a different declaring
+    FILE is separately caught by :func:`~abicheck.buildsource.
+    graph_reconcile._classify_outcome`'s own file-based ``moved`` check
+    (real declaring-file evidence, never derived from this marker text) --
+    so collapsing the basename here only changes such a pair's outcome from
+    the misleading ``declaration_renamed`` to the more accurate
+    ``declaration_moved``, never hides the file change itself.
+
+    A no-op for any identity carrying no closure/anonymous-tag marker at
+    all (ordinary qualified names are returned unchanged), and idempotent
+    (re-applying to an already-stripped identity is a no-op).
+    """
+    if "at" not in identity and ":" not in identity:
+        return identity
+    normalized = _normalize_graph_identity(identity)
+    if ":" not in normalized:
+        return normalized
+    return _NORMALIZED_CLOSURE_DISCRIMINATOR_RE.sub(r"\1", normalized)

--- a/abicheck/model/graph_identity.py
+++ b/abicheck/model/graph_identity.py
@@ -388,10 +388,26 @@ def closure_location_free_identity(identity: str) -> str:
     A no-op for any identity carrying no closure/anonymous-tag marker at
     all (ordinary qualified names are returned unchanged), and idempotent
     (re-applying to an already-stripped identity is a no-op).
+
+    A match inside a ``"..."`` quoted literal is left untouched, mirroring
+    :func:`_strip_bare_anonymous_type_location`'s own guard (CodeRabbit
+    review): ``_normalize_graph_identity`` already protects quoted spans, so
+    marker-shaped *content* -- a C++20 fixed-string NTTP argument like
+    ``Tag<"lambda:foo.h:1:2">`` -- can reach here verbatim. Without this
+    guard, two distinct specializations quoting different literal text would
+    collapse onto the same coordinate-free identity, silently reconciling a
+    genuine ``declaration_renamed`` as unchanged.
     """
     if "at" not in identity and ":" not in identity:
         return identity
     normalized = _normalize_graph_identity(identity)
     if ":" not in normalized:
         return normalized
-    return _NORMALIZED_CLOSURE_DISCRIMINATOR_RE.sub(r"\1", normalized)
+    quoted_spans = _quoted_spans(normalized)
+
+    def _replace(match: re.Match[str]) -> str:
+        if any(start <= match.start() < end for start, end in quoted_spans):
+            return match.group(0)
+        return match.group(1)
+
+    return _NORMALIZED_CLOSURE_DISCRIMINATOR_RE.sub(_replace, normalized)

--- a/changelog.d/20260910_200030_noreply_worktree_agent_aeb9ae17e4f475eed.md
+++ b/changelog.d/20260910_200030_noreply_worktree_agent_aeb9ae17e4f475eed.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **`declaration_renamed` no longer over-fires on a closure whose only
+  change is its own source coordinates.** L5 graph reconciliation
+  (`buildsource.graph_reconcile`) was labeling a lambda/anonymous-tag pair
+  it had already correctly matched (via structural context) as a genuine
+  rename purely because the closure's qualified-name spelling embeds its
+  own `:line:col`, which an unrelated edit elsewhere in the same header
+  shifts. A real-world report on oneTBB (template/lambda-heavy) showed 139
+  such findings against oneDNN's 3 for a comparable corpus size. The new
+  `model.graph_identity.closure_location_free_identity` primitive strips a
+  closure/anonymous-tag marker's basename+coordinates for the
+  rename-vs-not-renamed comparison only (never for matching/merging, so no
+  new merge rides on it); a genuine cross-file move is still reported as
+  `declaration_moved` via the separate, coordinate-text-blind declaring-file
+  check.

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -5666,16 +5666,53 @@ looked like the obvious fix and wasn't.
   `TestStdAllocatorSyntheticKeyNotFalselyDemoted` for the exact
   counterexample from review, reproduced and fixed.
 
-  Two related residuals from the same report, deliberately not addressed
-  here: the *type-level* churn among these same symbols (the compatible
-  `func_added`/risk `declaration_renamed` findings the same 5 removals
-  pair with, and 7 further `declaration_renamed` findings elsewhere in the
-  same report) is pure noise from the lambda's identity embedding its
+  Two related residuals from the same report. The compatible `func_added`
+  churn is ordinary add/remove pairing (not itself a bug), left as-is.
+
+  ~~The risk `declaration_renamed` findings elsewhere in the same report (7
+  further ones) is pure noise from the lambda's identity embedding its
   source `line:col` rather than an ordinal position — closing that needs
   changing how a closure is *identified*, a materially larger change to
-  `name_classification`/the castxml and clang backends' own closure
-  naming than this fix's binary-evidence check, and is not attempted
-  here. And a public-surface filter gap (ELF-only, mangled-only symbols
+  `name_classification`/the castxml and clang backends' own closure naming
+  than this fix's binary-evidence check, and is not attempted here.~~
+  **Update: fixed, narrower than the originally-scoped "change how a
+  closure is identified" (fresh report, real oneTBB 2021.12.0 -> 2023.0.0,
+  139 `declaration_renamed` L5 findings against oneDNN's 3 for a comparable
+  corpus size).** Tracing a representative sample confirmed the same
+  mechanism this entry already names: `buildsource.graph_reconcile`'s
+  structural-context tier correctly PAIRS an unrelated-edit-shifted
+  closure with its own unchanged predecessor (that matching evidence never
+  reads the coordinate text at all), but `_classify_outcome` then compared
+  the two nodes' *literal* qualified-name spelling — which embeds the
+  closure's own `:line:col` — to decide "renamed", so every closure an
+  unrelated header edit merely shifted read as a rename. Rather than the
+  originally-scoped identity-naming rewrite (which risks the exact
+  same-header-collision trade-off `strip_anonymous_type_location`'s own
+  docstring documents for *matching*), the actual fix is narrower and
+  provably safe: `model.graph_identity.closure_location_free_identity`
+  drops a closure/anonymous-tag marker's basename+coordinates entirely (not
+  merely the checkout-root prefix `_normalize_graph_identity` already
+  strips) for the *outcome-classification* comparison only, never for
+  matching/merging — the pair was already established by tier evidence that
+  never consults this text, so no new merge rides on it, and a genuine
+  cross-file move is still caught by the separate, coordinate-text-blind
+  `old_file`/`new_file` check right below it (reclassifying it
+  `declaration_moved` instead of the misleading `declaration_renamed`,
+  never hiding the file change). See
+  `tests/test_graph_reconcile_closure_rename.py` — both the oneTBB-shaped
+  regression cases and a standalone property-test class for the new
+  primitive (idempotence, location/basename invariance, parenthesized/bare
+  spelling agreement, marker-kind non-collapse, never-raises on arbitrary
+  text) per this file's own "Primitive-level property tests" guidance,
+  since this is a reusable identity-comparison helper, not a one-off
+  patch. The separate, still-open gap about the L5 graph's own node *ids*
+  not sharing the flat snapshot's ordinal renumbering (this file's own
+  "The L5 source graph's own node identities are never renumbered..."
+  entry, elsewhere in this file) is unaffected by this fix — it is about
+  node-id/flat-field spelling agreement, not the rename-vs-not-renamed
+  classification this fix corrects.
+
+  And a public-surface filter gap (ELF-only, mangled-only symbols
   such as `std::once_flag::_Prepare_execution<lambda>`'s internal guard
   thunks, which `surface.py` cannot scope-classify because it never
   demangles) is a separate detector, not this one, and is likewise not

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -1,0 +1,368 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A closure/anonymous-tag's coordinate shift must not read as a genuine
+``declaration_renamed`` (G31 Phase B, ADR-048).
+
+Regression for a real-world report: comparing real oneTBB releases (a
+template/lambda-heavy corpus) produced 139 ``declaration_renamed`` L5
+findings against oneDNN's 3 for a comparable corpus size. Manually tracing a
+representative sample (see ``docs/contribute/known-gaps.md``'s "Lambda-closure
+churn survives at the *function* level" entry, and this file's own cases)
+showed the graph-reconciliation matcher was correctly PAIRING an
+unrelated-edit-shifted closure with its own unchanged predecessor (via its
+structural-context tier -- unaffected by this fix, see
+``test_graph_reconcile.py``), but then mislabeling that pair
+``declaration_renamed`` purely because the closure's own qualified-name
+spelling embeds its source ``:line:col`` (``"(lambda:task_group.h:522:26)"``)
+-- an unrelated edit elsewhere in the same header shifts dozens of otherwise
+-unchanged closures' coordinates at once, and every one of them read as a
+"rename" though nothing about the declaration itself changed.
+
+Split out of ``test_graph_reconcile.py`` (own file, not folded into the
+larger suite) since this covers both the ``buildsource.graph_reconcile``
+outcome-classification call site and the general-purpose primitive behind
+it, ``model.graph_identity.closure_location_free_identity`` -- per this
+repo's AGENTS.md "Primitive-level property tests" guidance, a reusable
+identity-comparison helper gets its own contract-as-invariants property
+tests, not only example tests pinned to the oneTBB shape that motivated it.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from abicheck.buildsource.graph_reconcile import (
+    OUTCOME_MOVED,
+    OUTCOME_RECONCILED,
+    OUTCOME_RENAMED,
+    reconcile_added_removed,
+)
+from abicheck.buildsource.source_graph import GraphEdge, GraphNode, SourceGraphSummary
+from abicheck.model.graph_identity import closure_location_free_identity
+
+
+def _graph(nodes: list[GraphNode], edges: list[GraphEdge]) -> SourceGraphSummary:
+    g = SourceGraphSummary()
+    for n in nodes:
+        g.add_node(n)
+    for e in edges:
+        g.add_edge(e)
+    return g.finalize()
+
+
+def _reconcile_one_pair(
+    old_node: GraphNode, new_node: GraphNode, *, edge_kind: str = "TYPE_HAS_FIELD_TYPE"
+):
+    """Reconcile a single old/new node pair, wired to a shared parent so the
+    structural-context tier (the tier every closure-coordinate-only rename
+    actually matches through -- its qualified name differs, so canonical-id
+    and alias both miss) has a unique position to match on, mirroring
+    ``test_graph_reconcile.py``'s own ``test_rename_reconciles_via_
+    structural_context``.
+    """
+    parent = GraphNode(id="type://demo::Owner", kind="record_type", label="demo::Owner")
+    old_edge = GraphEdge(
+        src=parent.id, dst=old_node.id, kind=edge_kind, attrs={"role": "field"}
+    )
+    new_edge = GraphEdge(
+        src=parent.id, dst=new_node.id, kind=edge_kind, attrs={"role": "field"}
+    )
+    old_g = _graph([parent, old_node], [old_edge])
+    new_g = _graph([parent, new_node], [new_edge])
+    result = reconcile_added_removed([old_node], [new_node], old_g, new_g)
+    assert len(result.reconciled) == 1, (
+        f"expected exactly one reconciled pair, got {result.to_dict()}"
+    )
+    return result.reconciled[0]
+
+
+class TestClosureCoordinateShiftIsNotARename:
+    """Regression: the oneTBB-shaped case, through the real reconciliation
+    entry point (``reconcile_added_removed`` -> ``_classify_outcome``), not
+    just the underlying primitive in isolation.
+    """
+
+    def test_parenthesized_lambda_coordinate_shift_reconciles_not_renamed(self) -> None:
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="raii_guard<(lambda:task_group.h:522:26)>",
+            attrs={
+                "qualified_name": "raii_guard<(lambda:task_group.h:522:26)>",
+                "def_file": "task_group.h",
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="raii_guard<(lambda:task_group.h:525:12)>",
+            attrs={
+                "qualified_name": "raii_guard<(lambda:task_group.h:525:12)>",
+                "def_file": "task_group.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.match_kind == "structural_context"
+        assert pair.outcome == OUTCOME_RECONCILED, (
+            "a pure coordinate shift on an otherwise-identical closure must "
+            "not read as declaration_renamed"
+        )
+
+    def test_bare_anonymous_marker_coordinate_shift_reconciles_not_renamed(
+        self,
+    ) -> None:
+        # The bare (unparenthesized) "unnamed <kind> at ..." spelling that
+        # model.graph_identity also normalizes (see
+        # test_source_graph_directory_taint.py's sibling coverage).
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="unnamed struct at foo.h:56:5",
+            attrs={
+                "qualified_name": "unnamed struct at /old/checkout/foo.h:56:5",
+                "def_file": "foo.h",
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="unnamed struct at foo.h:61:5",
+            attrs={
+                "qualified_name": "unnamed struct at /new/checkout/foo.h:61:5",
+                "def_file": "foo.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_RECONCILED
+
+    def test_closure_owning_template_genuinely_renamed_still_detected(self) -> None:
+        # A REAL rename (the owning template's own name changed, not just
+        # the closure's coordinates) alongside a coordinate shift must still
+        # be reported as OUTCOME_RENAMED -- this fix must not blind the
+        # matcher to an actual rename that happens to also touch a closure.
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="raii_guard<(lambda:task_group.h:522:26)>",
+            attrs={
+                "qualified_name": "raii_guard<(lambda:task_group.h:522:26)>",
+                "def_file": "task_group.h",
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="scoped_guard<(lambda:task_group.h:525:12)>",
+            attrs={
+                "qualified_name": "scoped_guard<(lambda:task_group.h:525:12)>",
+                "def_file": "task_group.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_RENAMED
+
+    def test_closure_moved_to_different_file_reports_moved_not_renamed(self) -> None:
+        # A real cross-file move must still be OUTCOME_MOVED -- dropping the
+        # basename from the rename-vs-not comparison must not swallow a real
+        # file change, since that is caught separately via def_file/
+        # source_relative evidence, never via this marker text.
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="raii_guard<(lambda:old.h:522:26)>",
+            attrs={
+                "qualified_name": "raii_guard<(lambda:old.h:522:26)>",
+                "def_file": "old.h",
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="raii_guard<(lambda:new.h:8:2)>",
+            attrs={
+                "qualified_name": "raii_guard<(lambda:new.h:8:2)>",
+                "def_file": "new.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_MOVED
+
+    def test_ordinary_non_closure_rename_still_detected(self) -> None:
+        # Sanity: an ordinary (non-closure) rename is completely unaffected
+        # by this fix -- mirrors test_graph_reconcile.py's own
+        # test_rename_reconciles_via_structural_context.
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="demo::detail::RawConfig",
+            attrs={"qualified_name": "demo::detail::RawConfig", "def_file": "detail.h"},
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="demo::detail::RawConfigV2",
+            attrs={
+                "qualified_name": "demo::detail::RawConfigV2",
+                "def_file": "detail.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_RENAMED
+
+
+# ── closure_location_free_identity: primitive-level property tests ────────
+#
+# Per AGENTS.md's "Primitive-level property tests" guidance: this is a
+# reusable, general-purpose identity-comparison helper (not tied to any one
+# caller's domain logic), so it gets its own contract stated as invariants,
+# generated adversarially rather than only checked against the one oneTBB-
+# shaped example above.
+
+_HEADER_BASENAMES = st.sampled_from(["foo.h", "task_group.h", "detail.hpp", "a_b.h"])
+_MARKERS = st.sampled_from(
+    ["lambda", "unnamed struct", "unnamed union", "anonymous enum"]
+)
+_COORDS = st.tuples(
+    st.integers(min_value=1, max_value=99999), st.integers(min_value=1, max_value=999)
+)
+_CHECKOUT_ROOTS = st.sampled_from(["/old/checkout", "/mnt/ci/build-42", "", "C:/src"])
+
+
+def _parenthesized_marker(
+    marker: str, root: str, basename: str, line: int, col: int
+) -> str:
+    sep = "/" if root else ""
+    return f"({marker} at {root}{sep}{basename}:{line}:{col})"
+
+
+def _bare_marker(marker: str, root: str, basename: str, line: int, col: int) -> str:
+    sep = "/" if root else ""
+    return f"{marker} at {root}{sep}{basename}:{line}:{col}"
+
+
+class TestClosureLocationFreeIdentityProperties:
+    @given(
+        marker=_MARKERS,
+        basename=_HEADER_BASENAMES,
+        root1=_CHECKOUT_ROOTS,
+        root2=_CHECKOUT_ROOTS,
+        coords1=_COORDS,
+        coords2=_COORDS,
+    )
+    def test_location_invariant_for_same_marker_and_basename(
+        self, marker, basename, root1, root2, coords1, coords2
+    ) -> None:
+        """The whole point of the primitive: two spellings of the SAME
+        marker + basename differing only in checkout root and/or
+        line:col must always reduce to the identical identity, regardless
+        of which coordinates or roots were used."""
+        a = _parenthesized_marker(marker, root1, basename, *coords1)
+        b = _parenthesized_marker(marker, root2, basename, *coords2)
+        assert closure_location_free_identity(a) == closure_location_free_identity(b)
+
+    @given(
+        marker=_MARKERS,
+        basename1=_HEADER_BASENAMES,
+        basename2=_HEADER_BASENAMES,
+        root=_CHECKOUT_ROOTS,
+        coords1=_COORDS,
+        coords2=_COORDS,
+    )
+    def test_basename_invariant_for_same_marker(
+        self, marker, basename1, basename2, root, coords1, coords2
+    ) -> None:
+        """Deliberately basename-insensitive too (unlike the sibling
+        node-id normalizer in the same module): a real cross-file move is
+        caught separately via declaring-file evidence in
+        ``graph_reconcile._classify_outcome``, never via this marker text,
+        so collapsing the basename here only changes the outcome label from
+        the misleading ``renamed`` to the correct ``moved`` -- it never
+        hides the file difference itself (see
+        ``TestClosureCoordinateShiftIsNotARename.
+        test_closure_moved_to_different_file_reports_moved_not_renamed``)."""
+        a = _parenthesized_marker(marker, root, basename1, *coords1)
+        b = _parenthesized_marker(marker, root, basename2, *coords2)
+        assert closure_location_free_identity(a) == closure_location_free_identity(b)
+
+    @given(
+        marker=_MARKERS,
+        basename=_HEADER_BASENAMES,
+        root=_CHECKOUT_ROOTS,
+        coords=_COORDS,
+    )
+    def test_parenthesized_and_bare_forms_agree(
+        self, marker, basename, root, coords
+    ) -> None:
+        """Both spellings clang/castxml are known to produce for the exact
+        same underlying marker (see model.graph_identity's own docstring)
+        must reduce to an identity naming the same marker -- differing only
+        in the surrounding parens, never in substance."""
+        paren = closure_location_free_identity(
+            _parenthesized_marker(marker, root, basename, *coords)
+        )
+        bare = closure_location_free_identity(
+            _bare_marker(marker, root, basename, *coords)
+        )
+        assert paren == f"({bare})"
+
+    @given(
+        marker1=_MARKERS, marker2=_MARKERS, basename=_HEADER_BASENAMES, coords=_COORDS
+    )
+    def test_distinct_marker_kinds_never_collapse(
+        self, marker1, marker2, basename, coords
+    ) -> None:
+        """A lambda and an unnamed struct/union/enum are never the same
+        entity -- collapsing across marker kinds would be a real
+        over-merge, not the noise this primitive exists to remove."""
+        a = closure_location_free_identity(
+            _parenthesized_marker(marker1, "", basename, *coords)
+        )
+        b = closure_location_free_identity(
+            _parenthesized_marker(marker2, "", basename, *coords)
+        )
+        if marker1 == marker2:
+            assert a == b
+        else:
+            assert a != b
+
+    @given(st.text(min_size=0, max_size=80))
+    def test_idempotent(self, text) -> None:
+        once = closure_location_free_identity(text)
+        twice = closure_location_free_identity(once)
+        assert once == twice
+
+    @given(
+        st.text(
+            alphabet=st.characters(blacklist_categories=("Cs",)),
+            min_size=0,
+            max_size=200,
+        )
+    )
+    def test_never_raises_on_arbitrary_text(self, text) -> None:
+        # Must degrade gracefully on adversarial/malformed input -- the
+        # primitive is applied to producer-supplied qualified-name text,
+        # not just the well-formed shapes this test file otherwise builds.
+        closure_location_free_identity(text)
+
+    def test_plain_qualified_name_with_no_marker_is_unchanged(self) -> None:
+        # No closure/anonymous-tag marker at all -> a no-op, never mutates
+        # ordinary ABI-surface identifiers.
+        name = "ns::detail::Widget<int, std::vector<double>>"
+        assert closure_location_free_identity(name) == name
+
+    def test_no_op_on_text_with_neither_at_nor_colon(self) -> None:
+        # Exercises the cheap fast-path guard directly.
+        assert closure_location_free_identity("PlainName") == "PlainName"

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -395,6 +395,17 @@ class TestClosureLocationFreeIdentityProperties:
         name = "ns::detail::Widget<int, std::vector<double>>"
         assert closure_location_free_identity(name) == name
 
+    def test_no_op_when_at_present_but_no_colon_survives_normalization(self) -> None:
+        # Exercises the second fast-path guard directly: an identity can
+        # contain the substring "at" (failing the cheap first check) while
+        # still carrying no ":" anywhere, including after normalization --
+        # e.g. an ordinary spelling like "static_cast" embeds "at" but is
+        # not location-shaped at all, so no marker regex ever matches.
+        name = "static_cast<Foo>"
+        assert "at" in name
+        assert ":" not in name
+        assert closure_location_free_identity(name) == name
+
     def test_quoted_marker_shaped_text_is_never_stripped(self) -> None:
         # Regression (CodeRabbit review): marker-shaped text inside a
         # `"..."` quoted literal (a C++20 fixed-string NTTP argument, say)

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -222,6 +222,38 @@ class TestClosureCoordinateShiftIsNotARename:
         pair = _reconcile_one_pair(old_node, new_node)
         assert pair.outcome == OUTCOME_RENAMED
 
+    def test_quoted_marker_shaped_literal_is_not_stripped(self) -> None:
+        # Regression (CodeRabbit review): a C++20 fixed-string NTTP argument
+        # can quote text that merely *looks* like a normalized closure
+        # marker (e.g. a literal spelled "lambda:foo.h:1:2"). That text is
+        # not a real CastXML anonymous/lambda marker -- it must be left
+        # alone, so two specializations quoting genuinely different literal
+        # arguments must still classify as a real rename, not silently
+        # reconcile onto the same coordinate-free identity.
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label='Tag<"lambda:foo.h:1:2">',
+            attrs={
+                "qualified_name": 'Tag<"lambda:foo.h:1:2">',
+                "def_file": "detail.h",
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label='Tag<"lambda:foo.h:9:9">',
+            attrs={
+                "qualified_name": 'Tag<"lambda:foo.h:9:9">',
+                "def_file": "detail.h",
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_RENAMED, (
+            "distinct quoted literal template arguments must not be "
+            "silently reconciled as an incidental coordinate shift"
+        )
+
 
 # ── closure_location_free_identity: primitive-level property tests ────────
 #
@@ -362,6 +394,20 @@ class TestClosureLocationFreeIdentityProperties:
         # ordinary ABI-surface identifiers.
         name = "ns::detail::Widget<int, std::vector<double>>"
         assert closure_location_free_identity(name) == name
+
+    def test_quoted_marker_shaped_text_is_never_stripped(self) -> None:
+        # Regression (CodeRabbit review): marker-shaped text inside a
+        # `"..."` quoted literal (a C++20 fixed-string NTTP argument, say)
+        # is source *content*, not a real anonymous/lambda marker -- it
+        # must pass through completely unchanged, mirroring
+        # `_strip_bare_anonymous_type_location`'s own quoted-span guard.
+        # Without it, two distinct quoted literals would collapse onto the
+        # same coordinate-free identity.
+        a = 'Tag<"lambda:foo.h:1:2">'
+        b = 'Tag<"lambda:foo.h:9:9">'
+        assert closure_location_free_identity(a) == a
+        assert closure_location_free_identity(b) == b
+        assert closure_location_free_identity(a) != closure_location_free_identity(b)
 
     def test_no_op_on_text_with_neither_at_nor_colon(self) -> None:
         # Exercises the cheap fast-path guard directly.


### PR DESCRIPTION
## Summary

Fix `declaration_renamed` over-triggering on a closure/anonymous-tag whose only change is its own source coordinates (L5 graph reconciliation).

## Motivation

Investigated a reported false-positive concern: a scan of oneTBB found 139 `declaration_renamed` findings against oneDNN's 3 for a comparable corpus size. Tracing a representative sample confirmed a real bug, and `docs/contribute/known-gaps.md` already documented the exact mechanism as an investigated-but-deferred residual from an earlier oneTBB report ("Lambda-closure churn survives at the *function* level after the type-level fix").

`buildsource.graph_reconcile`'s structural-context tier correctly *pairs* an unrelated-edit-shifted closure with its own unchanged predecessor (that matching evidence never reads the coordinate text at all — see `test_graph_reconcile.py`'s existing coverage, unaffected by this fix). But `_classify_outcome` then compared the pair's *literal* qualified-name spelling — which embeds the closure's own `:line:col` (e.g. `raii_guard<(lambda:task_group.h:522:26)>`) — to decide "renamed". An unrelated edit elsewhere in the same header shifts many otherwise-unchanged closures' coordinates at once, so each one read as a spurious rename, though nothing about the declaration itself changed.

The originally-scoped fix in known-gaps.md ("closing that needs changing how a closure is *identified*") was deferred because it risked the same same-header-collision trade-off `strip_anonymous_type_location`'s own docstring documents for *matching*. This PR uses a narrower, provably safe fix instead — see Changes below.

## Changes

- Add `model.graph_identity.closure_location_free_identity`: strips a closure/anonymous-tag marker's basename + `:line:col` discriminator, used **only** for the rename-vs-not-renamed comparison inside `graph_reconcile._classify_outcome` — never for matching/merging. The pair is already established by canonical-id/alias/structural-context evidence that never reads this text, so no new merge rides on it. A genuine cross-file move is still caught by the separate, coordinate-text-blind `old_file`/`new_file` check right below it (reclassifying such a pair `declaration_moved` instead of the misleading `declaration_renamed`, never hiding the file change).
- Wire it into `buildsource.graph_reconcile._classify_outcome`.
- Add `tests/test_graph_reconcile_closure_rename.py`:
  - Regression cases through the real `reconcile_added_removed` → `_classify_outcome` entry point: the oneTBB-shaped parenthesized-lambda coordinate shift, the bare `unnamed <kind> at ...` spelling, a genuine rename alongside a coordinate shift (still `declaration_renamed` — proves this fix doesn't blind the matcher), a genuine cross-file move (still `declaration_moved`), and an ordinary non-closure rename (unaffected).
  - A Hypothesis property-test class for the new primitive (idempotence, location-invariance, basename-invariance, parenthesized/bare-spelling agreement, marker-kind non-collapse, never-raises-on-arbitrary-text) — per `AGENTS.md`'s "Primitive-level property tests" guidance, since this is a reusable identity-comparison helper, not a one-off patch pinned to the oneTBB example.
- Update `docs/contribute/known-gaps.md` to mark this residual fixed, distinguishing it from the separate, still-open gap about the L5 graph's own node ids not sharing the flat snapshot's ordinal renumbering (unaffected by this change).
- `changelog.d/` fragment.
- Follow-up commit: kept `abicheck/buildsource/graph_reconcile.py` within its `architecture/debt.yaml` `no_growth` baseline (872 lines) by computing the two coordinate-free keys via short local variables and tightening two comments in the touched function — no behavior change.

## Bug-fix test contract

- Bug class: declaration-rename-via-incidental-coordinate-spelling — a closure/anonymous-tag's identity embeds its source `:line:col`, so an unrelated edit that merely shifts it is misread as a semantic rename.
- Publicly observable failure: any run producing L5 graph-reconciliation findings (`--sources`/`--build-info`) emits a RISK `declaration_renamed` finding for a closure/anonymous-tag whose owning declaration did not actually change — only an unrelated edit elsewhere in the same header shifted its line/column.
- Regression test fails on base: yes — `TestClosureCoordinateShiftIsNotARename::test_parenthesized_lambda_coordinate_shift_reconciles_not_renamed` and `::test_bare_anonymous_marker_coordinate_shift_reconciles_not_renamed` assert `OUTCOME_RECONCILED`; on `main` (before this fix) the pair classifies `OUTCOME_RENAMED` instead, so both fail.
- Negative control: `::test_closure_owning_template_genuinely_renamed_still_detected` and `::test_ordinary_non_closure_rename_still_detected` assert `OUTCOME_RENAMED` is still produced for an actual rename — proving the fix doesn't just always report "not renamed".
- Must-merge / must-not-merge pair: this touches `model/graph_identity.py`, but the new `closure_location_free_identity` primitive is deliberately **not** an identity/matching function — it only feeds the *outcome-classification* (`renamed` vs `moved` vs `reconciled`) of a pair that canonical-id/alias/structural-context matching already established, so it can never cause two previously-distinct entities to merge. Its own must-merge/must-not-merge contract is stated and tested at the primitive level instead: **must-merge** — the same closure/anonymous-tag marker + basename must collapse to one key regardless of coordinate shift (`TestClosureLocationFreeIdentityProperties::test_location_invariant_for_same_marker_and_basename`, plus the real-pipeline `test_parenthesized_lambda_coordinate_shift_reconciles_not_renamed`/`test_bare_anonymous_marker_coordinate_shift_reconciles_not_renamed`, asserting `OUTCOME_RECONCILED`). **Must-not-merge** — two *different* marker kinds (e.g. `lambda` vs `unnamed struct`) must never collapse onto the same key (`test_distinct_marker_kinds_never_collapse`), and a pair whose owning declaration genuinely changed name must still classify `OUTCOME_RENAMED`, not silently reconcile (`test_closure_owning_template_genuinely_renamed_still_detected`).
- Public-surface test: goes through the real `reconcile_added_removed` entry point (the same one the production fold, `source_graph.build_source_graph` → `graph_reconcile.reconcile_graph_diff`, calls), not only the isolated primitive in unit tests.
- Axes covered: parenthesized `(lambda at ...)` vs. bare `unnamed <kind> at ...` marker spellings; genuine rename alongside a coordinate shift; genuine cross-file move; ordinary non-closure rename; plus a Hypothesis property-test class generating marker kind × basename × checkout-root × coordinate combinations.
- General invariant: `closure_location_free_identity` is idempotent, invariant under coordinate and basename changes for the same marker, agrees between parenthesized/bare spellings (`paren == f"({bare})"`), and never collapses two *different* marker kinds onto the same identity — stated as Hypothesis property tests over generated inputs (`TestClosureLocationFreeIdentityProperties`), not only the one oneTBB-shaped example.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/contribute/known-gaps.md`)
- [x] `scripts/verify.py --profile pr` run locally — 16 steps passed, 1 partial (`bugfix-test-contract`, expected without a fetched PR base locally), 4 pre-existing failures unrelated to this change (`test_extraction_and_resolution_work_when_python3_is_absent`, `test_adr_status_sync_holds`, `test_isolated_module_runner_preserves_user_site_without_root_shadowing`, `test_main_returns_zero_on_clean_tree` — confirmed via `git fetch origin main` that the ADR `**Verified:**` receipts genuinely predate this sandbox's fetched `origin/main`, a repo/environment staleness issue unrelated to `graph_identity.py`/`graph_reconcile.py`/the new test file). Unit-pr coverage floor passed (96.49%).
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/model/graph_identity.py abicheck/buildsource/graph_reconcile.py`, `ruff check`, `ruff format --check` all clean on touched files)
- [x] `architecture/debt.yaml`'s `no_growth` baseline for `graph_reconcile.py` re-checked and held (872 lines, follow-up commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nsap6kxvURVjHMC5czu8LT