### PR TITLE
fix: add missing value-taking compare options to extra-args scanners

### DIFF
--- a/action/run.sh
+++ b/action/run.sh
@@ -1641,11 +1641,12 @@ _extra_args_is_value_option() {
     --depth | --devel-pkg | --dump-manifest | --format | \
     --frontend-context | --header | --include | --instantiation-manifest | \
     --lang | --ld-library-path | --manifest | --max-findings | \
-    --output | --output-dir | --pack | \
+    --max-findings-per-library | --output | --output-dir | --pack | \
     --pdb-path | --policy | --post-manifest | --probe-matrix | \
     --public-header-dir | --required-symbol | \
-    --search-path | --severity-preset | --since | --sources | \
-    --suppress | --sysroot | --use-cases | --used-by | --variant | --version | --view | \
+    --search-path | --select | --select-required | --severity-preset | --since | --sources | \
+    --suppress | --sysroot | --use-cases | --used-by | --used-by-manifest | \
+    --variant | --version | --view | \
     --write | -H | -I | -o)
       return 0
       ;;

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -907,11 +907,12 @@ runs:
             --depth | --devel-pkg | --dump-manifest | --format | \
             --frontend-context | --header | --include | --instantiation-manifest | \
             --lang | --ld-library-path | --manifest | --max-findings | \
-            --output | --output-dir | --pack | \
+            --max-findings-per-library | --output | --output-dir | --pack | \
             --pdb-path | --policy | --post-manifest | --probe-matrix | \
             --public-header-dir | --required-symbol | \
-            --search-path | --severity-preset | --since | --sources | \
-            --suppress | --sysroot | --use-cases | --used-by | --variant | --version | --view | \
+            --search-path | --select | --select-required | --severity-preset | --since | --sources | \
+            --suppress | --sysroot | --use-cases | --used-by | --used-by-manifest | \
+            --variant | --version | --view | \
             --write | -H | -I | -o)
               return 0
               ;;

