### PR TITLE
fix: gate demangle() "unavailable" warning on both backends confirmed absent

### DIFF
--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -65,6 +65,18 @@ _warned_no_demangler = False
 # subprocess pair per row instead of degrading once).
 _cppfilt_binary_confirmed_missing = False
 
+# Set once an `import cxxfilt` inside demangle() raises ImportError -- proof
+# the package itself isn't installed, as distinct from the package being
+# installed but failing (or declining) to demangle one particular symbol.
+# Only *this* flag combined with `_cppfilt_binary_confirmed_missing` means
+# "no demangler available at all"; either backend being merely unable to
+# handle one malformed/foreign-ABI symbol is the normal, expected outcome for
+# plenty of real symbols and must never be conflated with both tools being
+# absent (the bug this flag exists to fix: the user-facing "no cxxfilt
+# package and no c++filt binary" warning used to fire on ANY single-symbol
+# demangle failure, including with a fully working c++filt installed).
+_cxxfilt_import_confirmed_missing = False
+
 
 def _is_itanium_mangled(symbol: str, *, accept_macho_prefix: bool = False) -> bool:
     """True for a plain ELF ``_Z...`` name, or its Mach-O ``__Z...`` spelling
@@ -128,20 +140,30 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
     if symbol in _BATCH_CACHE_FAIL:
         return None
     canonical = _canonical_mangled(symbol)
+    global _cxxfilt_import_confirmed_missing  # noqa: PLW0603
     try:
         import cxxfilt
-
-        out = str(cxxfilt.demangle(canonical))
-        # Some cxxfilt/__cxa_demangle versions return the input unchanged
-        # on failure rather than raising -- for a malformed `__Z...` token
-        # that echo is the canonical single-underscore form, which must be
-        # compared against `canonical`, not treated as a real demangling
-        # (Codex review, fresh evidence -- the batch cxxfilt path already
-        # guards this identically).
-        if out != canonical:
-            return out
-    except Exception:  # noqa: BLE001
-        _log.debug("cxxfilt demangling failed for %s", symbol)
+    except ImportError:
+        _cxxfilt_import_confirmed_missing = True
+    else:
+        try:
+            out = str(cxxfilt.demangle(canonical))
+            # Some cxxfilt/__cxa_demangle versions return the input unchanged
+            # on failure rather than raising -- for a malformed `__Z...` token
+            # that echo is the canonical single-underscore form, which must be
+            # compared against `canonical`, not treated as a real demangling
+            # (Codex review, fresh evidence -- the batch cxxfilt path already
+            # guards this identically).
+            if out != canonical:
+                return out
+        except Exception:  # noqa: BLE001
+            # cxxfilt is installed and imported fine; it just couldn't
+            # demangle *this* symbol (malformed/foreign-ABI mangled name).
+            # That is the normal, expected outcome for plenty of real
+            # symbols -- log at debug level only, never the user-facing
+            # "demangler unavailable" warning below, which is reserved for
+            # both backends being confirmed absent.
+            _log.debug("cxxfilt demangling failed for %s", symbol)
     global _cppfilt_binary_confirmed_missing  # noqa: PLW0603
     if not _cppfilt_binary_confirmed_missing:
         for cmd in _cppfilt_single_commands(canonical):
@@ -168,13 +190,23 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
             except (subprocess.TimeoutExpired, OSError):
                 pass
 
-    global _warned_no_demangler  # noqa: PLW0603
-    if not _warned_no_demangler:
-        _log.warning(
-            "C++ demangling unavailable (no cxxfilt package and no c++filt binary); "
-            "DWARF export matching and appcompat symbol matching may be incomplete"
-        )
-        _warned_no_demangler = True
+    # Only warn "demangler unavailable" when BOTH backends are confirmed
+    # absent from this environment. A working c++filt/cxxfilt that simply
+    # couldn't demangle this one symbol (malformed input, a non-Itanium
+    # mangled-looking token, a foreign ABI) is not "unavailable" and must
+    # stay silent here -- the bug this fixes: the warning used to fire on
+    # ANY per-symbol demangle failure regardless of tool presence, so a
+    # report where c++filt genuinely worked for other symbols could still
+    # falsely claim "no cxxfilt package and no c++filt binary".
+    if _cxxfilt_import_confirmed_missing and _cppfilt_binary_confirmed_missing:
+        global _warned_no_demangler  # noqa: PLW0603
+        if not _warned_no_demangler:
+            _log.warning(
+                "C++ demangling unavailable (no cxxfilt package and no c++filt "
+                "binary); DWARF export matching and appcompat symbol matching "
+                "may be incomplete"
+            )
+            _warned_no_demangler = True
     return None
 
 
@@ -350,9 +382,13 @@ def demangle_batch(
 def _reset_demangle_batch_cache() -> None:
     """Test helper — clear the process-wide cache."""
     global _cppfilt_binary_confirmed_missing  # noqa: PLW0603
+    global _cxxfilt_import_confirmed_missing  # noqa: PLW0603
+    global _warned_no_demangler  # noqa: PLW0603
     _BATCH_CACHE_OK.clear()
     _BATCH_CACHE_FAIL.clear()
     _cppfilt_binary_confirmed_missing = False
+    _cxxfilt_import_confirmed_missing = False
+    _warned_no_demangler = False
 
 
 def strip_signature(demangled: str) -> str:

--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -155,8 +155,19 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
     global _cxxfilt_import_confirmed_broken  # noqa: PLW0603
     try:
         import cxxfilt
-    except ImportError:
-        _cxxfilt_import_confirmed_missing = True
+    except ModuleNotFoundError as exc:
+        # A bare `ImportError` is not proof that `cxxfilt` itself is the
+        # missing module: cxxfilt could be installed and importable, but
+        # itself `import` a dependency that isn't -- that also raises
+        # `ImportError` (its `ModuleNotFoundError` subclass, specifically),
+        # naming the *dependency*, not `cxxfilt`, in `exc.name` (Codex
+        # review, fresh evidence, third round). Only a `ModuleNotFoundError`
+        # whose `.name` actually is "cxxfilt" proves the package itself is
+        # absent; anything else means cxxfilt is installed but broken.
+        if exc.name == "cxxfilt":
+            _cxxfilt_import_confirmed_missing = True
+        else:
+            _cxxfilt_import_confirmed_broken = True
     except Exception:  # noqa: BLE001
         # Not narrowed to ImportError alone: an installed cxxfilt module can
         # also fail to *import* for a reason other than "package not

--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -194,11 +194,20 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
                     # be misread as a real demangling (Codex review).
                     if out and out != canonical:
                         return out
+                    _log.debug(
+                        "c++filt echoed %s back unchanged (or empty) for %s",
+                        cmd[0],
+                        symbol,
+                    )
+                else:
+                    _log.debug(
+                        "c++filt exited %d demangling %s", result.returncode, symbol
+                    )
             except FileNotFoundError:
                 _cppfilt_binary_confirmed_missing = True
                 break
-            except (subprocess.TimeoutExpired, OSError):
-                pass
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                _log.debug("c++filt failed demangling %s: %s", symbol, exc)
 
     # Only warn "demangler unavailable" when BOTH backends are confirmed
     # absent from this environment. A working c++filt/cxxfilt that simply

--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -68,14 +68,25 @@ _cppfilt_binary_confirmed_missing = False
 # Set once an `import cxxfilt` inside demangle() raises ImportError -- proof
 # the package itself isn't installed, as distinct from the package being
 # installed but failing (or declining) to demangle one particular symbol.
-# Only *this* flag combined with `_cppfilt_binary_confirmed_missing` means
-# "no demangler available at all"; either backend being merely unable to
-# handle one malformed/foreign-ABI symbol is the normal, expected outcome for
-# plenty of real symbols and must never be conflated with both tools being
-# absent (the bug this flag exists to fix: the user-facing "no cxxfilt
-# package and no c++filt binary" warning used to fire on ANY single-symbol
-# demangle failure, including with a fully working c++filt installed).
+# Only *this* flag (or `_cxxfilt_import_confirmed_broken` below) combined with
+# `_cppfilt_binary_confirmed_missing` means "no demangler available at all";
+# either backend being merely unable to handle one malformed/foreign-ABI
+# symbol is the normal, expected outcome for plenty of real symbols and must
+# never be conflated with both tools being absent (the bug this flag exists
+# to fix: the user-facing "no cxxfilt package and no c++filt binary" warning
+# used to fire on ANY single-symbol demangle failure, including with a fully
+# working c++filt installed).
 _cxxfilt_import_confirmed_missing = False
+
+# Set once `import cxxfilt` raises something other than ImportError (e.g. an
+# OSError/RuntimeError from a broken native dependency at module-init time)
+# -- the package is *installed* but not usable, which is a different fact
+# from `_cxxfilt_import_confirmed_missing` above and must be worded
+# differently in the warning below (Codex review, fresh evidence: the
+# broad `except Exception` needed to preserve the c++filt fallback for this
+# case -- see `demangle()` -- must not also make the "no cxxfilt package"
+# wording fire for a package that is, in fact, installed).
+_cxxfilt_import_confirmed_broken = False
 
 
 def _is_itanium_mangled(symbol: str, *, accept_macho_prefix: bool = False) -> bool:
@@ -141,20 +152,26 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
         return None
     canonical = _canonical_mangled(symbol)
     global _cxxfilt_import_confirmed_missing  # noqa: PLW0603
+    global _cxxfilt_import_confirmed_broken  # noqa: PLW0603
     try:
         import cxxfilt
-    except Exception:  # noqa: BLE001
-        # Not narrowed to ImportError: an installed cxxfilt module can also
-        # fail to *import* for a reason other than "package not installed"
-        # (e.g. an OSError/RuntimeError from a broken native dependency at
-        # module-init time) -- the prior implementation caught all import-
-        # time exceptions here and fell through to the c++filt fallback,
-        # and `_batch_phase2_cxxfilt()` still does the same (Codex review,
-        # fresh evidence: narrowing this to ImportError let such an
-        # exception escape uncaught, aborting demangle() even when c++filt
-        # itself works fine). Either way cxxfilt is not usable this run, so
-        # it counts toward "confirmed missing" the same as an ImportError.
+    except ImportError:
         _cxxfilt_import_confirmed_missing = True
+    except Exception:  # noqa: BLE001
+        # Not narrowed to ImportError alone: an installed cxxfilt module can
+        # also fail to *import* for a reason other than "package not
+        # installed" (e.g. an OSError/RuntimeError from a broken native
+        # dependency at module-init time) -- the prior implementation caught
+        # all import-time exceptions here and fell through to the c++filt
+        # fallback, and `_batch_phase2_cxxfilt()` still does the same (Codex
+        # review, fresh evidence: narrowing this to ImportError let such an
+        # exception escape uncaught, aborting demangle() even when c++filt
+        # itself works fine). Recorded separately from
+        # `_cxxfilt_import_confirmed_missing`: the package IS installed here,
+        # just broken, and the warning below must say so accurately rather
+        # than falsely claiming "no cxxfilt package" (Codex review, fresh
+        # evidence, second round).
+        _cxxfilt_import_confirmed_broken = True
     else:
         try:
             out = str(cxxfilt.demangle(canonical))
@@ -210,20 +227,35 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
                 _log.debug("c++filt failed demangling %s: %s", symbol, exc)
 
     # Only warn "demangler unavailable" when BOTH backends are confirmed
-    # absent from this environment. A working c++filt/cxxfilt that simply
+    # unusable in this environment. A working c++filt/cxxfilt that simply
     # couldn't demangle this one symbol (malformed input, a non-Itanium
     # mangled-looking token, a foreign ABI) is not "unavailable" and must
     # stay silent here -- the bug this fixes: the warning used to fire on
     # ANY per-symbol demangle failure regardless of tool presence, so a
     # report where c++filt genuinely worked for other symbols could still
-    # falsely claim "no cxxfilt package and no c++filt binary".
-    if _cxxfilt_import_confirmed_missing and _cppfilt_binary_confirmed_missing:
+    # falsely claim "no cxxfilt package and no c++filt binary". The wording
+    # itself must also stay accurate to *which* cxxfilt fact is true (Codex
+    # review, fresh evidence, second round): "no cxxfilt package" only when
+    # the import genuinely failed with ImportError, never when the package
+    # is installed but broken (`_cxxfilt_import_confirmed_broken`) --
+    # claiming a broken package is a missing one is itself a false
+    # diagnostic, just a different one from the bug this function fixes.
+    cxxfilt_confirmed_unusable = (
+        _cxxfilt_import_confirmed_missing or _cxxfilt_import_confirmed_broken
+    )
+    if cxxfilt_confirmed_unusable and _cppfilt_binary_confirmed_missing:
         global _warned_no_demangler  # noqa: PLW0603
         if not _warned_no_demangler:
+            cxxfilt_state = (
+                "no cxxfilt package"
+                if _cxxfilt_import_confirmed_missing
+                else "cxxfilt failed to initialize"
+            )
             _log.warning(
-                "C++ demangling unavailable (no cxxfilt package and no c++filt "
-                "binary); DWARF export matching and appcompat symbol matching "
-                "may be incomplete"
+                "C++ demangling unavailable (%s and no c++filt binary); "
+                "DWARF export matching and appcompat symbol matching may be "
+                "incomplete",
+                cxxfilt_state,
             )
             _warned_no_demangler = True
     return None
@@ -402,11 +434,13 @@ def _reset_demangle_batch_cache() -> None:
     """Test helper — clear the process-wide cache."""
     global _cppfilt_binary_confirmed_missing  # noqa: PLW0603
     global _cxxfilt_import_confirmed_missing  # noqa: PLW0603
+    global _cxxfilt_import_confirmed_broken  # noqa: PLW0603
     global _warned_no_demangler  # noqa: PLW0603
     _BATCH_CACHE_OK.clear()
     _BATCH_CACHE_FAIL.clear()
     _cppfilt_binary_confirmed_missing = False
     _cxxfilt_import_confirmed_missing = False
+    _cxxfilt_import_confirmed_broken = False
     _warned_no_demangler = False
 
 

--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -143,7 +143,17 @@ def demangle(symbol: str, *, accept_macho_prefix: bool = False) -> str | None:
     global _cxxfilt_import_confirmed_missing  # noqa: PLW0603
     try:
         import cxxfilt
-    except ImportError:
+    except Exception:  # noqa: BLE001
+        # Not narrowed to ImportError: an installed cxxfilt module can also
+        # fail to *import* for a reason other than "package not installed"
+        # (e.g. an OSError/RuntimeError from a broken native dependency at
+        # module-init time) -- the prior implementation caught all import-
+        # time exceptions here and fell through to the c++filt fallback,
+        # and `_batch_phase2_cxxfilt()` still does the same (Codex review,
+        # fresh evidence: narrowing this to ImportError let such an
+        # exception escape uncaught, aborting demangle() even when c++filt
+        # itself works fine). Either way cxxfilt is not usable this run, so
+        # it counts toward "confirmed missing" the same as an ImportError.
         _cxxfilt_import_confirmed_missing = True
     else:
         try:

--- a/changelog.d/1789000000_claude_demangle-warning-false-positive.md
+++ b/changelog.d/1789000000_claude_demangle-warning-false-positive.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`demangle()` no longer warns "C++ demangling unavailable" when a
+  demangler is actually present.** The warning used to fire whenever a
+  single symbol failed to demangle through both the `cxxfilt` package and
+  the `c++filt` fallback — including when `c++filt` was genuinely installed
+  and working, but this one symbol just wasn't real Itanium mangling
+  (a malformed or foreign-ABI name c++filt legitimately echoes back
+  unchanged). It now fires only when the `cxxfilt` package is confirmed
+  unimportable *and* the `c++filt` binary is confirmed missing
+  (`FileNotFoundError`); a present tool failing on one symbol is logged at
+  debug level instead.

--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -184,6 +184,33 @@ class TestDemangle:
                 _mod.demangle("_ZN3foo3bazEv")
         assert _mod._warned_no_demangler is True
 
+    def test_non_importerror_cxxfilt_import_failure_falls_through_to_cppfilt(self):
+        """Codex review, fresh evidence: an installed `cxxfilt` module can
+        fail to *import* for a reason other than "package not installed"
+        (e.g. an OSError/RuntimeError from a broken native dependency at
+        module-init time). Narrowing the import's except clause to
+        `ImportError` let such an exception escape uncaught, aborting
+        demangle() entirely instead of falling through to the working
+        c++filt fallback -- must behave the same as an ImportError."""
+        real_import = __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "cxxfilt":
+                raise OSError("broken native dependency")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_fake_import):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt", "_ZN3foo3barEv"],
+                    returncode=0,
+                    stdout="foo::bar()\n",
+                    stderr="",
+                )
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result == "foo::bar()"
+        assert _mod._warned_no_demangler is False
+
     def test_no_warning_when_cppfilt_present_but_symbol_fails(self):
         """Root-cause regression for the false-positive warning: cxxfilt is
         importable (present, working for other symbols) and the c++filt

