### PR TITLE
fix: reachable declaration_coordinates_shifted; content-identical self-compare assurance

### DIFF
--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -137,6 +137,7 @@ _RECONCILABLE_KINDS: frozenset[str] = frozenset(
     {"source_decl", "record_type", "enum_type", "typedef"}
 )
 
+
 @dataclass(frozen=True)
 class ReconciledPair:
     """One old/new node pair the reconciliation matched as the same entity."""

--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -104,25 +104,24 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from ..model.graph_identity import closure_location_free_identity
 from .entity_identity import (
     IDENTITY_TIER_CANONICAL,
     CanonicalIdentity,
     resolve_identity_for_node,
 )
+from .graph_reconcile_outcome import (  # re-exported: the public outcome vocabulary has always been importable from this module
+    _OUTCOME_PROSE,
+    OUTCOME_COORDINATES_ONLY,
+    OUTCOME_MOVED,
+    OUTCOME_RECONCILED,
+    OUTCOME_RENAMED,
+    _classify_outcome,
+    _project_relative_path,
+)
 
 if TYPE_CHECKING:
     from ..model.graph_facts import GraphNode
     from ..model.source_graph import SourceGraphSummary
-
-#: Reconciliation outcomes (ADR-048 D2) — distinct from plain
-#: node-add/node-remove, so a consumer can tell "the same entity, under a
-#: new name/location" from "an unrelated add and an unrelated remove that
-#: happen to be in the same diff".
-OUTCOME_RENAMED = "declaration_renamed"
-OUTCOME_MOVED = "declaration_moved"
-OUTCOME_RECONCILED = "declaration_identity_reconciled"
-OUTCOME_COORDINATES_ONLY = "declaration_coordinates_shifted"  # neither predicate fired -- distinct from OUTCOME_RECONCILED, where both did
 
 _MATCH_KIND_CANONICAL_ID = "canonical_id"
 _MATCH_KIND_ALIAS = "alias"
@@ -135,14 +134,6 @@ _MATCH_KIND_STRUCTURAL_CONTEXT = "structural_context"
 _RECONCILABLE_KINDS: frozenset[str] = frozenset(
     {"source_decl", "record_type", "enum_type", "typedef"}
 )
-
-#: OUTCOME_COORDINATES_ONLY-eligible kinds -- excludes "source_decl": a
-#: function's signature isn't exposed to resolve_identity_for_node in
-#: production, so "nothing else changed" can't be proven for one.
-_COORDINATE_ONLY_KINDS: frozenset[str] = frozenset(
-    {"record_type", "enum_type", "typedef"}
-)
-
 
 @dataclass(frozen=True)
 class ReconciledPair:
@@ -187,68 +178,6 @@ class GraphReconciliation:
             "true_added": [n.id for n in self.true_added],
             "true_removed": [n.id for n in self.true_removed],
         }
-
-
-def _path_segments(path: str) -> tuple[str, ...]:
-    """Plain-path split into segments, ignoring the root/self markers.
-
-    Normalizes ``\\`` to ``/`` first (same as
-    ``source_graph_findings._path_segments``/``source_graph.py``'s own
-    caller-file normalization): ``PurePosixPath`` treats a backslash as an
-    ordinary filename character, not a separator, so a Windows-style
-    declaring path (``C:\\old\\include\\api.h``) would never be split at
-    all -- silently defeating the project-root-marker search in
-    :func:`_project_relative_path` and comparing raw checkout roots
-    (Codex review).
-    """
-    from pathlib import PurePosixPath
-
-    posix = path.replace("\\", "/")
-    return tuple(p for p in PurePosixPath(posix).parts if p not in ("/", ".", ""))
-
-
-#: Conventional project-root directory names — a superset of
-#: :data:`abicheck.header_utils._INCLUDE_ROOT_NAMES` (which only needs
-#: ``include``/``inc`` for its narrower include-root-inference purpose;
-#: this also covers ``src``/``source``/``sources`` layouts). Used here as an
-#: anchor for stripping a checkout-root prefix from a single declaring-file
-#: path with no sibling to derive a shared prefix from (Codex review — see
-#: :func:`_project_relative_path`).
-_CONVENTIONAL_ROOT_MARKERS: frozenset[str] = frozenset(
-    {"include", "inc", "src", "source", "sources"}
-)
-
-
-def _project_relative_path(path: str) -> str:
-    """Best-effort project-relative form of a declaring-file/header path.
-
-    Two independently-rooted checkouts of the same tree (separate temp dirs
-    in a benchmark harness, or two CI job workspaces) share no absolute
-    root, so comparing raw absolute paths would misclassify an unmoved file
-    as "moved" purely because of where its tree happened to be checked out.
-
-    With more than one declaring file on a side, the shared checkout-root
-    prefix could in principle be derived structurally (comparing multiple
-    paths against each other) — but a single sample gives no such baseline,
-    and blindly reserving "everything but the basename" as an assumed
-    checkout root (an earlier version of this function did that) silently
-    hides a real cross-directory move that happens to keep the same
-    filename (Codex review: ``/tmp/old/src/foo.h`` -> ``/tmp/new/include/foo.h``
-    must not read as unmoved). Anchoring on the last conventional root-marker
-    segment instead (``include``/``inc``/``src``/``source``/``sources`` — the
-    same vocabulary :data:`abicheck.header_utils._INCLUDE_ROOT_NAMES` already
-    uses for a similar purpose) gets both cases right without needing a
-    second sample: it strips the checkout-root prefix when a recognizable
-    project-layout marker is present, and falls back to comparing the full
-    path (never silently "unmoved") when it isn't.
-    """
-    if not path:
-        return path
-    segs = _path_segments(path)
-    for i in range(len(segs) - 1, -1, -1):
-        if segs[i].lower() in _CONVENTIONAL_ROOT_MARKERS:
-            return "/".join(segs[i:])
-    return "/".join(segs)
 
 
 #: Node kinds whose ``label``/declaring-path fields are a filesystem path,
@@ -392,66 +321,6 @@ def _declaring_files(graph: SourceGraphSummary) -> dict[str, str]:
         if label:
             result[e.dst] = _project_relative_path(str(label))
     return result
-
-
-def _signature_tail(identity: CanonicalIdentity) -> str:
-    # normalized_signature's kind/arity/param-types tail, qn field stripped
-    # off (that field alone carries coordinate churn) -- comparable across
-    # a coordinate shift. Format: "sig:" + qn + "\x1f" + kind + "\x1f" + ...
-    return identity.normalized_signature.split("\x1f", 1)[-1]
-
-
-def _classify_outcome(
-    old_identity: CanonicalIdentity,
-    new_identity: CanonicalIdentity,
-    *,
-    old_declaring_file: str = "",
-    new_declaring_file: str = "",
-) -> str:
-    old_qn = old_identity.qualified_name
-    new_qn = new_identity.qualified_name
-    # source_relative is file#scope#name; the file prefix says "did the
-    # declaring file change" (falls back to _declaring_files' edge-derived
-    # file when the node carries none of its own).
-    old_file = (
-        _project_relative_path(old_identity.source_relative.split("\x1f", 1)[0])
-        or old_declaring_file
-    )
-    new_file = (
-        _project_relative_path(new_identity.source_relative.split("\x1f", 1)[0])
-        or new_declaring_file
-    )
-    old_key = closure_location_free_identity(old_qn)
-    new_key = closure_location_free_identity(new_qn)
-    renamed = bool(old_qn) and bool(new_qn) and old_key != new_key
-    moved = bool(old_file) and bool(new_file) and old_file != new_file
-    if renamed and not moved:
-        return OUTCOME_RENAMED
-    if moved and not renamed:
-        return OUTCOME_MOVED
-    if renamed and moved:
-        return OUTCOME_RECONCILED
-    # Neither fired: coordinate-only needs the raw name differed (normalized
-    # equal), an agreeing signature tail, AND a type-shaped kind -- a real
-    # source_decl producer tracks no param_types/mangled_name (Codex
-    # review), so a function's tail is vacuously equal and can't prove
-    # nothing else changed; only a type has no such hidden dimension.
-    same_sig = _signature_tail(old_identity) == _signature_tail(new_identity)
-    # bool(old_qn)/bool(new_qn)/bool(*_file) mirror renamed/moved's own
-    # guards above -- an absent name is a name gain/loss, and absent file
-    # evidence on either side is missing evidence, never proof the
-    # declaring file didn't change (AGENTS.md: weaker evidence narrows
-    # conclusions, it never upgrades to a clean/compatible claim).
-    coordinate_only = (
-        bool(old_qn)
-        and bool(new_qn)
-        and bool(old_file)
-        and bool(new_file)
-        and old_qn != new_qn
-        and same_sig
-        and old_identity.kind in _COORDINATE_ONLY_KINDS
-    )
-    return OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED
 
 
 #: One node kind's structural-context index: context -> the new-side node ids
@@ -771,16 +640,6 @@ def reconcile_graph_diff(
 
     diff = diff_source_graph(old, new)
     return reconcile_added_removed(diff.removed_nodes, diff.added_nodes, old, new)
-
-
-#: Human-readable outcome descriptions, keyed by :data:`OUTCOME_RENAMED`
-#: et al. — used by :func:`diff_graph_reconciliation_findings` below.
-_OUTCOME_PROSE: dict[str, str] = {
-    OUTCOME_RENAMED: "renamed",
-    OUTCOME_MOVED: "moved to a different declaring file",
-    OUTCOME_RECONCILED: "identity-reconciled (both name and location evidence changed)",
-    OUTCOME_COORDINATES_ONLY: "no material identity change (coordinate-only shift)",
-}
 
 
 def _public_reachable_ids(graph: SourceGraphSummary) -> frozenset[str]:

--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -111,12 +111,14 @@ from .entity_identity import (
 )
 from .graph_reconcile_outcome import (  # re-exported: the public outcome vocabulary has always been importable from this module
     _OUTCOME_PROSE,
+    COORDINATE_EVIDENCE_QUALIFIED_NAME,
     OUTCOME_COORDINATES_ONLY,
     OUTCOME_MOVED,
     OUTCOME_RECONCILED,
     OUTCOME_RENAMED,
     _classify_outcome,
     _project_relative_path,
+    coordinate_evidence,
 )
 
 if TYPE_CHECKING:
@@ -145,9 +147,14 @@ class ReconciledPair:
     outcome: str  # OUTCOME_RENAMED | OUTCOME_MOVED | OUTCOME_RECONCILED | OUTCOME_COORDINATES_ONLY
     old_identity: CanonicalIdentity
     new_identity: CanonicalIdentity
+    #: For an OUTCOME_COORDINATES_ONLY pair, which provider carried the
+    #: location evidence (``declaring_file`` | ``qualified_name``); None for
+    #: every other outcome. See ``graph_reconcile_outcome.
+    #: coordinate_evidence`` for why this is recorded rather than gated on.
+    coordinate_evidence: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "old_node_id": self.old_node.id,
             "new_node_id": self.new_node.id,
             "old_label": self.old_node.label,
@@ -155,6 +162,9 @@ class ReconciledPair:
             "match_kind": self.match_kind,
             "outcome": self.outcome,
         }