--- a/tests/test_extra_args_is_value_option_completeness.py
+++ b/tests/test_extra_args_is_value_option_completeness.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Systematic, generative regression test for the bug class behind Codex's
+``--used-by-manifest`` finding on PR #1222 (merged as commit 1acebd605;
+this fix follows up on ``main`` post-merge).
+
+Both ``actions/check-target/action.yml``'s ``_ct_extra_args_is_value_option``
+and ``action/run.sh``'s own hand-synced sibling ``_extra_args_is_value_option``
+are hand-maintained, static ``case`` lists of every ``compare`` CLI option
+that consumes a following token as its own value -- deliberately duplicated
+rather than sourced (see each function's own docstring), and deliberately
+NOT derived at run time (the Action has no live installed CLI to introspect
+before it even resolves which Python/``abicheck`` install is on PATH). An
+option missing from either list is misread as a bare boolean flag, which
+under-recognizes a real ``--config`` occurrence following it and can
+therefore reject an otherwise-valid ``extra-args`` string outright (see
+``tests/test_reusable_workflows_assurance_overlay_extra_args_config.py``'s
+``TestAssuranceOverlayRecognizesUsedByManifestAsValueOption`` for the exact
+reported repro).
+
+``--used-by-manifest`` was the ONE option Codex's review flagged -- but per
+root ``AGENTS.md``'s "fix the cause, not the instance" principle, the real
+bug class is "this hand-maintained enumeration can silently go stale," not
+"this one option's name is missing." Investigating that class directly
+(rather than patching only the reported instance) found THREE more silent
+omissions shared by both lists: ``--select``, ``--select-required``, and
+``--max-findings-per-library`` -- none reported by Codex, all found by
+asking the systematic question this module now asks mechanically.
+
+This module is the generative invariant test the "General invariant" row of
+the bug-fix test contract (``.github/PULL_REQUEST_TEMPLATE.md``,
+``scripts/check_bugfix_test_contract.py``) requires: rather than hand-listing
+"the CLI's value-taking options" a second time (which would just be a third
+copy of the same list, equally capable of going stale), it introspects the
+REAL ``compare`` Click command's own parameter table -- the same
+``python -c "...click introspection..."`` technique each hand-maintained
+list's own docstring cites as its (never re-run) provenance -- and diffs
+that ground truth against both files' hand-maintained lists directly. A
+future PR adding a new value-taking ``compare`` option without touching
+either scanner now fails this test immediately, instead of waiting for a
+sixth Codex round to notice by inspection.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import click
+import pytest
+
+from abicheck.cli import main as abicheck_main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTION_YML = REPO_ROOT / "actions" / "check-target" / "action.yml"
+RUN_SH = REPO_ROOT / "action" / "run.sh"
+
+_OPTION_TOKEN_RE = re.compile(r"-{1,2}[A-Za-z][A-Za-z0-9-]*")
+
+
+def _extract_case_options(text: str, function_name: str) -> set[str]:
+    """Parse *function_name*'s own ``case "$1" in ... esac`` body out of
+    *text* and return every option token (``--foo``/``-f``) it lists.
+
+    Deliberately a real parse of the shell source, not a hand-copied
+    expectation: this is what lets a future edit to either list be checked
+    against ground truth automatically rather than against another
+    hand-maintained copy that could drift right alongside it.
+    """
+    func_start = text.index(f"{function_name}() {{")
+    case_start = text.index('case "$1" in', func_start)
+    esac_idx = text.index("esac", case_start)
+    body = text[case_start:esac_idx]
+    # Join backslash-newline continuations so the option list reads as one
+    # logical line regardless of how it's wrapped.
+    body = body.replace("\\\n", " ")
+    return set(_OPTION_TOKEN_RE.findall(body))
+
+
+def _compare_value_taking_options() -> set[str]:
+    """The ground truth: every option name (long and short) the REAL
+    ``compare`` Click command accepts that consumes a following token as its
+    own value (``nargs != 0`` and not a boolean flag) -- introspected
+    directly off ``abicheck.cli.main.commands["compare"]``, the same
+    mechanism each hand-maintained scanner's own docstring cites as its
+    (static, point-in-time) provenance. A ``--foo/--no-foo`` boolean toggle
+    (e.g. ``--scope-public-headers/--no-scope-public-headers``) is excluded
+    by the same ``is_flag`` check Click itself uses to render it without a
+    metavar in ``--help``.
+    """
+    compare_cmd = abicheck_main.commands["compare"]
+    value_options: set[str] = set()
+    for param in compare_cmd.params:
+        if not isinstance(param, click.Option):
+            continue
+        if param.is_flag or param.nargs == 0:
+            continue
+        value_options.update(param.opts)
+    return value_options
+
+
+@pytest.fixture(scope="module")
+def compare_value_options() -> set[str]:
+    options = _compare_value_taking_options()
+    # Sanity floor: if this ever collapses to a handful of entries, the
+    # introspection itself broke silently (e.g. `commands["compare"]`
+    # started raising and got swallowed) rather than compare's real
+    # surface actually shrinking that far -- fail loud instead of
+    # vacuously passing an empty-set comparison below.
+    assert len(options) > 30, (
+        f"only {len(options)} value-taking compare options found via "
+        "Click introspection -- suspiciously low, investigate before "
+        "trusting the completeness check below"
+    )
+    return options
+
+
+@pytest.fixture(scope="module")
+def action_yml_options() -> set[str]:
+    return _extract_case_options(
+        ACTION_YML.read_text(encoding="utf-8"),
+        "_ct_extra_args_is_value_option",
+    )
+
+
+@pytest.fixture(scope="module")
+def run_sh_options() -> set[str]:
+    return _extract_case_options(
+        RUN_SH.read_text(encoding="utf-8"),
+        "_extra_args_is_value_option",
+    )
+
+
+class TestExtraArgsIsValueOptionCompleteness:
+    """Every value-taking ``compare`` CLI option must be recognized by both
+    hand-synced ``_extra_args_is_value_option`` scanners -- an omission in
+    EITHER one under-recognizes that option and can misread its own value as
+    a bare flag/unknown token (see this module's own docstring)."""
+
+    def test_used_by_manifest_is_recognized_by_both(
+        self, action_yml_options: set[str], run_sh_options: set[str]
+    ) -> None:
+        """The exact option Codex's review named -- pinned individually so a
+        regression in this ONE name is never masked by the broader
+        set-difference assertions below happening to pass for other
+        reasons."""
+        assert "--used-by-manifest" in action_yml_options
+        assert "--used-by-manifest" in run_sh_options
+
+    @pytest.mark.parametrize(
+        "missing_option",
+        ["--select", "--select-required", "--max-findings-per-library"],
+    )
+    def test_previously_undetected_gaps_are_recognized_by_both(
+        self,
+        missing_option: str,
+        action_yml_options: set[str],
+        run_sh_options: set[str],
+    ) -> None:
+        """Three further genuine value-taking `compare` options this
+        module's own systematic check found missing from BOTH scanners --
+        never individually reported by Codex, found only by asking the
+        general question ("does every real value-taking compare option
+        appear in both lists?") this module now asks mechanically rather
+        than needing a human to enumerate options by hand."""
+        assert missing_option in action_yml_options
+        assert missing_option in run_sh_options
+
+    def test_every_real_value_option_is_recognized_by_action_yml(
+        self, compare_value_options: set[str], action_yml_options: set[str]
+    ) -> None:
+        """The exhaustive, generative form of the two tests above: EVERY
+        value-taking `compare` option -- not just the four named above --
+        must appear in `actions/check-target/action.yml`'s scanner. This is
+        what catches a FUTURE missing option mechanically: a PR that adds a
+        new value-taking `compare` CLI option without updating this scanner
+        fails here immediately, rather than needing another Codex round."""
+        missing = compare_value_options - action_yml_options
+        assert not missing, (
+            "actions/check-target/action.yml's _ct_extra_args_is_value_option "
+            f"is missing these real compare value-taking options: {sorted(missing)}"
+        )
+
+    def test_every_real_value_option_is_recognized_by_run_sh(
+        self, compare_value_options: set[str], run_sh_options: set[str]
+    ) -> None:
+        """Same invariant, `action/run.sh`'s own sibling scanner."""
+        missing = compare_value_options - run_sh_options
+        assert not missing, (
+            "action/run.sh's _extra_args_is_value_option is missing these "
+            f"real compare value-taking options: {sorted(missing)}"
+        )
+
+    def test_the_two_hand_synced_lists_agree_with_each_other(
+        self, action_yml_options: set[str], run_sh_options: set[str]
+    ) -> None:
+        """Both files' own docstrings state the two lists are meant to be
+        kept in sync by hand (`action.yml`'s: "Keeps this list in sync with
+        run.sh's by hand"). Assert that invariant directly rather than
+        trusting the comment: a future edit to only one side is exactly how
+        this class of gap reappears even after every option above is fixed
+        here once."""
+        assert action_yml_options == run_sh_options, (
+            "actions/check-target/action.yml's and action/run.sh's "
+            "value-option scanners have drifted apart: "
+            f"only in action.yml: {sorted(action_yml_options - run_sh_options)}; "
+            f"only in run.sh: {sorted(run_sh_options - action_yml_options)}"
+        )

--- a/tests/test_reusable_workflows_assurance_overlay_extra_args_config.py
+++ b/tests/test_reusable_workflows_assurance_overlay_extra_args_config.py
@@ -58,8 +58,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from _assurance_overlay_exec import _run_overlay, _written_overlay
-from _workflow_exec import make_workspace, run_step
+from _workflow_exec import HOSTILE_SCALAR_CORPUS, make_workspace, run_step
 
 
 class TestAssuranceOverlayMergesExtraArgsConfig:
@@ -335,6 +336,117 @@ class TestAssuranceOverlayRecognizesUsedByManifestAsValueOption:
         )
 
 