--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -211,6 +211,33 @@ class TestDemangle:
         assert result == "foo::bar()"
         assert _mod._warned_no_demangler is False
 
+    def test_warning_wording_distinguishes_broken_cxxfilt_from_missing_cxxfilt(
+        self, caplog
+    ):
+        """Codex review, fresh evidence (second round): when an installed
+        `cxxfilt` fails to import with something other than `ImportError`
+        (a broken native dependency, say) and c++filt is also genuinely
+        missing, the warning must still fire (no demangler actually works)
+        but must NOT claim "no cxxfilt package" -- that package IS
+        installed, just broken. Only a genuine ImportError earns that
+        specific wording."""
+        real_import = __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "cxxfilt":
+                raise OSError("broken native dependency")
+            return real_import(name, *args, **kwargs)
+
+        with caplog.at_level("WARNING", logger=_mod._log.name):
+            with patch("builtins.__import__", side_effect=_fake_import):
+                with patch("subprocess.run", side_effect=FileNotFoundError):
+                    result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+        assert _mod._warned_no_demangler is True
+        [warning_text] = [r.getMessage() for r in caplog.records]
+        assert "cxxfilt failed to initialize" in warning_text
+        assert "no cxxfilt package" not in warning_text
+
     def test_no_warning_when_cppfilt_present_but_symbol_fails(self):
         """Root-cause regression for the false-positive warning: cxxfilt is
         importable (present, working for other symbols) and the c++filt

--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -172,16 +172,74 @@ class TestDemangle:
                 result = _mod.demangle("_ZN3foo3barEv")
         assert result is None
 
-    def test_warning_emitted_once(self):
-        """The 'demangling unavailable' warning fires only once."""
-        mock_cxxfilt = MagicMock()
-        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
-        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+    def test_warning_emitted_once_when_both_backends_confirmed_absent(self):
+        """The 'demangling unavailable' warning fires, exactly once, only
+        when the cxxfilt package genuinely fails to import AND the c++filt
+        binary genuinely doesn't exist -- both backends confirmed absent,
+        not merely one symbol failing to demangle."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
             with patch("subprocess.run", side_effect=FileNotFoundError):
                 _mod.demangle("_ZN3foo3barEv")
                 _mod.demangle.cache_clear()
                 _mod.demangle("_ZN3foo3bazEv")
         assert _mod._warned_no_demangler is True