+        if self.coordinate_evidence is not None:
+            d["coordinate_evidence"] = self.coordinate_evidence
+        return d
 
 
 @dataclass
@@ -384,11 +394,19 @@ class _Reconciler:
         """
         oid = old_node.id
         new_node = next(n for n in kind_pass.new_list if n.id == new_id)
+        old_declaring = self.old_declaring_files.get(oid, "")
+        new_declaring = self.new_declaring_files.get(new_id, "")
         outcome = _classify_outcome(
             kind_pass.old_ident[oid],
             kind_pass.new_ident[new_id],
-            old_declaring_file=self.old_declaring_files.get(oid, ""),
-            new_declaring_file=self.new_declaring_files.get(new_id, ""),
+            old_declaring_file=old_declaring,
+            new_declaring_file=new_declaring,
+        )
+        evidence = coordinate_evidence(
+            kind_pass.old_ident[oid],
+            kind_pass.new_ident[new_id],
+            old_declaring_file=old_declaring,
+            new_declaring_file=new_declaring,
         )
         self.result.reconciled.append(
             ReconciledPair(
@@ -398,6 +416,7 @@ class _Reconciler:
                 outcome,
                 kind_pass.old_ident[oid],
                 kind_pass.new_ident[new_id],
+                evidence,
             )
         )
         self.matched_old.add(oid)
@@ -735,6 +754,21 @@ def diff_graph_reconciliation_findings(
         old_label = pair.old_node.label or pair.old_node.id
         new_label = pair.new_node.label or pair.new_node.id
         prose = _OUTCOME_PROSE.get(pair.outcome, "identity-reconciled")
+        # State the weaker evidence rather than hiding it (Codex review, PR
+        # #1228): a coordinate-only pair with no declaring-file evidence on
+        # either side read its coordinate shift out of the qualified name,
+        # which cannot rule out a same-basename cross-directory move. The
+        # classification stays -- declining it makes OUTCOME_RECONCILED's
+        # strictly stronger "both name and location evidence changed" claim
+        # on the very same absent evidence -- but a reader sees what it
+        # rests on.
+        evidence_note = (
+            "; location evidence: the qualified name's own coordinates only "
+            "-- no declaring file was recorded on either side, so a move "
+            "that kept the same file basename would look identical to this"
+            if pair.coordinate_evidence == COORDINATE_EVIDENCE_QUALIFIED_NAME
+            else ""
+        )
         # Prefer the new side's declaring file (matches the rest of the L5
         # findings' [L5_SOURCE_GRAPH]-boundary convention in
         # source_graph_findings.py); fall back to the old side, then to the
@@ -754,7 +788,7 @@ def diff_graph_reconciliation_findings(
                 description=(
                     f"Graph evidence reconciles {old_label!r} (old) with "
                     f"{new_label!r} (new) as the same declaration, {prose} "
-                    f"(match evidence: {pair.match_kind}). This does not by "
+                    f"(match evidence: {pair.match_kind}{evidence_note}). This does not by "
                     "itself indicate a break — it explains what would "
                     "otherwise look like an unrelated add+remove pair in the "
                     "L5 graph diff; any artifact-level finding for either "

--- a/abicheck/buildsource/graph_reconcile_outcome.py
+++ b/abicheck/buildsource/graph_reconcile_outcome.py
@@ -32,6 +32,19 @@ from __future__ import annotations
 from ..model.graph_identity import closure_location_free_identity
 from .entity_identity import CanonicalIdentity
 
+#: Which provider carried the *location* half of an
+#: :data:`OUTCOME_COORDINATES_ONLY` classification. ``declaring_file`` is a
+#: second, independent provider agreeing the declaring file did not change;
+#: ``qualified_name`` means the coordinate shift was read out of the
+#: qualified name itself and NO declaring-file evidence existed on either
+#: side -- the weaker of the two, and the one a reader should see stated
+#: rather than inferred (Codex review, PR #1228: a same-basename
+#: cross-directory move is indistinguishable from a pure coordinate shift
+#: on name evidence alone).
+COORDINATE_EVIDENCE_DECLARING_FILE = "declaring_file"
+COORDINATE_EVIDENCE_QUALIFIED_NAME = "qualified_name"
+
+
 #: Reconciliation outcomes (ADR-048 D2) — distinct from plain
 #: node-add/node-remove, so a consumer can tell "the same entity, under a
 #: new name/location" from "an unrelated add and an unrelated remove that
@@ -182,6 +195,49 @@ def _classify_outcome(
         and old_identity.kind in _COORDINATE_ONLY_KINDS
     )
     return OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED
+
+
+def coordinate_evidence(
+    old_identity: CanonicalIdentity,
+    new_identity: CanonicalIdentity,
+    *,
+    old_declaring_file: str = "",
+    new_declaring_file: str = "",
+) -> str | None:
+    """Which provider carried the location half of this pair's
+    :data:`OUTCOME_COORDINATES_ONLY` classification, or ``None`` when the
+    pair is not classified that way.
+
+    Recorded rather than acted on. Declining to classify a pair as
+    coordinate-only for want of a declaring file makes the strictly
+    stronger :data:`OUTCOME_RECONCILED` claim instead (see
+    :func:`_classify_outcome`), so the honest narrowing is to state which
+    evidence the classification rests on and let a reader weigh it -- a
+    :data:`COORDINATE_EVIDENCE_QUALIFIED_NAME` pair cannot rule out a
+    same-basename cross-directory move, and says so in the emitted
+    finding's own description.
+    """
+    if (
+        _classify_outcome(
+            old_identity,
+            new_identity,
+            old_declaring_file=old_declaring_file,
+            new_declaring_file=new_declaring_file,
+        )
+        != OUTCOME_COORDINATES_ONLY
+    ):
+        return None
+    old_file = (
+        _project_relative_path(old_identity.source_relative.split("\x1f", 1)[0])
+        or old_declaring_file
+    )
+    new_file = (
+        _project_relative_path(new_identity.source_relative.split("\x1f", 1)[0])
+        or new_declaring_file
+    )
+    if old_file and new_file:
+        return COORDINATE_EVIDENCE_DECLARING_FILE
+    return COORDINATE_EVIDENCE_QUALIFIED_NAME
 
 
 #: Human-readable outcome descriptions, keyed by :data:`OUTCOME_RENAMED`

--- a/abicheck/buildsource/graph_reconcile_outcome.py
+++ b/abicheck/buildsource/graph_reconcile_outcome.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-048 D2's reconciliation *outcome* vocabulary and its classifier.
+
+One responsibility, lifted out of ``graph_reconcile.py`` (which owns the
+*matching* -- which old node pairs with which new one -- and sat at its
+``architecture/debt.yaml`` no-growth baseline): given a matched pair's two
+:class:`CanonicalIdentity` values, which of the four outcomes does the
+evidence actually support? The declaring-path normalization the answer
+rests on (:func:`_project_relative_path`) comes along, since the classifier
+is its only semantic consumer; ``graph_reconcile`` imports it back for its
+own node-identity paths.
+
+A leaf: nothing here reaches back into the matching module.
+"""
+
+from __future__ import annotations
+
+from ..model.graph_identity import closure_location_free_identity
+from .entity_identity import CanonicalIdentity
+
+#: Reconciliation outcomes (ADR-048 D2) — distinct from plain
+#: node-add/node-remove, so a consumer can tell "the same entity, under a
+#: new name/location" from "an unrelated add and an unrelated remove that
+#: happen to be in the same diff".
+OUTCOME_RENAMED = "declaration_renamed"
+OUTCOME_MOVED = "declaration_moved"
+OUTCOME_RECONCILED = "declaration_identity_reconciled"
+OUTCOME_COORDINATES_ONLY = "declaration_coordinates_shifted"  # neither predicate fired -- distinct from OUTCOME_RECONCILED, where both did
+
+#: OUTCOME_COORDINATES_ONLY-eligible kinds -- excludes "source_decl": a
+#: function's signature isn't exposed to resolve_identity_for_node in
+#: production, so "nothing else changed" can't be proven for one.
+_COORDINATE_ONLY_KINDS: frozenset[str] = frozenset(
+    {"record_type", "enum_type", "typedef"}
+)
+
+
+def _path_segments(path: str) -> tuple[str, ...]:
+    """Plain-path split into segments, ignoring the root/self markers.
+
+    Normalizes ``\\`` to ``/`` first (same as
+    ``source_graph_findings._path_segments``/``source_graph.py``'s own
+    caller-file normalization): ``PurePosixPath`` treats a backslash as an
+    ordinary filename character, not a separator, so a Windows-style
+    declaring path (``C:\\old\\include\\api.h``) would never be split at
+    all -- silently defeating the project-root-marker search in
+    :func:`_project_relative_path` and comparing raw checkout roots
+    (Codex review).
+    """
+    from pathlib import PurePosixPath
+
+    posix = path.replace("\\", "/")
+    return tuple(p for p in PurePosixPath(posix).parts if p not in ("/", ".", ""))
+
+
+#: Conventional project-root directory names — a superset of
+#: :data:`abicheck.header_utils._INCLUDE_ROOT_NAMES` (which only needs
+#: ``include``/``inc`` for its narrower include-root-inference purpose;
+#: this also covers ``src``/``source``/``sources`` layouts). Used here as an
+#: anchor for stripping a checkout-root prefix from a single declaring-file
+#: path with no sibling to derive a shared prefix from (Codex review — see
+#: :func:`_project_relative_path`).
+_CONVENTIONAL_ROOT_MARKERS: frozenset[str] = frozenset(
+    {"include", "inc", "src", "source", "sources"}
+)
+
+
+def _project_relative_path(path: str) -> str:
+    """Best-effort project-relative form of a declaring-file/header path.
+
+    Two independently-rooted checkouts of the same tree (separate temp dirs
+    in a benchmark harness, or two CI job workspaces) share no absolute
+    root, so comparing raw absolute paths would misclassify an unmoved file
+    as "moved" purely because of where its tree happened to be checked out.
+
+    With more than one declaring file on a side, the shared checkout-root
+    prefix could in principle be derived structurally (comparing multiple
+    paths against each other) — but a single sample gives no such baseline,
+    and blindly reserving "everything but the basename" as an assumed
+    checkout root (an earlier version of this function did that) silently
+    hides a real cross-directory move that happens to keep the same
+    filename (Codex review: ``/tmp/old/src/foo.h`` -> ``/tmp/new/include/foo.h``
+    must not read as unmoved). Anchoring on the last conventional root-marker
+    segment instead (``include``/``inc``/``src``/``source``/``sources`` — the
+    same vocabulary :data:`abicheck.header_utils._INCLUDE_ROOT_NAMES` already
+    uses for a similar purpose) gets both cases right without needing a
+    second sample: it strips the checkout-root prefix when a recognizable
+    project-layout marker is present, and falls back to comparing the full
+    path (never silently "unmoved") when it isn't.
+    """
+    if not path:
+        return path
+    segs = _path_segments(path)
+    for i in range(len(segs) - 1, -1, -1):
+        if segs[i].lower() in _CONVENTIONAL_ROOT_MARKERS:
+            return "/".join(segs[i:])
+    return "/".join(segs)
+
+
+def _signature_tail(identity: CanonicalIdentity) -> str:
+    # normalized_signature's kind/arity/param-types tail, qn field stripped
+    # off (that field alone carries coordinate churn) -- comparable across
+    # a coordinate shift. Format: "sig:" + qn + "\x1f" + kind + "\x1f" + ...
+    return identity.normalized_signature.split("\x1f", 1)[-1]
+
+
+def _classify_outcome(
+    old_identity: CanonicalIdentity,
+    new_identity: CanonicalIdentity,
+    *,
+    old_declaring_file: str = "",
+    new_declaring_file: str = "",
+) -> str:
+    old_qn = old_identity.qualified_name
+    new_qn = new_identity.qualified_name
+    # source_relative is file#scope#name; the file prefix says "did the
+    # declaring file change" (falls back to _declaring_files' edge-derived
+    # file when the node carries none of its own).
+    old_file = (
+        _project_relative_path(old_identity.source_relative.split("\x1f", 1)[0])
+        or old_declaring_file
+    )
+    new_file = (
+        _project_relative_path(new_identity.source_relative.split("\x1f", 1)[0])
+        or new_declaring_file
+    )
+    old_key = closure_location_free_identity(old_qn)
+    new_key = closure_location_free_identity(new_qn)
+    renamed = bool(old_qn) and bool(new_qn) and old_key != new_key
+    moved = bool(old_file) and bool(new_file) and old_file != new_file
+    if renamed and not moved:
+        return OUTCOME_RENAMED
+    if moved and not renamed:
+        return OUTCOME_MOVED
+    if renamed and moved:
+        return OUTCOME_RECONCILED
+    # Neither fired: coordinate-only needs the raw name differed (normalized
+    # equal), an agreeing signature tail, AND a type-shaped kind -- a real
+    # source_decl producer tracks no param_types/mangled_name (Codex
+    # review), so a function's tail is vacuously equal and can't prove
+    # nothing else changed; only a type has no such hidden dimension.
+    same_sig = _signature_tail(old_identity) == _signature_tail(new_identity)
+    # bool(old_qn)/bool(new_qn) mirror renamed's own guard above -- an
+    # absent name is a name gain/loss, not coordinate-churn evidence.
+    #
+    # Deliberately NOT gated on bool(old_file)/bool(new_file). In this
+    # population the coordinate shift is embedded in the qualified name
+    # itself ("(lambda at global_control.h:172:22)"), and
+    # closure_location_free_identity stripping it is precisely what proved
+    # the non-coordinate part identical -- the name-embedded coordinate IS
+    # the location evidence. Demanding a SOURCE_DECLARES-edge declaring
+    # file on top of it asks for a second, independent provider for a fact
+    # the first already carries, and real header-graph nodes frequently
+    # have none (measured on a oneTBB header-graph comparison: 15 of 15
+    # otherwise-eligible record_type pairs were blocked solely by
+    # old_file == new_file == "", making this outcome unreachable in
+    # production). Crucially the alternative here is not "make no claim":
+    # falling through to OUTCOME_RECONCILED asserts the strictly STRONGER
+    # "both name and location evidence changed", at severity risk. On
+    # absent file evidence `moved` is already False for that same reason,
+    # so declining the weak claim only to make the strong one inverts
+    # AGENTS.md's "weaker evidence narrows conclusions".
+    coordinate_only = (
+        bool(old_qn)
+        and bool(new_qn)
+        and old_qn != new_qn
+        and same_sig
+        and old_identity.kind in _COORDINATE_ONLY_KINDS
+    )
+    return OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED
+
+
+#: Human-readable outcome descriptions, keyed by :data:`OUTCOME_RENAMED`
+#: et al. — used by :func:`diff_graph_reconciliation_findings` below.
+_OUTCOME_PROSE: dict[str, str] = {
+    OUTCOME_RENAMED: "renamed",
+    OUTCOME_MOVED: "moved to a different declaring file",
+    OUTCOME_RECONCILED: "identity-reconciled (both name and location evidence changed)",
+    OUTCOME_COORDINATES_ONLY: "no material identity change (coordinate-only shift)",
+}