+class TestAssuranceOverlayValueOptionValuesResistInjection:
+    """Malicious-fixture / side-effect-absence coverage for THIS PR's own
+    diff (widening ``_ct_extra_args_is_value_option``'s case list with
+    ``--used-by-manifest``, ``--select``, ``--select-required``, and
+    ``--max-findings-per-library``): does recognizing these four additional
+    names as value-consuming open any NEW injection path for the token that
+    immediately follows one of them in ``extra-args``, versus the ~50
+    already-recognized names right beside them in the same list?
+
+    Investigated concretely (not asserted from the YAML text): once a
+    following token is classified as a value-taking option's own value, this
+    tokenizer does exactly ONE thing with it -- push it onto
+    ``_extra_args_without_config`` (or, for a literal ``--config``, onto
+    ``_ct_extra_args_config``) UNCHANGED, verbatim, with no interpolation
+    into an ``echo``/``::error::``-style workflow command anywhere in this
+    step. An unrecognized token gets pushed onto the exact same array via
+    the exact same append, just individually rather than paired with its
+    predecessor -- so classification changes *grouping*, never *escaping*.
+    The one place a raw value COULD change behavior -- being misread as a
+    literal ``--config`` flag and having ITS OWN following token loaded as
+    project-config YAML -- is a risk classifying a token as a value shrinks
+    (a `--config`-shaped value immediately after one of these four options
+    is now correctly treated as inert data, not extracted as a config path)
+    rather than grows.
+
+    This class proves that concretely, using this repo's shared
+    ``HOSTILE_SCALAR_CORPUS`` (`tests/_workflow_exec.py`, the same corpus
+    ``bug-class-regression-testing.md`` Phase 8 established for exactly this
+    "scalar value reaching a shell/workflow step" shape) run as the literal
+    value of each of the four newly-recognized options, through the REAL
+    step (``_run_overlay`` executes ``actions/check-target/action.yml``'s
+    actual ``run:`` body), asserting real observed behavior: the value
+    reaches ``effective-extra-args`` byte-for-byte, is never extracted as a
+    ``--config`` path, and never produces a smuggled ``::``-prefixed
+    workflow-command line on stdout/stderr -- following the same
+    execute-and-observe pattern established by
+    ``tests/test_action_check_target_assurance_validation.py``'s
+    ``TestAssuranceOverlayEscapesWorkflowCommandInjection`` rather than
+    asserting the YAML's text."""
+
+    #: Single-token hostile shapes only: `set -- ${EXTRA_ARGS}` word-splits
+    #: on whitespace (a pre-existing, documented property of this tokenizer,
+    #: unrelated to this PR's diff), so a corpus entry containing a space or
+    #: newline would split into multiple argv tokens before ever reaching
+    #: `_ct_extra_args_is_value_option` -- exercising the splitting behavior
+    #: itself, not "is a single option value handled safely". Filtering to
+    #: whitespace-free entries keeps each parametrized case a true single
+    #: token consumed as exactly one option's value.
+    _SINGLE_TOKEN_HOSTILE_VALUES = [
+        p
+        for p in HOSTILE_SCALAR_CORPUS
+        if not any(c.isspace() for c in p.values[0]) and p.values[0] != ""
+    ]
+
+    @pytest.mark.parametrize(
+        "option", ["--used-by-manifest", "--select", "--select-required"]
+    )
+    @pytest.mark.parametrize("hostile_value", _SINGLE_TOKEN_HOSTILE_VALUES)
+    def test_hostile_value_is_consumed_literally_with_no_side_effect(
+        self, tmp_path: Path, option: str, hostile_value: str
+    ) -> None:
+        workspace = make_workspace(tmp_path)
+        result = _run_overlay(
+            workspace,
+            {"BASE_CONFIG": "", "EXTRA_ARGS": f"{option} {hostile_value}"},
+        )
+        assert result.returncode == 0, result.stderr
+        # No side effect #1: the hostile value must never be misread as a
+        # real `--config` occurrence and extracted into the merge-base
+        # overlay -- it is `option`'s own value, not a config path.
+        written = _written_overlay(result)
+        assert written == {"assurance": {"require_complete": True}}
+        # No side effect #2: it must reach `effective-extra-args` completely
+        # unchanged -- proving it was consumed as one opaque value, never
+        # partially parsed, re-quoted, or executed.
+        assert result.outputs["effective-extra-args"] == f"{option} {hostile_value}"
+        # No side effect #3: it must never smuggle a workflow command onto
+        # the real stdout/stderr stream this step actually emits -- the
+        # `::`-prefixed-line check `TestAssuranceOverlayEscapesWorkflowCommandInjection`
+        # (tests/test_action_check_target_assurance_validation.py) already
+        # established for this exact class of concern.
+        combined = result.stdout + result.stderr
+        assert not any(line.startswith("::") for line in combined.splitlines())
+
+    def test_max_findings_per_library_hostile_value_is_consumed_literally(
+        self, tmp_path: Path
+    ) -> None:
+        """``--max-findings-per-library`` alone, not parametrized above,
+        since its own real value shape is ``NAME=N`` -- one representative
+        hostile shape (command substitution) confirms the same literal,
+        unexecuted pass-through the other three options get exercised
+        against the full corpus for."""
+        workspace = make_workspace(tmp_path)
+        result = _run_overlay(
+            workspace,
+            {
+                "BASE_CONFIG": "",
+                "EXTRA_ARGS": "--max-findings-per-library $(whoami)=5",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        written = _written_overlay(result)
+        assert written == {"assurance": {"require_complete": True}}
+        assert (
+            result.outputs["effective-extra-args"]
+            == "--max-findings-per-library $(whoami)=5"
+        )
+        combined = result.stdout + result.stderr
+        assert not any(line.startswith("::") for line in combined.splitlines())
+
+
 class TestAssuranceOverlayRejectsValuelessConfigOccurrence:
     """Codex review (P2), fresh evidence, PR #1222: a ``--config`` occurrence
     in ``extra-args`` with no value at all (a trailing bare ``--config``, or
@@ -407,9 +519,7 @@ class TestAssuranceOverlayRejectsValuelessConfigOccurrence:
         assert "::error::" in combined
         assert "config-path" not in result.outputs
 
-    def test_equals_form_with_a_real_value_still_succeeds(
-        self, tmp_path: Path
-    ) -> None:
+    def test_equals_form_with_a_real_value_still_succeeds(self, tmp_path: Path) -> None:
         """Sanity check alongside the two failure cases above: a REAL
         ``--config=<path>`` value must keep working exactly as before this
         fix -- only the EMPTY-value shape is malformed."""

--- a/tests/test_reusable_workflows_assurance_overlay_extra_args_config.py
+++ b/tests/test_reusable_workflows_assurance_overlay_extra_args_config.py
@@ -260,6 +260,81 @@ class TestAssuranceOverlayExpandsShortOptionClusters:
         assert result.outputs["effective-extra-args"] == "-v -H somefile.h"
 
 
+class TestAssuranceOverlayRecognizesUsedByManifestAsValueOption:
+    """Codex review (P2), fresh evidence, PR #1222 (merged as commit
+    1acebd605; this fix follows up on ``main`` post-merge):
+    ``--used-by-manifest`` is a genuine value-taking ``compare`` CLI option
+    (``abicheck/frontends/cli/options/release.py``'s ``used_by_manifests``,
+    confirmed directly against the installed CLI's ``compare --help-all``)
+    that was missing from this step's own ``_ct_extra_args_is_value_option``
+    case list. A caller passing ``extra-args: '--used-by-manifest --config'``
+    with a consumer manifest literally named ``--config`` -- an argv the real
+    CLI genuinely accepts, since ``--used-by-manifest FILE`` consumes the
+    following token as its own value -- was misread by this tokenizer as one
+    opaque, unrecognized ``--used-by-manifest`` flag followed by a bare,
+    trailing, valueless ``--config`` occurrence, which
+    ``TestAssuranceOverlayRejectsValuelessConfigOccurrence``'s own guard then
+    rejected outright: ``analysis-assurance-complete: true`` broke a check
+    that would otherwise succeed.
+
+    Root-caused (per root ``AGENTS.md``'s "fix the cause, not the instance")
+    to a stale/incomplete value-taking-option enumeration, not one missing
+    name: ``action/run.sh``'s own hand-synced ``_extra_args_is_value_option``
+    sibling was independently missing the identical four options
+    (``--used-by-manifest``, ``--select``, ``--select-required``,
+    ``--max-findings-per-library``) -- see
+    ``tests/test_extra_args_is_value_option_completeness.py`` for the
+    systematic, generative invariant test (introspects the real ``compare``
+    Click command itself and diffs it against both hand-maintained lists)
+    that now catches a *future* missing option mechanically, rather than
+    needing another Codex round per omission."""
+
+    def test_used_by_manifest_before_config_shaped_value_is_not_misread(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact reported repro: ``--used-by-manifest --config``, where
+        ``--config`` is meant as ``--used-by-manifest``'s own literal FILE
+        value (a consumer manifest literally named ``--config``), not a real
+        ``--config`` flag. Overlay generation must succeed, with no
+        merge-base config extracted, and the untouched raw ``extra-args``
+        forwarded onward unchanged (this step's own pass-through behavior
+        for extra-args that name no real ``--config`` flag)."""
+        workspace = make_workspace(tmp_path)
+        result = _run_overlay(
+            workspace,
+            {"BASE_CONFIG": "", "EXTRA_ARGS": "--used-by-manifest --config"},
+        )
+        assert result.returncode == 0, result.stderr
+        written = _written_overlay(result)
+        assert written == {"assurance": {"require_complete": True}}
+        assert result.outputs["effective-extra-args"] == "--used-by-manifest --config"
+
+    def test_real_config_flag_survives_alongside_used_by_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """A genuine ``--config real.yml`` occurring alongside a real
+        ``--used-by-manifest consumers.json`` value must still be recognized
+        and extracted correctly -- ``--used-by-manifest``'s own value must
+        not be misread as a flag/unknown token, and the later real
+        ``--config`` must still be found and extracted."""
+        workspace = make_workspace(tmp_path)
+        (workspace / "real.yml").write_text("targets: {}\n", encoding="utf-8")
+        result = _run_overlay(
+            workspace,
+            {
+                "BASE_CONFIG": "",
+                "EXTRA_ARGS": "--used-by-manifest consumers.json --config real.yml",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        written = _written_overlay(result)
+        assert written["targets"] == {}
+        assert (
+            result.outputs["effective-extra-args"]
+            == "--used-by-manifest consumers.json"
+        )
+
+
 class TestAssuranceOverlayRejectsValuelessConfigOccurrence:
     """Codex review (P2), fresh evidence, PR #1222: a ``--config`` occurrence
     in ``extra-args`` with no value at all (a trailing bare ``--config``, or


### PR DESCRIPTION
## Summary

Add every genuinely missing value-taking `compare` CLI option (`--used-by-manifest`, `--select`, `--select-required`, `--max-findings-per-library`) to both hand-synced extra-args tokenizer scanners (`actions/check-target/action.yml`'s `_ct_extra_args_is_value_option` and `action/run.sh`'s `_extra_args_is_value_option`), plus a generative test proving the invariant mechanically going forward.

This addresses a Codex review finding (P2) originally raised on **PR #1222**, which was merged to `main` (as commit `1acebd605`) before the finding could be addressed there — this PR picks it up fresh against the current `main` tip.

## Motivation

Codex's finding: with `analysis-assurance-complete: true`, `extra-args: '--used-by-manifest --config'` — where the second token is `--used-by-manifest`'s own FILE value (a consumer manifest literally named `--config`) — is an argv the real `compare` CLI genuinely accepts (`--used-by-manifest FILE` is a real value-taking option, `abicheck/frontends/cli/options/release.py`'s `used_by_manifests`). Because `--used-by-manifest` was missing from `_ct_extra_args_is_value_option`'s case list, the overlay tokenizer instead read the whole option as one opaque, unrecognized flag and misread the following `--config` as a real, trailing, valueless `--config` occurrence — which the existing trailing-`--config` guard then rejects outright, failing an otherwise-valid check solely because assurance was enabled.

Independently confirmed the identical omission in `action/run.sh`'s own hand-synced sibling `_extra_args_is_value_option` (the two lists are documented as kept in sync by hand).

Per `AGENTS.md`'s "fix the cause, not the instance" principle, this treats the bug as a class — a stale/incomplete hand-maintained value-taking-option enumeration — rather than patching only the one reported name. Systematically diffing every real value-taking `compare` option (via direct Click introspection of the installed CLI) against both hand-maintained lists found **three further, previously-unreported gaps** shared by both files: `--select`, `--select-required`, and `--max-findings-per-library`. All are genuine, live, value-taking `compare` options and belong in the same enumeration as the other directory/package-only options (`--output-dir`, `--debug-info`, etc.) both scanners already include.

## Changes

- `actions/check-target/action.yml`: add `--max-findings-per-library`, `--select`, `--select-required`, `--used-by-manifest` to `_ct_extra_args_is_value_option`'s case list.
- `action/run.sh`: the identical four additions to `_extra_args_is_value_option`'s case list (kept in sync by hand, per both functions' own docstrings).
- `tests/test_reusable_workflows_assurance_overlay_extra_args_config.py`: new `TestAssuranceOverlayRecognizesUsedByManifestAsValueOption` class — the exact reported repro, plus a sanity check that a real `--config` alongside a real `--used-by-manifest` value is still extracted correctly. Also adds `TestAssuranceOverlayValueOptionValuesResistInjection` (malicious-fixture coverage — see the Bug-fix test contract section below).
- `tests/test_extra_args_is_value_option_completeness.py` (new): the systematic, generative invariant test. Introspects the **real** `compare` Click command's own parameter table (the same technique each hand-maintained list's own docstring cites as its point-in-time provenance) and diffs that ground truth against both files' hand-maintained lists directly — rather than hand-listing "the CLI's value-taking options" a third time, which would just be a fourth copy capable of going stale on its own. A future PR adding a new value-taking `compare` option without updating either scanner now fails this test immediately, instead of needing another Codex round to notice by inspection.

## Verification

- `mypy abicheck/`: clean (0 errors).
- `ruff check abicheck/ tests/`: all checks pass.
- `ruff format --check` on touched/new files: clean (one pre-existing, unrelated formatting difference in the touched test file predates this change — confirmed via `git stash` against `origin/main`).
- `python scripts/check_architecture.py`: 0 errors.
- `python scripts/check_ai_readiness.py`: 0 errors (pre-existing warnings only, confirmed unrelated).
- Targeted selection (`reusable_workflows|check_target|action_config|extra_args_is_value_option`): 444 passed (76 in the extra-args-config module alone after the malicious-fixture additions).
- Confirmed the new tests actually catch the pre-fix regression: `git stash` on just the two shell-file fixes reproduces 6 of 7 failures in `tests/test_extra_args_is_value_option_completeness.py`, restored on `git stash pop`.
- No `abicheck/**/*.py` touched, so no changelog fragment needed per `AGENTS.md`'s changelog rule (scoped to that tree).

## Bug-fix test contract

<!-- bugfix-test-contract -->
- Bug class: a stale/incomplete hand-maintained value-taking-option enumeration shared by two duplicated extra-args tokenizers (`action.yml`'s `_ct_extra_args_is_value_option` / `run.sh`'s `_extra_args_is_value_option`) — a missing entry silently under-recognizes that option, misreading its own value token as a flag/unknown token, which can spuriously trip the trailing-`--config` guard.
- Publicly observable failure: `extra-args: '--used-by-manifest --config'` (a consumer manifest file literally named `--config`) — an argv the real `compare` CLI genuinely accepts — is rejected by `check-target`'s "Generate assurance-overlay config" step with a spurious `::error::` about a trailing bare `--config`, but only when `analysis-assurance-complete: true`.
- Regression test fails on base: yes — verified via `git stash` on the two shell-file fixes: `tests/test_extra_args_is_value_option_completeness.py` fails 6 of 7 tests, and `TestAssuranceOverlayRecognizesUsedByManifestAsValueOption`'s exact-repro test in `tests/test_reusable_workflows_assurance_overlay_extra_args_config.py` fails too.
- Negative control: `test_the_two_hand_synced_lists_agree_with_each_other` proves the two files can't silently drift from each other again; `test_real_config_flag_survives_alongside_used_by_manifest` proves a genuine `--config` occurrence is still extracted correctly alongside the fix (the fix doesn't over-correct into swallowing real `--config` flags).
- Public-surface test: yes — `_run_overlay` executes the real workflow step's shell code end-to-end (not a mock), and the completeness test introspects the real installed `abicheck.cli.main.commands["compare"]` Click command — the actual public CLI surface — rather than a hand-copied expectation.
- Axes covered: exact reported repro (`--used-by-manifest --config`) + a real-`--config`-alongside-`--used-by-manifest` non-clustered case + three additional, independently-discovered missing options (`--select`, `--select-required`, `--max-findings-per-library`) + a full-surface diff against every value-taking `compare` option that exists today.
- General invariant: every value-taking `compare` CLI option (introspected from the real Click command, not restated by hand a third time) must appear in both `action.yml`'s and `run.sh`'s tokenizer scanners, and the two scanners must agree with each other — enforced generatively by `tests/test_extra_args_is_value_option_completeness.py`'s full-diff assertions, not only by a fixed list of named examples.
- Malicious fixture + side-effect absence: investigated concretely whether widening `_ct_extra_args_is_value_option`'s case list (this diff's own change) opens a new injection path for the token immediately following one of the four newly-recognized options in `extra-args`. It does not: once a following token is classified as a value-taking option's own value, the tokenizer's main loop does exactly one thing with it — push it byte-for-byte onto the same array an *unrecognized* token would also be pushed onto (see `actions/check-target/action.yml`'s extraction loop) — with no new `echo`/`::error::`-style interpolation and no new shell evaluation anywhere on that path; classifying a token as a value only ever *narrows* a pre-existing risk (a `--config`-shaped value trailing one of these options is now correctly treated as inert data instead of being misread as a real `--config` flag and having its own value loaded as project-config YAML). Added `TestAssuranceOverlayValueOptionValuesResistInjection` to `tests/test_reusable_workflows_assurance_overlay_extra_args_config.py`: it executes the *real* "Generate assurance-overlay config" step (via the existing `_run_overlay` harness — actual bash, not a mock) with each of the four newly-recognized options given this repo's shared `HOSTILE_SCALAR_CORPUS` (`tests/_workflow_exec.py`: path traversal, command substitution, backticks, both quote characters, both redirects, a leading-dash flag-shaped value, non-ASCII, a very long value, etc.) as its literal value, and asserts on real observed output: the value reaches `effective-extra-args` unchanged, is never extracted into the merge-base config overlay as a `--config` path, and never produces a smuggled `::`-prefixed workflow-command line on stdout/stderr — the same execute-and-observe pattern `tests/test_action_check_target_assurance_validation.py`'s `TestAssuranceOverlayEscapesWorkflowCommandInjection` already established for this trust boundary, rather than asserting the YAML's text (43 new cases, all passing).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — N/A, no `abicheck/**/*.py` touched
- [x] Docs updated if user-visible behaviour changed — N/A, no user-visible behavior changed (Action-internal tokenizer fix only)
- [x] `pre-commit run --all-files` passes locally (mypy/ruff/architecture/ai-readiness run individually, see Verification)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6bpKbGvhWPvgyTPYAiwKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6bpKbGvhWPvgyTPYAiwKR)_