+
+    def test_no_warning_when_cppfilt_present_but_symbol_fails(self):
+        """Root-cause regression for the false-positive warning: cxxfilt is
+        importable (present, working for other symbols) and the c++filt
+        binary is genuinely installed and runs to completion -- it just
+        can't demangle THIS particular symbol (foreign ABI / malformed
+        mangled name / echoes the input back unchanged, exit 0). That must
+        never be reported as "demangler unavailable": the tool is present
+        and working, this one input just isn't real Itanium mangling."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("not itanium")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                # c++filt ran fine (returncode 0) but simply echoed the
+                # input back unchanged -- the canonical "couldn't demangle
+                # this one" outcome, not a missing-tool outcome.
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt", "_ZNOTVALID"],
+                    returncode=0,
+                    stdout="_ZNOTVALID\n",
+                    stderr="",
+                )
+                result = _mod.demangle("_ZNOTVALID")
+        assert result is None
+        assert _mod._warned_no_demangler is False
+
+    @pytest.mark.parametrize(
+        "cxxfilt_effect,cppfilt_returncode,cppfilt_stdout",
+        [
+            (RuntimeError("no"), 1, ""),
+            (RuntimeError("no"), 0, "_ZFAILS\n"),
+            (lambda s: s, 1, ""),
+            (lambda s: s, 0, "_ZFAILS\n"),
+        ],
+    )
+    def test_no_warning_across_present_tool_failure_combinations(
+        self, cxxfilt_effect, cppfilt_returncode, cppfilt_stdout
+    ):
+        """Parametrized over several present-tool/failing-symbol
+        combinations (cxxfilt raising vs. echoing unchanged, c++filt
+        non-zero exit vs. exit-0-echo) -- pins the actual invariant broken
+        by the reported bug (a working c++filt alongside a false
+        "unavailable" warning for some other symbol in the same run), not
+        just the one reported symbol/code path."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = cxxfilt_effect
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt", "_ZFAILS"],
+                    returncode=cppfilt_returncode,
+                    stdout=cppfilt_stdout,
+                    stderr="",
+                )
+                result = _mod.demangle("_ZFAILS")
+        assert result is None
+        assert _mod._warned_no_demangler is False
 
     def test_macho_double_underscore_prefix_via_cxxfilt(self):
         """Codex review, fresh evidence: clang's own `mangledName` carries the

--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -211,6 +211,49 @@ class TestDemangle:
         assert result == "foo::bar()"
         assert _mod._warned_no_demangler is False
 
+    def test_cxxfilt_dependency_modulenotfounderror_is_not_cxxfilt_missing(
+        self, caplog
+    ):
+        """Codex review, fresh evidence (third round): a bare `ImportError`
+        is not proof that `cxxfilt` itself is the missing module -- cxxfilt
+        can be installed and importable, but its own `import` of some
+        dependency can fail, raising a `ModuleNotFoundError` (an
+        `ImportError` subclass) naming the DEPENDENCY, not `cxxfilt`, in
+        `.name`. That must be recorded as "cxxfilt broken", never as
+        "cxxfilt confirmed missing" -- and the eventual warning (with
+        c++filt also missing) must say so, not falsely claim "no cxxfilt
+        package"."""
+        real_import = __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "cxxfilt":
+                raise ModuleNotFoundError(
+                    "No module named 'some_cxxfilt_dependency'",
+                    name="some_cxxfilt_dependency",
+                )
+            return real_import(name, *args, **kwargs)
+
+        with caplog.at_level("WARNING", logger=_mod._log.name):
+            with patch("builtins.__import__", side_effect=_fake_import):
+                with patch("subprocess.run", side_effect=FileNotFoundError):
+                    result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+        assert _mod._cxxfilt_import_confirmed_missing is False
+        assert _mod._cxxfilt_import_confirmed_broken is True
+        [warning_text] = [r.getMessage() for r in caplog.records]
+        assert "cxxfilt failed to initialize" in warning_text
+        assert "no cxxfilt package" not in warning_text
+
+    def test_genuine_cxxfilt_modulenotfounderror_is_confirmed_missing(self):
+        """The positive counterpart: a `ModuleNotFoundError` whose `.name`
+        actually IS "cxxfilt" is genuine proof the package itself isn't
+        installed, and must still set `_cxxfilt_import_confirmed_missing`
+        (not merely `_cxxfilt_import_confirmed_broken`)."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            _mod.demangle("_ZN3foo3barEv")
+        assert _mod._cxxfilt_import_confirmed_missing is True
+        assert _mod._cxxfilt_import_confirmed_broken is False
+
     def test_warning_wording_distinguishes_broken_cxxfilt_from_missing_cxxfilt(
         self, caplog
     ):


### PR DESCRIPTION
## Summary

`demangle()`'s "C++ demangling unavailable" warning no longer fires just because one symbol failed to demangle — only when both `cxxfilt` and `c++filt` are confirmed genuinely absent.

## Motivation

`abicheck/demangle.py`'s `_warned_no_demangler` block was reached whenever BOTH the `cxxfilt` package attempt and the `c++filt` subprocess fallback failed to demangle ONE symbol — not specifically when the tool was confirmed absent. The message text unconditionally claimed "no cxxfilt package and no c++filt binary", which is false whenever `c++filt` exists and works: a run could successfully demangle most symbols via `c++filt` and still emit this warning the moment any other single symbol (malformed name, foreign ABI, a name the tool legitimately echoes back unchanged) failed to demangle.

## Changes

- Added `_cxxfilt_import_confirmed_missing`, set only on a real `ImportError` from `import cxxfilt` — distinct from the package importing fine but declining/failing to demangle one particular symbol.
- The "demangling unavailable" warning in `demangle()` now fires only when `_cxxfilt_import_confirmed_missing` **and** the existing `_cppfilt_binary_confirmed_missing` are both true (both backends confirmed absent).
- A present tool failing on one symbol is no longer treated as "unavailable" — it now logs at debug level, matching the existing `cxxfilt`-exception debug log two lines above.
- `_reset_demangle_batch_cache()` (test helper) now also resets the two flags and `_warned_no_demangler`, so tests don't leak state between cases.
- Added/updated regression tests in `tests/test_demangle_unit.py`.

## Bug-fix test contract

- Bug class: false-positive "demangler unavailable" warning triggered by a single per-symbol demangle failure, independent of whether the tool is actually present and working.
- Publicly observable failure: `demangle()` logs `"C++ demangling unavailable (no cxxfilt package and no c++filt binary)..."` even in a run where `c++filt` is installed and successfully demangled other symbols in the same process.
- Regression test fails on base: `TestDemangle::test_no_warning_when_cppfilt_present_but_symbol_fails` and `TestDemangle::test_no_warning_across_present_tool_failure_combinations` (all 4 parametrizations) — on the pre-fix code, the warning fires unconditionally once both the cxxfilt attempt and every `c++filt` command variant fail for a given symbol, regardless of whether c++filt genuinely ran and returned a real (if useless) result.
- Negative control: `TestDemangle::test_warning_emitted_once_when_both_backends_confirmed_absent` — asserts the warning DOES still fire (once) when `cxxfilt` genuinely fails to import and `c++filt` genuinely raises `FileNotFoundError`, proving the fix narrows the warning's trigger condition rather than disabling it outright.
- Public-surface test: all new/changed tests call the public `demangle()` function only, asserting on its return value and the module-level `_warned_no_demangler` flag it sets — no internal-helper-only assertions.
- Axes covered: `cxxfilt.demangle` raising vs. echoing input back unchanged; `c++filt` subprocess non-zero exit vs. exit-0-with-unchanged-echo; cxxfilt genuinely unimportable vs. genuinely raising per-symbol.
- General invariant: the "demangler unavailable" warning fires if and only if both the `cxxfilt` package is confirmed unimportable and the `c++filt` binary is confirmed missing — never merely because one symbol (of any shape) failed to demangle through an actually-present tool.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — `changelog.d/1789000000_claude_demangle-warning-false-positive.md`
- [ ] Docs updated if user-visible behaviour changed (log-message-only fix, no docs reference this warning text)
- [x] `ruff check` / `mypy abicheck/demangle.py` pass locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuLLuJ5wDwfvW7douHKzcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuLLuJ5wDwfvW7douHKzcR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ symbol demangling warnings to appear only when both supported demangling methods are unavailable.
  * Prevented misleading unavailable-demangler warnings when a demangler is available but cannot process a specific symbol.
  * Ensured demangling availability status resets correctly when clearing cached results.

* **Tests**
  * Added coverage for unavailable demanglers and individual symbol-processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->