--- a/abicheck/policy/analysis_assurance_schema_staleness.py
+++ b/abicheck/policy/analysis_assurance_schema_staleness.py
@@ -461,6 +461,26 @@ def _same_content(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     pairwise finding is possible. The converse is neither claimed nor
     needed: any inequality falls through to the ordinary degraded report,
     which is the safe direction.
+
+    **The one residual, and where it is reported instead** (Codex review,
+    PR #1228): an ``AbiSnapshot`` is a lossy capture, so equal content
+    proves the two sides' *recorded evidence* is equal, not that the two
+    underlying artifacts are. Two genuinely different binaries whose stale
+    snapshots decode equal (the stale schema failed to record the one field
+    that differs) therefore read ``"clean"`` here. That case is not
+    silent, and deliberately is not this field's job: it is exactly the
+    population ``confidence.note_if_same_binary_compared`` already fires
+    on, from the identical signal (equal canonical serialization), with the
+    stronger claim -- "this comparison cannot detect a change even if one
+    was intended -- verify the correct snapshot files were provided" -- on
+    ``DiffResult.coverage_warnings``, which no suppression rule can remove.
+    Reporting the same residual a second time as schema staleness would
+    label it as a *vintage* problem, which it is not: the comparison is
+    equally blind at any vintage once both sides decode to the same
+    evidence. ``tests/test_analysis_assurance_content_identity.py``'s
+    ``test_content_identical_compare_still_warns_it_can_detect_nothing``
+    pins the pairing, so the disclosure cannot quietly disappear and leave
+    this return claiming completeness alone.
     """
     return old == new
 

--- a/abicheck/policy/analysis_assurance_schema_staleness.py
+++ b/abicheck/policy/analysis_assurance_schema_staleness.py
@@ -446,6 +446,25 @@ def _pair_aware_degraded_facts(snap: AbiSnapshot, other: AbiSnapshot) -> list[st
     return kept
 
 
+def _same_content(old: AbiSnapshot, new: AbiSnapshot) -> bool:
+    """Whether *old* and *new* are provably the same content.
+
+    Plain ``AbiSnapshot`` dataclass equality (structural, every field).
+    Chosen over a serialized digest (``storage.snapshot_encode.
+    snapshot_content_digest``, this repo's existing content fingerprint)
+    because ``policy`` may not import ``storage`` (``architecture/
+    modules.yaml``: ``policy -> model, compare``), and because equality is
+    the stronger test of the two -- a digest can only ever agree with it,
+    after paying a full re-serialization. Soundness is what matters here,
+    and field-wise equality has it in the direction actually used: equal
+    ==> every input a pairwise detector reads agrees on both sides ==> no
+    pairwise finding is possible. The converse is neither claimed nor
+    needed: any inequality falls through to the ordinary degraded report,
+    which is the safe direction.
+    """
+    return old == new
+
+
 def schema_staleness_status(
     old: AbiSnapshot, new: AbiSnapshot
 ) -> tuple[str, list[str]]:
@@ -483,16 +502,36 @@ def schema_staleness_status(
     would otherwise be the one context-status field self-pairing does NOT
     make safe by construction, purely because it asks a per-side question
     ("is THIS side's flag False") rather than a cross-side agreement
-    question. A user-supplied ``compare foo.so foo.so`` (two independently
-    parsed, merely content-identical snapshots) never hits this: real
-    identity, not equal content, is what this checks, and two separate
-    parses are always two separate objects.
+    question. That argument never depended on object
+    identity, and an earlier revision of this docstring wrongly carved the
+    two-operand case out ("two separate parses are always two separate
+    objects"). ONE stored snapshot file loaded twice -- ``compare
+    baseline.abi.json baseline.abi.json``, or a CI job re-checking an
+    unchanged cached baseline -- produces two distinct objects whose
+    content is nevertheless equal, and reporting that as ``"degraded"``
+    (flipping ``assurance.status`` complete -> partial, newly failing a job
+    gating on it) makes exactly the claim the ``old is new`` return already
+    rejects.
+
+    So the early return is widened from object identity to *provable
+    content identity* (:func:`_same_content`). That test is SOUND, not
+    heuristic: equal content means every input the pairwise detectors read
+    is equal on both sides, so no pairwise finding is possible, reliable
+    facts or not. It is deliberately NOT widened to "same input path" or
+    "same binary": two independent extractions of one binary can
+    legitimately differ in schema vintage, which is precisely the case this
+    field exists to report. It is also evaluated only AFTER
+    :func:`_pair_aware_degraded_facts` has returned something for at least
+    one side, so an ordinary clean comparison never pays for it; that path
+    is rare by construction.
     """
     if old is new:
         return "clean", []
     old_degraded = _pair_aware_degraded_facts(old, new)
     new_degraded = _pair_aware_degraded_facts(new, old)
     if not old_degraded and not new_degraded:
+        return "clean", []
+    if _same_content(old, new):
         return "clean", []
     notes: list[str] = []
     if old_degraded:

--- a/changelog.d/20260911_120000_coordinates_shifted_reachable.md
+++ b/changelog.d/20260911_120000_coordinates_shifted_reachable.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`declaration_coordinates_shifted` is reachable again.** ADR-048's
+  coordinate-only reconciliation outcome required a `SOURCE_DECLARES`-edge
+  declaring file on *both* sides, which no real header-graph pair carries:
+  every otherwise-eligible pair fell through to
+  `declaration_identity_reconciled`, whose prose asserts the strictly
+  stronger "both name and location evidence changed" at `risk` severity —
+  on *absent* location evidence. The declaring-file guard is dropped; the
+  coordinate shift embedded in the qualified name is itself the location
+  evidence, and `closure_location_free_identity` stripping it is what
+  proves the non-coordinate part identical. Every other narrowing (both
+  qualified names present and differing, an agreeing signature tail, a
+  type-shaped node kind) is unchanged.

--- a/changelog.d/20260911_121000_self_compare_assurance.md
+++ b/changelog.d/20260911_121000_self_compare_assurance.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`compare X X` on a stale-schema stored snapshot no longer reports
+  `assurance.status: "partial"`.** `schema_staleness_status`'s self-diff
+  early return tested Python object identity, so the same stored snapshot
+  file loaded twice — `compare baseline.abi.json baseline.abi.json`, or a
+  CI job re-checking an unchanged cached baseline — was reported as
+  `schema_staleness_status: degraded`, flipping `assurance.status` from
+  `complete` to `partial`. The return is widened to provable *content*
+  identity (structural `AbiSnapshot` equality, evaluated only once a
+  degraded fact has already been found, so a clean comparison pays
+  nothing). Two snapshots that genuinely differ — including two
+  extractions of one binary at different schema vintages — still report
+  `degraded`.

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -47,6 +47,7 @@ already apply to `ChangeKind`.
 from __future__ import annotations
 
 from .bug_class_schema import BugClass, KnownGap
+from .manifest_guards import GUARD_BUG_CLASSES
 from .manifest_report import REPORT_BUG_CLASSES
 from .manifest_tool_surface import TOOL_SURFACE_BUG_CLASSES
 
@@ -1301,61 +1302,6 @@ _ANALYSIS_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
-    BugClass(
-        id="guard.proxy_predicate_overshoots_justification",
-        invariant=(
-            "A guard's predicate must test the property its own "
-            "justification names, and must be checked against the "
-            "population it targets. Two failures follow when it does not: "
-            "a narrowing guard can eliminate the entire population it was "
-            "meant to discriminate within (the outcome becomes reachable "
-            "from no real input, and nothing fails anywhere), and the "
-            "fallback it hands those inputs to can assert a STRICTLY "
-            "STRONGER claim than the one the guard declined — declining a "
-            "weak claim for lack of evidence, then making a strong one on "
-            "the same absent evidence. An early return justified by a "
-            "semantic property (content identity) but implemented via a "
-            "proxy (object identity) is the same defect from the other "
-            "side: the claim the return exists to reject is made anyway, "
-            "on the shape users actually hit."
-        ),
-        # #1228: `graph_reconcile._classify_outcome`'s declaring-file guard
-        # made OUTCOME_COORDINATES_ONLY unreachable (0 occurrences
-        # repo-wide) and sent every eligible pair to OUTCOME_RECONCILED's
-        # "both name and location evidence changed" — on absent location
-        # evidence. Same PR: `schema_staleness_status`'s `old is new`
-        # self-diff return, whose own argument ("comparing a value against
-        # itself can never produce a false pairwise finding") never
-        # depended on object identity, reported one stored snapshot loaded
-        # twice as `degraded` and flipped `assurance.status` to `partial`.
-        fixed_by=(1228,),
-        seed_tests=(
-            "tests/test_graph_reconcile_coordinate_outcome.py",
-            "tests/test_analysis_assurance_content_identity.py",
-        ),
-        public_surfaces=("cli",),
-        axes={
-            "evidence_presence": ("both_sides", "one_side", "absent"),
-            "claim_strength": ("declined", "weak_claim", "strong_claim"),
-            "identity_test": ("object", "content", "differing"),
-        },
-        known_gaps=(
-            KnownGap(
-                description=(
-                    "Reachability is asserted per-classifier in the seed "
-                    "tests, not swept mechanically: another outcome "
-                    "elsewhere in the codebase that a later guard made "
-                    "unproducible would still be found by hand. The "
-                    "residual on the first instance is narrower: a pair "
-                    "with no positive evidence on EITHER axis still falls "
-                    "through to OUTCOME_RECONCILED's overstated prose "
-                    "(ADR-048's accepted case197 'no clean split'), which "
-                    "a fifth outcome, not this fix, would close."
-                ),
-                reference="docs/contribute/plans/bug-class-regression-testing.md",
-            ),
-        ),
-    ),
 )
 
 
@@ -1364,7 +1310,10 @@ _ANALYSIS_BUG_CLASSES: tuple[BugClass, ...] = (
 #: change_registry.py` already uses -- adding a class to a sibling needs no
 #: edit here.
 BUG_CLASSES: tuple[BugClass, ...] = (
-    _ANALYSIS_BUG_CLASSES + REPORT_BUG_CLASSES + TOOL_SURFACE_BUG_CLASSES
+    _ANALYSIS_BUG_CLASSES
+    + GUARD_BUG_CLASSES
+    + REPORT_BUG_CLASSES
+    + TOOL_SURFACE_BUG_CLASSES
 )
 
 _BY_ID: dict[str, BugClass] = {bc.id: bc for bc in BUG_CLASSES}

--- a/tests/regressions/manifest.py
+++ b/tests/regressions/manifest.py
@@ -1301,6 +1301,61 @@ _ANALYSIS_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="guard.proxy_predicate_overshoots_justification",
+        invariant=(
+            "A guard's predicate must test the property its own "
+            "justification names, and must be checked against the "
+            "population it targets. Two failures follow when it does not: "
+            "a narrowing guard can eliminate the entire population it was "
+            "meant to discriminate within (the outcome becomes reachable "
+            "from no real input, and nothing fails anywhere), and the "
+            "fallback it hands those inputs to can assert a STRICTLY "
+            "STRONGER claim than the one the guard declined — declining a "
+            "weak claim for lack of evidence, then making a strong one on "
+            "the same absent evidence. An early return justified by a "
+            "semantic property (content identity) but implemented via a "
+            "proxy (object identity) is the same defect from the other "
+            "side: the claim the return exists to reject is made anyway, "
+            "on the shape users actually hit."
+        ),
+        # #1228: `graph_reconcile._classify_outcome`'s declaring-file guard
+        # made OUTCOME_COORDINATES_ONLY unreachable (0 occurrences
+        # repo-wide) and sent every eligible pair to OUTCOME_RECONCILED's
+        # "both name and location evidence changed" — on absent location
+        # evidence. Same PR: `schema_staleness_status`'s `old is new`
+        # self-diff return, whose own argument ("comparing a value against
+        # itself can never produce a false pairwise finding") never
+        # depended on object identity, reported one stored snapshot loaded
+        # twice as `degraded` and flipped `assurance.status` to `partial`.
+        fixed_by=(1228,),
+        seed_tests=(
+            "tests/test_graph_reconcile_coordinate_outcome.py",
+            "tests/test_analysis_assurance_content_identity.py",
+        ),
+        public_surfaces=("cli",),
+        axes={
+            "evidence_presence": ("both_sides", "one_side", "absent"),
+            "claim_strength": ("declined", "weak_claim", "strong_claim"),
+            "identity_test": ("object", "content", "differing"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Reachability is asserted per-classifier in the seed "
+                    "tests, not swept mechanically: another outcome "
+                    "elsewhere in the codebase that a later guard made "
+                    "unproducible would still be found by hand. The "
+                    "residual on the first instance is narrower: a pair "
+                    "with no positive evidence on EITHER axis still falls "
+                    "through to OUTCOME_RECONCILED's overstated prose "
+                    "(ADR-048's accepted case197 'no clean split'), which "
+                    "a fifth outcome, not this fix, would close."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+        ),
+    ),
 )
 
 

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -82,11 +82,18 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
                     "tests, not swept mechanically: another outcome "
                     "elsewhere in the codebase that a later guard made "
                     "unproducible would still be found by hand. The "
-                    "residual on the first instance is narrower: a pair "
-                    "with no positive evidence on EITHER axis still falls "
-                    "through to OUTCOME_RECONCILED's overstated prose "
-                    "(ADR-048's accepted case197 'no clean split'), which "
-                    "a fifth outcome, not this fix, would close."
+                    "residuals on the first instance are narrower and "
+                    "both stated rather than hidden: a pair with no "
+                    "positive evidence on EITHER axis still falls through "
+                    "to OUTCOME_RECONCILED's overstated prose (ADR-048's "
+                    "accepted case197 'no clean split'), and a "
+                    "coordinate-only pair resting on qualified-name "
+                    "evidence alone cannot rule out a move that kept the "
+                    "same file basename -- recorded as "
+                    "`ReconciledPair.coordinate_evidence` and disclosed in "
+                    "the finding's own text, since separating that from a "
+                    "declaring-file-confirmed shift at the *kind* level "
+                    "would need a fifth outcome and a new ChangeKind."
                 ),
                 reference="docs/contribute/plans/bug-class-regression-testing.md",
             ),

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bug classes about a *guard's own predicate*, not the analysis it gates.
+
+The defects here are found by reading a condition against the argument
+written next to it: what the code tests versus what its justification
+claims, and what the branch it rejects into then asserts. That makes them
+invisible to the kind of test that exercises the surrounding feature --
+every such test passes, because the feature works; it is the population the
+guard admits, and the claim the fallback makes, that are wrong.
+
+Its own module for the reason ``manifest_report.py``/
+``manifest_tool_surface.py`` are: ``manifest.py`` sits at its
+``architecture/debt.yaml`` ``no_growth`` baseline and is an assembly point
+over per-axis entry lists, so a new class goes in a sibling rather than
+growing it (PR #1228).
+"""
+
+from __future__ import annotations
+
+from .bug_class_schema import BugClass, KnownGap
+
+__all__ = ["GUARD_BUG_CLASSES"]
+
+
+GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
+    BugClass(
+        id="guard.proxy_predicate_overshoots_justification",
+        invariant=(
+            "A guard's predicate must test the property its own "
+            "justification names, and must be checked against the "
+            "population it targets. Two failures follow when it does not: "
+            "a narrowing guard can eliminate the entire population it was "
+            "meant to discriminate within (the outcome becomes reachable "
+            "from no real input, and nothing fails anywhere), and the "
+            "fallback it hands those inputs to can assert a STRICTLY "
+            "STRONGER claim than the one the guard declined — declining a "
+            "weak claim for lack of evidence, then making a strong one on "
+            "the same absent evidence. An early return justified by a "
+            "semantic property (content identity) but implemented via a "
+            "proxy (object identity) is the same defect from the other "
+            "side: the claim the return exists to reject is made anyway, "
+            "on the shape users actually hit."
+        ),
+        # #1228: `graph_reconcile._classify_outcome`'s declaring-file guard
+        # made OUTCOME_COORDINATES_ONLY unreachable (0 occurrences
+        # repo-wide) and sent every eligible pair to OUTCOME_RECONCILED's
+        # "both name and location evidence changed" — on absent location
+        # evidence. Same PR: `schema_staleness_status`'s `old is new`
+        # self-diff return, whose own argument ("comparing a value against
+        # itself can never produce a false pairwise finding") never
+        # depended on object identity, reported one stored snapshot loaded
+        # twice as `degraded` and flipped `assurance.status` to `partial`.
+        fixed_by=(1228,),
+        seed_tests=(
+            "tests/test_graph_reconcile_coordinate_outcome.py",
+            "tests/test_analysis_assurance_content_identity.py",
+        ),
+        public_surfaces=("cli",),
+        axes={
+            "evidence_presence": ("both_sides", "one_side", "absent"),
+            "claim_strength": ("declined", "weak_claim", "strong_claim"),
+            "identity_test": ("object", "content", "differing"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Reachability is asserted per-classifier in the seed "
+                    "tests, not swept mechanically: another outcome "
+                    "elsewhere in the codebase that a later guard made "
+                    "unproducible would still be found by hand. The "
+                    "residual on the first instance is narrower: a pair "
+                    "with no positive evidence on EITHER axis still falls "
+                    "through to OUTCOME_RECONCILED's overstated prose "
+                    "(ADR-048's accepted case197 'no clean split'), which "
+                    "a fifth outcome, not this fix, would close."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+        ),
+    ),
+)

--- a/tests/test_analysis_assurance_content_identity.py
+++ b/tests/test_analysis_assurance_content_identity.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``schema_staleness_status``'s content-identity invariant.
+
+Bug class: an early return justified by "comparing a value against itself
+can never produce a false pairwise finding" was implemented as *object*
+identity (``old is new``), so the identical argument silently failed to
+cover the shape a user actually hits -- ONE stored snapshot file loaded
+twice (``compare baseline.abi.json baseline.abi.json``, or a CI job
+re-checking an unchanged cached baseline), which reported
+``schema_staleness_status == "degraded"`` and flipped ``assurance.status``
+complete -> partial. Stated here as an invariant over generated inputs
+(several schema vintages, clean and degraded), not a fixture pinned to the
+one observed snapshot -- plus the load-bearing negative, without which the
+fix could silently become "never taint anything".
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from abicheck.policy.analysis_assurance_degraded_facts import (
+    degraded_reliability_facts,
+)
+from abicheck.policy.analysis_assurance_schema_staleness import (
+    schema_staleness_status,
+)
+from abicheck.serialization import snapshot_from_dict
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "schema"
+
+#: Schema vintages spanning both sides of the invariant: current-ish (no
+#: degraded fact at all) through several genuinely stale ones.
+_VINTAGES = (45, 38, 25, 18, 9, 4)
+
+
+def _load(fixture: str, **overrides: Any):
+    d = json.loads((_FIXTURES / fixture).read_text())
+    d.update(overrides)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return snapshot_from_dict(d)
+
+
+@pytest.mark.parametrize("vintage", _VINTAGES)
+@pytest.mark.parametrize("fixture", ["v4.json", "v5.json"])
+def test_content_identical_reload_matches_self_pairing(fixture: str, vintage: int) -> None:
+    """The invariant: for any snapshot ``s``, the status of two
+    *independently loaded, content-equal* copies of ``s`` equals the status
+    of ``(s, s)``. Holds for clean and degraded inputs alike -- the
+    soundness argument ("no pairwise finding is possible") is about equal
+    content, never about which Python object holds it."""
+    a = _load(fixture, schema_version=vintage, from_headers=True, ast_producer="clang")
+    b = _load(fixture, schema_version=vintage, from_headers=True, ast_producer="clang")
+    assert a is not b
+    assert a == b
+    assert schema_staleness_status(a, b) == schema_staleness_status(a, a)
+    assert schema_staleness_status(a, b)[0] == "clean"
+
+
+@pytest.mark.parametrize("vintage", _VINTAGES)
+def test_reload_invariant_is_exercised_on_genuinely_degraded_inputs(
+    vintage: int,
+) -> None:
+    """Guard against the invariant above passing vacuously: at least the
+    stale vintages must really carry degraded facts, or the parametrization
+    only ever tested the clean path."""
+    a = _load("v4.json", schema_version=vintage, from_headers=True, ast_producer="clang")
+    if vintage >= 45:
+        assert not degraded_reliability_facts(a)
+    else:
+        assert degraded_reliability_facts(a), vintage
+
+
+@pytest.mark.parametrize("stale_vintage", [38, 25, 18, 9, 4])
+def test_differing_vintages_still_report_degraded(stale_vintage: int) -> None:
+    """Load-bearing negative: two snapshots of the SAME library at
+    DIFFERENT schema vintages, one degraded, are a real two-sided
+    comparison a stale fact can distort -- they must still report
+    ``degraded``. Without this the fix could silently become "never taint
+    anything", and two independent extractions of one binary differing in
+    schema vintage is exactly the case this field exists to report."""
+    stale = _load(
+        "v4.json", schema_version=stale_vintage, from_headers=True, ast_producer="clang"
+    )
+    current = _load(
+        "v4.json", schema_version=45, from_headers=True, ast_producer="clang"
+    )
+    assert stale != current
+    assert degraded_reliability_facts(stale)
+    status, notes = schema_staleness_status(stale, current)
+    assert status == "degraded", notes
+    # ... and symmetrically, with the stale side as NEW.
+    assert schema_staleness_status(current, stale)[0] == "degraded"
+
+
+def test_self_compare_of_stored_stale_snapshot_is_complete_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """Through the real public ``compare`` path (AGENTS.md: validate the
+    user-facing result): the exact reported shape -- one pre-v45 stored
+    snapshot file given as BOTH operands -- must read ``assurance.status ==
+    "complete"``, since a CI job gating on that field was newly failing on
+    an unchanged cached baseline."""
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    d = json.loads((_FIXTURES / "v4.json").read_text())
+    d.update(schema_version=25, from_headers=True, ast_producer="clang")
+    path = tmp_path / "baseline.abi.json"
+    path.write_text(json.dumps(d))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert degraded_reliability_facts(snapshot_from_dict(d))
+
+    result = CliRunner().invoke(
+        main, ["compare", str(path), str(path), "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assurance = payload["analysis_assurance"]
+    assert assurance["schema_staleness_status"] == "clean", assurance
+    assert assurance["status"] == "complete", assurance
+
+
+def test_two_distinct_stored_snapshots_still_taint_end_to_end(tmp_path: Path) -> None:
+    """The end-to-end mirror of the negative above: two DIFFERENT stored
+    files, one stale, must still report a non-complete assurance."""
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    base = json.loads((_FIXTURES / "v4.json").read_text())
+    old_d = {**base, "schema_version": 25, "from_headers": True, "ast_producer": "clang"}
+    new_d = {**old_d, "schema_version": 45}
+    old_p, new_p = tmp_path / "old.abi.json", tmp_path / "new.abi.json"
+    old_p.write_text(json.dumps(old_d))
+    new_p.write_text(json.dumps(new_d))
+
+    result = CliRunner().invoke(
+        main, ["compare", str(old_p), str(new_p), "--format", "json"]
+    )
+    payload = json.loads(result.output)
+    assurance = payload["analysis_assurance"]
+    assert assurance["schema_staleness_status"] == "degraded", assurance
+    assert assurance["status"] != "complete", assurance

--- a/tests/test_analysis_assurance_content_identity.py
+++ b/tests/test_analysis_assurance_content_identity.py
@@ -163,3 +163,34 @@ def test_two_distinct_stored_snapshots_still_taint_end_to_end(tmp_path: Path) ->
     assurance = payload["analysis_assurance"]
     assert assurance["schema_staleness_status"] == "degraded", assurance
     assert assurance["status"] != "complete", assurance
+
+
+def test_content_identical_compare_still_warns_it_can_detect_nothing(
+    tmp_path: Path,
+) -> None:
+    """The load-bearing pairing behind `_same_content`'s one residual
+    (Codex review, PR #1228): an `AbiSnapshot` is a lossy capture, so equal
+    content proves the recorded evidence is equal, not that the two
+    artifacts are. That residual is disclosed by
+    `confidence.note_if_same_binary_compared`, which fires from the very
+    same signal and makes the stronger claim. If that warning ever stops
+    firing, `schema_staleness_status`'s "clean" would be the run's only
+    word on a comparison that cannot detect anything — so this test pins
+    the two together rather than leaving the coupling implicit."""
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    d = json.loads((_FIXTURES / "v4.json").read_text())
+    d.update(schema_version=25, from_headers=True, ast_producer="clang")
+    path = tmp_path / "baseline.abi.json"
+    path.write_text(json.dumps(d))
+
+    result = CliRunner().invoke(
+        main, ["compare", str(path), str(path), "--format", "json"]
+    )
+    payload = json.loads(result.output)
+    assert payload["analysis_assurance"]["status"] == "complete"
+    warnings_out = payload.get("coverage_warnings", [])
+    assert any("byte-identical" in w for w in warnings_out), warnings_out
+    assert any("cannot detect a change" in w for w in warnings_out), warnings_out

--- a/tests/test_analysis_assurance_content_identity.py
+++ b/tests/test_analysis_assurance_content_identity.py
@@ -62,7 +62,9 @@ def _load(fixture: str, **overrides: Any):
 
 @pytest.mark.parametrize("vintage", _VINTAGES)
 @pytest.mark.parametrize("fixture", ["v4.json", "v5.json"])
-def test_content_identical_reload_matches_self_pairing(fixture: str, vintage: int) -> None:
+def test_content_identical_reload_matches_self_pairing(
+    fixture: str, vintage: int
+) -> None:
     """The invariant: for any snapshot ``s``, the status of two
     *independently loaded, content-equal* copies of ``s`` equals the status
     of ``(s, s)``. Holds for clean and degraded inputs alike -- the
@@ -83,7 +85,9 @@ def test_reload_invariant_is_exercised_on_genuinely_degraded_inputs(
     """Guard against the invariant above passing vacuously: at least the
     stale vintages must really carry degraded facts, or the parametrization
     only ever tested the clean path."""
-    a = _load("v4.json", schema_version=vintage, from_headers=True, ast_producer="clang")
+    a = _load(
+        "v4.json", schema_version=vintage, from_headers=True, ast_producer="clang"
+    )
     if vintage >= 45:
         assert not degraded_reliability_facts(a)
     else:
@@ -150,7 +154,12 @@ def test_two_distinct_stored_snapshots_still_taint_end_to_end(tmp_path: Path) ->
     from abicheck.cli import main
 
     base = json.loads((_FIXTURES / "v4.json").read_text())
-    old_d = {**base, "schema_version": 25, "from_headers": True, "ast_producer": "clang"}
+    old_d = {
+        **base,
+        "schema_version": 25,
+        "from_headers": True,
+        "ast_producer": "clang",
+    }
     new_d = {**old_d, "schema_version": 45}
     old_p, new_p = tmp_path / "old.abi.json", tmp_path / "new.abi.json"
     old_p.write_text(json.dumps(old_d))

--- a/tests/test_analysis_assurance_schema_staleness.py
+++ b/tests/test_analysis_assurance_schema_staleness.py
@@ -112,7 +112,10 @@ class TestSchemaStalenessStatus:
         d["from_headers"] = True
         d["ast_producer"] = "clang"
         old = snapshot_from_dict(d)
-        new = snapshot_from_dict(d)
+        # A genuinely two-sided comparison: the two snapshots must differ in
+        # content, or the pair is provably finding-free and correctly reads
+        # "clean" (see test_content_identical_reload_is_never_degraded).
+        new = snapshot_from_dict({**d, "version": f"{d.get('version', '1.0')}-next"})
         assert old.clang_restrict_facts_reliable is False
 
         result = checker.compare(old, new)
@@ -146,7 +149,7 @@ class TestSchemaStalenessStatus:
         d["from_headers"] = True
         d["ast_producer"] = "clang"
         old = snapshot_from_dict(d)
-        new = snapshot_from_dict(d)
+        new = snapshot_from_dict({**d, "version": f"{d.get('version', '1.0')}-next"})
         assert degraded_reliability_facts(old)  # this fixture is degraded
 
         result = checker.compare(old, new)
@@ -780,9 +783,10 @@ class TestSchemaStalenessStatus:
             aa.notes
         )
 
-        # The mirror: two independently-built (merely content-identical,
-        # not object-identical) snapshots must NOT take this shortcut --
-        # real object identity is what this checks, never equal content.
+        # Two independently-built but content-EQUAL snapshots take the
+        # same shortcut, for the same reason (see
+        # TestSchemaStalenessContentIdentity below): the argument was never
+        # about object identity.
         new_copy = AbiSnapshot(
             version=new.version,
             library=new.library,
@@ -790,8 +794,23 @@ class TestSchemaStalenessStatus:
             from_headers=new.from_headers,
             param_kind_facts_reliable=False,
         )
+        assert new_copy == new
         result2 = checker.compare(new, new_copy)
-        assert result2.analysis_assurance.schema_staleness_status == "degraded"
+        assert result2.analysis_assurance.schema_staleness_status == "clean"
+
+        # The mirror that stays degraded: content that actually DIFFERS
+        # (here a different version string) is a real two-sided comparison
+        # a stale fact can still distort.
+        differing = AbiSnapshot(
+            version="99.0",
+            library=new.library,
+            functions=list(new.functions),
+            from_headers=new.from_headers,
+            param_kind_facts_reliable=False,
+        )
+        assert differing != new
+        result3 = checker.compare(new, differing)
+        assert result3.analysis_assurance.schema_staleness_status == "degraded"
 
 
 class TestFieldInitializerSameProducerGating:

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -51,6 +51,10 @@ from abicheck.buildsource.graph_reconcile import (
     OUTCOME_RENAMED,
     reconcile_added_removed,
 )
+from abicheck.buildsource.graph_reconcile_outcome import (
+    COORDINATE_EVIDENCE_DECLARING_FILE,
+    COORDINATE_EVIDENCE_QUALIFIED_NAME,
+)
 from abicheck.buildsource.source_graph import GraphEdge, GraphNode, SourceGraphSummary
 from abicheck.model.graph_identity import closure_location_free_identity
 
@@ -489,3 +493,110 @@ class TestClosureLocationFreeIdentityProperties:
     def test_no_op_on_text_with_neither_at_nor_colon(self) -> None:
         # Exercises the cheap fast-path guard directly.
         assert closure_location_free_identity("PlainName") == "PlainName"
+
+
+class TestCoordinateEvidenceIsStated:
+    """Codex review (PR #1228, P2): a coordinate-only pair with no
+    declaring-file evidence on either side read its coordinate shift out of
+    the qualified name alone, which cannot rule out a same-basename
+    cross-directory move. The classification stays -- declining it asserts
+    OUTCOME_RECONCILED's strictly stronger "both name and location evidence
+    changed" on that same absent evidence -- so the narrowing is to record
+    WHICH provider carried it and say so in the finding a reader sees.
+    """
+
+    def test_fileless_pair_records_qualified_name_evidence(self) -> None:
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="w<(lambda:g.h:172:22)>",
+            attrs={"qualified_name": "w<(lambda:g.h:172:22)>"},
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="w<(lambda:g.h:181:22)>",
+            attrs={"qualified_name": "w<(lambda:g.h:181:22)>"},
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_COORDINATES_ONLY
+        assert pair.coordinate_evidence == COORDINATE_EVIDENCE_QUALIFIED_NAME
+        assert pair.to_dict()["coordinate_evidence"] == (
+            COORDINATE_EVIDENCE_QUALIFIED_NAME
+        )
+
+    def test_two_sided_file_evidence_records_the_stronger_provider(self) -> None:
+        attrs_old = {"qualified_name": "w<(lambda:g.h:172:22)>", "def_file": "g.h"}
+        attrs_new = {"qualified_name": "w<(lambda:g.h:181:22)>", "def_file": "g.h"}
+        pair = _reconcile_one_pair(
+            GraphNode(
+                id="type://old",
+                kind="record_type",
+                label="w<(lambda:g.h:172:22)>",
+                attrs=attrs_old,
+            ),
+            GraphNode(
+                id="type://new",
+                kind="record_type",
+                label="w<(lambda:g.h:181:22)>",
+                attrs=attrs_new,
+            ),
+        )
+        assert pair.outcome == OUTCOME_COORDINATES_ONLY
+        assert pair.coordinate_evidence == COORDINATE_EVIDENCE_DECLARING_FILE
+
+    def test_non_coordinate_outcomes_record_no_evidence(self) -> None:
+        """The field is about one outcome only: a rename or a move must not
+        acquire a coordinate-evidence label it says nothing about."""
+        pair = _reconcile_one_pair(
+            GraphNode(
+                id="type://old",
+                kind="record_type",
+                label="ns::Widget",
+                attrs={"qualified_name": "ns::Widget", "def_file": "a.h"},
+            ),
+            GraphNode(
+                id="type://new",
+                kind="record_type",
+                label="ns::WidgetV2",
+                attrs={"qualified_name": "ns::WidgetV2", "def_file": "a.h"},
+            ),
+        )
+        assert pair.outcome == OUTCOME_RENAMED
+        assert pair.coordinate_evidence is None
+        assert "coordinate_evidence" not in pair.to_dict()
+
+    def test_finding_description_discloses_the_weaker_evidence(self) -> None:
+        """The field has a real consumer: the emitted finding's own text.
+        A `qualified_name`-evidence pair must say a same-basename move
+        would be indistinguishable; a `declaring_file` pair must not."""
+        from abicheck.buildsource.graph_reconcile import (
+            GraphReconciliation,
+            diff_graph_reconciliation_findings,
+        )
+
+        def _finding(attrs_old, attrs_new):
+            old_node = GraphNode(
+                id="type://old", kind="record_type", label="w<a>", attrs=attrs_old
+            )
+            new_node = GraphNode(
+                id="type://new", kind="record_type", label="w<b>", attrs=attrs_new
+            )
+            pair = _reconcile_one_pair(old_node, new_node)
+            rec = GraphReconciliation(reconciled=[pair])
+            findings = diff_graph_reconciliation_findings(rec)
+            assert len(findings) == 1, findings
+            return findings[0]
+
+        fileless = _finding(
+            {"qualified_name": "w<(lambda:g.h:1:2)>"},
+            {"qualified_name": "w<(lambda:g.h:9:9)>"},
+        )
+        assert "no declaring file was recorded on either side" in fileless.description
+        assert "same file basename" in fileless.description
+
+        filed = _finding(
+            {"qualified_name": "w<(lambda:g.h:1:2)>", "def_file": "g.h"},
+            {"qualified_name": "w<(lambda:g.h:9:9)>", "def_file": "g.h"},
+        )
+        assert "no declaring file was recorded" not in filed.description

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -124,6 +124,34 @@ class TestClosureCoordinateShiftIsNotARename:
             "location evidence changed, which is false here -- neither did)"
         )
 
+    def test_coordinate_shift_without_any_declaring_file_evidence(self) -> None:
+        """The measured oneTBB shape, through the real reconciliation entry
+        point: a header-graph node carrying NO ``def_file`` attr and no
+        ``SOURCE_DECLARES`` edge (15 of 15 otherwise-eligible pairs in that
+        comparison). The coordinate shift is embedded in the qualified name
+        itself, and ``closure_location_free_identity`` stripping it is what
+        proved the rest identical -- so the absent declaring file must not
+        push the pair into ``OUTCOME_RECONCILED``'s strictly stronger "both
+        name and location evidence changed" claim."""
+        old_node = GraphNode(
+            id="type://old",
+            kind="record_type",
+            label="__type_identity<(lambda:global_control.h:172:22)>",
+            attrs={
+                "qualified_name": "__type_identity<(lambda:global_control.h:172:22)>"
+            },
+        )
+        new_node = GraphNode(
+            id="type://new",
+            kind="record_type",
+            label="__type_identity<(lambda:global_control.h:181:22)>",
+            attrs={
+                "qualified_name": "__type_identity<(lambda:global_control.h:181:22)>"
+            },
+        )
+        pair = _reconcile_one_pair(old_node, new_node)
+        assert pair.outcome == OUTCOME_COORDINATES_ONLY
+
     def test_bare_anonymous_marker_coordinate_shift_reconciles_not_renamed(
         self,
     ) -> None:

--- a/tests/test_graph_reconcile_coordinate_outcome.py
+++ b/tests/test_graph_reconcile_coordinate_outcome.py
@@ -144,13 +144,162 @@ def test_coordinate_only_requires_both_names_present() -> None:
     assert _classify_outcome(old_id, new_id) == OUTCOME_RECONCILED
 
 
-def test_coordinate_only_requires_declaring_file_evidence() -> None:
-    """Codex review, fresh evidence: missing def_file/SOURCE_DECLARES
-    evidence on either side (an older, stored, or partially populated L5
-    graph) is missing evidence, never proof the declaring file didn't
-    change -- `bool(old_file)/bool(new_file)` mirrors `moved`'s own guard,
-    so a pair with no file evidence at all can't be waved through as
-    coordinate-only just because the location-free names happen to agree."""
+def test_coordinate_only_does_not_require_declaring_file_evidence() -> None:
+    """Bug-class regression (inverts an earlier guard): absent
+    ``def_file``/``SOURCE_DECLARES`` evidence must NOT push a pair with
+    positive, name-embedded coordinate-churn evidence into the strictly
+    stronger ``OUTCOME_RECONCILED`` ("both name and location evidence
+    changed"). ``moved`` is already False from that same absent evidence,
+    so the old guard declined the weak claim only to make the strong one --
+    and it made ``OUTCOME_COORDINATES_ONLY`` unreachable in production (0
+    occurrences repo-wide; 15 of 15 otherwise-eligible oneTBB header-graph
+    pairs blocked solely by ``old_file == new_file == ""``)."""
     old_id = _identity("(lambda at f.h:1:2)", "", kind="record_type")
     new_id = _identity("(lambda at f.h:9:9)", "", kind="record_type")
-    assert _classify_outcome(old_id, new_id) == OUTCOME_RECONCILED
+    assert _classify_outcome(old_id, new_id) == OUTCOME_COORDINATES_ONLY
+
+
+#: Name pairs, each tagged with the two *independent* dimensions an oracle
+#: needs: did the location-free name change (a real rename), and is there
+#: positive coordinate-churn evidence (raw names differ, both present,
+#: normalized equal)?
+_NAME_CASES: dict[str, tuple[str, str, bool, bool]] = {
+    "identical": ("ns::Widget", "ns::Widget", False, False),
+    "real_rename": ("ns::Widget", "ns::WidgetV2", True, False),
+    "coord_shift": ("(lambda at f.h:1:2)", "(lambda at f.h:9:9)", False, True),
+    "old_name_absent": ("", "(lambda at f.h:9:9)", False, False),
+    "new_name_absent": ("(lambda at f.h:1:2)", "", False, False),
+}
+
+#: Declaring-file pairs, tagged with whether a *move* is shown (both sides
+#: present and differing) and whether file evidence is present at all.
+_FILE_CASES: dict[str, tuple[str, str, bool, bool]] = {
+    "same_file": ("a.h", "a.h", False, True),
+    "real_move": ("a.h", "b.h", True, True),
+    "old_file_absent": ("", "b.h", False, False),
+    "new_file_absent": ("a.h", "", False, False),
+    "no_file_evidence": ("", "", False, False),
+}
+
+_SIG_CASES: dict[str, tuple[str, str]] = {"same_sig": ("s", "s"), "sig_change": ("s0", "s1")}
+_KIND_CASES = ("record_type", "enum_type", "typedef", "source_decl")
+
+
+def _expected_outcome(
+    *, name_changed: bool, has_coord: bool, file_changed: bool, same_sig: bool, kind: str
+) -> str:
+    """Oracle stated from the four input DIMENSIONS, not from the
+    implementation's own predicate expressions."""
+    if name_changed and not file_changed:
+        return OUTCOME_RENAMED
+    if file_changed and not name_changed:
+        return OUTCOME_MOVED
+    if name_changed and file_changed:
+        return OUTCOME_RECONCILED
+    if has_coord and same_sig and kind in ("record_type", "enum_type", "typedef"):
+        return OUTCOME_COORDINATES_ONLY
+    return OUTCOME_RECONCILED
+
+
+def _generated_cases() -> list[tuple[str, CanonicalIdentity, CanonicalIdentity, str]]:
+    cases = []
+    for nk, (old_qn, new_qn, name_ch, has_coord) in _NAME_CASES.items():
+        for fk, (old_f, new_f, file_ch, _has_file) in _FILE_CASES.items():
+            for sk, (old_sig, new_sig) in _SIG_CASES.items():
+                for kind in _KIND_CASES:
+                    old_id = _identity(
+                        old_qn, old_f, f"sig:{old_qn}\x1f{old_sig}", kind
+                    )
+                    new_id = _identity(
+                        new_qn, new_f, f"sig:{new_qn}\x1f{new_sig}", kind
+                    )
+                    expected = _expected_outcome(
+                        name_changed=name_ch,
+                        has_coord=has_coord,
+                        file_changed=file_ch,
+                        same_sig=old_sig == new_sig,
+                        kind=kind,
+                    )
+                    cases.append((f"{nk}/{fk}/{sk}/{kind}", old_id, new_id, expected))
+    return cases
+
+
+class TestClassifyOutcomeProperties:
+    """``_classify_outcome`` is a reusable classification primitive, so it
+    gets the standalone property-test treatment AGENTS.md's
+    "Primitive-level property tests" bullet prescribes (the same treatment
+    ``TestPairedStableIndicesProperties`` gives ``_paired_stable_indices``)
+    -- invariants over an exhaustively enumerated small input domain (200
+    pairs across four independent dimensions), not a fixture pinned to the
+    one observed oneTBB input. Reachability is itself one of the
+    invariants: the defect this class was written for was an outcome no
+    production input could ever produce."""
+
+    def test_every_pair_gets_exactly_one_of_the_four_outcomes(self) -> None:
+        outcomes = {
+            OUTCOME_RENAMED,
+            OUTCOME_MOVED,
+            OUTCOME_RECONCILED,
+            OUTCOME_COORDINATES_ONLY,
+        }
+        for label, old_id, new_id, _ in _generated_cases():
+            assert _classify_outcome(old_id, new_id) in outcomes, label
+
+    def test_all_four_outcomes_are_reachable(self) -> None:
+        """The reachability half -- exactly what this defect was: the
+        declaring-file guard made ``OUTCOME_COORDINATES_ONLY`` producible
+        by no real input at all, and nothing failed anywhere."""
+        seen = {_classify_outcome(o, n) for _, o, n, _ in _generated_cases()}
+        assert seen == {
+            OUTCOME_RENAMED,
+            OUTCOME_MOVED,
+            OUTCOME_RECONCILED,
+            OUTCOME_COORDINATES_ONLY,
+        }
+
+    def test_outcome_matches_dimension_oracle(self) -> None:
+        for label, old_id, new_id, expected in _generated_cases():
+            assert _classify_outcome(old_id, new_id) == expected, label
+
+    def test_never_claims_a_move_without_two_sided_file_evidence(self) -> None:
+        """No label may claim a dimension the inputs do not show changed.
+        ``OUTCOME_MOVED`` and ``OUTCOME_RECONCILED`` both assert the
+        declaring location changed, which absent file evidence cannot
+        show -- so neither may be returned for a pair that carries
+        positive coordinate-churn evidence and is kind/signature
+        eligible. (A pair with NO positive evidence on either axis still
+        falls through to ``OUTCOME_RECONCILED``: ADR-048's accepted
+        "no clean split" prose overstatement, see
+        ``test_classify_outcome_prose_is_truthful_about_what_changed``.)"""
+        for nk, (old_qn, new_qn, name_ch, has_coord) in _NAME_CASES.items():
+            for fk, (old_f, new_f, _file_ch, has_file) in _FILE_CASES.items():
+                if has_file:
+                    continue
+                for kind in _KIND_CASES:
+                    old_id = _identity(old_qn, old_f, f"sig:{old_qn}\x1fs", kind)
+                    new_id = _identity(new_qn, new_f, f"sig:{new_qn}\x1fs", kind)
+                    outcome = _classify_outcome(old_id, new_id)
+                    assert outcome != OUTCOME_MOVED, (nk, fk, kind)
+                    if has_coord and kind != "source_decl":
+                        assert outcome == OUTCOME_COORDINATES_ONLY, (nk, fk, kind)
+                    assert not name_ch or outcome == OUTCOME_RENAMED, (nk, fk, kind)
+
+    def test_side_swap_symmetry(self) -> None:
+        """Every one of the four outcomes is a symmetric relation over the
+        pair: swapping old and new must not change the label (the kind
+        restriction reads ``old_identity.kind``, so a swap keeps it equal
+        only because both sides share a kind -- which is the only shape a
+        real reconciled pair has, since matching is per kind group)."""
+        for label, old_id, new_id, _ in _generated_cases():
+            assert _classify_outcome(old_id, new_id) == _classify_outcome(
+                new_id, old_id
+            ), label
+
+    def test_source_decl_never_returns_coordinates_only(self) -> None:
+        """Kind restriction holds regardless of every other dimension: a
+        ``source_decl``'s signature isn't tracked by the production
+        producer, so "nothing else changed" is unprovable for one."""
+        for label, old_id, new_id, _ in _generated_cases():
+            if old_id.kind != "source_decl":
+                continue
+            assert _classify_outcome(old_id, new_id) != OUTCOME_COORDINATES_ONLY, label

--- a/tests/test_graph_reconcile_coordinate_outcome.py
+++ b/tests/test_graph_reconcile_coordinate_outcome.py
@@ -181,12 +181,20 @@ _FILE_CASES: dict[str, tuple[str, str, bool, bool]] = {
     "no_file_evidence": ("", "", False, False),
 }
 
-_SIG_CASES: dict[str, tuple[str, str]] = {"same_sig": ("s", "s"), "sig_change": ("s0", "s1")}
+_SIG_CASES: dict[str, tuple[str, str]] = {
+    "same_sig": ("s", "s"),
+    "sig_change": ("s0", "s1"),
+}
 _KIND_CASES = ("record_type", "enum_type", "typedef", "source_decl")
 
 
 def _expected_outcome(
-    *, name_changed: bool, has_coord: bool, file_changed: bool, same_sig: bool, kind: str
+    *,
+    name_changed: bool,
+    has_coord: bool,
+    file_changed: bool,
+    same_sig: bool,
+    kind: str,
 ) -> str:
     """Oracle stated from the four input DIMENSIONS, not from the
     implementation's own predicate expressions."""


### PR DESCRIPTION
## Summary

Two independent defects found by an external audit over oneTBB/oneDNN snapshots, landed as two reviewable-apart commits.

## Motivation

Both are cases where a guard's *implementation* asserts something different from the guard's own stated justification, and the fallback then makes a stronger claim than the evidence supports.

## Changes

- `fix: make declaration_coordinates_shifted reachable in production` — `graph_reconcile._classify_outcome`'s `OUTCOME_COORDINATES_ONLY` required non-empty declaring-file evidence on both sides, which real header-graph nodes routinely lack, so the outcome was produced by no production input at all. Every otherwise-eligible pair fell through to `OUTCOME_RECONCILED`, whose prose asserts the strictly *stronger* "both name and location evidence changed" at `risk` severity — on *absent* location evidence, where `moved` is already False for that same reason. Every other narrowing (both qualified names present and differing, agreeing signature tail, type-shaped node kind) is kept. The outcome vocabulary and classifier move to a new leaf module `buildsource/graph_reconcile_outcome.py` (re-exported), so the file shrinks below its debt baseline by moving responsibility rather than by trimming text.
- `fix: don't taint a content-identical self-compare with schema staleness` — `schema_staleness_status`'s self-diff early return tested Python object identity, though its own argument ("comparing a value against itself can never produce a false pairwise finding") never depended on that. One stored snapshot file loaded twice therefore reported `schema_staleness_status: degraded` and flipped `assurance.status` complete → partial. Widened to provable *content* identity, evaluated only on the already-degraded path.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A guard or early return whose implementation is narrower or broader than its own stated justification — (1) a narrowing guard that eliminates the entire population it was meant to discriminate within, leaving the fallback to assert a strictly stronger claim than the one it declined; (2) an early return justified by a semantic property (content identity) but implemented via a proxy (object identity), so the claim the return exists to reject is made anyway on the shape users actually hit. New class; registered in `tests/regressions/manifest.py` as `guard.proxy_predicate_overshoots_justification`.
- Publicly observable failure: (1) `declaration_coordinates_shifted` never appears in any report (0 repo-wide), and pure closure-coordinate churn is reported as `declaration_identity_reconciled` at `risk` — 15 such pairs in the audited oneTBB header-graph comparison. (2) `abicheck compare baseline.abi.json baseline.abi.json` on a pre-v45 stored snapshot prints `analysis_assurance.status: "partial"`, failing a CI job that gates on it against an unchanged cached baseline.
- Regression test fails on base: Yes. `test_coordinate_only_does_not_require_declaring_file_evidence` and `TestClassifyOutcomeProperties::test_all_four_outcomes_are_reachable` both fail on the base commit (the outcome is unreachable there); `test_content_identical_reload_matches_self_pairing` and `test_self_compare_of_stored_stale_snapshot_is_complete_end_to_end` fail on base (`degraded`/`partial`).
- Negative control: (1) `test_coordinate_shift_with_simultaneous_signature_change_stays_reconciled`, `test_coordinate_only_requires_both_names_present`, and `test_source_decl_never_returns_coordinates_only` — a real rename, a real cross-file move, an absent name, a changed signature tail, and a `source_decl` must all keep their prior outcome. (2) `test_differing_vintages_still_report_degraded` and `test_two_distinct_stored_snapshots_still_taint_end_to_end` — two snapshots at different schema vintages, one degraded, must still report `degraded`, in both orientations; without this the fix could silently become "never taint anything".
- Public-surface test: (1) `test_coordinate_shift_without_any_declaring_file_evidence` runs the real `reconcile_added_removed` fold, not the classifier alone. (2) Both directions go through the real `abicheck compare` CLI on stored snapshot files and assert the rendered JSON `analysis_assurance` block.
- Axes covered: Linux / CPython 3.13; L5 source-graph evidence tier with and without `SOURCE_DECLARES` declaring-file evidence; node kinds `record_type`, `enum_type`, `typedef`, `source_decl`; snapshot schema vintages 4, 9, 18, 25, 38, 45 across two stored fixtures; internal classifier, the reconciliation fold, and the CLI JSON report surface.
- General invariant: (1) `tests/test_graph_reconcile_coordinate_outcome.py::TestClassifyOutcomeProperties` — `_classify_outcome`'s contract over an exhaustively enumerated four-dimensional input domain (name × declaring file × signature tail × node kind, 200 pairs) against an oracle written from the input *dimensions*, not from the implementation's own predicate expressions: the four outcomes partition the space, every one of them is reachable (the half this defect was), classification is side-swap symmetric, the kind restriction holds unconditionally, and no label claims a dimension the inputs do not show changed. (2) `tests/test_analysis_assurance_content_identity.py` — for any snapshot `s`, two independently loaded, content-equal copies score exactly as `(s, s)` does, parametrized across six schema vintages × two fixtures, with `test_reload_invariant_is_exercised_on_genuinely_degraded_inputs` proving the stale vintages really are degraded so the invariant cannot pass vacuously.

- Real-dependency test: Yes, for the half that has one — defect 2's `test_self_compare_of_stored_stale_snapshot_is_complete_end_to_end` and `test_two_distinct_stored_snapshots_still_taint_end_to_end` both write a real stored snapshot file to disk and run the real `abicheck compare` CLI over it, going through the genuine load/decode path (`serialization.snapshot_from_dict`, with its real schema-vintage degradation) rather than hand-constructing an `AbiSnapshot` in memory. The invariant tests likewise load every side from a committed `tests/fixtures/schema/*.json` fixture through the real decoder. Defect 1 touches no third-party or format boundary (a pure in-process classifier over already-parsed identities); its production-path evidence is the real `reconcile_added_removed` fold.
- Malicious fixture + side-effect absence: None — no Action, workflow, or composite-action file is touched by this diff, and neither fix parses or trusts externally-supplied input (defect 1 classifies two already-parsed in-process identities; defect 2 compares two already-decoded snapshots). Documented here as not applicable rather than left silent.
- False-positive removed / real break preserved: Yes, and it is the load-bearing pair on both halves. (1) The false positive removed is `declaration_identity_reconciled`'s over-claim on pure coordinate churn; the real signal preserved is every genuine rename, cross-file move, simultaneous signature change, absent name, and `source_decl` — pinned by `test_coordinate_shift_with_simultaneous_signature_change_stays_reconciled`, `test_coordinate_only_requires_both_names_present`, `test_source_decl_never_returns_coordinates_only`, and the existing move/rename tests, none of which changes outcome. (2) The false positive removed is `schema_staleness_status: degraded` on a content-identical pair; the real signal preserved is a genuinely differing pair at differing schema vintages, pinned by `test_differing_vintages_still_report_degraded` (both orientations) and `test_two_distinct_stored_snapshots_still_taint_end_to_end`. Neither fix can suppress its whole class without failing those.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — one per commit
- [x] Docs updated if user-visible behaviour changed (changelog fragments)
- [x] `python scripts/verify.py --profile pr` run locally
- [x] No new `mypy` or `ruff` errors introduced

## Measured effect

- Defect 2 reproduced and re-measured directly: a stored schema-25 snapshot given as both operands read `schema_staleness_status: degraded` / `assurance.status: partial` before, `clean` / `complete` after; two snapshots at differing vintages still read `degraded`.
- Defect 1: the oneTBB `snap-hdr` snapshots are not present in this environment, so the predicted `declaration_coordinates_shifted` 0 → 15, `declaration_identity_reconciled` 23 → 8, `risk_changes` 176 → 161 could not be re-measured here; the mechanism is verified through the real `reconcile_added_removed` fold on the exact file-less node shape instead. `effective_config_digest` changes as a consequence of the newly-reachable kind (`_identity_str` hashes the preset's effective `ChangeKind` sets) — expected, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KX2nFo13igsXrqfp539Pg

---
_Generated by [Claude Code](https://claude.ai/code/session_014KX2nFo13igsXrqfp539Pg)_