### PR TITLE
refactor: give the release fan-out a typed pre-execution request/plan (ADR-061 gap D)

### DIFF
--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -69,7 +69,7 @@ from .cli_compare_release_helpers import (  # noqa: F401
 from .cli_compare_release_matrix import (
     _collect_matrix_result,
     _finalize_release_output,
-    _prepare_compare_release_inputs,
+    _prepare_compare_release_inputs as _prepare_compare_release_inputs,  # re-exported, direct tests still call it
     _release_finding_dicts as _release_finding_dicts,
     _release_gating_buckets as _release_gating_buckets,
     _strip_diff_results_and_adjust_verdict,
@@ -113,18 +113,11 @@ from .workflows.release_scope import (
     StrandedLibraryResolution,
     build_release_scope_record,
     out_of_scope_provider_names,
-    release_inventory_evidence,
-    resolve_release_scope_plan,
     resolve_release_scope_result,
     scoped_bundle_maps,
 )
-from .workflows.release_stored_inventory import (
-    stored_degraded_members,
-    stored_side_degraded_members,
-    stored_side_inventory_complete,
-)
+from .workflows.release_stored_inventory import stored_side_degraded_members
 from .workflows.release_support_promise import support_promise_results
-from .workflows.storage import is_project_snapshot_package_dir
 
 if TYPE_CHECKING:
     from .compile_context import CompileContext
@@ -510,10 +503,6 @@ def compare_release_cmd(
     """
 
     from .workflows.extraction import (
-        _is_elf_shared_object,
-        detect_extractor,
-        discover_shared_libraries,
-        is_package,
         resolve_package_debug_info as resolve_debug_info,
     )
 
@@ -567,18 +556,6 @@ def compare_release_cmd(
         _temp_dir_paths.append(path)
         return Path(path)
 
-    def _do_extract(
-        input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None
-    ) -> tuple[Path, Path | None, Path | None, Path | None, bool]:
-        return _extract_if_package(
-            input_path,
-            debug_pkg,
-            devel_pkg,
-            _make_temp_dir,
-            is_package,
-            detect_extractor,
-        )
-
     # dedup_validate_overrides_warnings(): this whole release run reloads
     # the same --policy-file several times over -- the early strict-
     # suppression validation just below, the per-library fan-out (including
@@ -600,123 +577,70 @@ def compare_release_cmd(
             require_justification,
         )
 
+        # ADR-061 gap D / DoD item 8, closure package 4: the release fan-out's
+        # entire pre-execution resolution (input discovery, ADR-065 scope/
+        # inventory evidence, the ReleaseScopePlan, the resolved GateOptions,
+        # and each side's stored-degraded markers) as one typed request/plan
+        # pair -- ``ReleaseCompareRequest``/``ReleaseComparePlan`` -- rather
+        # than the dozen independent locals this block used to thread by
+        # hand across four separate calls. See that module's own docstring
+        # for exactly what this closes and what remains open.
         try:
-            (
-                old_debug_dir,
-                new_debug_dir,
-                old_h,
-                new_h,
-                old_inc,
-                new_inc,
-                old_map,
-                new_map,
-                warning_msgs,
-                matched_keys,
-                old_unclassified,
-                new_unclassified,
-                old_inventory,
-                new_inventory,
-            ) = _prepare_compare_release_inputs(
-                old_dir,
-                new_dir,
-                debug_info1,
-                debug_info2,
-                devel_pkg1,
-                devel_pkg2,
-                include_private_dso,
-                dso_only,
-                headers,
-                old_headers_only,
-                new_headers_only,
-                includes,
-                old_includes_only,
-                new_includes_only,
-                config_includes,
-                _do_extract,
-                discover_shared_libraries,
-                is_package,
-                _is_elf_shared_object,
+            from .frontends.cli.release_compare_request import (
+                ReleaseCompareRequest,
+                resolve_release_compare_plan,
+            )
+
+            request = ReleaseCompareRequest(
+                old_dir=old_dir,
+                new_dir=new_dir,
+                debug_info1=debug_info1,
+                debug_info2=debug_info2,
+                devel_pkg1=devel_pkg1,
+                devel_pkg2=devel_pkg2,
+                include_private_dso=include_private_dso,
+                dso_only=dso_only,
+                headers=headers,
+                old_headers_only=old_headers_only,
+                new_headers_only=new_headers_only,
+                includes=includes,
+                old_includes_only=old_includes_only,
+                new_includes_only=new_includes_only,
+                config_includes=config_includes,
                 old_variant=old_variant,
                 new_variant=new_variant,
-                make_temp_dir=_make_temp_dir,
+                release_selection=release_selection,
+                pack_application=pack_application,
+                severity_preset=severity_preset,
+                severity_abi_breaking=severity_abi_breaking,
+                severity_potential_breaking=severity_potential_breaking,
+                severity_quality_issues=severity_quality_issues,
+                severity_addition=severity_addition,
+                on_incomplete_scope=on_incomplete_scope,
+                fail_on_removed_library=fail_on_removed,
             )
-            # ADR-065 D2's inventory proof for this release (S2): a stored
-            # ProjectSnapshot package whose capture asserted a complete
-            # inventory (`inventory_complete`, persisted with its
-            # composition); the package type alone, a live directory, an
-            # extracted archive, or a direct file pair never proves it.
-            old_stored = old_dir.is_dir() and is_project_snapshot_package_dir(old_dir)
-            new_stored = new_dir.is_dir() and is_project_snapshot_package_dir(new_dir)
             try:
-                old_complete = old_stored and stored_side_inventory_complete(
-                    old_dir, variant_id=old_variant
+                plan = resolve_release_compare_plan(
+                    request, make_temp_dir=_make_temp_dir
                 )
-                new_complete = new_stored and stored_side_inventory_complete(
-                    new_dir, variant_id=new_variant
-                )
-            except SnapshotError as exc:  # a damaged composition (fail closed)
+            except SnapshotError as exc:  # a damaged composition/marker (fail closed)
                 raise click.UsageError(str(exc)) from exc
-            inventory_evidence = release_inventory_evidence(
-                old_stored=old_stored,
-                new_stored=new_stored,
-                old_complete=old_complete,
-                new_complete=new_complete,
-                direct_pair=list(matched_keys) == [DIRECT_PAIR_KEY],
-                # D9 reads intent from the operand shape: a single-file NEW
-                # (not a directory/archive that discovered one member).
-                new_single_artifact=new_dir.is_file() and not is_package(new_dir),
-                # ADR-065 D2 (Codex review): a stored member --dso-only
-                # could not classify withholds that side's proof.
-                old_unclassified=old_unclassified,
-                new_unclassified=new_unclassified,
-                # ADR-065 S3: a package archive's own declared component
-                # inventory, complete because the container was unpacked in
-                # full -- the live-operand counterpart of a stored package's
-                # persisted `inventory_complete` assertion.
-                old_inventory=old_inventory,
-                new_inventory=new_inventory,
-            )
-            # ADR-061 gap D / DoD item 8, closure package 4: the pre-
-            # execution half of ADR-065's scope model (which members are
-            # paired, and each side's own completeness evidence) as one
-            # resolved plan object rather than four independent locals
-            # threaded by hand -- see `ReleaseScopePlan`'s own docstring.
-            #
-            # Codex review (PR #1192, follow-up finding): rebinding
-            # `old_map`/`new_map`/`matched_keys` to the plan's own copies
-            # here -- rather than only reading `scope_plan.*` at the record
-            # builder after execution -- is what makes `scope_plan` the
-            # actual input execution consumes, not a DTO wrapper computed
-            # alongside it. `stored_degraded_members`, `compare_keys`, and
-            # `_compare_release_libraries` below (and every other reader in
-            # this function) now see exactly what the plan resolved, so a
-            # future normalization/selection rule added to
-            # `resolve_release_scope_plan` changes which pairs actually run,
-            # not merely how the post-execution record describes them.
-            #
-            # Codex review (PR #1192, second follow-up finding): an explicit
-            # `--select`/`--select-required` selection is folded into
-            # `matched_keys` *before* `resolve_release_scope_plan` runs, not
-            # as a separate filter applied to `compare_keys` afterward (see
-            # the now-removed second filter below) -- so `scope_plan` itself,
-            # not a step downstream of it, is what narrows what executes.
-            # The direct-pair sentinel is exempt: `DIRECT_PAIR_KEY` names no
-            # real declared library for a selection to match against.
-            plan_matched_keys = matched_keys
-            if release_selection is not None and list(matched_keys) != [
-                DIRECT_PAIR_KEY
-            ]:
-                plan_matched_keys = [
-                    k for k in matched_keys if k in release_selection
-                ]
-            scope_plan = resolve_release_scope_plan(
-                old_map, new_map, plan_matched_keys, inventory_evidence
-            )
+
+            scope_plan = plan.scope
             old_map, new_map, matched_keys = (
                 dict(scope_plan.old_map),
                 dict(scope_plan.new_map),
                 list(scope_plan.matched_keys),
             )
+            old_debug_dir, new_debug_dir = plan.old_debug_dir, plan.new_debug_dir
+            old_h, new_h = list(plan.old_headers), list(plan.new_headers)
+            old_inc, new_inc = list(plan.old_includes), list(plan.new_includes)
+            warning_msgs = list(plan.warnings)
+            old_unclassified, new_unclassified = (
+                plan.old_unclassified,
+                plan.new_unclassified,
+            )
+            old_inventory, new_inventory = plan.old_inventory, plan.new_inventory
 
             if fmt != "json":
                 for msg in warning_msgs:
@@ -726,45 +650,13 @@ def compare_release_cmd(
             if output_dir:
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-            # CLI cleanup phase two, ADR-064 "GateOptions" rewrite: one
-            # resolution replaces the release fan-out's previous three
-            # independent re-derivations of the same SeverityConfig from
-            # five raw preset/category strings. `resolve_release_gate_
-            # options` folds a selected `kind: gate` pack's gate.severity.
-            # <category> contribution (`apply_release_gate_pack`), then
-            # resolves the severity config -- since PR G2 removed the
-            # manual algorithm selector, `gate.exit_code_scheme` is purely
-            # derived from whether `gate.severity` ended up non-`None`, not
-            # a fourth independent input any more. Every downstream
-            # consumer (this function's own `severity_config`, the
-            # per-library JSON write inside `_compare_release_libraries`,
-            # `_compute_release_severity_exit_code`,
-            # `_fold_release_global_severity`) now reads the resulting
-            # `GateOptions` instead of independently re-deriving it.
-            # Codex review, PR #1192, third follow-up round: `on_incomplete_
-            # scope`/`fail_on_removed` are this run's own already-resolved
-            # ADR-065 release-scope axes (the identical locals `compare_
-            # keys`'s scope-decision resolution and `_exit_compare_release`
-            # read below) -- passed straight through so `GateOptions`/
-            # `EffectiveGate`'s own digest-facing fields cannot silently
-            # disagree with the values that actually govern this run's exit
-            # code.
-            gate = resolve_release_gate_options(
-                pack_application,
-                severity_preset=severity_preset,
-                severity_abi_breaking=severity_abi_breaking,
-                severity_potential_breaking=severity_potential_breaking,
-                severity_quality_issues=severity_quality_issues,
-                severity_addition=severity_addition,
-                on_incomplete_scope=on_incomplete_scope,
-                fail_on_removed_library=fail_on_removed,
-            )
             # Resolved before the compare pass (its inputs are plain CLI values, no
             # dependency on compare results) so persisted per-library annotations
             # (schema 2.43/2.44, computed inside _compare_release_libraries's
             # primary pass and read by the Action, not the CLI) reflect the same
             # severity-aware gate as the exit code below, instead of the legacy
             # kind-set mapping. `None` when no severity setting was in effect.
+            gate = plan.gate
             severity_config = gate.severity
             severity_preset = gate.severity_preset
 
@@ -783,17 +675,10 @@ def compare_release_cmd(
             # An unmatched one is `failed` on the record too (below), so a
             # proven inventory on the other side never turns a degraded
             # capture into a removal or an addition (twenty-seventh round).
-            try:
-                degraded = stored_degraded_members(
-                    old_dir,
-                    new_dir,
-                    old_map,
-                    new_map,
-                    old_variant=old_variant,
-                    new_variant=new_variant,
-                )
-            except SnapshotError as exc:  # a damaged marker section (Codex review)
-                raise click.UsageError(str(exc)) from exc
+            degraded = plan.degraded
+            assert (
+                degraded is not None
+            )  # always resolved by resolve_release_compare_plan
             degraded_matched = degraded.matched
             # ADR-065 S1: with an explicit selection, a matched key the
             # caller did not declare is never run through the (expensive)
@@ -802,7 +687,7 @@ def compare_release_cmd(
             # compared anyway. `matched_keys` is already selection-narrowed
             # (folded into `scope_plan` above), so no second filter is
             # needed here.
-            compare_keys = [k for k in matched_keys if k not in degraded_matched]
+            compare_keys = plan.compare_keys
             library_results, worst_verdict, diff_pairs = _compare_release_libraries(
                 compare_keys,
                 old_map,
@@ -888,7 +773,7 @@ def compare_release_cmd(
                 else {},
             }
             if release_selection is not None and not (
-                inventory_evidence.direct_pair
+                scope_plan.evidence.direct_pair
                 or list(matched_keys) == [DIRECT_PAIR_KEY]
             ):
                 # ADR-065 S1: an explicit selection overrides D9's inference

--- a/abicheck/frontends/cli/release_compare_request.py
+++ b/abicheck/frontends/cli/release_compare_request.py
@@ -291,101 +291,116 @@ def resolve_release_compare_plan(
         allocated_temp_dirs.append(path)
         return path
 
-    (
-        old_debug_dir,
-        new_debug_dir,
-        old_h,
-        new_h,
-        old_inc,
-        new_inc,
-        old_map,
-        new_map,
-        warning_msgs,
-        matched_keys,
-        old_unclassified,
-        new_unclassified,
-        old_inventory,
-        new_inventory,
-    ) = _prepare_compare_release_inputs(
-        request.old_dir,
-        request.new_dir,
-        request.debug_info1,
-        request.debug_info2,
-        request.devel_pkg1,
-        request.devel_pkg2,
-        request.include_private_dso,
-        request.dso_only,
-        request.headers,
-        request.old_headers_only,
-        request.new_headers_only,
-        request.includes,
-        request.old_includes_only,
-        request.new_includes_only,
-        request.config_includes,
-        _do_extract,
-        discover_shared_libraries,
-        is_package,
-        _is_elf_shared_object,
-        old_variant=request.old_variant,
-        new_variant=request.new_variant,
-        make_temp_dir=_make_temp_dir,
-    )
+    try:
+        (
+            old_debug_dir,
+            new_debug_dir,
+            old_h,
+            new_h,
+            old_inc,
+            new_inc,
+            old_map,
+            new_map,
+            warning_msgs,
+            matched_keys,
+            old_unclassified,
+            new_unclassified,
+            old_inventory,
+            new_inventory,
+        ) = _prepare_compare_release_inputs(
+            request.old_dir,
+            request.new_dir,
+            request.debug_info1,
+            request.debug_info2,
+            request.devel_pkg1,
+            request.devel_pkg2,
+            request.include_private_dso,
+            request.dso_only,
+            request.headers,
+            request.old_headers_only,
+            request.new_headers_only,
+            request.includes,
+            request.old_includes_only,
+            request.new_includes_only,
+            request.config_includes,
+            _do_extract,
+            discover_shared_libraries,
+            is_package,
+            _is_elf_shared_object,
+            old_variant=request.old_variant,
+            new_variant=request.new_variant,
+            make_temp_dir=_make_temp_dir,
+        )
 
-    old_stored = request.old_dir.is_dir() and is_project_snapshot_package_dir(
-        request.old_dir
-    )
-    new_stored = request.new_dir.is_dir() and is_project_snapshot_package_dir(
-        request.new_dir
-    )
-    old_complete = old_stored and stored_side_inventory_complete(
-        request.old_dir, variant_id=request.old_variant
-    )
-    new_complete = new_stored and stored_side_inventory_complete(
-        request.new_dir, variant_id=request.new_variant
-    )
-    inventory_evidence = release_inventory_evidence(
-        old_stored=old_stored,
-        new_stored=new_stored,
-        old_complete=old_complete,
-        new_complete=new_complete,
-        direct_pair=list(matched_keys) == [DIRECT_PAIR_KEY],
-        new_single_artifact=request.new_dir.is_file()
-        and not is_package(request.new_dir),
-        old_unclassified=old_unclassified,
-        new_unclassified=new_unclassified,
-        old_inventory=old_inventory,
-        new_inventory=new_inventory,
-    )
+        old_stored = request.old_dir.is_dir() and is_project_snapshot_package_dir(
+            request.old_dir
+        )
+        new_stored = request.new_dir.is_dir() and is_project_snapshot_package_dir(
+            request.new_dir
+        )
+        old_complete = old_stored and stored_side_inventory_complete(
+            request.old_dir, variant_id=request.old_variant
+        )
+        new_complete = new_stored and stored_side_inventory_complete(
+            request.new_dir, variant_id=request.new_variant
+        )
+        inventory_evidence = release_inventory_evidence(
+            old_stored=old_stored,
+            new_stored=new_stored,
+            old_complete=old_complete,
+            new_complete=new_complete,
+            direct_pair=list(matched_keys) == [DIRECT_PAIR_KEY],
+            new_single_artifact=request.new_dir.is_file()
+            and not is_package(request.new_dir),
+            old_unclassified=old_unclassified,
+            new_unclassified=new_unclassified,
+            old_inventory=old_inventory,
+            new_inventory=new_inventory,
+        )
 
-    plan_matched_keys = matched_keys
-    if request.release_selection is not None and list(matched_keys) != [
-        DIRECT_PAIR_KEY
-    ]:
-        plan_matched_keys = [k for k in matched_keys if k in request.release_selection]
+        plan_matched_keys = matched_keys
+        if request.release_selection is not None and list(matched_keys) != [
+            DIRECT_PAIR_KEY
+        ]:
+            plan_matched_keys = [
+                k for k in matched_keys if k in request.release_selection
+            ]
 
-    scope_plan = resolve_release_scope_plan(
-        old_map, new_map, plan_matched_keys, inventory_evidence
-    )
+        scope_plan = resolve_release_scope_plan(
+            old_map, new_map, plan_matched_keys, inventory_evidence
+        )
 
-    gate = resolve_release_gate_options(
-        request.pack_application,
-        severity_preset=request.severity_preset,
-        severity_abi_breaking=request.severity_abi_breaking,
-        severity_potential_breaking=request.severity_potential_breaking,
-        severity_quality_issues=request.severity_quality_issues,
-        severity_addition=request.severity_addition,
-        on_incomplete_scope=request.on_incomplete_scope,
-        fail_on_removed_library=request.fail_on_removed_library,
-    )
+        gate = resolve_release_gate_options(
+            request.pack_application,
+            severity_preset=request.severity_preset,
+            severity_abi_breaking=request.severity_abi_breaking,
+            severity_potential_breaking=request.severity_potential_breaking,
+            severity_quality_issues=request.severity_quality_issues,
+            severity_addition=request.severity_addition,
+            on_incomplete_scope=request.on_incomplete_scope,
+            fail_on_removed_library=request.fail_on_removed_library,
+        )
 
-    degraded = stored_degraded_members(
-        request.old_dir,
-        request.new_dir,
-        dict(scope_plan.old_map),
-        dict(scope_plan.new_map),
-        old_variant=request.old_variant,
-        new_variant=request.new_variant,
-    )
+        degraded = stored_degraded_members(
+            request.old_dir,
+            request.new_dir,
+            dict(scope_plan.old_map),
+            dict(scope_plan.new_map),
+            old_variant=request.old_variant,
+            new_variant=request.new_variant,
+        )
+    except BaseException:
+        # Codex review (PR #1215, second finding): a failure partway
+        # through resolution -- an old-side archive already extracted
+        # before a malformed new-side stored-package variant raises, or a
+        # later inventory/degraded-marker read failing -- must not leave
+        # whatever this call already allocated behind just because no
+        # ReleaseComparePlan was ever returned for a caller to clean up.
+        import shutil
+
+        for path in allocated_temp_dirs:
+            shutil.rmtree(path, ignore_errors=True)
+        raise
 
     return ReleaseComparePlan(
         request=request,

--- a/abicheck/frontends/cli/release_compare_request.py
+++ b/abicheck/frontends/cli/release_compare_request.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``ReleaseCompareRequest``/``ReleaseComparePlan`` -- ADR-061 gap D,
+closure package 4's next slice: the release fan-out's own *pre-execution*
+resolution (input discovery, ADR-065 scope/inventory evidence, the
+``ReleaseScopePlan``, the resolved ``GateOptions``, and each side's
+degraded-member markers) as one typed request/plan pair, constructible and
+resolvable with a single ordinary function call -- not only reachable by
+running the ``compare-release`` Click command.
+
+**What this closes.** Before this module existed, ``cli_compare_release.
+compare_release_cmd`` assembled this same information as roughly a dozen
+independent local variables threaded by hand through four separate calls
+(``_prepare_compare_release_inputs``, ``release_inventory_evidence``,
+``resolve_release_scope_plan``, ``resolve_release_gate_options``, plus
+``stored_side_inventory_complete``/``stored_degraded_members``) — exactly
+the "selection, inventory, and acquisition state reach the engine as CLI
+parameters" gap ADR-061's gap D and
+``docs/contribute/plans/vision-api-abi-evolution.md`` both name. Those
+locals are now fields on :class:`ReleaseCompareRequest` (the caller's
+inputs) and :class:`ReleaseComparePlan` (the resolved outcome), and
+:func:`resolve_release_compare_plan` is the one function that turns one
+into the other — callable directly from Python with no Click context, no
+``click.Context``, and no CLI invocation at all.
+:class:`TestReleaseCompareRequestParity` (``tests/
+test_release_compare_request.py``) is the completion test: a CLI-shaped
+invocation of ``compare-release`` and a direct, typed-request-shaped call
+to :func:`resolve_release_compare_plan` -- given the same operands and
+options -- resolve to the *same* scope, gate configuration, and degraded-
+member markers.
+
+**What this does not yet close.** ``resolve_release_compare_plan`` is
+"reachable from Python without Click" in the sense that matters for the
+completion test above (it is one plain function call, and every unit test
+in this module's own test file constructs a request and calls it directly)
+-- but it is not yet reachable from ``abicheck.service``'s typed Python API
+surface, because the functions it necessarily calls
+(``_prepare_compare_release_inputs``, ``_resolve_release_package_side``,
+and siblings) are still classified ``frontends``/flat ``cli_*``, not
+``workflows`` -- the ``engine-cli-boundary`` AI-readiness gate forbids
+``abicheck.service`` (an engine-adjacent module under that gate) from
+importing them, and at least one of them
+(``frontends.cli.release_variant_operand._resolve_release_package_side``)
+still raises a real ``click.UsageError`` on a malformed stored-package
+variant, which a caller with no Click context receives as a plain,
+uncaught exception rather than a documented typed one. Relocating that
+whole call chain into ``workflows``/``extract`` (and converting its
+Click-exception raises to the typed ``errors.py`` hierarchy the rest of
+the engine uses) is real, separately-scoped follow-up work -- see the
+"Remaining scope" note in ADR-061's own gap D section, added alongside
+this module.
+
+Deliberately placed under ``frontends/cli/`` (not ``workflows/``) for
+exactly the reason above: everything this module composes is already
+``frontends``/flat-``cli_*``-classified, so this stays a real, direct,
+supported CLI-input-translation module (Phase 4's own pattern -- "Move
+command input translation into ``frontends/cli/commands``") rather than a
+new false-engine-classified wrapper around code the dependency-direction
+gate would still flag.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from ...cli_compare_release_helpers import _extract_if_package
+from ...cli_compare_release_matrix import _prepare_compare_release_inputs
+from ...workflows.extraction import (
+    _is_elf_shared_object,
+    detect_extractor,
+    discover_shared_libraries,
+    is_package,
+)
+
+# `resolve_release_gate_options`/`GateOptions` are `policy`-classified;
+# reached through `workflows.gate`'s own re-export since `frontends` may
+# only import `model`/`report`/`workflows` (`check_architecture.py`'s
+# dependency-direction rule).
+from ...workflows.gate import GateOptions, resolve_release_gate_options
+
+# Module-level (not function-local) so a test can `unittest.mock.patch(
+# "abicheck.frontends.cli.release_compare_request.resolve_release_scope_plan",
+# ...)` -- the same "unit tests patch the owner module" convention
+# `workflows/AGENTS.md` documents for every other module-level import
+# binding in this release fan-out (e.g. `cli_compare_release.py`'s own
+# `resolve_release_scope_result` binding).
+from ...workflows.release_scope import (
+    DIRECT_PAIR_KEY,
+    release_inventory_evidence,
+    resolve_release_scope_plan,
+)
+from ...workflows.release_stored_inventory import (
+    stored_degraded_members,
+    stored_side_inventory_complete,
+)
+from ...workflows.storage import is_project_snapshot_package_dir
+
+if TYPE_CHECKING:
+    from ...model.package_inventory import PackageInventory
+    from ...model.release_selection import ReleaseSelection
+    from ...workflows.release_scope import ReleaseScopePlan
+    from ...workflows.release_stored_inventory import StoredDegradedMembers
+
+
+class _GatePackApplicationLike(Protocol):
+    """The structural shape :func:`~abicheck.policy.release_gate_options.
+    resolve_release_gate_options` needs from a
+    :class:`~abicheck.pack_application.PackApplication` -- a local
+    :class:`~typing.Protocol`, not an import of the real class, for the
+    identical dependency-direction reason
+    ``policy.release_gate_options._GatePackApplication`` (which this
+    mirrors) already gives: ``frontends`` may not import the unclassified
+    ``pack_application`` module, and a real ``PackApplication`` instance
+    satisfies this structurally regardless."""
+
+    @property
+    def severity_levels(self) -> Mapping[str, Any]: ...
+
+
+__all__ = [
+    "ReleaseCompareRequest",
+    "ReleaseComparePlan",
+    "resolve_release_compare_plan",
+]
+
+
+@dataclass(frozen=True)
+class ReleaseCompareRequest:
+    """A fully-specified directory/package release-comparison *resolution*
+    request -- the release fan-out's counterpart to
+    :class:`abicheck.workflows.contracts.CompareRequest`, scoped to the
+    pre-execution half (:func:`resolve_release_compare_plan` resolves it;
+    it does not itself run any per-library dump/compare).
+
+    Every field here previously reached ``_prepare_compare_release_inputs``/
+    ``release_inventory_evidence``/``resolve_release_scope_plan``/
+    ``resolve_release_gate_options`` as one of ``compare_release_cmd``'s own
+    local variables (parsed straight from Click options); this dataclass is
+    the one typed shape both that command and a direct Python caller now
+    build.
+    """
+
+    old_dir: Path
+    new_dir: Path
+    debug_info1: Path | None = None
+    debug_info2: Path | None = None
+    devel_pkg1: Path | None = None
+    devel_pkg2: Path | None = None
+    include_private_dso: bool = False
+    dso_only: bool = False
+    headers: tuple[Path, ...] = ()
+    old_headers_only: tuple[Path, ...] = ()
+    new_headers_only: tuple[Path, ...] = ()
+    includes: tuple[Path, ...] = ()
+    old_includes_only: tuple[Path, ...] = ()
+    new_includes_only: tuple[Path, ...] = ()
+    config_includes: tuple[Path, ...] = ()
+    old_variant: str | None = None
+    new_variant: str | None = None
+    #: ADR-065 S1's explicit, identity-keyed selection -- ``None`` (the
+    #: default) is D9's narrow current-artifact inference, unchanged.
+    release_selection: ReleaseSelection | None = None
+    pack_application: _GatePackApplicationLike | None = None
+    severity_preset: str | None = None
+    severity_abi_breaking: str | None = None
+    severity_potential_breaking: str | None = None
+    severity_quality_issues: str | None = None
+    severity_addition: str | None = None
+    on_incomplete_scope: str = "warn"
+    fail_on_removed_library: bool = False
+
+
+@dataclass(frozen=True)
+class ReleaseComparePlan:
+    """*request*'s resolved pre-execution outcome: everything
+    ``compare_release_cmd`` used to compute before its per-library
+    comparison loop, as fields rather than locals.
+
+    ``compare_keys`` is ``scope.matched_keys`` with any degraded matched
+    member removed -- the exact set the comparison loop below this plan
+    actually dumps/compares; a degraded member stays out of it but is still
+    named on ``degraded`` (and, downstream, recorded ``failed`` on the
+    acquisition record) rather than silently dropped.
+    """
+
+    request: ReleaseCompareRequest
+    scope: ReleaseScopePlan
+    gate: GateOptions
+    old_debug_dir: Path | None
+    new_debug_dir: Path | None
+    old_headers: tuple[Path, ...]
+    new_headers: tuple[Path, ...]
+    old_includes: tuple[Path, ...]
+    new_includes: tuple[Path, ...]
+    warnings: tuple[str, ...]
+    old_unclassified: dict[str, str] = field(default_factory=dict)
+    new_unclassified: dict[str, str] = field(default_factory=dict)
+    old_inventory: PackageInventory | None = None
+    new_inventory: PackageInventory | None = None
+    degraded: StoredDegradedMembers | None = None
+
+    @property
+    def compare_keys(self) -> list[str]:
+        degraded_matched = self.degraded.matched if self.degraded is not None else {}
+        return [k for k in self.scope.matched_keys if k not in degraded_matched]
+
+
+def resolve_release_compare_plan(
+    request: ReleaseCompareRequest,
+    *,
+    make_temp_dir: Callable[[str], Path] | None = None,
+) -> ReleaseComparePlan:
+    """Resolve *request* into a :class:`ReleaseComparePlan` -- the same
+    four-step sequence (``_prepare_compare_release_inputs`` ->
+    ``release_inventory_evidence`` -> ``resolve_release_scope_plan`` ->
+    ``resolve_release_gate_options``), plus each side's stored-degraded
+    markers, that ``compare_release_cmd`` itself now calls this function to
+    perform, rather than repeating inline.
+
+    *make_temp_dir* defaults to a plain, untracked ``tempfile.mkdtemp``-
+    backed factory when omitted -- sufficient for a direct Python caller
+    that does not need cleanup tracking; ``compare_release_cmd`` passes its
+    own tracked factory so its ``finally`` block still removes every
+    directory this resolution allocates, unchanged from before this
+    function existed.
+    """
+
+    def _do_extract(
+        input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None
+    ) -> tuple[Path, Path | None, Path | None, Path | None, bool]:
+        return _extract_if_package(
+            input_path,
+            debug_pkg,
+            devel_pkg,
+            _make_temp_dir,
+            is_package,
+            detect_extractor,
+        )
+
+    def _default_make_temp_dir(prefix: str) -> Path:
+        return Path(tempfile.mkdtemp(prefix=prefix))
+
+    _make_temp_dir: Callable[[str], Path] = (
+        make_temp_dir if make_temp_dir is not None else _default_make_temp_dir
+    )
+
+    (
+        old_debug_dir,
+        new_debug_dir,
+        old_h,
+        new_h,
+        old_inc,
+        new_inc,
+        old_map,
+        new_map,
+        warning_msgs,
+        matched_keys,
+        old_unclassified,
+        new_unclassified,
+        old_inventory,
+        new_inventory,
+    ) = _prepare_compare_release_inputs(
+        request.old_dir,
+        request.new_dir,
+        request.debug_info1,
+        request.debug_info2,
+        request.devel_pkg1,
+        request.devel_pkg2,
+        request.include_private_dso,
+        request.dso_only,
+        request.headers,
+        request.old_headers_only,
+        request.new_headers_only,
+        request.includes,
+        request.old_includes_only,
+        request.new_includes_only,
+        request.config_includes,
+        _do_extract,
+        discover_shared_libraries,
+        is_package,
+        _is_elf_shared_object,
+        old_variant=request.old_variant,
+        new_variant=request.new_variant,
+        make_temp_dir=_make_temp_dir,
+    )
+
+    old_stored = request.old_dir.is_dir() and is_project_snapshot_package_dir(
+        request.old_dir
+    )
+    new_stored = request.new_dir.is_dir() and is_project_snapshot_package_dir(
+        request.new_dir
+    )
+    old_complete = old_stored and stored_side_inventory_complete(
+        request.old_dir, variant_id=request.old_variant
+    )
+    new_complete = new_stored and stored_side_inventory_complete(
+        request.new_dir, variant_id=request.new_variant
+    )
+    inventory_evidence = release_inventory_evidence(
+        old_stored=old_stored,
+        new_stored=new_stored,
+        old_complete=old_complete,
+        new_complete=new_complete,
+        direct_pair=list(matched_keys) == [DIRECT_PAIR_KEY],
+        new_single_artifact=request.new_dir.is_file()
+        and not is_package(request.new_dir),
+        old_unclassified=old_unclassified,
+        new_unclassified=new_unclassified,
+        old_inventory=old_inventory,
+        new_inventory=new_inventory,
+    )
+
+    plan_matched_keys = matched_keys
+    if request.release_selection is not None and list(matched_keys) != [
+        DIRECT_PAIR_KEY
+    ]:
+        plan_matched_keys = [k for k in matched_keys if k in request.release_selection]
+
+    scope_plan = resolve_release_scope_plan(
+        old_map, new_map, plan_matched_keys, inventory_evidence
+    )
+
+    gate = resolve_release_gate_options(
+        request.pack_application,
+        severity_preset=request.severity_preset,
+        severity_abi_breaking=request.severity_abi_breaking,
+        severity_potential_breaking=request.severity_potential_breaking,
+        severity_quality_issues=request.severity_quality_issues,
+        severity_addition=request.severity_addition,
+        on_incomplete_scope=request.on_incomplete_scope,
+        fail_on_removed_library=request.fail_on_removed_library,
+    )
+
+    degraded = stored_degraded_members(
+        request.old_dir,
+        request.new_dir,
+        dict(scope_plan.old_map),
+        dict(scope_plan.new_map),
+        old_variant=request.old_variant,
+        new_variant=request.new_variant,
+    )
+
+    return ReleaseComparePlan(
+        request=request,
+        scope=scope_plan,
+        gate=gate,
+        old_debug_dir=old_debug_dir,
+        new_debug_dir=new_debug_dir,
+        old_headers=tuple(old_h),
+        new_headers=tuple(new_h),
+        old_includes=tuple(old_inc),
+        new_includes=tuple(new_inc),
+        warnings=tuple(warning_msgs),
+        old_unclassified=dict(old_unclassified),
+        new_unclassified=dict(new_unclassified),
+        old_inventory=old_inventory,
+        new_inventory=new_inventory,
+        degraded=degraded,
+    )

--- a/abicheck/frontends/cli/release_compare_request.py
+++ b/abicheck/frontends/cli/release_compare_request.py
@@ -137,6 +137,7 @@ class _GatePackApplicationLike(Protocol):
 __all__ = [
     "ReleaseCompareRequest",
     "ReleaseComparePlan",
+    "cleanup_release_compare_plan",
     "resolve_release_compare_plan",
 ]
 
@@ -215,11 +216,31 @@ class ReleaseComparePlan:
     old_inventory: PackageInventory | None = None
     new_inventory: PackageInventory | None = None
     degraded: StoredDegradedMembers | None = None
+    #: Every temporary directory this resolution allocated (package/debug-
+    #: package/devel-package extraction, stored-package-variant unpacking),
+    #: regardless of whether the caller supplied its own ``make_temp_dir``
+    #: or relied on the default one -- see :func:`cleanup_release_compare_plan`.
+    temp_dirs: tuple[Path, ...] = ()
 
     @property
     def compare_keys(self) -> list[str]:
         degraded_matched = self.degraded.matched if self.degraded is not None else {}
         return [k for k in self.scope.matched_keys if k not in degraded_matched]
+
+
+def cleanup_release_compare_plan(plan: ReleaseComparePlan) -> None:
+    """Remove every directory :func:`resolve_release_compare_plan` allocated
+    for *plan* (``plan.temp_dirs``) -- the direct-call counterpart of
+    ``compare_release_cmd``'s own tracked ``_make_temp_dir``/
+    ``_cleanup_temp_dirs`` pair (Codex review, PR #1215: a direct caller that
+    lets a package/debug-package/devel-package/stored-package operand use
+    the default ``make_temp_dir`` factory would otherwise leak the extracted
+    directories for the process's lifetime, since nothing else ever removes
+    them). A no-op, per entry, when a directory is already gone."""
+    import shutil
+
+    for path in plan.temp_dirs:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def resolve_release_compare_plan(
@@ -234,12 +255,15 @@ def resolve_release_compare_plan(
     markers, that ``compare_release_cmd`` itself now calls this function to
     perform, rather than repeating inline.
 
-    *make_temp_dir* defaults to a plain, untracked ``tempfile.mkdtemp``-
-    backed factory when omitted -- sufficient for a direct Python caller
-    that does not need cleanup tracking; ``compare_release_cmd`` passes its
-    own tracked factory so its ``finally`` block still removes every
-    directory this resolution allocates, unchanged from before this
-    function existed.
+    *make_temp_dir* defaults to a plain ``tempfile.mkdtemp``-backed factory
+    when omitted; every directory either factory creates -- the caller's own
+    or the default -- is recorded on the returned plan's ``temp_dirs``
+    (Codex review, PR #1215), so a direct caller can pass the plan to
+    :func:`cleanup_release_compare_plan` when done with it.
+    ``compare_release_cmd`` passes its own tracked factory and keeps
+    removing them in its own ``finally`` block exactly as before this
+    function existed; ``plan.temp_dirs`` duplicating that tracking for the
+    CLI path is harmless since the CLI never reads it.
     """
 
     def _do_extract(
@@ -257,9 +281,15 @@ def resolve_release_compare_plan(
     def _default_make_temp_dir(prefix: str) -> Path:
         return Path(tempfile.mkdtemp(prefix=prefix))
 
-    _make_temp_dir: Callable[[str], Path] = (
+    _base_make_temp_dir: Callable[[str], Path] = (
         make_temp_dir if make_temp_dir is not None else _default_make_temp_dir
     )
+    allocated_temp_dirs: list[Path] = []
+
+    def _make_temp_dir(prefix: str) -> Path:
+        path = _base_make_temp_dir(prefix)
+        allocated_temp_dirs.append(path)
+        return path
 
     (
         old_debug_dir,
@@ -373,4 +403,5 @@ def resolve_release_compare_plan(
         old_inventory=old_inventory,
         new_inventory=new_inventory,
         degraded=degraded,
+        temp_dirs=tuple(allocated_temp_dirs),
     )

--- a/architecture/debt.yaml
+++ b/architecture/debt.yaml
@@ -471,7 +471,7 @@
       "disposition": "migrate",
       "category": "legacy_workflow_or_frontend_monolith",
       "owner": "abicheck maintainers",
-      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice.",
+      "rationale": "Existing implementation predates ADR-061 and cannot move safely without a behavior-preserving vertical slice. Shrank 1995 -> ~1190 (ADR-061 gap D, closure package 4's next slice): compare_release_cmd's own pre-execution resolution (input discovery, ADR-065 scope/inventory evidence, the ReleaseScopePlan, the resolved GateOptions, each side's stored-degraded markers -- previously ~180 lines of locals threaded by hand through four separate calls) moved to a real Request -> ResolvedPlan pair, `frontends.cli.release_compare_request.ReleaseCompareRequest`/`ReleaseComparePlan`/`resolve_release_compare_plan`, callable directly from Python with no Click context -- this command now builds one request and unpacks one plan. Still `no_growth`/`migrate`: the command itself (execution dispatch, output rendering, bundle-facts writing) is unmoved, and the new module still depends on `_prepare_compare_release_inputs`/`_resolve_release_package_side` (still `frontends`/flat-`cli_*`-classified, one of which still raises a real `click.UsageError`) -- see `release_compare_request.py`'s own docstring and ADR-061's gap D section for the exact remaining scope.",
       "review_by": "2026-11-30"
     },
     {

--- a/changelog.d/1789103300_claude_release-compare-request-plan.md
+++ b/changelog.d/1789103300_claude_release-compare-request-plan.md
@@ -1,0 +1,20 @@
+### Changed
+
+- **Internal (ADR-061 gap D, closure package 4): the release fan-out's
+  pre-execution resolution is now a typed request/plan pair, not CLI
+  locals.** `compare-release`'s own input discovery, ADR-065 scope/inventory
+  evidence, `ReleaseScopePlan` resolution, resolved `GateOptions`, and each
+  side's stored-degraded markers -- previously about a dozen local variables
+  `cli_compare_release.py` threaded by hand through four separate calls --
+  are now fields on `frontends.cli.release_compare_request.
+  ReleaseCompareRequest`/`ReleaseComparePlan`, resolved by one function,
+  `resolve_release_compare_plan`, callable directly from Python with no
+  Click context. `compare-release` itself now builds one request and reads
+  one resolved plan; behavior is unchanged (verified against the existing
+  `test_compare_release.py`/`test_release_scope_*.py` suite, plus a new
+  parity test asserting a CLI-shaped invocation and a direct typed-request
+  call resolve to the same scope, gate configuration, and degraded-member
+  markers). See `release_compare_request.py`'s own docstring, and ADR-061's
+  gap D section, for what remains open (a typed `abicheck.service` entry
+  point still needs the underlying input-discovery/package-extraction call
+  chain relocated out of `frontends`/flat `cli_*` into `workflows`/`extract`).

--- a/docs/contribute/adr/061-responsibility-package-architecture.md
+++ b/docs/contribute/adr/061-responsibility-package-architecture.md
@@ -1075,10 +1075,14 @@ paths (ELF under CLI cleanup phase two PR C, PE/Mach-O under ADR-063 Phase
 1) now execute through the one shared `execute_dump_request`.
 
 **What the label does not mean.** This is the typed-resolution foundation,
-not universal frontend convergence. The shared request/plan types still do
-not carry selection, inventory, or acquisition state (ADR-065's scope
-model), so a package or multi-member comparison still assembles that in
-command-level orchestration — gap D below, and the same gap
+not universal frontend convergence. `CompareRequest`/`DumpRequest`
+themselves still carry no selection, inventory, or acquisition state
+(ADR-065's scope model does not apply to a single-pair/single-artifact
+request at all); the release fan-out's own multi-member selection,
+inventory, and acquisition state now live on a sibling typed pair,
+`ReleaseCompareRequest`/`ReleaseComparePlan`, resolvable with one direct
+Python call — see gap D below for exactly what that closes and what is
+still command-level orchestration. The same gap
 [`vision-api-abi-evolution.md`](../plans/vision-api-abi-evolution.md)
 records against scope convergence. The PE/Mach-O migration is verified by
 mock-based CLI/unit tests only: the layering claim is proven, an end-to-end
@@ -1540,20 +1544,80 @@ projection).
 
 ### D. Typed request/plan and operand convergence
 
-The shared per-artifact contracts exist (Phase 3), but they carry no
-selection, inventory, or acquisition state, so ADR-065's scope model is
-still assembled by command-level orchestration and the release fan-out still
-has no `ResolvedCompareConfig`-shaped object of its own (`gate.py`'s two
-callers fold onto different shapes — see
-[ADR-064](064-canonical-gate-algorithm-and-exit-decision.md) and this plan's
-own `EffectiveGate`/`EffectiveEvaluationConfig` target). Equivalent CLI and
-API input must resolve to equivalent scope, configuration, acquisition
-records, and outcomes.
+**Re-measured, closure package 4 (this section was stale — it described a
+2026-09 snapshot of the tree that several PRs have since moved past; see
+this ADR's own "A blocker recorded once goes stale" lesson under Phase 3).**
+The gap's two original halves are now in different states:
+
+- **The gate-shape half is closed.** `gate.py`'s two callers (`compare`'s
+  `ResolvedCompareConfig` and the release fan-out's `GateOptions`) no
+  longer fold onto independent shapes: `policy/effective_gate.py`'s
+  `EffectiveGate`/`GateSeverityState`/`ScopedGateSelection` is the one
+  converged runtime object both resolve to (`ResolvedCompareConfig.
+  effective_gate`/`GateOptions.effective_gate`, and
+  `workflows.gate.effective_gate_for_resolved_compare_config` for the
+  former's own no-growth-capped module), covering severity, exit-code
+  scheme, `require_complete_analysis`, and ADR-043 scoped-gate selection —
+  see `tests/test_effective_gate.py`'s own characterization/completion
+  split. This is deliberately narrower than the plan's full
+  `EffectiveEvaluationConfig` (policy/contract/assurance/surface/evidence/
+  suppressions namespaces beyond gate) — see this ADR's link to
+  `docs/contribute/plans/duplication-and-convergence-assessment.md`'s P0
+  section, which still names that wider object as not yet attempted.
+- **The scope/inventory/acquisition-state half is landed for the release
+  fan-out's own resolution, but not yet reachable from a typed Python
+  entry point.** `workflows/release_scope.py`'s `ReleaseScopePlan`/
+  `ReleaseScopeResult` (a real `Request -> ResolvedPlan -> Result` pair for
+  ADR-065's scope model) replaced the four independent locals
+  (`old_map`/`new_map`/`matched_keys`/`inventory_evidence`)
+  `cli_compare_release.py` used to thread by hand, and is the actual
+  execution-authoritative input, not a DTO computed alongside it (see
+  `tests/test_release_scope_plan.py`'s completion tests, including
+  `TestScopePlanIsExecutionAuthoritative`). This closure package's own next
+  slice widened that to the *entire* pre-execution resolution — input
+  discovery, inventory evidence, the scope plan, the resolved `GateOptions`,
+  and each side's stored-degraded markers — as one typed request/plan pair,
+  `frontends.cli.release_compare_request.ReleaseCompareRequest`/
+  `ReleaseComparePlan`/`resolve_release_compare_plan`: selection, inventory,
+  and acquisition state are now fields on that shared plan, constructible
+  and resolvable with one ordinary Python function call, not frontend
+  locals (`tests/test_release_compare_request.py`'s
+  `TestReleaseCompareRequestParity` is the completion test: a CLI-shaped
+  invocation and a direct typed-request-shaped call resolve to the same
+  scope, gate configuration, and degraded-member markers).
+
+**What remains open, precisely** (see
+`abicheck/frontends/cli/release_compare_request.py`'s own docstring for the
+same account in code): `resolve_release_compare_plan` is reachable from
+Python with no Click context — but it is not yet reachable from
+`abicheck.service`'s typed API surface, because the functions it must call
+(`_prepare_compare_release_inputs`, `frontends.cli.
+release_variant_operand._resolve_release_package_side`, and their own
+siblings — input discovery, package extraction, stored-variant resolution)
+are still classified `frontends`/flat `cli_*`, not `workflows`/`extract`.
+The `engine-cli-boundary` AI-readiness gate forbids `abicheck.service` from
+importing them directly, and at least one of them
+(`_resolve_release_package_side`) still raises a real `click.UsageError` on
+a malformed stored-package variant rather than a typed `errors.py`
+exception — a caller with no Click context receives that as a plain,
+uncaught exception. Closing this fully needs a real migration slice: move
+that call chain (and its Click-exception raises, converted to the typed
+exception hierarchy the rest of the engine uses) into `workflows`/`extract`
+per this ADR's own migration rules, then give `abicheck.service` a real
+entry point built on it. Also still open: the wider `EffectiveEvaluationConfig`
+namespaces beyond gate (above), and the release fan-out's execution half
+(per-library dump/compare dispatch, matrix/probe expansion, bundle-facts
+writing, output rendering) — this closure package's slice covers only the
+*resolution* half, matching `workflows/artifact/contracts.py`'s own
+Milestone A/B precedent of resolving before executing.
 
 **Completion test:** equivalent CLI and typed-API inputs produce equal
 resolved scope, configuration, acquisition records, and outcomes across
 live and stored operands; selection, inventory, and acquisition state are
-fields on the shared request/plan, not frontend locals.
+fields on the shared request/plan, not frontend locals. Met for the
+release fan-out's own pre-execution resolution, reachable as one direct
+Python call; not yet met for a caller with no CLI-layer dependency at all
+(`abicheck.service`), which is the remaining scope above.
 
 ### E. Storage and model ownership, not file placement
 

--- a/tests/test_release_compare_request.py
+++ b/tests/test_release_compare_request.py
@@ -154,3 +154,70 @@ class TestReleaseCompareRequestParity:
         assert cli_plan.degraded == direct_plan.degraded
         # 5. the actual execution set agrees.
         assert cli_plan.compare_keys == direct_plan.compare_keys
+
+
+class TestTempDirTracking:
+    """Codex review (PR #1215): a direct caller that lets a package/
+    stored-package operand resolve through the default ``make_temp_dir``
+    factory must not leak the directories it allocates -- every directory
+    either factory creates is recorded on the resolved plan's ``temp_dirs``,
+    and :func:`cleanup_release_compare_plan` removes them.
+
+    No real stored ``ProjectSnapshot`` package fixture is built here --
+    ``_resolve_release_package_side`` (the one call site that actually
+    invokes ``make_temp_dir`` for a package operand) is patched to call it
+    directly, isolating the tracking wrapper's own contract from that
+    unrelated package-format machinery."""
+
+    def test_a_directory_ever_created_via_make_temp_dir_is_tracked(
+        self, tmp_path: Path
+    ) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        created: list[Path] = []
+
+        def _fake_resolve_release_package_side(side_dir, variant_id, make_temp_dir, *, side):
+            # Simulate what a real stored-package side does: ask for one
+            # temp dir, then decline (this fixture is not a real package).
+            path = make_temp_dir(f"abicheck_relpkg_{side}_")
+            created.append(path)
+            return None
+
+        with patch(
+            "abicheck.cli_compare_release_matrix._resolve_release_package_side",
+            side_effect=_fake_resolve_release_package_side,
+        ):
+            request = ReleaseCompareRequest(old_dir=old_dir, new_dir=new_dir)
+            plan = resolve_release_compare_plan(request)
+
+        assert created  # the fake actually ran and asked for temp dirs
+        assert all(p.is_dir() for p in created)
+        assert set(plan.temp_dirs) == set(created)
+
+        from abicheck.frontends.cli.release_compare_request import (
+            cleanup_release_compare_plan,
+        )
+
+        cleanup_release_compare_plan(plan)
+        assert not any(p.exists() for p in created)
+
+    def test_cleanup_is_a_no_op_on_an_empty_plan(self, tmp_path: Path) -> None:
+        from abicheck.frontends.cli.release_compare_request import (
+            cleanup_release_compare_plan,
+        )
+
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        plan = resolve_release_compare_plan(
+            ReleaseCompareRequest(old_dir=old_dir, new_dir=new_dir)
+        )
+        assert plan.temp_dirs == ()
+        cleanup_release_compare_plan(plan)  # must not raise

--- a/tests/test_release_compare_request.py
+++ b/tests/test_release_compare_request.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from test_compare_release import _invoke, _snap, _write_snap
 
 from abicheck.frontends.cli.release_compare_request import (
@@ -221,3 +222,38 @@ class TestTempDirTracking:
         )
         assert plan.temp_dirs == ()
         cleanup_release_compare_plan(plan)  # must not raise
+
+    def test_a_directory_allocated_before_a_later_failure_is_still_removed(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review (PR #1215, second finding): a temp dir allocated by
+        ``_prepare_compare_release_inputs`` (e.g. for the old side) must not
+        survive a failure raised *after* that allocation but *before* a
+        ``ReleaseComparePlan`` is ever returned -- there is no plan for a
+        caller to pass to :func:`cleanup_release_compare_plan` in that case,
+        so this module's own resolution must clean up after itself."""
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        created: list[Path] = []
+
+        def _fake_resolve_release_package_side(side_dir, variant_id, make_temp_dir, *, side):
+            path = make_temp_dir(f"abicheck_relpkg_{side}_")
+            created.append(path)
+            if side == "new":
+                raise RuntimeError("simulated failure after the old side allocated")
+            return None
+
+        with patch(
+            "abicheck.cli_compare_release_matrix._resolve_release_package_side",
+            side_effect=_fake_resolve_release_package_side,
+        ):
+            request = ReleaseCompareRequest(old_dir=old_dir, new_dir=new_dir)
+            with pytest.raises(RuntimeError, match="simulated failure"):
+                resolve_release_compare_plan(request)
+
+        assert created  # both sides' factories ran before the raise
+        assert not any(p.exists() for p in created)

--- a/tests/test_release_compare_request.py
+++ b/tests/test_release_compare_request.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADR-061 gap D / Definition-of-Done item 8, closure package 4's next
+slice: :class:`~abicheck.frontends.cli.release_compare_request.
+ReleaseCompareRequest`/:class:`~abicheck.frontends.cli.
+release_compare_request.ReleaseComparePlan` and
+:func:`~abicheck.frontends.cli.release_compare_request.
+resolve_release_compare_plan`.
+
+**Direct-call half**: :class:`TestResolveReleaseComparePlanDirectly` proves
+the completion test's core claim -- the release fan-out's scope/inventory/
+gate resolution is reachable with one ordinary Python function call, no
+Click context, no ``click.Context``, no CLI invocation of any kind.
+
+**Parity half**: :class:`TestReleaseCompareRequestParity` is the actual
+completion test this closure package's slice states: a CLI-shaped
+invocation of ``compare-release`` and a direct, typed-request-shaped call
+to :func:`resolve_release_compare_plan`, given equivalent operands and
+options, resolve to the *same* scope, gate configuration, and degraded-
+member markers -- proven by spying on the one production call site
+(``cli_compare_release.py``'s lazy import of ``resolve_release_compare_plan``)
+to capture the real ``ReleaseComparePlan`` the CLI run actually used, then
+comparing it against a plan built by calling the function directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from test_compare_release import _invoke, _snap, _write_snap
+
+from abicheck.frontends.cli.release_compare_request import (
+    ReleaseComparePlan,
+    ReleaseCompareRequest,
+    resolve_release_compare_plan,
+)
+
+
+class TestResolveReleaseComparePlanDirectly:
+    """No Click, no CLI invocation -- a plain function call."""
+
+    def test_resolves_a_plan_from_two_directories(self, tmp_path: Path) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        request = ReleaseCompareRequest(old_dir=old_dir, new_dir=new_dir)
+        plan = resolve_release_compare_plan(request)
+
+        assert isinstance(plan, ReleaseComparePlan)
+        assert plan.scope.matched_keys == ("libfoo.json",)
+        assert plan.compare_keys == ["libfoo.json"]
+        # No severity setting given -> the legacy (non-severity-aware) gate.
+        assert plan.gate.severity is None
+
+    def test_selection_narrows_the_resolved_scope(self, tmp_path: Path) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libbar.json", _snap("libbar.so"))
+        _write_snap(new_dir / "libbar.json", _snap("libbar.so"))
+
+        from abicheck.model.release_selection import ReleaseSelection
+
+        request = ReleaseCompareRequest(
+            old_dir=old_dir,
+            new_dir=new_dir,
+            release_selection=ReleaseSelection.from_lists(
+                required=[], optional=["libfoo.json"]
+            ),
+        )
+        plan = resolve_release_compare_plan(request)
+
+        assert plan.scope.matched_keys == ("libfoo.json",)
+
+    def test_severity_preset_reaches_the_resolved_gate(self, tmp_path: Path) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        request = ReleaseCompareRequest(
+            old_dir=old_dir, new_dir=new_dir, severity_preset="strict"
+        )
+        plan = resolve_release_compare_plan(request)
+
+        assert plan.gate.severity is not None
+        assert plan.gate.severity_preset == "strict"
+
+
+class TestReleaseCompareRequestParity:
+    """Completion test: CLI-shaped and typed-request-shaped invocations
+    agree on the resolved scope, gate configuration, and degraded-member
+    markers."""
+
+    def test_cli_and_direct_call_resolve_the_same_plan(self, tmp_path: Path) -> None:
+        old_dir, new_dir = tmp_path / "old", tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libbar.json", _snap("libbar.so"))
+        _write_snap(new_dir / "libbar.json", _snap("libbar.so"))
+
+        captured: list[ReleaseComparePlan] = []
+        real = resolve_release_compare_plan
+
+        def _spy(request, **kwargs):
+            plan = real(request, **kwargs)
+            captured.append(plan)
+            return plan
+
+        with patch(
+            "abicheck.frontends.cli.release_compare_request.resolve_release_compare_plan",
+            side_effect=_spy,
+        ):
+            code, _out = _invoke(
+                "compare",
+                str(old_dir),
+                str(new_dir),
+                "--format",
+                "json",
+                "--severity-preset",
+                "strict",
+            )
+        assert code in (
+            0,
+            1,
+            2,
+            4,
+        )  # a real run completed (exit code is not the point here)
+        assert len(captured) == 1
+        cli_plan = captured[0]
+
+        direct_request = ReleaseCompareRequest(
+            old_dir=old_dir, new_dir=new_dir, severity_preset="strict"
+        )
+        direct_plan = resolve_release_compare_plan(direct_request)
+
+        # 1. scope: the same members are matched.
+        assert cli_plan.scope.matched_keys == direct_plan.scope.matched_keys
+        # 2. inventory evidence: the same completeness proof on each side.
+        assert cli_plan.scope.evidence == direct_plan.scope.evidence
+        # 3. gate configuration: the same resolved severity/exit-code-scheme.
+        assert cli_plan.gate == direct_plan.gate
+        # 4. acquisition-relevant: the same degraded-member markers.
+        assert cli_plan.degraded == direct_plan.degraded
+        # 5. the actual execution set agrees.
+        assert cli_plan.compare_keys == direct_plan.compare_keys

--- a/tests/test_release_scope_plan.py
+++ b/tests/test_release_scope_plan.py
@@ -279,7 +279,8 @@ class TestScopePlanIsExecutionAuthoritative:
     how the reported `ReleaseScopeResult` describes them.
 
     Proven here by patching `resolve_release_scope_plan` (where
-    `cli_compare_release.py` resolves it) to return a plan whose
+    `frontends.cli.release_compare_request.resolve_release_compare_plan`
+    resolves it, on `cli_compare_release.py`'s behalf) to return a plan whose
     `matched_keys` *narrows out* one of the two real, on-disk members, and
     asserting the real execution never compares it -- if execution still
     read the original locals instead of the plan, this member would still
@@ -311,7 +312,7 @@ class TestScopePlanIsExecutionAuthoritative:
             )
 
         with patch(
-            "abicheck.cli_compare_release.resolve_release_scope_plan",
+            "abicheck.frontends.cli.release_compare_request.resolve_release_scope_plan",
             side_effect=_narrow_to_libfoo_only,
         ):
             code, out = _invoke(
@@ -358,7 +359,7 @@ class TestExplicitSelectionFoldedIntoScopePlan:
             return plan
 
         with patch(
-            "abicheck.cli_compare_release.resolve_release_scope_plan",
+            "abicheck.frontends.cli.release_compare_request.resolve_release_scope_plan",
             side_effect=_spy,
         ):
             code, out = _invoke(


### PR DESCRIPTION
## Summary

Closes the next real slice of ADR-061's "Remaining acceptance gaps" item D
("Typed request/plan and operand convergence", closure package 4): the
release fan-out's own pre-execution resolution (input discovery, ADR-065
scope/inventory evidence, the `ReleaseScopePlan`, the resolved
`GateOptions`, and each side's stored-degraded markers) is now one typed
request/plan pair, resolvable with a single ordinary Python call — not
only reachable by running the `compare-release` Click command.

## Motivation

ADR-061's gap D section had gone stale: it still described selection,
inventory, and acquisition state as unconverged CLI locals, but prior PRs
(#1190, #1192, and the `EffectiveGate`/`GateSeverityState` work) had
already landed most of the actual convergence — `ReleaseScopePlan`/
`ReleaseScopeResult` and the shared `EffectiveGate` object. Re-measuring
the gap found one concrete piece still genuinely open: nothing let a
caller resolve the release fan-out's scope/inventory/gate state without
going through `cli_compare_release.py`'s Click command — the values
reached the engine as roughly a dozen local variables threaded by hand
through four separate calls.

## Changes

- New `abicheck/frontends/cli/release_compare_request.py`:
  `ReleaseCompareRequest` / `ReleaseComparePlan` / `resolve_release_compare_plan`
  fold `compare-release`'s entire pre-execution resolution into one typed
  request/plan pair, callable directly from Python with no Click context.
- `cli_compare_release.py`'s `compare_release_cmd` now builds one request
  and reads one resolved plan instead of threading ~a dozen locals through
  four separate calls; behavior is unchanged (verified against the
  existing suite plus a new parity test).
- New `tests/test_release_compare_request.py`: direct-call tests (no CLI
  at all) plus the completion-test parity check — a CLI-shaped invocation
  and a direct typed-request-shaped call resolve to the same scope, gate
  configuration, and degraded-member markers.
- Updated `tests/test_release_scope_plan.py`'s two patch targets that
  moved with the resolution logic (`unittest.mock.patch` targets the new
  owner module, per this repo's own "unit tests patch the owner module"
  convention).
- Updated ADR-061's gap D section to record precisely what's closed (the
  gate-shape convergence via `EffectiveGate`; the release scope/plan
  convergence) and what remains open: a real `abicheck.service` entry
  point still needs `_prepare_compare_release_inputs` and
  `_resolve_release_package_side` relocated out of `frontends`/flat
  `cli_*` into `workflows`/`extract` (including converting a remaining
  `click.UsageError` raise to a typed exception) — a real, separately-scoped
  migration, not attempted here.
- `architecture/debt.yaml`: recorded `cli_compare_release.py`'s shrink
  (1995 → ~1190 lines against its `no_growth` baseline) and why it stays
  `migrate`/`no_growth`.
- Changelog fragment (`scriv`).

## Verification

- `mypy abicheck/` — clean (755 files)
- `ruff check abicheck/ tests/` — clean
- `python scripts/check_architecture.py` — 0 errors
- `python scripts/check_ai_readiness.py` — only pre-existing, unrelated
  errors/warnings (stale ADR `Verified:` receipts, retired `scan`-surface
  doc mentions — confirmed present on `main` before this branch)
- `python scripts/check_docs_contract.py` — 0 errors
- Full existing `tests/test_compare_release.py` (91 tests),
  `tests/test_release_scope_plan.py`, `tests/test_effective_gate.py`,
  `tests/test_release_gate_pack_fold_parity.py` pass unchanged, plus the
  new `tests/test_release_compare_request.py`
- Manual end-to-end CLI smoke test (`abicheck compare <dir> <dir> --format json`)
  through the refactored path
- Full `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` run in progress; no new failures observed beyond the pre-existing `scan`-removal-related failures already present on `main` (confirmed via `git stash` comparison)

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (ADR-061 gap D section)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mxCDAZJhrq9CbMbPfxWwc


---
_Generated by [Claude Code](https://claude.ai/code/session_016mxCDAZJhrq9CbMbPfxWwc)_