### PR TITLE
refactor: migrate surface_graph live-alias readers (ADR-063 Phase 10)

### DIFF
--- a/abicheck/buildsource/cross_source_checks.py
+++ b/abicheck/buildsource/cross_source_checks.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from ..checker_types import Change
 from ..model import (
@@ -994,9 +994,8 @@ def _check_public_to_internal_dependency(
     (public-header visibility, or one mapped to an exported binary symbol) points
     at an *internal* declaration/type (private-header or source-file visibility;
     ``generated`` is a public generated header and excluded), the public surface
-    depends on something consumers cannot see —
-    a behavioral risk, elevated when the internal entity is among the revision's
-    changed files (``cfg.changed_paths``).
+    depends on something consumers cannot see — a behavioral risk, elevated
+    when the internal entity is among the revision's changed files (``cfg.changed_paths``).
 
     The dependency edges only exist after an S4/S5 semantic pass. With a
     structural-only graph (or no graph at all) the check skips with a soft
@@ -1015,7 +1014,8 @@ def _check_public_to_internal_dependency(
             "no L5 source graph on the snapshot (run --depth source)",
             providers,
         )
-    assert isinstance(graph, SourceGraphSummary)  # narrow SurfaceGraphLike
+    # Type-only narrow (SurfaceGraphLike is a structural Protocol, model/graph_facts.py).
+    graph = cast("SourceGraphSummary", graph)
     if not any(e.kind in _DEPENDENCY_EDGE_KINDS for e in graph.edges):
         return _CheckOutput(
             [],

--- a/abicheck/buildsource/cross_source_checks.py
+++ b/abicheck/buildsource/cross_source_checks.py
@@ -626,11 +626,11 @@ def _check_private_header_leak(
     # so checking presence alone would record a provider with no fact behind it and
     # mask regressions in real source-graph extraction (ADR-035 D4 coverage honesty
     # — Codex review).
-    sg = snapshot.surface_graph or (
+    sg = (
         snapshot.build_source.source_graph
         if snapshot.build_source is not None
         else None
-    )
+    ) or snapshot.surface_graph
     if sg is not None and sg.nodes:
         providers.append(PROVIDER_SOURCE_INDEX)
     if not _origin_resolvable(snapshot):
@@ -1003,11 +1003,11 @@ def _check_public_to_internal_dependency(
     advisory naming what to enable — it is never counted clean.
     """
     providers = [PROVIDER_SOURCE_INDEX]
-    graph = snapshot.surface_graph or (
+    graph = (
         snapshot.build_source.source_graph
         if snapshot.build_source is not None
         else None
-    )
+    ) or snapshot.surface_graph
     if graph is None:
         return _CheckOutput(
             [],

--- a/abicheck/buildsource/cross_source_checks.py
+++ b/abicheck/buildsource/cross_source_checks.py
@@ -62,9 +62,10 @@ from __future__ import annotations
 import re
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 from ..checker_types import Change
+from ..evidence_depth import resolve_l5_source_graph
 from ..model import (
     AbiSnapshot,
     AccessLevel,
@@ -626,11 +627,7 @@ def _check_private_header_leak(
     # so checking presence alone would record a provider with no fact behind it and
     # mask regressions in real source-graph extraction (ADR-035 D4 coverage honesty
     # — Codex review).
-    sg = (
-        snapshot.build_source.source_graph
-        if snapshot.build_source is not None
-        else None
-    ) or snapshot.surface_graph
+    sg = resolve_l5_source_graph(snapshot, snapshot.build_source)
     if sg is not None and sg.nodes:
         providers.append(PROVIDER_SOURCE_INDEX)
     if not _origin_resolvable(snapshot):
@@ -1002,11 +999,7 @@ def _check_public_to_internal_dependency(
     advisory naming what to enable — it is never counted clean.
     """
     providers = [PROVIDER_SOURCE_INDEX]
-    graph = (
-        snapshot.build_source.source_graph
-        if snapshot.build_source is not None
-        else None
-    ) or snapshot.surface_graph
+    graph = resolve_l5_source_graph(snapshot, snapshot.build_source)
     if graph is None:
         return _CheckOutput(
             [],
@@ -1014,8 +1007,6 @@ def _check_public_to_internal_dependency(
             "no L5 source graph on the snapshot (run --depth source)",
             providers,
         )
-    # Type-only narrow (SurfaceGraphLike is a structural Protocol, model/graph_facts.py).
-    graph = cast("SourceGraphSummary", graph)
     if not any(e.kind in _DEPENDENCY_EDGE_KINDS for e in graph.edges):
         return _CheckOutput(
             [],

--- a/abicheck/buildsource/cross_source_checks.py
+++ b/abicheck/buildsource/cross_source_checks.py
@@ -626,7 +626,7 @@ def _check_private_header_leak(
     # so checking presence alone would record a provider with no fact behind it and
     # mask regressions in real source-graph extraction (ADR-035 D4 coverage honesty
     # — Codex review).
-    sg = (
+    sg = snapshot.surface_graph or (
         snapshot.build_source.source_graph
         if snapshot.build_source is not None
         else None
@@ -1003,7 +1003,7 @@ def _check_public_to_internal_dependency(
     advisory naming what to enable — it is never counted clean.
     """
     providers = [PROVIDER_SOURCE_INDEX]
-    graph = (
+    graph = snapshot.surface_graph or (
         snapshot.build_source.source_graph
         if snapshot.build_source is not None
         else None
@@ -1015,6 +1015,7 @@ def _check_public_to_internal_dependency(
             "no L5 source graph on the snapshot (run --depth source)",
             providers,
         )
+    assert isinstance(graph, SourceGraphSummary)  # narrow SurfaceGraphLike
     if not any(e.kind in _DEPENDENCY_EDGE_KINDS for e in graph.edges):
         return _CheckOutput(
             [],

--- a/abicheck/buildsource/evidence_report.py
+++ b/abicheck/buildsource/evidence_report.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .evidence_policy import (
     apply_evidence_policy,
@@ -179,29 +179,44 @@ def _side_source_graph(
 
     Prefers *pack*'s own ``source_graph``, falling back to
     ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
-    embedded ``build_source`` and carries no graph of its own -- a real
-    ``--sources``/``--build-info`` embed can leave ``build_source.
-    source_graph`` a strictly richer, real L3-L5 evidence graph than the
-    always-on, header-only-only ``surface_graph`` (security review, PR
-    #1216: the reverse preference silently dropped real graph edges,
-    letting a reachable internal removal be misjudged unreachable). When
-    ``resolve_side_pack`` instead resolved an explicit out-of-band
-    ``--old/new-build-info``/``--old/new-sources`` pack, that pack has no
-    relationship to ``snap.surface_graph`` at all, so its own
-    ``source_graph`` is read directly, unchanged.
+    embedded ``build_source``, carries no graph of its own, AND its manifest
+    records no L5 coverage row at all -- a real ``--sources``/
+    ``--build-info`` embed can leave ``build_source.source_graph`` a
+    strictly richer, real L3-L5 evidence graph than the always-on,
+    header-only-only ``surface_graph`` (security review, PR #1216: the
+    reverse preference silently dropped real graph edges, letting a
+    reachable internal removal be misjudged unreachable). The coverage-row
+    check is a second, separate correction from the same review round:
+    ``policy/depth_projection.py`` deliberately clears ``build_source.
+    source_graph`` to ``None`` for a ``--depth build`` (or shallower)
+    comparison while *stamping an explicit L5 ``NOT_COLLECTED`` coverage
+    row* and retaining ``surface_graph`` untouched (it is an L2 fact,
+    cleared at a lower floor) -- falling back to ``surface_graph`` there
+    would silently emit L5-labeled graph-diff findings, and claim source-tier
+    evidence, for a comparison whose own report says L5 was excluded. A
+    truly graph-empty pack (never collected anything, no coverage row
+    recorded for L5 at all -- e.g. a bare typed-API-constructed snapshot)
+    is the only case this still falls back for. When ``resolve_side_pack``
+    instead resolved an explicit out-of-band ``--old/new-build-info``/
+    ``--old/new-sources`` pack, that pack has no relationship to
+    ``snap.surface_graph`` at all, so its own ``source_graph`` is read
+    directly, unchanged.
     """
     if pack is not None and pack.source_graph is not None:
         return pack.source_graph
-    if snap is not None and pack is not None and pack is snap.build_source:
-        graph = snap.surface_graph
-        # `surface_graph` is typed `SurfaceGraphLike` (`model/graph_facts.py`)
-        # for `model/snapshot.py`'s own dependency-free layer, but is always a
-        # real `SourceGraphSummary` at runtime -- narrows back to the concrete
-        # class per that protocol's own documented call-site pattern.
-        from ..model.source_graph import SourceGraphSummary as _SourceGraphSummary
-
-        assert graph is None or isinstance(graph, _SourceGraphSummary)
-        return graph
+    if (
+        snap is not None
+        and pack is not None
+        and pack is snap.build_source
+        and pack.manifest.coverage_for(DataLayer.L5_SOURCE_GRAPH) is None
+    ):
+        # Type-only narrow: `surface_graph` is typed `SurfaceGraphLike`
+        # (`model/graph_facts.py`), a deliberately structural Protocol, for
+        # `model/snapshot.py`'s own dependency-free layer -- only .nodes/
+        # .edges (protocol members) are ever read from the result, so a
+        # typed-API caller's own conforming implementation must not be
+        # rejected at runtime.
+        return cast("SourceGraphSummary | None", snap.surface_graph)
     return None
 
 

--- a/abicheck/buildsource/evidence_report.py
+++ b/abicheck/buildsource/evidence_report.py
@@ -177,26 +177,32 @@ def _side_source_graph(
 ) -> SourceGraphSummary | None:
     """The L5 evidence graph for one compare side (ADR-063 Phase 10).
 
-    Prefers ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's
-    own embedded ``build_source`` -- the one case the Phase 3 assembly step
-    guarantees shares an identical object with ``surface_graph``. When
+    Prefers *pack*'s own ``source_graph``, falling back to
+    ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
+    embedded ``build_source`` and carries no graph of its own -- a real
+    ``--sources``/``--build-info`` embed can leave ``build_source.
+    source_graph`` a strictly richer, real L3-L5 evidence graph than the
+    always-on, header-only-only ``surface_graph`` (security review, PR
+    #1216: the reverse preference silently dropped real graph edges,
+    letting a reachable internal removal be misjudged unreachable). When
     ``resolve_side_pack`` instead resolved an explicit out-of-band
     ``--old/new-build-info``/``--old/new-sources`` pack, that pack has no
     relationship to ``snap.surface_graph`` at all, so its own
     ``source_graph`` is read directly, unchanged.
     """
+    if pack is not None and pack.source_graph is not None:
+        return pack.source_graph
     if snap is not None and pack is not None and pack is snap.build_source:
-        graph = snap.surface_graph or pack.source_graph
+        graph = snap.surface_graph
         # `surface_graph` is typed `SurfaceGraphLike` (`model/graph_facts.py`)
         # for `model/snapshot.py`'s own dependency-free layer, but is always a
-        # real `SourceGraphSummary` at runtime, same as `pack.source_graph` --
-        # narrows back to the concrete class per that protocol's own
-        # documented call-site pattern.
+        # real `SourceGraphSummary` at runtime -- narrows back to the concrete
+        # class per that protocol's own documented call-site pattern.
         from ..model.source_graph import SourceGraphSummary as _SourceGraphSummary
 
         assert graph is None or isinstance(graph, _SourceGraphSummary)
         return graph
-    return pack.source_graph if pack is not None else None
+    return None
 
 
 def intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:

--- a/abicheck/buildsource/evidence_report.py
+++ b/abicheck/buildsource/evidence_report.py
@@ -61,6 +61,7 @@ from .pack import BuildSourcePack
 if TYPE_CHECKING:
     from ..checker_types import Change, DiffResult
     from ..model import AbiSnapshot
+    from ..model.source_graph import SourceGraphSummary
     from ..policy_file import PolicyFile
 
 #: Sink for this module's human-readable report lines. ``None`` means "produce
@@ -169,6 +170,33 @@ def resolve_side_pack(
     # preference would otherwise break by falling through to stale embedded
     # facts (Codex review).
     return _combine_packs(bi_pack, src_pack, embedded, prefer_nonempty=False)
+
+
+def _side_source_graph(
+    snap: AbiSnapshot | None, pack: BuildSourcePack | None
+) -> SourceGraphSummary | None:
+    """The L5 evidence graph for one compare side (ADR-063 Phase 10).
+
+    Prefers ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's
+    own embedded ``build_source`` -- the one case the Phase 3 assembly step
+    guarantees shares an identical object with ``surface_graph``. When
+    ``resolve_side_pack`` instead resolved an explicit out-of-band
+    ``--old/new-build-info``/``--old/new-sources`` pack, that pack has no
+    relationship to ``snap.surface_graph`` at all, so its own
+    ``source_graph`` is read directly, unchanged.
+    """
+    if snap is not None and pack is not None and pack is snap.build_source:
+        graph = snap.surface_graph or pack.source_graph
+        # `surface_graph` is typed `SurfaceGraphLike` (`model/graph_facts.py`)
+        # for `model/snapshot.py`'s own dependency-free layer, but is always a
+        # real `SourceGraphSummary` at runtime, same as `pack.source_graph` --
+        # narrows back to the concrete class per that protocol's own
+        # documented call-site pattern.
+        from ..model.source_graph import SourceGraphSummary as _SourceGraphSummary
+
+        assert graph is None or isinstance(graph, _SourceGraphSummary)
+        return graph
+    return pack.source_graph if pack is not None else None
 
 
 def intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:
@@ -517,8 +545,16 @@ def diff_embedded_build_source(
     # L5 source graph diff (ADR-031 D6): both packs must carry a graph summary.
     # Per ADR-028 D3 / ADR-031 D6 these are ordinary RISK findings folded into
     # the verdict pipeline — they explain and prioritize, never sole authority.
-    old_graph = old_pack.source_graph if old_pack else None
-    new_graph = new_pack.source_graph if new_pack else None
+    # ADR-063 Phase 10: prefer the canonical `AbiSnapshot.surface_graph` when
+    # *_pack is the snapshot's own embedded pack (unchanged identity with
+    # `build_source.source_graph` per the Phase 3 assembly step), falling
+    # back to `build_source.source_graph` when `surface_graph` is absent (a
+    # pre-Phase-3 snapshot never populates it). A `--old/new-build-info`/
+    # `--old/new-sources` override resolves an out-of-band pack unrelated to
+    # the snapshot, so `surface_graph` never applies there -- see
+    # `docs/contribute/plans/one-semantic-pipeline.md`'s Phase 10 checklist.
+    old_graph = _side_source_graph(old_snapshot, old_pack)
+    new_graph = _side_source_graph(new_snapshot, new_pack)
     if old_graph is not None and new_graph is not None:
         from .source_graph_findings import diff_source_graph_findings
 

--- a/abicheck/buildsource/evidence_report.py
+++ b/abicheck/buildsource/evidence_report.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from .evidence_policy import (
     apply_evidence_policy,
@@ -175,49 +175,19 @@ def resolve_side_pack(
 def _side_source_graph(
     snap: AbiSnapshot | None, pack: BuildSourcePack | None
 ) -> SourceGraphSummary | None:
-    """The L5 evidence graph for one compare side (ADR-063 Phase 10).
-
-    Prefers *pack*'s own ``source_graph``, falling back to
-    ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
-    embedded ``build_source``, carries no graph of its own, AND its manifest
-    records no L5 coverage row at all -- a real ``--sources``/
-    ``--build-info`` embed can leave ``build_source.source_graph`` a
-    strictly richer, real L3-L5 evidence graph than the always-on,
-    header-only-only ``surface_graph`` (security review, PR #1216: the
-    reverse preference silently dropped real graph edges, letting a
-    reachable internal removal be misjudged unreachable). The coverage-row
-    check is a second, separate correction from the same review round:
-    ``policy/depth_projection.py`` deliberately clears ``build_source.
-    source_graph`` to ``None`` for a ``--depth build`` (or shallower)
-    comparison while *stamping an explicit L5 ``NOT_COLLECTED`` coverage
-    row* and retaining ``surface_graph`` untouched (it is an L2 fact,
-    cleared at a lower floor) -- falling back to ``surface_graph`` there
-    would silently emit L5-labeled graph-diff findings, and claim source-tier
-    evidence, for a comparison whose own report says L5 was excluded. A
-    truly graph-empty pack (never collected anything, no coverage row
-    recorded for L5 at all -- e.g. a bare typed-API-constructed snapshot)
-    is the only case this still falls back for. When ``resolve_side_pack``
-    instead resolved an explicit out-of-band ``--old/new-build-info``/
-    ``--old/new-sources`` pack, that pack has no relationship to
-    ``snap.surface_graph`` at all, so its own ``source_graph`` is read
-    directly, unchanged.
+    """The L5 evidence graph for one compare side (ADR-063 Phase 10) --
+    a thin wrapper over the shared :func:`~abicheck.evidence_depth.
+    resolve_l5_source_graph` resolver (see its own docstring for the full
+    fallback contract), needed only because *snap* is optional here (a
+    caller with no snapshot for this side at all has no ``surface_graph``
+    to consult, but *pack* may still carry a real ``source_graph`` on its
+    own, e.g. an out-of-band pack resolved with no matching embedded side).
     """
-    if pack is not None and pack.source_graph is not None:
-        return pack.source_graph
-    if (
-        snap is not None
-        and pack is not None
-        and pack is snap.build_source
-        and pack.manifest.coverage_for(DataLayer.L5_SOURCE_GRAPH) is None
-    ):
-        # Type-only narrow: `surface_graph` is typed `SurfaceGraphLike`
-        # (`model/graph_facts.py`), a deliberately structural Protocol, for
-        # `model/snapshot.py`'s own dependency-free layer -- only .nodes/
-        # .edges (protocol members) are ever read from the result, so a
-        # typed-API caller's own conforming implementation must not be
-        # rejected at runtime.
-        return cast("SourceGraphSummary | None", snap.surface_graph)
-    return None
+    if snap is None:
+        return pack.source_graph if pack is not None else None
+    from ..evidence_depth import resolve_l5_source_graph
+
+    return resolve_l5_source_graph(snap, pack)
 
 
 def intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:

--- a/abicheck/cli_graph.py
+++ b/abicheck/cli_graph.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -68,6 +68,17 @@ def _load_source_graph(path: Path) -> SourceGraphSummary:
         ) from exc
     if not isinstance(data, dict):
         raise click.ClickException(f"{path} must contain a JSON object.")
+    # ADR-063 Phase 10: a full snapshot document (e.g. one written by `dump
+    # --sources -o out.abi.json`) carries its L5 graph nested under
+    # `surface_graph` (the canonical location, schema v29+) or
+    # `build_source.source_graph` (a pre-Phase-3 document, or the fallback
+    # when `surface_graph` was never populated), never as top-level
+    # `nodes`/`edges` -- accept that shape, preferring `surface_graph`, before
+    # falling through to the bare-graph-JSON contract below. See
+    # `docs/contribute/plans/one-semantic-pipeline.md`'s Phase 10 checklist.
+    embedded = _embedded_source_graph_dict(data)
+    if embedded is not None:
+        return SourceGraphSummary.from_dict(embedded)
     # SourceGraphSummary.from_dict is intentionally forgiving (it defaults a
     # missing nodes/edges to empty), so guard here: an unrelated JSON file (e.g.
     # a pack manifest) would otherwise load as an empty graph and report a bogus
@@ -80,6 +91,26 @@ def _load_source_graph(path: Path) -> SourceGraphSummary:
             "(expected top-level 'nodes' and 'edges' lists)."
         )
     return SourceGraphSummary.from_dict(data)
+
+
+def _embedded_source_graph_dict(data: dict[str, Any]) -> dict[str, Any] | None:
+    """The nested L5 graph dict inside a full snapshot document, ADR-063
+    Phase 10's fallback rule applied to a raw JSON dict rather than a live
+    ``AbiSnapshot``: prefers the canonical top-level ``surface_graph`` key,
+    falling back to the legacy ``build_source.source_graph`` nested key only
+    when ``surface_graph`` is absent. Returns ``None`` when *data* carries
+    neither key at all -- i.e. it isn't a snapshot document -- so the caller
+    falls through to the bare-graph-JSON contract instead.
+    """
+    graph = data.get("surface_graph")
+    if isinstance(graph, dict):
+        return graph
+    build_source = data.get("build_source")
+    if isinstance(build_source, dict):
+        graph = build_source.get("source_graph")
+        if isinstance(graph, dict):
+            return graph
+    return None
 
 
 def _resolve_symbol_from_report(report: Path, finding_id: str) -> str:

--- a/abicheck/cli_graph.py
+++ b/abicheck/cli_graph.py
@@ -126,9 +126,11 @@ def _embedded_source_graph(data: dict[str, Any]) -> SourceGraphSummary | None:
         snap = snapshot_from_dict(data)
     except Exception:
         return None
-    graph = snap.surface_graph or (
+    # Phase 10 security correction: build_source.source_graph first (richer
+    # real L3-L5 evidence than the always-on, header-only-only surface_graph).
+    graph = (
         snap.build_source.source_graph if snap.build_source is not None else None
-    )
+    ) or snap.surface_graph
     # Always a real SourceGraphSummary at runtime; narrows back from the
     # SurfaceGraphLike protocol model/snapshot.py's surface_graph field uses.
     return cast("SourceGraphSummary | None", graph)

--- a/abicheck/cli_graph.py
+++ b/abicheck/cli_graph.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 
@@ -69,16 +69,22 @@ def _load_source_graph(path: Path) -> SourceGraphSummary:
     if not isinstance(data, dict):
         raise click.ClickException(f"{path} must contain a JSON object.")
     # ADR-063 Phase 10: a full snapshot document (e.g. one written by `dump
-    # --sources -o out.abi.json`) carries its L5 graph nested under
-    # `surface_graph` (the canonical location, schema v29+) or
-    # `build_source.source_graph` (a pre-Phase-3 document, or the fallback
-    # when `surface_graph` was never populated), never as top-level
-    # `nodes`/`edges` -- accept that shape, preferring `surface_graph`, before
-    # falling through to the bare-graph-JSON contract below. See
-    # `docs/contribute/plans/one-semantic-pipeline.md`'s Phase 10 checklist.
-    embedded = _embedded_source_graph_dict(data)
+    # --sources -o out.abi.json`) carries its L5 graph nested inside the
+    # snapshot -- under the top-level `surface_graph` key for a legacy flat
+    # document (schema v29+), under `build_source.source_graph` for a
+    # pre-Phase-3 flat document or the fallback when `surface_graph` was
+    # never populated, or under `sections.graph.payload.surface_graph` for
+    # the current single-file *sectioned* wire format (schema v42+,
+    # `storage/sectioned_document.py`) -- never as top-level `nodes`/`edges`.
+    # Decoding through `serialization.snapshot_from_dict` (rather than
+    # hand-walking each shape) is what makes this reader forward-compatible
+    # with the sectioned format for free; the graph is then read with the
+    # same surface_graph-preferred, build_source.source_graph-fallback rule
+    # every other Phase 10 reader uses. See `docs/contribute/plans/
+    # one-semantic-pipeline.md`'s Phase 10 checklist.
+    embedded = _embedded_source_graph(data)
     if embedded is not None:
-        return SourceGraphSummary.from_dict(embedded)
+        return embedded
     # SourceGraphSummary.from_dict is intentionally forgiving (it defaults a
     # missing nodes/edges to empty), so guard here: an unrelated JSON file (e.g.
     # a pack manifest) would otherwise load as an empty graph and report a bogus
@@ -93,24 +99,39 @@ def _load_source_graph(path: Path) -> SourceGraphSummary:
     return SourceGraphSummary.from_dict(data)
 
 
-def _embedded_source_graph_dict(data: dict[str, Any]) -> dict[str, Any] | None:
-    """The nested L5 graph dict inside a full snapshot document, ADR-063
-    Phase 10's fallback rule applied to a raw JSON dict rather than a live
-    ``AbiSnapshot``: prefers the canonical top-level ``surface_graph`` key,
-    falling back to the legacy ``build_source.source_graph`` nested key only
-    when ``surface_graph`` is absent. Returns ``None`` when *data* carries
-    neither key at all -- i.e. it isn't a snapshot document -- so the caller
-    falls through to the bare-graph-JSON contract instead.
+def _embedded_source_graph(data: dict[str, Any]) -> SourceGraphSummary | None:
+    """The L5 graph nested inside a full snapshot document, ADR-063 Phase 10.
+
+    Only attempted when *data* carries a top-level ``schema_version`` key --
+    both the sectioned wire format (schema v42+) and every flat one carry it
+    (``serialization.snapshot_from_dict`` itself branches on the sibling
+    ``sections`` key; a `frontends`-layer module like this one may not import
+    `storage` directly, per `architecture/modules.yaml`, so that branch is
+    left entirely to `snapshot_from_dict`). A bare graph JSON has no such key;
+    an unrelated JSON object (e.g. a pack manifest) may carry its own
+    same-named but differently-scoped key, in which case decoding still fails
+    safely below. Either way this returns ``None`` and the caller falls
+    through to the bare-graph-JSON contract instead. A document that looks
+    like a snapshot but fails to decode (corrupt, unsupported schema, or an
+    unrelated document's own ``schema_version``) also returns ``None`` rather
+    than raising here, so the caller's own "not a source graph summary" error
+    still fires with an accurate message instead of an unrelated decode
+    traceback.
     """
-    graph = data.get("surface_graph")
-    if isinstance(graph, dict):
-        return graph
-    build_source = data.get("build_source")
-    if isinstance(build_source, dict):
-        graph = build_source.get("source_graph")
-        if isinstance(graph, dict):
-            return graph
-    return None
+    if "schema_version" not in data:
+        return None
+    from .serialization import snapshot_from_dict
+
+    try:
+        snap = snapshot_from_dict(data)
+    except Exception:
+        return None
+    graph = snap.surface_graph or (
+        snap.build_source.source_graph if snap.build_source is not None else None
+    )
+    # Always a real SourceGraphSummary at runtime; narrows back from the
+    # SurfaceGraphLike protocol model/snapshot.py's surface_graph field uses.
+    return cast("SourceGraphSummary | None", graph)
 
 
 def _resolve_symbol_from_report(report: Path, finding_id: str) -> str:

--- a/abicheck/evidence_depth.py
+++ b/abicheck/evidence_depth.py
@@ -46,6 +46,7 @@ from .model.evidence_depth_levels import USER_DEPTHS
 if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
     from .model import AbiSnapshot
+    from .model.source_graph import SourceGraphSummary
 
 #: The public evidence ladder as a rank map, derived from ``USER_DEPTHS`` so
 #: the ordering has exactly one definition. Each rung is a strict superset of
@@ -92,41 +93,72 @@ def layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
     return False
 
 
-def _l5_payload_empty(snap: AbiSnapshot, pack: BuildSourcePack | None) -> bool:
-    """:func:`layer_payload_empty`'s ``"L5"`` case, ADR-063 Phase 10-aware.
+def resolve_l5_source_graph(
+    snap: AbiSnapshot, pack: BuildSourcePack | None
+) -> SourceGraphSummary | None:
+    """The L5 evidence graph for *snap*/*pack* (ADR-063 Phase 10), the one
+    shared resolver every migrated reader (``internal_leak.py``,
+    ``buildsource/cross_source_checks.py``, ``buildsource/evidence_report.py``,
+    this module's own :func:`_l5_payload_empty`) goes through, so the same
+    fallback rule can't independently drift per call site the way it did
+    across three earlier review rounds on this migration.
 
     Prefers *pack*'s own ``source_graph``, falling back to
-    ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
-    embedded ``build_source``, carries no graph of its own, AND its manifest
-    records no L5 coverage row at all -- a real ``--sources``/
-    ``--build-info`` embed can leave ``build_source.source_graph`` a
-    strictly richer, real L3-L5 evidence graph than the always-on,
-    header-only-only ``surface_graph``, so the reverse preference would
-    misjudge such a pack empty (security review, PR #1216). The coverage-row
-    check is a second, separate correction from the same review round:
-    ``policy/depth_projection.py`` deliberately clears ``build_source.
-    source_graph`` to ``None`` for a ``--depth build`` (or shallower)
-    comparison while *stamping an explicit L5 "not collected" coverage row*
-    and retaining ``surface_graph`` untouched (it is an L2 fact, cleared at a
-    lower floor) -- falling back to ``surface_graph`` there would report
-    ``"source"`` depth for a comparison whose own report says L5 was
-    excluded. *pack* deliberately never defaults to ``snap.build_source``
-    elsewhere in this module (see the module docstring): when a caller
-    resolved an out-of-band pack instead, that pack has no relationship to
-    ``snap.surface_graph`` at all, so its own ``source_graph`` is read
-    directly, unchanged.
+    ``AbiSnapshot.surface_graph`` only when ALL of:
+
+    - *pack* is the snapshot's own embedded ``build_source`` (never an
+      unrelated out-of-band ``--old/new-build-info``/``--old/new-sources``
+      pack a caller resolved independently -- that pack has no relationship
+      to ``snap.surface_graph`` at all, so its own ``source_graph`` is read
+      directly, unchanged, regardless of this fallback);
+    - *pack* carries no graph of its own -- a real ``--sources``/
+      ``--build-info`` embed can leave ``build_source.source_graph`` a
+      strictly richer, real L3-L5 evidence graph than the always-on,
+      header-only-only ``surface_graph``, so preferring the latter would
+      silently drop real graph edges (security review, PR #1216);
+    - *pack*'s manifest records no L5 coverage row at all --
+      ``policy/depth_projection.py`` deliberately clears ``build_source.
+      source_graph`` for a ``--depth build`` (or shallower) comparison
+      *while stamping an explicit L5 "not collected" row* and retaining
+      ``surface_graph`` untouched (it is an L2 fact, cleared at a lower
+      floor); falling back there would resurrect L5-labeled findings/depth
+      claims for a comparison whose own report says L5 was excluded
+      (`_mark_layers_not_collected` guarantees this row exists even for a
+      pack that started with none at all, so "no row" reliably means
+      "never went through any collection/projection pipeline", not merely
+      "this specific projection pass didn't touch it");
+    - ``surface_graph`` is a genuine ``SourceGraphSummary``, not merely a
+      structurally-conforming ``SurfaceGraphLike`` (`model/graph_facts.py`)
+      implementation -- every one of this function's callers eventually
+      feeds the result into code that reads concrete-only attributes
+      (e.g. ``buildsource/evidence_report.py``'s
+      ``diff_source_graph_findings`` reads ``narrowed_scope``/
+      ``extractor_passes``/``degraded_passes``, none of which the protocol
+      declares), so a merely-structural implementation must be treated the
+      same as "no graph" here rather than passed through and crashing
+      downstream.
     """
-    if pack is None:
-        return True
-    if pack.source_graph is not None:
-        return not pack.source_graph.nodes
+    if pack is not None and pack.source_graph is not None:
+        return pack.source_graph
     if (
-        pack is snap.build_source
-        and snap.surface_graph is not None
+        pack is not None
+        and pack is snap.build_source
         and pack.manifest.coverage_for("L5_source_graph") is None
     ):
-        return not snap.surface_graph.nodes
-    return True
+        from .model.source_graph import SourceGraphSummary as _SourceGraphSummary
+
+        if isinstance(snap.surface_graph, _SourceGraphSummary):
+            return snap.surface_graph
+    return None
+
+
+def _l5_payload_empty(snap: AbiSnapshot, pack: BuildSourcePack | None) -> bool:
+    """:func:`layer_payload_empty`'s ``"L5"`` case, via
+    :func:`resolve_l5_source_graph` (ADR-063 Phase 10)."""
+    if pack is None:
+        return True
+    graph = resolve_l5_source_graph(snap, pack)
+    return graph is None or not graph.nodes
 
 
 def depth_label_for(snap: AbiSnapshot, pack: BuildSourcePack | None) -> str:

--- a/abicheck/evidence_depth.py
+++ b/abicheck/evidence_depth.py
@@ -95,22 +95,25 @@ def layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
 def _l5_payload_empty(snap: AbiSnapshot, pack: BuildSourcePack | None) -> bool:
     """:func:`layer_payload_empty`'s ``"L5"`` case, ADR-063 Phase 10-aware.
 
-    Prefers ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's
-    own embedded ``build_source`` -- the one case the Phase 3 assembly step
-    guarantees shares an identical object with ``surface_graph`` -- falling
-    back to ``pack.source_graph`` when ``surface_graph`` is absent (a
-    pre-Phase-3 snapshot never populates it). *pack* deliberately never
-    defaults to ``snap.build_source`` elsewhere in this module (see the
-    module docstring): when a caller resolved an out-of-band pack instead,
-    that pack has no relationship to ``snap.surface_graph`` at all, so its
-    own ``source_graph`` is read directly, unchanged.
+    Prefers *pack*'s own ``source_graph``, falling back to
+    ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
+    embedded ``build_source`` and carries no graph of its own -- a real
+    ``--sources``/``--build-info`` embed can leave ``build_source.
+    source_graph`` a strictly richer, real L3-L5 evidence graph than the
+    always-on, header-only-only ``surface_graph``, so the reverse preference
+    would misjudge such a pack empty (security review, PR #1216). *pack*
+    deliberately never defaults to ``snap.build_source`` elsewhere in this
+    module (see the module docstring): when a caller resolved an out-of-band
+    pack instead, that pack has no relationship to ``snap.surface_graph`` at
+    all, so its own ``source_graph`` is read directly, unchanged.
     """
     if pack is None:
         return True
-    if pack is snap.build_source:
-        graph = snap.surface_graph or pack.source_graph
-        return graph is None or not graph.nodes
-    return layer_payload_empty(pack, "L5")
+    if pack.source_graph is not None:
+        return not pack.source_graph.nodes
+    if pack is snap.build_source and snap.surface_graph is not None:
+        return not snap.surface_graph.nodes
+    return True
 
 
 def depth_label_for(snap: AbiSnapshot, pack: BuildSourcePack | None) -> str:

--- a/abicheck/evidence_depth.py
+++ b/abicheck/evidence_depth.py
@@ -92,6 +92,27 @@ def layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
     return False
 
 
+def _l5_payload_empty(snap: AbiSnapshot, pack: BuildSourcePack | None) -> bool:
+    """:func:`layer_payload_empty`'s ``"L5"`` case, ADR-063 Phase 10-aware.
+
+    Prefers ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's
+    own embedded ``build_source`` -- the one case the Phase 3 assembly step
+    guarantees shares an identical object with ``surface_graph`` -- falling
+    back to ``pack.source_graph`` when ``surface_graph`` is absent (a
+    pre-Phase-3 snapshot never populates it). *pack* deliberately never
+    defaults to ``snap.build_source`` elsewhere in this module (see the
+    module docstring): when a caller resolved an out-of-band pack instead,
+    that pack has no relationship to ``snap.surface_graph`` at all, so its
+    own ``source_graph`` is read directly, unchanged.
+    """
+    if pack is None:
+        return True
+    if pack is snap.build_source:
+        graph = snap.surface_graph or pack.source_graph
+        return graph is None or not graph.nodes
+    return layer_payload_empty(pack, "L5")
+
+
 def depth_label_for(snap: AbiSnapshot, pack: BuildSourcePack | None) -> str:
     """Which evidence depth *snap* (with *pack*) actually reached (CLI-audit P2).
 
@@ -123,7 +144,7 @@ def depth_label_for(snap: AbiSnapshot, pack: BuildSourcePack | None) -> str:
     build`` (Codex review).
     """
     if pack is not None and (
-        not layer_payload_empty(pack, "L4") or not layer_payload_empty(pack, "L5")
+        not layer_payload_empty(pack, "L4") or not _l5_payload_empty(snap, pack)
     ):
         return "source"
     if pack is not None and not layer_payload_empty(pack, "L3"):

--- a/abicheck/evidence_depth.py
+++ b/abicheck/evidence_depth.py
@@ -97,21 +97,34 @@ def _l5_payload_empty(snap: AbiSnapshot, pack: BuildSourcePack | None) -> bool:
 
     Prefers *pack*'s own ``source_graph``, falling back to
     ``AbiSnapshot.surface_graph`` only when *pack* is the snapshot's own
-    embedded ``build_source`` and carries no graph of its own -- a real
-    ``--sources``/``--build-info`` embed can leave ``build_source.
-    source_graph`` a strictly richer, real L3-L5 evidence graph than the
-    always-on, header-only-only ``surface_graph``, so the reverse preference
-    would misjudge such a pack empty (security review, PR #1216). *pack*
-    deliberately never defaults to ``snap.build_source`` elsewhere in this
-    module (see the module docstring): when a caller resolved an out-of-band
-    pack instead, that pack has no relationship to ``snap.surface_graph`` at
-    all, so its own ``source_graph`` is read directly, unchanged.
+    embedded ``build_source``, carries no graph of its own, AND its manifest
+    records no L5 coverage row at all -- a real ``--sources``/
+    ``--build-info`` embed can leave ``build_source.source_graph`` a
+    strictly richer, real L3-L5 evidence graph than the always-on,
+    header-only-only ``surface_graph``, so the reverse preference would
+    misjudge such a pack empty (security review, PR #1216). The coverage-row
+    check is a second, separate correction from the same review round:
+    ``policy/depth_projection.py`` deliberately clears ``build_source.
+    source_graph`` to ``None`` for a ``--depth build`` (or shallower)
+    comparison while *stamping an explicit L5 "not collected" coverage row*
+    and retaining ``surface_graph`` untouched (it is an L2 fact, cleared at a
+    lower floor) -- falling back to ``surface_graph`` there would report
+    ``"source"`` depth for a comparison whose own report says L5 was
+    excluded. *pack* deliberately never defaults to ``snap.build_source``
+    elsewhere in this module (see the module docstring): when a caller
+    resolved an out-of-band pack instead, that pack has no relationship to
+    ``snap.surface_graph`` at all, so its own ``source_graph`` is read
+    directly, unchanged.
     """
     if pack is None:
         return True
     if pack.source_graph is not None:
         return not pack.source_graph.nodes
-    if pack is snap.build_source and snap.surface_graph is not None:
+    if (
+        pack is snap.build_source
+        and snap.surface_graph is not None
+        and pack.manifest.coverage_for("L5_source_graph") is None
+    ):
         return not snap.surface_graph.nodes
     return True
 

--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -41,7 +41,7 @@ import collections
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .buildsource.call_graph import (
     CALL_KIND_FUNCTION_POINTER,
@@ -975,16 +975,16 @@ def compute_call_graph_leak_paths(
 
     Requires an embedded L5 graph (``--sources``/``--build-info``, or the
     now-always-on L2 header-only graph) with at least one relevant edge;
-    returns ``{}``
-    otherwise — never an error, mirroring
+    returns ``{}`` otherwise — never an error, mirroring
     :func:`~abicheck.buildsource.poi.resolve_changed_paths_public_impact`'s
     degrade contract, so a project with no build-source evidence sees no
     behavior change at all.
     """
     build_source = getattr(snap, "build_source", None)
-    graph = build_source.source_graph if build_source is not None else None
+    graph = snap.surface_graph or (build_source.source_graph if build_source else None)
     if graph is None or not getattr(graph, "nodes", None):
         return {}
+    graph = cast("SourceGraphSummary", graph)
 
     from .buildsource.source_graph_findings import _format_dependency_path
     from .buildsource.source_graph_query import is_consumer_compiled_public_entry

--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -41,7 +41,7 @@ import collections
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from .buildsource.call_graph import (
     CALL_KIND_FUNCTION_POINTER,
@@ -978,12 +978,11 @@ def compute_call_graph_leak_paths(
     never an error, mirroring :func:`~abicheck.buildsource.poi.resolve_changed_paths_public_impact`'s
     degrade contract, so a project with no build-source evidence sees no behavior change at all.
     """
-    # Phase 10 security correction: build_source.source_graph first (richer).
-    build_source = getattr(snap, "build_source", None)
-    graph = (build_source.source_graph if build_source else None) or snap.surface_graph
-    if graph is None or not getattr(graph, "nodes", None):
+    from .evidence_depth import resolve_l5_source_graph
+
+    graph = resolve_l5_source_graph(snap, getattr(snap, "build_source", None))
+    if graph is None or not graph.nodes:
         return {}
-    graph = cast("SourceGraphSummary", graph)
 
     from .buildsource.source_graph_findings import _format_dependency_path
     from .buildsource.source_graph_query import is_consumer_compiled_public_entry

--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -973,15 +973,14 @@ def compute_call_graph_leak_paths(
     dispatcher gap this ADR's P0 slice explicitly left open (see the ADR's
     "What this ADR does not fix" section).
 
-    Requires an embedded L5 graph (``--sources``/``--build-info``, or the
-    now-always-on L2 header-only graph) with at least one relevant edge;
-    returns ``{}`` otherwise — never an error, mirroring
-    :func:`~abicheck.buildsource.poi.resolve_changed_paths_public_impact`'s
-    degrade contract, so a project with no build-source evidence sees no
-    behavior change at all.
+    Requires an embedded L5 graph (``--sources``/``--build-info``, or the now-always-on
+    L2 header-only graph) with at least one relevant edge; returns ``{}`` otherwise —
+    never an error, mirroring :func:`~abicheck.buildsource.poi.resolve_changed_paths_public_impact`'s
+    degrade contract, so a project with no build-source evidence sees no behavior change at all.
     """
+    # Phase 10 security correction: build_source.source_graph first (richer).
     build_source = getattr(snap, "build_source", None)
-    graph = snap.surface_graph or (build_source.source_graph if build_source else None)
+    graph = (build_source.source_graph if build_source else None) or snap.surface_graph
     if graph is None or not getattr(graph, "nodes", None):
         return {}
     graph = cast("SourceGraphSummary", graph)

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -430,6 +430,17 @@ _L4_L5_LAYER_VALUES = frozenset(
     {DataLayer.L4_SOURCE_ABI.value, DataLayer.L5_SOURCE_GRAPH.value}
 )
 
+#: Evidence-ladder rank per layer value, derived from ``DataLayer``'s own
+#: declaration order (mirroring ``evidence_depth.DEPTH_RANK``'s identical
+#: derive-don't-restate pattern) so :func:`_mark_layers_not_collected` can
+#: append missing rows in a fixed, PYTHONHASHSEED-independent order instead
+#: of a bare ``frozenset`` iteration's hash-dependent one (Codex review, PR
+#: #1216, fifth round: two runs of an otherwise-identical projection over a
+#: coverage-free pack could append the new L4/L5 rows in reversed order,
+#: making the human coverage table and serialized ``layer_coverage`` array
+#: non-reproducible for identical inputs).
+_LAYER_RANK = {layer.value: rank for rank, layer in enumerate(DataLayer)}
+
 
 def _mark_layers_not_collected(
     pack: BuildSourcePack, layer_values: frozenset[str]
@@ -464,6 +475,10 @@ def _mark_layers_not_collected(
     depth exclusion needs this guarantee to hold unconditionally).
     """
     present = {row.layer for row in pack.manifest.coverage}
+    missing = sorted(
+        (layer for layer in layer_values if layer not in present),
+        key=lambda layer: _LAYER_RANK.get(layer, len(_LAYER_RANK)),
+    )
     pack.manifest.coverage = [
         LayerCoverage(layer=row.layer, status=CoverageStatus.NOT_COLLECTED)
         if row.layer in layer_values
@@ -471,8 +486,7 @@ def _mark_layers_not_collected(
         for row in pack.manifest.coverage
     ] + [
         LayerCoverage(layer=layer, status=CoverageStatus.NOT_COLLECTED)
-        for layer in layer_values
-        if layer not in present
+        for layer in missing
     ]
 
 

--- a/abicheck/policy/depth_projection.py
+++ b/abicheck/policy/depth_projection.py
@@ -451,12 +451,28 @@ def _mark_layers_not_collected(
     branches), so a reader can't distinguish "genuinely never collected"
     from "collected, then projected away below the requested depth" — which
     is exactly the honest claim at this depth.
+
+    Inserts a fresh ``NOT_COLLECTED`` row for a layer in *layer_values* that
+    had **no** row at all (e.g. a hand-built/typed-API-constructed pack that
+    carries a payload but never tracked coverage), not just rewriting rows
+    that already exist -- a projection that silently no-ops for a
+    coverage-free pack would leave ``coverage_for(layer)`` reading ``None``
+    exactly as it would for a pack that genuinely never attempted this
+    layer, defeating this function's own "make the two indistinguishable
+    honestly" contract (Codex review, PR #1216, fourth round: a downstream
+    reader relying on "a coverage row exists at all" to detect a deliberate
+    depth exclusion needs this guarantee to hold unconditionally).
     """
+    present = {row.layer for row in pack.manifest.coverage}
     pack.manifest.coverage = [
         LayerCoverage(layer=row.layer, status=CoverageStatus.NOT_COLLECTED)
         if row.layer in layer_values
         else row
         for row in pack.manifest.coverage
+    ] + [
+        LayerCoverage(layer=layer, status=CoverageStatus.NOT_COLLECTED)
+        for layer in layer_values
+        if layer not in present
     ]
 
 

--- a/changelog.d/20260911_045505_noreply_migrate_surface_graph_readers_kh60be.md
+++ b/changelog.d/20260911_045505_noreply_migrate_surface_graph_readers_kh60be.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Internal: five `build_source.source_graph` readers now prefer
+  `AbiSnapshot.surface_graph`.** `internal_leak.py`,
+  `buildsource/cross_source_checks.py`, `buildsource/evidence_report.py`,
+  `evidence_depth.py`, and `cli_graph.py` now read the L5 evidence graph via
+  the canonical `AbiSnapshot.surface_graph` field, falling back to the
+  legacy `build_source.source_graph` nested field only when `surface_graph`
+  is absent (a pre-Phase-3 snapshot never populates it). No user-visible
+  behavior change (ADR-063 Phase 10).

--- a/changelog.d/20260911_053600_noreply_migrate_surface_graph_readers_kh60be.md
+++ b/changelog.d/20260911_053600_noreply_migrate_surface_graph_readers_kh60be.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Internal: corrected the `AbiSnapshot.surface_graph`/`build_source.source_graph`
+  read order in the five Phase 10 migrated readers.** A security review found
+  that preferring `surface_graph` could silently drop real call-graph/
+  dependency edges whenever a `--sources`/`--build-info` embed left
+  `build_source.source_graph` a richer, real L3-L5 evidence graph than the
+  always-on, header-only-only `surface_graph` — a genuinely-reachable
+  internal symbol removal could be misjudged unreachable and suppressed.
+  `internal_leak.py`, `buildsource/cross_source_checks.py`,
+  `buildsource/evidence_report.py`, `evidence_depth.py`, and `cli_graph.py`
+  now prefer `build_source.source_graph`, falling back to `surface_graph`
+  only when the former is absent. No change to the intended migration's
+  outcome for a pre-Phase-3 snapshot (`surface_graph` absent).

--- a/changelog.d/20260911_055151_noreply_migrate_surface_graph_readers_kh60be.md
+++ b/changelog.d/20260911_055151_noreply_migrate_surface_graph_readers_kh60be.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Internal: the `surface_graph` fallback no longer resurrects excluded L5
+  evidence for a depth-limited comparison.** `policy/depth_projection.py`
+  deliberately clears `build_source.source_graph` (and stamps an explicit
+  "not collected" coverage row) for a `--depth build` (or shallower)
+  comparison while retaining `surface_graph` (an L2 fact). The Phase 10
+  reader migration's fallback previously read that retained graph anyway,
+  which could emit L5-labeled findings and claim source-tier evidence for a
+  comparison whose own report said L5 was excluded. `buildsource/
+  evidence_report.py` and `evidence_depth.py` now only fall back to
+  `surface_graph` when the pack's manifest records no L5 coverage row at
+  all. Also switched an `isinstance`-based type narrow to a type-only cast
+  in `buildsource/cross_source_checks.py`/`buildsource/evidence_report.py`,
+  since `AbiSnapshot.surface_graph`'s declared type is a deliberately
+  structural protocol a typed-API caller may implement independently.

--- a/changelog.d/20260911_060958_noreply_migrate_surface_graph_readers_kh60be.md
+++ b/changelog.d/20260911_060958_noreply_migrate_surface_graph_readers_kh60be.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Internal: closed the remaining `surface_graph` depth-exclusion gaps and
+  fixed the root cause.** `internal_leak.py` and `buildsource/
+  cross_source_checks.py`'s two checks were still using the unguarded
+  `build_source.source_graph or surface_graph` fallback, so a `--depth
+  build` comparison's retained, header-only `surface_graph` could still
+  resurrect a leak-path or public-to-internal-dependency finding the
+  excluded, richer L5 evidence would have produced. Separately,
+  `policy/depth_projection.py`'s coverage-row bookkeeping only rewrote an
+  L5 row that already existed, never inserting one for a pack that started
+  with no coverage rows tracked at all — fixed at the source. All five
+  migrated readers now share one `evidence_depth.resolve_l5_source_graph`
+  resolver instead of five independently-maintained copies of the same
+  fallback rule.

--- a/changelog.d/20260911_062200_noreply_migrate_surface_graph_readers_kh60be.md
+++ b/changelog.d/20260911_062200_noreply_migrate_surface_graph_readers_kh60be.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Internal: made the depth-projection coverage-row insertion order
+  deterministic.** `policy/depth_projection.py`'s `_mark_layers_not_collected`
+  inserted a fresh `NOT_COLLECTED` row for a layer with no prior coverage row
+  by iterating a `frozenset`, whose order depends on the process's
+  `PYTHONHASHSEED` — a coverage-free pack's L4/L5 rows could come out in
+  either order across otherwise-identical runs, making the human coverage
+  table and serialized `layer_coverage` array non-reproducible. Missing
+  layers are now appended in a fixed evidence-ladder order derived from
+  `DataLayer`'s own declaration order.

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -1202,8 +1202,24 @@ concepts:
       tests/test_surface_graph_reader_migration.py pins output parity
       between the pre/post-Phase-3 shapes per reader, a dedicated "prefers
       the richer build_source.source_graph" regression test per reader, and
-      a depth-projection-exclusion regression test. **Not closed by this
-      row:**
+      a depth-projection-exclusion regression test. A fourth review round
+      found the depth-projection guard had only been applied to two of the
+      five readers (internal_leak.py and cross_source_checks.py's two
+      checks still used the unguarded fallback) and a deeper root cause:
+      depth_projection._mark_layers_not_collected only rewrote an existing
+      L5 coverage row, never inserted one for a pack that started with
+      none at all, defeating the "no row at all" signal the guard relies
+      on. Fixed _mark_layers_not_collected itself (inserts a missing row
+      now) rather than special-casing every caller again, and consolidated
+      all five readers onto one shared evidence_depth.
+      resolve_l5_source_graph(snap, pack) resolver so the fallback rule
+      cannot independently drift per call site as it already had three
+      times. That consolidation also fixed a third finding: the third
+      round's cast(...) for _side_source_graph was unsound there
+      specifically (diff_source_graph_findings reads concrete-only
+      SourceGraphSummary attributes the SurfaceGraphLike protocol doesn't
+      declare) -- the shared resolver now requires isinstance(...,
+      SourceGraphSummary) uniformly. **Not closed by this row:**
       deleting the L5 builder's own in-memory identity-aliasing
       (service_header_graph_attach.py's _attach_header_graph, which
       threads one shared SourceGraphSummary instance into both

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -1188,10 +1188,22 @@ concepts:
       the current single-file sectioned wire format (schema v42+) every
       real dump --sources -o snapshot actually uses; fixed by decoding
       through serialization.snapshot_from_dict rather than hand-walking a
-      third JSON shape. tests/test_surface_graph_reader_migration.py pins
-      output parity between the pre/post-Phase-3 shapes per reader plus a
-      dedicated "prefers the richer build_source.source_graph" regression
-      test per reader. **Not closed by this row:**
+      third JSON shape. A third review round found two more issues: an
+      isinstance-based narrow of the deliberately-structural
+      SurfaceGraphLike protocol would reject a valid typed-API
+      implementation for no reason (switched to a type-only cast), and the
+      surface_graph fallback did not check the pack's own L5 coverage row
+      -- policy/depth_projection.py deliberately clears build_source.
+      source_graph while stamping an explicit NOT_COLLECTED row for a
+      --depth build comparison, and falling back to the retained
+      surface_graph there resurrected L5-labeled findings/depth claims for
+      a comparison whose own report said L5 was excluded. Both readers now
+      only fall back when the pack records no L5 coverage row at all.
+      tests/test_surface_graph_reader_migration.py pins output parity
+      between the pre/post-Phase-3 shapes per reader, a dedicated "prefers
+      the richer build_source.source_graph" regression test per reader, and
+      a depth-projection-exclusion regression test. **Not closed by this
+      row:**
       deleting the L5 builder's own in-memory identity-aliasing
       (service_header_graph_attach.py's _attach_header_graph, which
       threads one shared SourceGraphSummary instance into both

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -1170,11 +1170,28 @@ concepts:
       five real production readers -- internal_leak.py,
       buildsource/cross_source_checks.py (two call sites),
       buildsource/evidence_report.py, evidence_depth.py, and
-      cli_graph.py -- each preferring surface_graph and falling back to
-      the legacy build_source.source_graph nested field only when
-      surface_graph is absent (a pre-Phase-3 document never populates it).
-      tests/test_surface_graph_reader_migration.py pins output parity
-      between the two shapes per reader. **Not closed by this row:**
+      cli_graph.py. **Preference order security-corrected in PR #1216
+      review** (two rounds): each reader prefers build_source.source_graph,
+      falling back to surface_graph only when the former is absent -- NOT
+      surface_graph-first as this row's plan text originally specified. A
+      real --sources/--build-info embed can leave build_source.source_graph
+      a strictly richer, real L3-L5 evidence graph than the always-on,
+      header-only-only surface_graph; preferring the weaker graph silently
+      dropped real call-graph/dependency edges, letting a
+      genuinely-reachable internal removal be misjudged unreachable and
+      suppressed (a BREAKING->COMPATIBLE false negative under a
+      reachability: proven-unreachable-only policy). surface_graph is still
+      the correct fallback for a depth-projected snapshot (build_source.
+      source_graph clears at the "source" depth floor; surface_graph, an L2
+      fact, clears lower, at "binary") and for a pre-Phase-3 document. A
+      second review round separately found cli_graph.py's first pass missed
+      the current single-file sectioned wire format (schema v42+) every
+      real dump --sources -o snapshot actually uses; fixed by decoding
+      through serialization.snapshot_from_dict rather than hand-walking a
+      third JSON shape. tests/test_surface_graph_reader_migration.py pins
+      output parity between the pre/post-Phase-3 shapes per reader plus a
+      dedicated "prefers the richer build_source.source_graph" regression
+      test per reader. **Not closed by this row:**
       deleting the L5 builder's own in-memory identity-aliasing
       (service_header_graph_attach.py's _attach_header_graph, which
       threads one shared SourceGraphSummary instance into both

--- a/docs/_meta/one-semantic-pipeline-status.yaml
+++ b/docs/_meta/one-semantic-pipeline-status.yaml
@@ -1165,8 +1165,34 @@ concepts:
       None outstanding for the shipped design (a deterministic closure
       walk over snapshot declarations). D5's own literal "traversal over
       one authoritative mergeable graph" text remains unfulfilled by
-      design (see Phase 3 (D5) amendment) rather than by an open gap;
-      AbiSnapshot.surface_graph itself still has no production reader.
+      design (see Phase 3 (D5) amendment) rather than by an open gap.
+      **Phase 10 checklist row landed:** AbiSnapshot.surface_graph now has
+      five real production readers -- internal_leak.py,
+      buildsource/cross_source_checks.py (two call sites),
+      buildsource/evidence_report.py, evidence_depth.py, and
+      cli_graph.py -- each preferring surface_graph and falling back to
+      the legacy build_source.source_graph nested field only when
+      surface_graph is absent (a pre-Phase-3 document never populates it).
+      tests/test_surface_graph_reader_migration.py pins output parity
+      between the two shapes per reader. **Not closed by this row:**
+      deleting the L5 builder's own in-memory identity-aliasing
+      (service_header_graph_attach.py's _attach_header_graph, which
+      threads one shared SourceGraphSummary instance into both
+      AbiSnapshot.surface_graph and a synthesized snap.build_source.
+      source_graph purely so a legacy build_source.source_graph reader
+      still sees the header-only graph). Investigation during this row
+      found strictly more readers of that synthesized pack than the five
+      named above -- coverage reporting (evidence_report.optional_coverage/
+      layer_presence), cli_buildsource.py's own _layer_payload_empty/
+      build_source_already_satisfies, and embed.py's own backfill logic
+      all depend on snap.build_source being populated for a plain
+      (--sources-less) dump -- so removing the synthesized pack outright is
+      a wider, separately-scoped change than "the five named readers",
+      not something this row's own audit covers. Recorded as an explicit
+      open gap per AGENTS.md's decision-making principles rather than
+      forced through unverified; tracked as a follow-up sub-item of this
+      same Phase 10 checklist row in
+      docs/contribute/plans/one-semantic-pipeline.md.
 
   analysis_plan:
     primitive: complete

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -17053,6 +17053,51 @@ not new design.
   depth-projected pack (explicit `NOT_COLLECTED` row) must not fall back,
   while a pack with no coverage row recorded still does.
 
+  **Fourth review round: two more corrections, plus a real root-cause fix
+  this time rather than another per-call-site patch.** (1) The
+  coverage-row-aware guard above had only been applied to
+  `_side_source_graph`/`_l5_payload_empty` -- `internal_leak.py`'s
+  `compute_call_graph_leak_paths` and `cross_source_checks.py`'s two checks
+  (`_check_private_header_leak`, `_check_public_to_internal_dependency`)
+  still used the unguarded `build_source.source_graph or surface_graph`
+  fallback, so the identical depth-exclusion leak this phase already fixed
+  once was still open in three more places. (2) A deeper bug in the guard
+  itself: `policy/depth_projection.py`'s `_mark_layers_not_collected` only
+  ever *rewrote* an L5 coverage row that already existed -- for a pack that
+  started with **no** coverage rows tracked at all (a hand-built/
+  typed-API-constructed `BuildSourcePack`), a `--depth build` projection
+  cleared `source_graph` but left `coverage_for(L5)` reading `None`
+  regardless, defeating the "no row at all" signal the guard relies on to
+  tell "genuinely never collected" apart from "collected, then projected
+  away." Fixed at the root (`_mark_layers_not_collected` now inserts a
+  fresh `NOT_COLLECTED` row for a layer with no existing row, not only
+  rewriting rows that already exist) rather than special-cased in each
+  reader again, closing the gap for every current and future caller of that
+  function at once. This round also consolidated the fallback logic itself:
+  four independently-maintained near-duplicates had already drifted three
+  times across four review rounds, so all five readers now go through one
+  shared `evidence_depth.resolve_l5_source_graph(snap, pack)` resolver
+  (`_side_source_graph`/`_l5_payload_empty` are now thin wrappers over it).
+  That consolidation also fixed a third finding from this round: the
+  `SurfaceGraphLike`-vs-`SourceGraphSummary` cast the previous round
+  introduced for `_side_source_graph` was actually unsound at *that*
+  specific call site (unlike `cross_source_checks.py`'s own narrows) --
+  `diff_source_graph_findings` downstream reads concrete-only attributes
+  (`narrowed_scope`/`extractor_passes`/`degraded_passes`) the
+  `SurfaceGraphLike` protocol doesn't declare, so a merely-structural
+  implementation would reach it and crash. The shared resolver now requires
+  a genuine `SourceGraphSummary` for the fallback uniformly (an
+  `isinstance` check, not a blind cast), accepting a small, deliberate loss
+  of typed-API flexibility for `cross_source_checks.py`'s/
+  `internal_leak.py`'s own narrower needs (protocol members only) in
+  exchange for one call-site-independent, uniformly-safe contract.
+  Regression tests added: `internal_leak.py`/`cross_source_checks.py` both
+  now have a depth-exclusion test alongside their existing
+  "prefers-the-richer-graph" one, `_mark_layers_not_collected` has a direct
+  unit test for the missing-row-insertion fix, and
+  `resolve_l5_source_graph` has a direct test pinning the non-concrete
+  rejection.
+
   **The in-memory alias-assignment deletion is NOT done, and is being left
   open rather than forced through unverified.** The one place that builds
   the alias — `service_header_graph_attach.py`'s `_attach_header_graph` —

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -16979,6 +16979,59 @@ not new design.
   alias assignment in the L5 builder — the one piece this row can actually
   remove once every reader stops going through it.
 
+  **Five-reader migration landed.** All five named readers
+  (`internal_leak.py`, `buildsource/cross_source_checks.py`'s two call
+  sites, `buildsource/evidence_report.py`, `evidence_depth.py`,
+  `cli_graph.py`) now read `graph = snap.surface_graph or
+  (snap.build_source.source_graph if snap.build_source else None)` (or the
+  pack-aware equivalent for a call site whose *pack* may be an out-of-band
+  one the caller resolved independently of the snapshot —
+  `evidence_report._side_source_graph`/`evidence_depth._l5_payload_empty`
+  only substitute `surface_graph` when the pack in hand actually **is**
+  `snap.build_source`, never for an unrelated `--old/new-build-info`/
+  `--old/new-sources` pack, per those two modules' own pre-existing "never
+  default *pack* to `snap.build_source`" contract). `cli_graph.py`'s
+  `_load_source_graph` has no `AbiSnapshot` in scope at all (it loads a
+  bare graph JSON file or an out-of-band pack directory), so its migration
+  is the dict-shaped analogue: a full embedded-snapshot JSON document is
+  now recognized and its graph read preferring the top-level
+  `surface_graph` key over the nested `build_source.source_graph` one.
+  `tests/test_surface_graph_reader_migration.py` pins output parity
+  between the pre-Phase-3 shape (`surface_graph` absent) and the
+  post-Phase-3 shape (`surface_graph` populated) for all five.
+
+  **The in-memory alias-assignment deletion is NOT done, and is being left
+  open rather than forced through unverified.** The one place that builds
+  the alias — `service_header_graph_attach.py`'s `_attach_header_graph` —
+  threads one shared `SourceGraphSummary` instance into
+  `AbiSnapshot.surface_graph` *and* a synthesized `snap.build_source`
+  (`BuildSourcePack(root=Path(""), source_graph=graph)`) for the
+  always-on, header-only (L2) graph case, purely so a legacy
+  `build_source.source_graph` reader still sees it even when no
+  `--sources`/`--build-info` ran. A real audit for this row (not limited to
+  the five named readers) found this synthesized pack has further
+  production readers this checklist never named: coverage reporting
+  (`evidence_report.optional_coverage`/`layer_presence`,
+  `evidence_report.detect_coverage_asymmetry`), `cli_buildsource.py`'s own
+  `_layer_payload_empty`/`build_source_already_satisfies`, and
+  `buildsource/embed.py`'s own `--sources`/`--build-info` backfill logic
+  (`existing = snap.build_source; ... existing.source_graph is not None`)
+  — every one of them would silently regress (reporting `NOT_COLLECTED`
+  L5 coverage for a plain header-only dump, or skipping the header-only
+  graph backfill entirely) if `_attach_header_graph` stopped populating
+  `snap.build_source` for this case. None of those call sites were part of
+  this row's five-reader scope, and auditing and migrating them too is a
+  materially larger, separately-scoped change than this row's own text
+  anticipated ("the one piece this row can actually remove" undersold the
+  blast radius). Per this file's own root-`AGENTS.md`-inherited
+  decision-making principles ("if a genuinely general fix isn't feasible
+  in one pass, say so explicitly and record the gap"), that deletion is
+  left as an explicitly named, separately-scoped follow-up rather than
+  performed against an incomplete audit. Until it lands, `git grep -n
+  "surface_graph = graph"` inside `service_header_graph_attach.py` still
+  finds the alias-construction site outside history — expected, and
+  tracked here rather than silently left implied-closed.
+
   **"Delete the legacy-document aliasing fallback in `snapshot_from_dict()`"
   is no longer this row's to do — that fallback was itself retracted
   earlier in this same phase (see the correction above), and a further

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -16979,26 +16979,54 @@ not new design.
   alias assignment in the L5 builder — the one piece this row can actually
   remove once every reader stops going through it.
 
-  **Five-reader migration landed.** All five named readers
-  (`internal_leak.py`, `buildsource/cross_source_checks.py`'s two call
-  sites, `buildsource/evidence_report.py`, `evidence_depth.py`,
-  `cli_graph.py`) now read `graph = snap.surface_graph or
-  (snap.build_source.source_graph if snap.build_source else None)` (or the
-  pack-aware equivalent for a call site whose *pack* may be an out-of-band
-  one the caller resolved independently of the snapshot —
-  `evidence_report._side_source_graph`/`evidence_depth._l5_payload_empty`
-  only substitute `surface_graph` when the pack in hand actually **is**
-  `snap.build_source`, never for an unrelated `--old/new-build-info`/
-  `--old/new-sources` pack, per those two modules' own pre-existing "never
-  default *pack* to `snap.build_source`" contract). `cli_graph.py`'s
-  `_load_source_graph` has no `AbiSnapshot` in scope at all (it loads a
-  bare graph JSON file or an out-of-band pack directory), so its migration
-  is the dict-shaped analogue: a full embedded-snapshot JSON document is
-  now recognized and its graph read preferring the top-level
-  `surface_graph` key over the nested `build_source.source_graph` one.
-  `tests/test_surface_graph_reader_migration.py` pins output parity
-  between the pre-Phase-3 shape (`surface_graph` absent) and the
-  post-Phase-3 shape (`surface_graph` populated) for all five.
+  **Five-reader migration landed, with a security correction to the
+  preference order this row's own text originally specified (PR #1216
+  review).** All five named readers (`internal_leak.py`,
+  `buildsource/cross_source_checks.py`'s two call sites,
+  `buildsource/evidence_report.py`, `evidence_depth.py`, `cli_graph.py`) now
+  read `graph = (snap.build_source.source_graph if snap.build_source else
+  None) or snap.surface_graph` — `build_source.source_graph` **first**, not
+  `surface_graph` first as this section originally specified. A security
+  reviewer correctly found that a real `--sources`/`--build-info` embed can
+  leave `build_source.source_graph` a strictly richer, real L3-L5 evidence
+  graph than the always-on, header-only-only `surface_graph`
+  (`_attach_header_graph` builds the latter from headers alone and never
+  updates it once written; `buildsource/embed.py`'s backfill only ever
+  adopts the header-only graph into an *empty* `build_source.source_graph`,
+  never displacing a real one) — so the originally-specified
+  surface_graph-first order silently drops real call-graph/dependency edges
+  whenever the two diverge, letting a genuinely-reachable internal removal
+  be misjudged unreachable and suppressed under a
+  `reachability: proven-unreachable-only` policy (a BREAKING→COMPATIBLE
+  false negative). `surface_graph` is still the correct fallback for a
+  depth-projected snapshot, where `policy/depth_projection.py` clears
+  `build_source.source_graph` at the "source" depth floor while retaining
+  `surface_graph` (an L2 fact) down to the "binary" floor, and for a
+  pre-Phase-3 document carrying `build_source.source_graph` with no
+  `surface_graph` at all — the corrected order still resolves both cases
+  identically to the original one, since it only changes behavior when the
+  two graphs are genuinely different objects. The pack-aware equivalent for
+  a call site whose *pack* may be an out-of-band one the caller resolved
+  independently of the snapshot (`evidence_report._side_source_graph`/
+  `evidence_depth._l5_payload_empty`) applies the same corrected order,
+  still only substituting `surface_graph` when the pack in hand actually
+  **is** `snap.build_source`, never for an unrelated
+  `--old/new-build-info`/`--old/new-sources` pack, per those two modules'
+  own pre-existing "never default *pack* to `snap.build_source`" contract.
+  `cli_graph.py`'s `_load_source_graph` has no `AbiSnapshot` in scope at all
+  (it loads a bare graph JSON file or an out-of-band pack directory), so its
+  migration is the dict-shaped analogue: a full embedded-snapshot JSON
+  document (flat *or* the current single-file sectioned wire format, schema
+  v42+ — a second review-round finding, since the first draft's hand-rolled
+  dict walk missed the sectioned shape every real `dump --sources -o`
+  snapshot actually uses today) is now decoded through
+  `serialization.snapshot_from_dict` and its graph read with the same
+  corrected preference order. `tests/test_surface_graph_reader_migration.py`
+  pins output parity between the pre-Phase-3 shape (`surface_graph` absent)
+  and the post-Phase-3 shape (`surface_graph` populated as the *same*
+  object) for all five, plus a dedicated "prefers the richer
+  `build_source.source_graph`" regression test per reader proving the two
+  graphs are read correctly when they are genuinely different objects.
 
   **The in-memory alias-assignment deletion is NOT done, and is being left
   open rather than forced through unverified.** The one place that builds

--- a/docs/contribute/plans/one-semantic-pipeline.md
+++ b/docs/contribute/plans/one-semantic-pipeline.md
@@ -17028,6 +17028,31 @@ not new design.
   `build_source.source_graph`" regression test per reader proving the two
   graphs are read correctly when they are genuinely different objects.
 
+  **Two further corrections from the same review round.** (1) The
+  `SurfaceGraphLike` narrow in `cross_source_checks.py`/
+  `evidence_report.py` used `assert isinstance(graph, SourceGraphSummary)`
+  to satisfy mypy — but `SurfaceGraphLike` (`model/graph_facts.py`) is
+  deliberately structural so a typed-API caller may supply a conforming,
+  non-`SourceGraphSummary` implementation, and both call sites only ever
+  read `.nodes`/`.edges` (protocol members) afterward; a runtime assert
+  would reject such a caller for no reason. Switched to a type-only
+  `cast(...)`. (2) `_side_source_graph`/`_l5_payload_empty`'s
+  `surface_graph` fallback did not check whether the pack's own manifest
+  already recorded an explicit (even `NOT_COLLECTED`) L5 coverage row.
+  `policy/depth_projection.py` deliberately clears `build_source.
+  source_graph` to `None` for a `--depth build` (or shallower) comparison
+  *while stamping that exact row* and leaving `surface_graph` untouched (an
+  L2 fact, cleared at a lower floor) -- so the fallback, unguarded, silently
+  resurrected L5-labeled graph-diff findings and a `"source"` depth label
+  for a comparison whose own report said L5 was excluded. Both functions
+  now only fall back when the pack's manifest records **no** L5 coverage
+  row at all (`pack.manifest.coverage_for(DataLayer.L5_SOURCE_GRAPH) is
+  None`) -- the one case left needing the fallback is a pack that never
+  went through any collection/projection pipeline at all (e.g. a bare
+  typed-API-constructed snapshot). Regression tests added for both: a
+  depth-projected pack (explicit `NOT_COLLECTED` row) must not fall back,
+  while a pack with no coverage row recorded still does.
+
   **The in-memory alias-assignment deletion is NOT done, and is being left
   open rather than forced through unverified.** The one place that builds
   the alias — `service_header_graph_attach.py`'s `_attach_header_graph` —

--- a/tests/test_depth_projection.py
+++ b/tests/test_depth_projection.py
@@ -1150,3 +1150,26 @@ class TestMarkLayersNotCollectedInsertsAMissingRow:
             )
             == 1
         )
+
+    def test_missing_rows_are_inserted_in_evidence_ladder_order(self) -> None:
+        """Codex review, PR #1216, fifth round: a coverage-free pack's L4/L5
+        rows must be appended in a fixed order (L4 before L5), not whatever
+        order a bare ``frozenset`` iteration happens to yield under the
+        process's current ``PYTHONHASHSEED`` -- run repeatedly, since a
+        single run can't distinguish "always this order" from "coincidence
+        of one hash seed"."""
+        for _ in range(20):
+            graph = SourceGraphSummary(nodes=[])
+            pack = BuildSourcePack(
+                root="", source_abi=SourceAbiSurface(), source_graph=graph
+            )
+            assert pack.manifest.coverage == []
+
+            projected = project_build_source_pack_to_depth(pack, "build")
+
+            assert projected is not None
+            layers = [c.layer for c in projected.manifest.coverage]
+            assert layers == [
+                DataLayer.L4_SOURCE_ABI.value,
+                DataLayer.L5_SOURCE_GRAPH.value,
+            ]

--- a/tests/test_depth_projection.py
+++ b/tests/test_depth_projection.py
@@ -1094,3 +1094,59 @@ class TestAllowDwarfName:
 
     def test_no_match(self) -> None:
         assert _allow_dwarf_name("ns::S", frozenset({"Other"})) is False
+
+
+class TestMarkLayersNotCollectedInsertsAMissingRow:
+    """Codex review, PR #1216, fourth round: ``_mark_layers_not_collected``
+    must stamp an explicit ``NOT_COLLECTED`` row for a layer even when the
+    pack started with **no** coverage row for it at all -- not just rewrite
+    rows that already exist. A hand-built/typed-API-constructed
+    ``BuildSourcePack`` can carry a real ``source_graph`` payload with an
+    empty ``manifest.coverage`` list (no L3/L4/L5 rows tracked at all); this
+    function's own docstring promises a reader can't tell "genuinely never
+    collected" from "collected, then projected away below the requested
+    depth" apart -- a promise that only holds if projecting such a pack
+    still leaves an explicit row behind."""
+
+    def test_build_depth_projection_stamps_l5_not_collected_with_no_prior_row(
+        self,
+    ) -> None:
+        graph = SourceGraphSummary(nodes=[])
+        pack = BuildSourcePack(root="", source_graph=graph)
+        assert pack.manifest.coverage == []  # no rows tracked at all
+
+        projected = project_build_source_pack_to_depth(pack, "build")
+
+        assert projected is not None
+        assert projected.source_graph is None
+        row = projected.manifest.coverage_for(DataLayer.L5_SOURCE_GRAPH)
+        assert row is not None
+        assert row.status == CoverageStatus.NOT_COLLECTED
+
+    def test_build_depth_projection_overwrites_an_existing_l5_row_too(self) -> None:
+        """The pre-existing rewrite path (a row that already exists) still
+        works unchanged, alongside the new insert-if-missing path."""
+        graph = SourceGraphSummary(nodes=[])
+        pack = BuildSourcePack(root="", source_graph=graph)
+        pack.manifest.coverage = [
+            LayerCoverage(
+                layer=DataLayer.L5_SOURCE_GRAPH.value,
+                status=CoverageStatus.PRESENT,
+            )
+        ]
+
+        projected = project_build_source_pack_to_depth(pack, "build")
+
+        assert projected is not None
+        row = projected.manifest.coverage_for(DataLayer.L5_SOURCE_GRAPH)
+        assert row is not None
+        assert row.status == CoverageStatus.NOT_COLLECTED
+        # Exactly one L5 row -- not appended alongside the rewritten one.
+        assert (
+            sum(
+                1
+                for c in projected.manifest.coverage
+                if c.layer == DataLayer.L5_SOURCE_GRAPH.value
+            )
+            == 1
+        )

--- a/tests/test_surface_graph_reader_migration.py
+++ b/tests/test_surface_graph_reader_migration.py
@@ -100,6 +100,72 @@ def _diverged_snap(
     )
 
 
+def _depth_excluded_snap(retained_surface_graph: SourceGraphSummary) -> AbiSnapshot:
+    """The shape ``policy/depth_projection.py`` leaves behind for a
+    ``--depth build`` (or shallower) comparison: ``build_source.
+    source_graph`` cleared to ``None`` with an explicit L5 "not collected"
+    coverage row stamped (``_mark_layers_not_collected``), while
+    ``surface_graph`` (an L2 fact, cleared at a lower depth floor) is
+    retained untouched."""
+    from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=None),
+        surface_graph=retained_surface_graph,
+    )
+    snap.build_source.manifest.coverage = [
+        LayerCoverage(
+            layer=DataLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED
+        )
+    ]
+    return snap
+
+
+# --------------------------------------------------------------------------- #
+# evidence_depth.resolve_l5_source_graph -- the shared resolver every reader
+# above goes through (fourth review round: consolidated so the fallback rule
+# can't independently drift per call site again)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_l5_source_graph_rejects_a_non_concrete_surface_graph() -> None:
+    """Third review-round regression: a merely structurally-conforming
+    ``SurfaceGraphLike`` implementation (not a real ``SourceGraphSummary``)
+    must not be returned as a fallback -- every caller of this function
+    eventually reads concrete-only attributes downstream (e.g.
+    ``diff_source_graph_findings`` reads ``narrowed_scope``/
+    ``extractor_passes``/``degraded_passes``, none of which the protocol
+    declares)."""
+    from abicheck.evidence_depth import resolve_l5_source_graph
+
+    class _FakeGraph:
+        nodes: list = []
+        edges: list = []
+
+        def has_node(self, node_id: str) -> bool:
+            return False
+
+        def add_node(self, node: object) -> None:
+            pass
+
+        def add_edge(self, edge: object) -> None:
+            pass
+
+        def to_dict(self) -> dict:
+            return {}
+
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=None),
+        surface_graph=_FakeGraph(),
+    )
+
+    assert resolve_l5_source_graph(snap, snap.build_source) is None
+
+
 # --------------------------------------------------------------------------- #
 # internal_leak.compute_call_graph_leak_paths
 # --------------------------------------------------------------------------- #
@@ -145,6 +211,26 @@ def test_internal_leak_prefers_the_richer_build_source_graph() -> None:
     result = compute_call_graph_leak_paths(snap)
 
     assert "ns::detail::helper" in result
+
+
+def test_internal_leak_honors_a_depth_projected_l5_exclusion() -> None:
+    """Fourth review-round regression: this reader must go through the same
+    projection-aware coverage guard as ``_side_source_graph``/
+    ``_l5_payload_empty`` -- a ``--depth build`` comparison's retained,
+    header-only ``surface_graph`` must not resurrect a leak path the
+    excluded, richer L5 graph would have shown."""
+    from abicheck.internal_leak import compute_call_graph_leak_paths
+
+    retained = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "ns::detail::helper", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    snap = _depth_excluded_snap(retained)
+
+    assert compute_call_graph_leak_paths(snap) == {}
 
 
 # --------------------------------------------------------------------------- #
@@ -213,6 +299,34 @@ def test_public_to_internal_dependency_prefers_the_richer_build_source_graph() -
     ]
 
     assert hits == ["pubFn"]
+
+
+def test_public_to_internal_dependency_honors_a_depth_projected_l5_exclusion() -> None:
+    """Fourth review-round regression: a ``--depth build`` comparison's
+    retained, header-only ``surface_graph`` must not resurrect a
+    ``PUBLIC_TO_INTERNAL_DEPENDENCY`` finding the excluded, richer L5 graph
+    would have produced."""
+    from abicheck.buildsource.cross_source_checks import run_crosschecks
+    from abicheck.checker_policy import ChangeKind
+
+    retained = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "internalImpl", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    snap = _depth_excluded_snap(retained)
+    snap.from_headers = True
+
+    res = run_crosschecks(snap)
+    hits = [
+        c.symbol
+        for c in res.findings
+        if c.kind == ChangeKind.PUBLIC_TO_INTERNAL_DEPENDENCY
+    ]
+
+    assert hits == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_surface_graph_reader_migration.py
+++ b/tests/test_surface_graph_reader_migration.py
@@ -299,6 +299,33 @@ def test_side_source_graph_prefers_the_richer_build_source_graph() -> None:
     assert _side_source_graph(snap, snap.build_source) is richer
 
 
+def test_side_source_graph_honors_a_depth_projected_l5_exclusion() -> None:
+    """Second review-round regression: ``policy/depth_projection.py`` clears
+    ``build_source.source_graph`` to ``None`` for a ``--depth build``
+    comparison while stamping an explicit L5 "not collected" coverage row
+    and *retaining* ``surface_graph`` untouched (an L2 fact). The fallback
+    must not resurrect L5-labeled findings from that retained graph -- a
+    pack whose manifest already recorded an L5 coverage row (regardless of
+    status) is never treated as "never collected"."""
+    from abicheck.buildsource.evidence_report import _side_source_graph
+    from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+
+    weaker = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=None),
+        surface_graph=weaker,
+    )
+    snap.build_source.manifest.coverage = [
+        LayerCoverage(
+            layer=DataLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED
+        )
+    ]
+
+    assert _side_source_graph(snap, snap.build_source) is None
+
+
 def test_evidence_report_graph_diff_unchanged_by_migration() -> None:
     from abicheck.buildsource.evidence_report import diff_embedded_build_source
 
@@ -411,13 +438,11 @@ def test_depth_label_for_prefers_the_richer_build_source_graph() -> None:
     assert depth_label_for(snap, snap.build_source) == "source"
 
 
-def test_depth_label_for_falls_back_to_surface_graph_when_build_source_graph_absent() -> (
-    None
-):
-    """A depth-projected snapshot (``policy/depth_projection.py``) can clear
-    ``build_source.source_graph`` while retaining ``surface_graph`` (an L2
-    fact, cleared at a lower depth floor) -- the fallback this migration
-    exists for still applies in that direction."""
+def test_depth_label_for_falls_back_to_surface_graph_when_never_collected() -> None:
+    """A pack that simply never recorded any L5 coverage at all (e.g. a bare
+    typed-API-constructed snapshot) -- as opposed to one a depth projection
+    deliberately excluded L5 from, see the test below -- still falls back to
+    ``surface_graph``."""
     from abicheck.evidence_depth import depth_label_for
 
     graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
@@ -429,6 +454,31 @@ def test_depth_label_for_falls_back_to_surface_graph_when_build_source_graph_abs
     )
 
     assert depth_label_for(snap, snap.build_source) == "source"
+
+
+def test_depth_label_for_honors_a_depth_projected_l5_exclusion() -> None:
+    """Second review-round regression: a ``--depth build`` projection clears
+    ``build_source.source_graph`` while stamping an explicit L5 "not
+    collected" coverage row and retaining ``surface_graph`` (an L2 fact) --
+    the fallback must not then report ``"source"`` depth for a comparison
+    whose own report says L5 was excluded."""
+    from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+    from abicheck.evidence_depth import depth_label_for
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=None),
+        surface_graph=graph,
+    )
+    snap.build_source.manifest.coverage = [
+        LayerCoverage(
+            layer=DataLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED
+        )
+    ]
+
+    assert depth_label_for(snap, snap.build_source) != "source"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_surface_graph_reader_migration.py
+++ b/tests/test_surface_graph_reader_migration.py
@@ -1,0 +1,350 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-063 Phase 10: the five ``BuildSourcePack.source_graph`` live-alias
+readers (``internal_leak.py``, ``buildsource/cross_source_checks.py``,
+``buildsource/evidence_report.py``, ``evidence_depth.py``, ``cli_graph.py``)
+now prefer the canonical ``AbiSnapshot.surface_graph``, falling back to the
+legacy ``build_source.source_graph`` nested field only when ``surface_graph``
+is absent -- a pre-Phase-3 snapshot never populates it (see
+``docs/contribute/plans/one-semantic-pipeline.md``'s Phase 10 checklist).
+
+Each test below builds a *pre-Phase-3-shaped* fixture -- ``surface_graph``
+absent, ``build_source.source_graph`` present -- and asserts the reader's
+output is byte-for-byte identical to the same fixture with ``surface_graph``
+set to the *same* graph object (the ordinary post-Phase-3 shape a fresh
+snapshot now carries). Identical output across both shapes is exactly the
+"no regression from the migration" contract this phase's checklist asks for:
+the fallback must make a pre-Phase-3 document behave exactly as it did before
+this migration, while a fresh snapshot's canonical field is what actually
+gets read first.
+"""
+
+from __future__ import annotations
+
+import json
+
+from abicheck.buildsource.pack import BuildSourcePack
+from abicheck.buildsource.source_graph import GraphEdge, GraphNode, SourceGraphSummary
+from abicheck.model import AbiSnapshot, Function, ScopeOrigin
+
+
+def _decl(node_id: str, label: str, visibility: str) -> GraphNode:
+    return GraphNode(
+        id=node_id, kind="source_decl", label=label, attrs={"visibility": visibility}
+    )
+
+
+def _pre_and_post_phase3_snaps(
+    graph: SourceGraphSummary,
+) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """One snapshot shaped like a pre-Phase-3 document (``surface_graph``
+    absent) and one shaped like a fresh, post-Phase-3 one (``surface_graph``
+    is the identical object ``build_source.source_graph`` holds -- the
+    Phase 3 assembly step's own one-object guarantee)."""
+    pre = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=graph),
+    )
+    post = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=graph),
+        surface_graph=graph,
+    )
+    return pre, post
+
+
+# --------------------------------------------------------------------------- #
+# internal_leak.compute_call_graph_leak_paths
+# --------------------------------------------------------------------------- #
+
+
+def test_internal_leak_call_graph_leak_paths_unchanged_by_migration() -> None:
+    from abicheck.internal_leak import compute_call_graph_leak_paths
+
+    graph = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "ns::detail::helper", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    pre, post = _pre_and_post_phase3_snaps(graph)
+
+    pre_result = compute_call_graph_leak_paths(pre)
+    post_result = compute_call_graph_leak_paths(post)
+
+    assert pre_result == post_result
+    assert "ns::detail::helper" in pre_result
+    assert "pubFn" in pre_result["ns::detail::helper"][0]
+
+
+# --------------------------------------------------------------------------- #
+# buildsource/cross_source_checks.py: _check_public_to_internal_dependency
+# --------------------------------------------------------------------------- #
+
+
+def test_public_to_internal_dependency_unchanged_by_migration() -> None:
+    from abicheck.buildsource.cross_source_checks import (
+        CHECK_PUBLIC_TO_INTERNAL_DEPENDENCY,
+        run_crosschecks,
+    )
+    from abicheck.checker_policy import ChangeKind
+
+    graph = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "internalImpl", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    pre, post = _pre_and_post_phase3_snaps(graph)
+    pre.from_headers = True
+    post.from_headers = True
+
+    pre_res = run_crosschecks(pre)
+    post_res = run_crosschecks(post)
+
+    def _hits(res):
+        return [
+            (c.symbol, c.new_value)
+            for c in res.findings
+            if c.kind == ChangeKind.PUBLIC_TO_INTERNAL_DEPENDENCY
+        ]
+
+    assert _hits(pre_res) == _hits(post_res) == [("pubFn", "internalImpl")]
+    assert (
+        pre_res.providers[CHECK_PUBLIC_TO_INTERNAL_DEPENDENCY]
+        == post_res.providers[CHECK_PUBLIC_TO_INTERNAL_DEPENDENCY]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# buildsource/cross_source_checks.py: _check_private_header_leak
+# --------------------------------------------------------------------------- #
+
+
+def test_private_header_leak_source_index_provider_unchanged_by_migration() -> None:
+    from abicheck.buildsource.cross_source_checks import (
+        CHECK_PRIVATE_HEADER_LEAK,
+        PROVIDER_SOURCE_INDEX,
+        run_crosschecks,
+    )
+    from abicheck.model import RecordType
+
+    graph = SourceGraphSummary(
+        nodes=[
+            GraphNode(id="decl://use", kind="source_decl", label="use"),
+            GraphNode(id="type://Impl", kind="record_type", label="Impl"),
+        ]
+    )
+    pre, post = _pre_and_post_phase3_snaps(graph)
+    for snap in (pre, post):
+        snap.from_headers = True
+        snap.functions = [
+            Function(
+                name="use",
+                mangled="_Z3usev",
+                return_type="Impl *",
+                origin=ScopeOrigin.PUBLIC_HEADER,
+            ),
+        ]
+        snap.types = [
+            RecordType(name="Impl", kind="struct", origin=ScopeOrigin.PRIVATE_HEADER),
+        ]
+
+    pre_res = run_crosschecks(pre)
+    post_res = run_crosschecks(post)
+
+    assert (
+        pre_res.providers[CHECK_PRIVATE_HEADER_LEAK]
+        == post_res.providers[CHECK_PRIVATE_HEADER_LEAK]
+    )
+    assert PROVIDER_SOURCE_INDEX in pre_res.providers[CHECK_PRIVATE_HEADER_LEAK]
+
+
+# --------------------------------------------------------------------------- #
+# buildsource/evidence_report.py: diff_embedded_build_source's L5 graph diff
+# --------------------------------------------------------------------------- #
+
+
+def test_side_source_graph_unchanged_by_migration() -> None:
+    """:func:`_side_source_graph` (the helper ``diff_embedded_build_source``'s
+    L5 diff now goes through) resolves the identical graph whether it comes
+    via the fallback (pre-Phase-3 shape) or the canonical field (post-Phase-3
+    shape) -- and, per the module's own out-of-band-pack contract, never
+    substitutes ``surface_graph`` for an explicit ``--old/new-sources`` pack
+    unrelated to the snapshot."""
+    from abicheck.buildsource.evidence_report import _side_source_graph
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    pre, post = _pre_and_post_phase3_snaps(graph)
+
+    assert _side_source_graph(pre, pre.build_source) is graph
+    assert _side_source_graph(post, post.build_source) is graph
+
+    unrelated_graph = SourceGraphSummary(
+        nodes=[_decl("decl://b", "b", "public_header")]
+    )
+    out_of_band_pack = BuildSourcePack(root="", source_graph=unrelated_graph)
+    assert _side_source_graph(post, out_of_band_pack) is unrelated_graph
+
+
+def test_evidence_report_graph_diff_unchanged_by_migration() -> None:
+    from abicheck.buildsource.evidence_report import diff_embedded_build_source
+
+    old_graph = SourceGraphSummary(
+        nodes=[
+            GraphNode(id="binary_symbol://_Z1av", kind="binary_symbol", label="_Z1av"),
+            GraphNode(
+                id="decl://a",
+                kind="source_decl",
+                label="a",
+                attrs={"visibility": "public_header"},
+            ),
+        ],
+        edges=[
+            GraphEdge(
+                src="decl://a",
+                dst="binary_symbol://_Z1av",
+                kind="SOURCE_DECL_MAPS_TO_SYMBOL",
+            ),
+        ],
+    )
+    new_graph = SourceGraphSummary(
+        nodes=[
+            GraphNode(id="binary_symbol://_Z1av", kind="binary_symbol", label="_Z1av"),
+            GraphNode(
+                id="decl://a",
+                kind="source_decl",
+                label="a",
+                attrs={"visibility": "public_header"},
+            ),
+        ],
+        edges=[],
+    )
+
+    def _snap(graph: SourceGraphSummary, with_surface_graph: bool) -> AbiSnapshot:
+        kw = dict(
+            library="libfoo.so",
+            version="1.0",
+            build_source=BuildSourcePack(root="", source_graph=graph),
+        )
+        if with_surface_graph:
+            kw["surface_graph"] = graph
+        return AbiSnapshot(**kw)
+
+    def _run(with_surface_graph: bool):
+        old_snap = _snap(old_graph, with_surface_graph)
+        new_snap = _snap(new_graph, with_surface_graph)
+        changes, _coverage_rows, _metrics = diff_embedded_build_source(
+            None,
+            None,
+            None,
+            None,
+            "source",
+            new_snap,
+            old_snapshot=old_snap,
+        )
+        return changes
+
+    pre_changes = _run(with_surface_graph=False)
+    post_changes = _run(with_surface_graph=True)
+
+    assert [(c.kind, c.symbol) for c in pre_changes] == [
+        (c.kind, c.symbol) for c in post_changes
+    ]
+    assert pre_changes, "dropping the mapping edge must produce an L5 graph finding"
+
+
+# --------------------------------------------------------------------------- #
+# evidence_depth.depth_label_for
+# --------------------------------------------------------------------------- #
+
+
+def test_depth_label_for_unchanged_by_migration() -> None:
+    from abicheck.evidence_depth import depth_label_for
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    pre, post = _pre_and_post_phase3_snaps(graph)
+
+    assert depth_label_for(pre, pre.build_source) == "source"
+    assert depth_label_for(post, post.build_source) == "source"
+
+
+def test_depth_label_for_out_of_band_pack_ignores_unrelated_surface_graph() -> None:
+    """An explicit out-of-band pack (never attached to *snap*) must not have
+    its emptiness judged by an unrelated ``snap.surface_graph`` -- the
+    ``evidence_depth`` module's own long-standing "never default *pack* to
+    ``snap.build_source``" contract (docstring at the top of the module),
+    unaffected by this migration."""
+    from abicheck.evidence_depth import depth_label_for
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    unrelated_pack = BuildSourcePack(root="", source_graph=None)
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", surface_graph=graph)
+
+    # snap.surface_graph is populated, but *pack* is an unrelated, empty
+    # out-of-band pack -- the answer must come from *pack*, not *snap*.
+    assert depth_label_for(snap, unrelated_pack) != "source"
+
+
+# --------------------------------------------------------------------------- #
+# cli_graph._load_source_graph
+# --------------------------------------------------------------------------- #
+
+
+def test_load_source_graph_from_embedded_snapshot_unchanged_by_migration(
+    tmp_path,
+) -> None:
+    from abicheck.cli_graph import _load_source_graph
+
+    graph_dict = {
+        "nodes": [{"id": "decl://a", "kind": "source_decl", "label": "a"}],
+        "edges": [],
+    }
+
+    pre_path = tmp_path / "pre_phase3.abi.json"
+    pre_path.write_text(json.dumps({"build_source": {"source_graph": graph_dict}}))
+
+    post_path = tmp_path / "post_phase3.abi.json"
+    post_path.write_text(
+        json.dumps(
+            {
+                "surface_graph": graph_dict,
+                "build_source": {"source_graph": graph_dict},
+            }
+        )
+    )
+
+    pre_graph = _load_source_graph(pre_path)
+    post_graph = _load_source_graph(post_path)
+
+    assert pre_graph.to_dict() == post_graph.to_dict()
+    assert [n.id for n in pre_graph.nodes] == ["decl://a"]
+
+
+def test_load_source_graph_prefers_surface_graph_over_build_source() -> None:
+    """When both are present, the top-level ``surface_graph`` key wins --
+    the canonical location, per ADR-063 Phase 3/10."""
+    from abicheck.cli_graph import _embedded_source_graph_dict
+
+    surface = {"nodes": [{"id": "decl://surface", "kind": "source_decl"}], "edges": []}
+    legacy = {"nodes": [{"id": "decl://legacy", "kind": "source_decl"}], "edges": []}
+    data = {"surface_graph": surface, "build_source": {"source_graph": legacy}}
+
+    assert _embedded_source_graph_dict(data) == surface

--- a/tests/test_surface_graph_reader_migration.py
+++ b/tests/test_surface_graph_reader_migration.py
@@ -311,25 +311,33 @@ def test_depth_label_for_out_of_band_pack_ignores_unrelated_surface_graph() -> N
 def test_load_source_graph_from_embedded_snapshot_unchanged_by_migration(
     tmp_path,
 ) -> None:
+    """A pre-Phase-3 **flat** document (``surface_graph`` absent, no
+    ``sections`` envelope, ``build_source.source_graph`` present) yields the
+    identical graph as a real, current **sectioned** document written by
+    ``serialization.snapshot_to_json`` for the same evidence (``surface_graph``
+    populated) -- proving ``_load_source_graph`` handles both wire shapes,
+    including the sectioned one this module's own reader didn't originally
+    account for (``sections.graph.payload.surface_graph``, schema v42+)."""
+    from abicheck import serialization
     from abicheck.cli_graph import _load_source_graph
 
-    graph_dict = {
-        "nodes": [{"id": "decl://a", "kind": "source_decl", "label": "a"}],
-        "edges": [],
-    }
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
 
     pre_path = tmp_path / "pre_phase3.abi.json"
-    pre_path.write_text(json.dumps({"build_source": {"source_graph": graph_dict}}))
-
-    post_path = tmp_path / "post_phase3.abi.json"
-    post_path.write_text(
+    pre_path.write_text(
         json.dumps(
             {
-                "surface_graph": graph_dict,
-                "build_source": {"source_graph": graph_dict},
+                "schema_version": 20,
+                "library": "libfoo.so",
+                "version": "1.0",
+                "build_source": {"source_graph": graph.to_dict()},
             }
         )
     )
+
+    post_path = tmp_path / "post_phase3.abi.json"
+    pre, post = _pre_and_post_phase3_snaps(graph)
+    post_path.write_text(serialization.snapshot_to_json(post))
 
     pre_graph = _load_source_graph(pre_path)
     post_graph = _load_source_graph(post_path)
@@ -341,10 +349,35 @@ def test_load_source_graph_from_embedded_snapshot_unchanged_by_migration(
 def test_load_source_graph_prefers_surface_graph_over_build_source() -> None:
     """When both are present, the top-level ``surface_graph`` key wins --
     the canonical location, per ADR-063 Phase 3/10."""
-    from abicheck.cli_graph import _embedded_source_graph_dict
+    from abicheck.cli_graph import _embedded_source_graph
 
-    surface = {"nodes": [{"id": "decl://surface", "kind": "source_decl"}], "edges": []}
-    legacy = {"nodes": [{"id": "decl://legacy", "kind": "source_decl"}], "edges": []}
-    data = {"surface_graph": surface, "build_source": {"source_graph": legacy}}
+    surface = SourceGraphSummary(
+        nodes=[_decl("decl://surface", "surface", "public_header")]
+    )
+    legacy = SourceGraphSummary(
+        nodes=[_decl("decl://legacy", "legacy", "public_header")]
+    )
+    data = {
+        "schema_version": 45,
+        "library": "libfoo.so",
+        "version": "1.0",
+        "surface_graph": surface.to_dict(),
+        "build_source": {"source_graph": legacy.to_dict()},
+    }
 
-    assert _embedded_source_graph_dict(data) == surface
+    result = _embedded_source_graph(data)
+    assert result is not None
+    assert [n.id for n in result.nodes] == ["decl://surface"]
+
+
+def test_embedded_source_graph_ignores_non_snapshot_documents() -> None:
+    """A bare graph JSON or an unrelated JSON object (no ``schema_version``,
+    no ``sections``) is not a snapshot document at all -- returns ``None``
+    so the caller falls through to its own bare-graph-JSON contract."""
+    from abicheck.cli_graph import _embedded_source_graph
+
+    bare_graph = {"nodes": [{"id": "decl://a", "kind": "source_decl"}], "edges": []}
+    assert _embedded_source_graph(bare_graph) is None
+
+    pack_manifest = {"build_source_pack_version": 1, "coverage": []}
+    assert _embedded_source_graph(pack_manifest) is None

--- a/tests/test_surface_graph_reader_migration.py
+++ b/tests/test_surface_graph_reader_migration.py
@@ -16,20 +16,36 @@
 """ADR-063 Phase 10: the five ``BuildSourcePack.source_graph`` live-alias
 readers (``internal_leak.py``, ``buildsource/cross_source_checks.py``,
 ``buildsource/evidence_report.py``, ``evidence_depth.py``, ``cli_graph.py``)
-now prefer the canonical ``AbiSnapshot.surface_graph``, falling back to the
-legacy ``build_source.source_graph`` nested field only when ``surface_graph``
-is absent -- a pre-Phase-3 snapshot never populates it (see
-``docs/contribute/plans/one-semantic-pipeline.md``'s Phase 10 checklist).
+now read the L5 evidence graph from ``AbiSnapshot`` directly rather than only
+through the legacy ``build_source.source_graph`` nested field, so a snapshot
+carrying only the canonical ``surface_graph`` (no ``build_source`` at all) is
+no longer silently invisible to them.
 
-Each test below builds a *pre-Phase-3-shaped* fixture -- ``surface_graph``
-absent, ``build_source.source_graph`` present -- and asserts the reader's
-output is byte-for-byte identical to the same fixture with ``surface_graph``
-set to the *same* graph object (the ordinary post-Phase-3 shape a fresh
-snapshot now carries). Identical output across both shapes is exactly the
-"no regression from the migration" contract this phase's checklist asks for:
-the fallback must make a pre-Phase-3 document behave exactly as it did before
-this migration, while a fresh snapshot's canonical field is what actually
-gets read first.
+**Preference order, security-corrected (PR #1216 review):** each reader
+prefers ``build_source.source_graph``, falling back to ``surface_graph`` only
+when the former is absent -- NOT the reverse order this phase's plan text
+originally specified. A real ``--sources``/``--build-info`` embed can leave
+``build_source.source_graph`` a strictly richer, real L3-L5 evidence graph
+than the always-on, header-only-only ``surface_graph`` (`_attach_header_graph`
+builds the latter from headers alone, and `buildsource/embed.py`'s backfill
+only ever adopts it into an *empty* `build_source.source_graph`, never
+displacing a real one) -- preferring the weaker graph would silently drop
+real call-graph/dependency edges, letting a genuinely-reachable internal
+removal be misjudged unreachable and suppressed. ``surface_graph`` is still
+needed as the fallback: `policy/depth_projection.py` clears
+`build_source.source_graph` at the "source" depth floor while retaining
+`surface_graph` (an L2 fact) down to the "binary" floor, and a pre-Phase-3
+document may carry ``build_source.source_graph`` with no ``surface_graph`` at
+all.
+
+Each "unchanged by migration" test below builds a pre-Phase-3-shaped fixture
+(``surface_graph`` absent, ``build_source.source_graph`` present) and asserts
+output parity against the same fixture shaped as a fresh, post-Phase-3
+snapshot (``surface_graph`` populated too, as the *same* object -- the
+Phase 3 assembly step's one-object guarantee, so this pair says nothing about
+ordering on its own). ``test_*_prefers_the_richer_build_source_graph`` pins
+the ordering itself: ``build_source.source_graph`` and ``surface_graph`` are
+two *different* objects, and the richer one must win.
 """
 
 from __future__ import annotations
@@ -68,6 +84,22 @@ def _pre_and_post_phase3_snaps(
     return pre, post
 
 
+def _diverged_snap(
+    richer_graph: SourceGraphSummary, weaker_graph: SourceGraphSummary
+) -> AbiSnapshot:
+    """A snapshot with two genuinely *different* graph objects -- the shape a
+    real ``--sources``/``--build-info`` embed leaves behind: ``build_source.
+    source_graph`` is the richer, real L3-L5 evidence graph, ``surface_graph``
+    is the weaker, always-on header-only one `_attach_header_graph` built
+    first and never updates."""
+    return AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=richer_graph),
+        surface_graph=weaker_graph,
+    )
+
+
 # --------------------------------------------------------------------------- #
 # internal_leak.compute_call_graph_leak_paths
 # --------------------------------------------------------------------------- #
@@ -91,6 +123,28 @@ def test_internal_leak_call_graph_leak_paths_unchanged_by_migration() -> None:
     assert pre_result == post_result
     assert "ns::detail::helper" in pre_result
     assert "pubFn" in pre_result["ns::detail::helper"][0]
+
+
+def test_internal_leak_prefers_the_richer_build_source_graph() -> None:
+    """Security regression (PR #1216 review): a weaker, header-only
+    ``surface_graph`` with none of the real call-graph edges must never hide
+    a leak path that only ``build_source.source_graph`` (the richer, real
+    L3-L5 evidence) carries."""
+    from abicheck.internal_leak import compute_call_graph_leak_paths
+
+    richer = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "ns::detail::helper", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    weaker = SourceGraphSummary(nodes=[_decl("decl://pub", "pubFn", "public_header")])
+    snap = _diverged_snap(richer, weaker)
+
+    result = compute_call_graph_leak_paths(snap)
+
+    assert "ns::detail::helper" in result
 
 
 # --------------------------------------------------------------------------- #
@@ -131,6 +185,34 @@ def test_public_to_internal_dependency_unchanged_by_migration() -> None:
         pre_res.providers[CHECK_PUBLIC_TO_INTERNAL_DEPENDENCY]
         == post_res.providers[CHECK_PUBLIC_TO_INTERNAL_DEPENDENCY]
     )
+
+
+def test_public_to_internal_dependency_prefers_the_richer_build_source_graph() -> None:
+    """Security regression (PR #1216 review): a weaker ``surface_graph`` with
+    no dependency edges must never hide a public-to-internal dependency that
+    only the richer ``build_source.source_graph`` carries."""
+    from abicheck.buildsource.cross_source_checks import run_crosschecks
+    from abicheck.checker_policy import ChangeKind
+
+    richer = SourceGraphSummary(
+        nodes=[
+            _decl("decl://pub", "pubFn", "public_header"),
+            _decl("decl://int", "internalImpl", "source"),
+        ],
+        edges=[GraphEdge(src="decl://pub", dst="decl://int", kind="DECL_CALLS_DECL")],
+    )
+    weaker = SourceGraphSummary(nodes=[_decl("decl://pub", "pubFn", "public_header")])
+    snap = _diverged_snap(richer, weaker)
+    snap.from_headers = True
+
+    res = run_crosschecks(snap)
+    hits = [
+        c.symbol
+        for c in res.findings
+        if c.kind == ChangeKind.PUBLIC_TO_INTERNAL_DEPENDENCY
+    ]
+
+    assert hits == ["pubFn"]
 
 
 # --------------------------------------------------------------------------- #
@@ -202,6 +284,19 @@ def test_side_source_graph_unchanged_by_migration() -> None:
     )
     out_of_band_pack = BuildSourcePack(root="", source_graph=unrelated_graph)
     assert _side_source_graph(post, out_of_band_pack) is unrelated_graph
+
+
+def test_side_source_graph_prefers_the_richer_build_source_graph() -> None:
+    """Security regression (PR #1216 review): when ``build_source.
+    source_graph`` and ``surface_graph`` are two different objects, the
+    richer one (``build_source.source_graph``) must win."""
+    from abicheck.buildsource.evidence_report import _side_source_graph
+
+    richer = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    weaker = SourceGraphSummary(nodes=[])
+    snap = _diverged_snap(richer, weaker)
+
+    assert _side_source_graph(snap, snap.build_source) is richer
 
 
 def test_evidence_report_graph_diff_unchanged_by_migration() -> None:
@@ -303,6 +398,39 @@ def test_depth_label_for_out_of_band_pack_ignores_unrelated_surface_graph() -> N
     assert depth_label_for(snap, unrelated_pack) != "source"
 
 
+def test_depth_label_for_prefers_the_richer_build_source_graph() -> None:
+    """Security regression (PR #1216 review): a non-empty
+    ``build_source.source_graph`` must report ``"source"`` even when
+    ``surface_graph`` is a different, empty graph object."""
+    from abicheck.evidence_depth import depth_label_for
+
+    richer = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    weaker = SourceGraphSummary(nodes=[])
+    snap = _diverged_snap(richer, weaker)
+
+    assert depth_label_for(snap, snap.build_source) == "source"
+
+
+def test_depth_label_for_falls_back_to_surface_graph_when_build_source_graph_absent() -> (
+    None
+):
+    """A depth-projected snapshot (``policy/depth_projection.py``) can clear
+    ``build_source.source_graph`` while retaining ``surface_graph`` (an L2
+    fact, cleared at a lower depth floor) -- the fallback this migration
+    exists for still applies in that direction."""
+    from abicheck.evidence_depth import depth_label_for
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        build_source=BuildSourcePack(root="", source_graph=None),
+        surface_graph=graph,
+    )
+
+    assert depth_label_for(snap, snap.build_source) == "source"
+
+
 # --------------------------------------------------------------------------- #
 # cli_graph._load_source_graph
 # --------------------------------------------------------------------------- #
@@ -346,28 +474,50 @@ def test_load_source_graph_from_embedded_snapshot_unchanged_by_migration(
     assert [n.id for n in pre_graph.nodes] == ["decl://a"]
 
 
-def test_load_source_graph_prefers_surface_graph_over_build_source() -> None:
-    """When both are present, the top-level ``surface_graph`` key wins --
-    the canonical location, per ADR-063 Phase 3/10."""
+def test_embedded_source_graph_prefers_the_richer_build_source_graph() -> None:
+    """Security regression (PR #1216 review): when both keys are present and
+    differ, ``build_source.source_graph`` wins -- NOT the top-level
+    ``surface_graph`` key, since a real ``--sources``/``--build-info`` embed
+    leaves the former the richer, real L3-L5 evidence graph."""
     from abicheck.cli_graph import _embedded_source_graph
 
-    surface = SourceGraphSummary(
-        nodes=[_decl("decl://surface", "surface", "public_header")]
+    richer = SourceGraphSummary(
+        nodes=[_decl("decl://richer", "richer", "public_header")]
     )
-    legacy = SourceGraphSummary(
-        nodes=[_decl("decl://legacy", "legacy", "public_header")]
+    weaker = SourceGraphSummary(
+        nodes=[_decl("decl://weaker", "weaker", "public_header")]
     )
     data = {
         "schema_version": 45,
         "library": "libfoo.so",
         "version": "1.0",
-        "surface_graph": surface.to_dict(),
-        "build_source": {"source_graph": legacy.to_dict()},
+        "surface_graph": weaker.to_dict(),
+        "build_source": {"source_graph": richer.to_dict()},
     }
 
     result = _embedded_source_graph(data)
     assert result is not None
-    assert [n.id for n in result.nodes] == ["decl://surface"]
+    assert [n.id for n in result.nodes] == ["decl://richer"]
+
+
+def test_embedded_source_graph_falls_back_to_surface_graph_when_build_source_absent() -> (
+    None
+):
+    """No ``build_source`` at all -- the top-level ``surface_graph`` key is
+    still read as the fallback."""
+    from abicheck.cli_graph import _embedded_source_graph
+
+    graph = SourceGraphSummary(nodes=[_decl("decl://a", "a", "public_header")])
+    data = {
+        "schema_version": 45,
+        "library": "libfoo.so",
+        "version": "1.0",
+        "surface_graph": graph.to_dict(),
+    }
+
+    result = _embedded_source_graph(data)
+    assert result is not None
+    assert [n.id for n in result.nodes] == ["decl://a"]
 
 
 def test_embedded_source_graph_ignores_non_snapshot_documents() -> None:


### PR DESCRIPTION
## Summary

Migrate the five readers of the legacy `BuildSourcePack.source_graph` live-alias onto `AbiSnapshot.surface_graph`, per the Phase 10 checklist row in `docs/contribute/plans/one-semantic-pipeline.md`.

## Motivation

ADR-063 Phase 3 introduced `AbiSnapshot.surface_graph` as the canonical L5 evidence-graph location, kept in sync with the legacy `build_source.source_graph` nested field via an in-memory identity alias. Phase 3's own text named migrating the five readers of the legacy field as "real, scoped, follow-up work" with no phase ever scheduled to do it, and no Phase 10 row removing the alias once it was. This PR does that migration.

## Changes

- `internal_leak.py`: `compute_call_graph_leak_paths` now prefers `snap.surface_graph`.
- `buildsource/cross_source_checks.py`: `_check_private_header_leak` and `_check_public_to_internal_dependency` now prefer `snapshot.surface_graph`.
- `buildsource/evidence_report.py`: `diff_embedded_build_source`'s L5 graph diff now goes through a new `_side_source_graph` helper, which only substitutes `surface_graph` when the pack in hand **is** the snapshot's own embedded `build_source` — never for an out-of-band `--old/new-build-info`/`--old/new-sources` pack the caller resolved independently.
- `evidence_depth.py`: `depth_label_for`'s L5-emptiness check now goes through a new `_l5_payload_empty` helper with the same out-of-band-pack safeguard.
- `cli_graph.py`: `_load_source_graph` has no `AbiSnapshot` in scope at all (it loads a bare graph JSON file or an out-of-band pack directory), so its migration is the dict-shaped analogue — it now also recognizes a full embedded-snapshot JSON document, preferring the top-level `surface_graph` key over the nested `build_source.source_graph` one.

Each reader prefers `AbiSnapshot.surface_graph` and falls back to `build_source.source_graph` only when `surface_graph` is absent (a pre-Phase-3 snapshot never populates it) — not a hard cutover.

`tests/test_surface_graph_reader_migration.py` adds one regression test per reader: each builds a pre-Phase-3-shaped fixture (`surface_graph` absent, `build_source.source_graph` present) and asserts output parity against the same fixture shaped as a fresh, post-Phase-3 snapshot (`surface_graph` populated).

**Not done in this change, and explicitly recorded as an open follow-up:** deleting the L5 builder's own in-memory identity-aliasing (`service_header_graph_attach.py`'s `_attach_header_graph`, which threads one shared graph instance into both `AbiSnapshot.surface_graph` and a synthesized `snap.build_source` purely so a legacy reader still sees it). Investigation for this PR found real production readers of that synthesized pack beyond the five named in the checklist — coverage reporting (`evidence_report.optional_coverage`/`layer_presence`), `cli_buildsource.py`'s own `_layer_payload_empty`/`build_source_already_satisfies`, and `buildsource/embed.py`'s own `--sources`/`--build-info` backfill logic all depend on it — so removing it outright is a materially larger, separately-scoped change than the checklist row's own text anticipated. Recorded in `docs/contribute/plans/one-semantic-pipeline.md` and `docs/_meta/one-semantic-pipeline-status.yaml`'s `public_surface` entry rather than forced through against an incomplete audit, per this repo's `AGENTS.md` decision-making principles.

- Changelog fragment added (`changelog.d/`).

## Verification

- `ruff check` / `ruff format --check`: clean.
- `mypy abicheck/` (full repo): clean, no new errors.
- `python scripts/check_architecture.py`: no new debt-ledger growth from this change (the two touched large files — `cross_source_checks.py`, `internal_leak.py` — were trimmed back to their exact adoption-baseline line counts); the 5 remaining errors are pre-existing on `main`, unrelated to this branch.
- `python scripts/check_fp_rate.py`: 0 false positives / 0 false negatives, no delta vs. baseline.
- `python scripts/check_tier_accuracy.py`: top-tier correct, under-call monotonic, no regression.
- `pytest tests/test_surface_graph_reader_migration.py` plus every directly affected/adjacent test module (`test_internal_leak*.py`, `test_cross_source_checks.py`, `test_cross_source_evolution.py`, `test_evidence_report_contract.py`, `test_source_graph.py`, `test_dump_depth_provenance.py`, `test_dump_source_only_execution.py`, `test_typed_dump_request.py`, `test_service_header_graph_attach_surface_graph.py`, `test_surface_graph.py`): 642 passed.
- The full default `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` run was started but did not finish within this session's environment (unusually slow here — well past its documented ~45s baseline); given the clean full-repo mypy/ruff/architecture results and the targeted-but-comprehensive test runs above, I'm confident in this change, but flagging that the full default suite wasn't observed to completion in this session.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/contribute/plans/one-semantic-pipeline.md`, `docs/_meta/one-semantic-pipeline-status.yaml`)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7y8gehf6NKa8KTHCSA6Fy

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7y8gehf6NKa8KTHCSA6Fy)_