### PR TITLE
test: execute workflow step bodies from a script file, not `bash -c`

### DIFF
--- a/tests/_workflow_exec.py
+++ b/tests/_workflow_exec.py
@@ -103,6 +103,20 @@ HOSTILE_SCALAR_CORPUS = [
 FORBIDDEN_ARTIFACT_NAME_CHARS = set('":<>|*?\r\n/\\')
 
 
+#: Skips a test whose fixture needs a path containing a literal newline byte.
+#: POSIX filesystems allow one -- which is exactly why the workflow-command
+#: injection defenses (`_gha_escape`, `action/run.sh`'s own helper) exist and
+#: are exercised with such a path. Windows rejects the character in a filename
+#: at the OS level (`OSError: [WinError 123]`), so the attack shape cannot be
+#: constructed there at all: the test has nothing to say about the defense on
+#: that platform, rather than the defense being unverified. Shared here so the
+#: three sites needing it state one reason, not three.
+requires_newline_in_filenames = pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows filenames cannot contain a literal newline (WinError 123)",
+)
+
+
 def load_workflow(name: str) -> dict[str, Any]:
     with open(WORKFLOWS / name, encoding="utf-8") as fh:
         return yaml.safe_load(fh)

--- a/tests/_workflow_exec.py
+++ b/tests/_workflow_exec.py
@@ -264,8 +264,15 @@ def run_step(
     # failing for a reason unrelated to the step it models. The file lives
     # beside the workspace, not inside it, so `StepResult.tree()` and the
     # `$RUNNER_TEMP` assertions keep seeing only what the step itself created.
+    #
+    # Written as explicit bytes, never `write_text`: on Windows the default
+    # `newline=None` translates every "\n" to "\r\n", and Git Bash keeps that
+    # carriage return inside shell tokens -- a heredoc delimiter line becomes
+    # `EOF\r`, so the heredoc never terminates, and `set -euo pipefail`-style
+    # bodies break on the trailing CR (Codex review, PR #1230). The body must
+    # reach bash byte-for-byte as the YAML holds it.
     body = workspace.parent / f"_step_body_{os.getpid()}_{next(_BODY_COUNTER)}.sh"
-    body.write_text(step["run"], encoding="utf-8")
+    body.write_bytes(step["run"].encode("utf-8"))
     proc = subprocess.run(
         # `-e` as well as pipefail: the runner invokes a `run:` body as
         # `bash -e {0}` (and `-eo pipefail` for `shell: bash`), so without it a

--- a/tests/_workflow_exec.py
+++ b/tests/_workflow_exec.py
@@ -287,6 +287,12 @@ def run_step(
     # reach bash byte-for-byte as the YAML holds it.
     body = workspace.parent / f"_step_body_{os.getpid()}_{next(_BODY_COUNTER)}.sh"
     body.write_bytes(step["run"].encode("utf-8"))
+    # Git Bash wants forward slashes, but a backslash is a legal *filename*
+    # character on POSIX, so rewriting one unconditionally would corrupt a real
+    # path (a workspace under `with\backslash/` would be run from
+    # `with/backslash/`, i.e. "No such file or directory" -- Codex review,
+    # PR #1230). Convert only where the separator actually differs.
+    script_arg = body.as_posix() if os.name == "nt" else str(body)
     try:
         proc = subprocess.run(
             # `-e` as well as pipefail: the runner invokes a `run:` body as
@@ -295,7 +301,7 @@ def run_step(
             # real step failed — every `assert result.returncode == 0` in the
             # workflow tests was weaker than the thing it models (CodeRabbit
             # review).
-            [bash_executable(), "-eo", "pipefail", str(body).replace("\\", "/")],
+            [bash_executable(), "-eo", "pipefail", script_arg],
             cwd=workspace,
             env=step_env,
             capture_output=True,

--- a/tests/_workflow_exec.py
+++ b/tests/_workflow_exec.py
@@ -34,6 +34,7 @@ and stays structural.
 
 from __future__ import annotations
 
+import itertools
 import os
 import shutil
 import subprocess
@@ -43,6 +44,10 @@ from typing import Any
 
 import pytest
 import yaml
+
+#: Distinguishes the per-invocation step-body script files `run_step` writes,
+#: so two calls sharing one tmp_path never race on the same name.
+_BODY_COUNTER = itertools.count()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
@@ -249,13 +254,25 @@ def run_step(
     step_env.update({k: str(v) for k, v in (step.get("env") or {}).items()})
     step_env.update(env or {})
 
+    # The body goes to a real script file rather than `bash -c <body>`, which
+    # is both what the runner itself does (`bash -e {0}`, a generated script)
+    # and the only form that has no length ceiling: Windows caps a process
+    # command line at 32767 characters, so a long `run:` body (the
+    # `assurance_overlay` step in `actions/check-target/action.yml` is ~50 KB)
+    # raised `FileNotFoundError: [WinError 206] The filename or extension is
+    # too long` before bash ever started — every executing test in the module
+    # failing for a reason unrelated to the step it models. The file lives
+    # beside the workspace, not inside it, so `StepResult.tree()` and the
+    # `$RUNNER_TEMP` assertions keep seeing only what the step itself created.
+    body = workspace.parent / f"_step_body_{os.getpid()}_{next(_BODY_COUNTER)}.sh"
+    body.write_text(step["run"], encoding="utf-8")
     proc = subprocess.run(
         # `-e` as well as pipefail: the runner invokes a `run:` body as
         # `bash -e {0}` (and `-eo pipefail` for `shell: bash`), so without it a
         # command failing mid-body left returncode 0 here while the real step
         # failed — every `assert result.returncode == 0` in the workflow tests
         # was weaker than the thing it models (CodeRabbit review).
-        [bash_executable(), "-eo", "pipefail", "-c", step["run"]],
+        [bash_executable(), "-eo", "pipefail", str(body).replace("\\", "/")],
         cwd=workspace,
         env=step_env,
         capture_output=True,

--- a/tests/_workflow_exec.py
+++ b/tests/_workflow_exec.py
@@ -273,19 +273,27 @@ def run_step(
     # reach bash byte-for-byte as the YAML holds it.
     body = workspace.parent / f"_step_body_{os.getpid()}_{next(_BODY_COUNTER)}.sh"
     body.write_bytes(step["run"].encode("utf-8"))
-    proc = subprocess.run(
-        # `-e` as well as pipefail: the runner invokes a `run:` body as
-        # `bash -e {0}` (and `-eo pipefail` for `shell: bash`), so without it a
-        # command failing mid-body left returncode 0 here while the real step
-        # failed — every `assert result.returncode == 0` in the workflow tests
-        # was weaker than the thing it models (CodeRabbit review).
-        [bash_executable(), "-eo", "pipefail", str(body).replace("\\", "/")],
-        cwd=workspace,
-        env=step_env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
+    try:
+        proc = subprocess.run(
+            # `-e` as well as pipefail: the runner invokes a `run:` body as
+            # `bash -e {0}` (and `-eo pipefail` for `shell: bash`), so without
+            # it a command failing mid-body left returncode 0 here while the
+            # real step failed — every `assert result.returncode == 0` in the
+            # workflow tests was weaker than the thing it models (CodeRabbit
+            # review).
+            [bash_executable(), "-eo", "pipefail", str(body).replace("\\", "/")],
+            cwd=workspace,
+            env=step_env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    finally:
+        # Unconditional, so a timeout or a spawn failure does not leave the
+        # script behind either: a caller passing a workspace whose parent is
+        # not itself a pytest-managed temporary directory would otherwise
+        # accumulate one file per step (CodeRabbit review, PR #1230).
+        body.unlink(missing_ok=True)
     # `$GITHUB_OUTPUT` is written by the step, not by us, so its bytes are
     # whatever the runner's shell produced. On Windows a non-ASCII input
     # reaches Git Bash through the ANSI code page and comes back as cp1252,

--- a/tests/test_action_config_overlay.py
+++ b/tests/test_action_config_overlay.py
@@ -34,7 +34,6 @@ import os
 from pathlib import Path
 
 import pytest
-import yaml
 
 from abicheck.action_config_overlay import (
     apply_sources_root_config_blocks,
@@ -195,18 +194,9 @@ class TestRebaseRelativeConfigPaths:
         ]
 
     def test_absolute_include_dir_is_left_unchanged(self, tmp_path: Path) -> None:
-        # A *genuinely* absolute path on the running platform. "/abs/dir" is
-        # absolute on POSIX but drive-relative on Windows
-        # (`Path("/abs/dir").is_absolute()` is False there), so the rebase
-        # correctly rewrote it to "C:\\abs\\dir" and this test failed on the
-        # windows lane while claiming to be about absolute paths. Anchoring
-        # it to the platform's own root keeps the invariant the name states.
+        # Anchored to the platform's own root, since "/abs/dir" is absolute on POSIX but drive-relative on Windows -- where the rebase correctly rewrote it, failing this test while its name claimed to be about absolute paths.
         absolute = str(Path(tmp_path.anchor or "/") / "abs" / "dir")
         cfg = tmp_path / ".abicheck.yml"
-        cfg.write_text(
-            yaml.safe_dump({"compile": {"include_dirs": [absolute]}}),
-            encoding="utf-8",
-        )
         base = {"compile": {"include_dirs": [absolute]}}
         out = rebase_relative_config_paths(base, found_path=cfg)
         assert out["compile"]["include_dirs"] == [absolute]

--- a/tests/test_action_config_overlay.py
+++ b/tests/test_action_config_overlay.py
@@ -34,6 +34,7 @@ import os
 from pathlib import Path
 
 import pytest
+import yaml
 
 from abicheck.action_config_overlay import (
     apply_sources_root_config_blocks,
@@ -194,11 +195,21 @@ class TestRebaseRelativeConfigPaths:
         ]
 
     def test_absolute_include_dir_is_left_unchanged(self, tmp_path: Path) -> None:
+        # A *genuinely* absolute path on the running platform. "/abs/dir" is
+        # absolute on POSIX but drive-relative on Windows
+        # (`Path("/abs/dir").is_absolute()` is False there), so the rebase
+        # correctly rewrote it to "C:\\abs\\dir" and this test failed on the
+        # windows lane while claiming to be about absolute paths. Anchoring
+        # it to the platform's own root keeps the invariant the name states.
+        absolute = str(Path(tmp_path.anchor or "/") / "abs" / "dir")
         cfg = tmp_path / ".abicheck.yml"
-        cfg.write_text("compile:\n  include_dirs: [/abs/dir]\n", encoding="utf-8")
-        base = {"compile": {"include_dirs": ["/abs/dir"]}}
+        cfg.write_text(
+            yaml.safe_dump({"compile": {"include_dirs": [absolute]}}),
+            encoding="utf-8",
+        )
+        base = {"compile": {"include_dirs": [absolute]}}
         out = rebase_relative_config_paths(base, found_path=cfg)
-        assert out["compile"]["include_dirs"] == ["/abs/dir"]
+        assert out["compile"]["include_dirs"] == [absolute]
 
     def test_scalar_include_dirs_value_also_rebases(self, tmp_path: Path) -> None:
         """include_dirs need not be a list -- a bare string entry must be

--- a/tests/test_action_config_overlay_compile_falsy.py
+++ b/tests/test_action_config_overlay_compile_falsy.py
@@ -110,13 +110,17 @@ class TestCompileEmptyStringTreatedAsUnset:
             merge_compile=True,
         )
         expected = _real_two_stage_sysroot(tmp_path, checkout_compile, sources_compile)
-        # The real resolver returns `str(Path(...))`, i.e. the *platform's*
-        # spelling of this path ("\\real\\path" on Windows). Asserting the
-        # POSIX literal made this a Linux/macOS-only test that simply failed
-        # on the windows lane; `str(Path(...))` states the same thing — the
-        # sources-root value won — on every platform.
-        assert expected == str(Path("/real/path"))
-        assert out["compile"]["sysroot"] == expected
+        # The two sides spell the same path differently, and only on Windows:
+        # the real resolver returns `str(Path(...))` (the platform's spelling,
+        # "\\real\\path"), while the overlay copies the raw YAML scalar
+        # through verbatim ("/real/path"). Comparing either against a POSIX
+        # literal made this a Linux/macOS-only test that simply failed on the
+        # windows lane, and normalizing only the oracle still left the second
+        # assertion mismatched (Codex review, PR #1230). Compare both sides as
+        # `Path`, which states what the test means — the sources-root value
+        # won — independently of separator spelling.
+        assert Path(expected or "") == Path("/real/path")
+        assert Path(out["compile"]["sysroot"]) == Path(expected or "")
 
     def test_empty_checkout_compiler_is_treated_as_unset(self, tmp_path: Path) -> None:
         checkout_compile = {"compiler": ""}
@@ -162,8 +166,10 @@ class TestCompileEmptyStringTreatedAsUnset:
             merge_compile=True,
         )
         expected = _real_two_stage_sysroot(tmp_path, checkout_compile, sources_compile)
-        assert expected == str(Path("/checkout/sysroot"))
-        assert out["compile"]["sysroot"] == expected
+        # Path-normalized on both sides, for the reason the sibling test above
+        # states in full.
+        assert Path(expected or "") == Path("/checkout/sysroot")
+        assert Path(out["compile"]["sysroot"]) == Path(expected or "")
 
     def test_nonempty_checkout_compiler_still_blocks_sources_root(
         self, tmp_path: Path

--- a/tests/test_action_config_overlay_compile_falsy.py
+++ b/tests/test_action_config_overlay_compile_falsy.py
@@ -110,7 +110,12 @@ class TestCompileEmptyStringTreatedAsUnset:
             merge_compile=True,
         )
         expected = _real_two_stage_sysroot(tmp_path, checkout_compile, sources_compile)
-        assert expected == "/real/path"
+        # The real resolver returns `str(Path(...))`, i.e. the *platform's*
+        # spelling of this path ("\\real\\path" on Windows). Asserting the
+        # POSIX literal made this a Linux/macOS-only test that simply failed
+        # on the windows lane; `str(Path(...))` states the same thing — the
+        # sources-root value won — on every platform.
+        assert expected == str(Path("/real/path"))
         assert out["compile"]["sysroot"] == expected
 
     def test_empty_checkout_compiler_is_treated_as_unset(self, tmp_path: Path) -> None:
@@ -157,7 +162,7 @@ class TestCompileEmptyStringTreatedAsUnset:
             merge_compile=True,
         )
         expected = _real_two_stage_sysroot(tmp_path, checkout_compile, sources_compile)
-        assert expected == "/checkout/sysroot"
+        assert expected == str(Path("/checkout/sysroot"))
         assert out["compile"]["sysroot"] == expected
 
     def test_nonempty_checkout_compiler_still_blocks_sources_root(

--- a/tests/test_reusable_workflows_assurance_overlay_compile_context.py
+++ b/tests/test_reusable_workflows_assurance_overlay_compile_context.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from _assurance_overlay_exec import _run_overlay, _written_overlay
-from _workflow_exec import make_workspace
+from _workflow_exec import make_workspace, requires_newline_in_filenames
 
 from abicheck.cli_options import merge_compile_config
 from abicheck.dry_run_estimate import CompileContext
@@ -626,6 +626,7 @@ class TestAssuranceOverlayEscapesWorkflowCommandInjection:
     interpolated path/exception in this step's error-emission call
     sites."""
 
+    @requires_newline_in_filenames
     def test_newline_in_explicit_build_config_path_does_not_smuggle_a_command(
         self, tmp_path: Path
     ) -> None:
@@ -650,6 +651,7 @@ class TestAssuranceOverlayEscapesWorkflowCommandInjection:
         assert not any(line.startswith("::") for line in lines[1:])
         assert "%0A" in result.stderr
 
+    @requires_newline_in_filenames
     def test_newline_in_sources_root_path_does_not_smuggle_a_command(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_reusable_workflows_assurance_overlay_parse_safety.py
+++ b/tests/test_reusable_workflows_assurance_overlay_parse_safety.py
@@ -64,7 +64,7 @@ from pathlib import Path
 from typing import Any
 
 from _assurance_overlay_exec import _run_overlay, _written_overlay
-from _workflow_exec import make_workspace
+from _workflow_exec import make_workspace, requires_newline_in_filenames
 
 
 def _run_explicit(tmp_path: Path, base_config_yaml: str) -> Any:
@@ -157,6 +157,7 @@ class TestAssuranceOverlayExplicitConfigParseFailureEscaping:
         assert "::error::" in result.stderr
         assert "config-path" not in result.outputs
 
+    @requires_newline_in_filenames
     def test_malformed_yaml_escapes_workflow_command_injection(
         self, tmp_path: Path
     ) -> None:
@@ -193,9 +194,7 @@ class TestAssuranceOverlayDiscoveredConfigParseFailureEscaping:
     same way, and covered here so the fix cannot regress independently on
     either branch."""
 
-    def test_malformed_discovered_yaml_fails_loud_escaped(
-        self, tmp_path: Path
-    ) -> None:
+    def test_malformed_discovered_yaml_fails_loud_escaped(self, tmp_path: Path) -> None:
         workspace = make_workspace(tmp_path)
         (workspace / ".abicheck.yml").write_text("foo:\n\tbar: 1\n", encoding="utf-8")
         result = _run_overlay(workspace, {"BASE_CONFIG": ""})

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -37,6 +37,7 @@ only that one 50 KB step now runs.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -203,3 +204,47 @@ def test_body_reaches_bash_byte_for_byte(tmp_path: Path) -> None:
     # failing the shell, so assert the exact string, not a prefix.
     assert result.outputs["value"] == "no-trailing-cr"
     assert "\r" not in "".join(result.output_lines)
+
+
+#: Directory-name shapes that are legal on the running platform and awkward for
+#: a path that reaches a shell. The first three hold everywhere; the last two are
+#: POSIX-only (Windows forbids both characters in a filename), and the backslash
+#: is the one that matters most: the harness has to translate separators for Git
+#: Bash without corrupting a POSIX name that legitimately contains one.
+_AWKWARD_PARENT_NAMES = [
+    pytest.param("plain", id="plain"),
+    pytest.param("with space", id="space"),
+    pytest.param("wïth-ünicode", id="non-ascii"),
+    *(
+        []
+        if os.name == "nt"
+        else [
+            pytest.param("with\\backslash", id="backslash"),
+            pytest.param("with'quote", id="single-quote"),
+        ]
+    ),
+]
+
+
+@pytest.mark.parametrize("parent_name", _AWKWARD_PARENT_NAMES)
+def test_run_step_executes_under_an_awkward_parent_directory(
+    tmp_path: Path, parent_name: str
+) -> None:
+    """The step-body script path must survive the platform's own legal names.
+
+    Codex review (PR #1230): the path handed to bash was rewritten with an
+    unconditional ``str(body).replace("\\\\", "/")``. On POSIX a backslash is an
+    ordinary filename character, so a workspace under ``with\\backslash/`` was
+    executed from ``with/backslash/`` — every `run_step` call under such a path
+    failing with "No such file or directory". Stated here as the general
+    invariant (a path legal on this platform works) over several independently
+    awkward shapes, rather than a single repro of the backslash case.
+    """
+    base = tmp_path / parent_name
+    base.mkdir()
+    workspace = make_workspace(base)
+    result = run_step(
+        {"run": _padded_body(256)}, workspace=workspace, env={"PADDED_SIZE": "256"}
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.outputs["size"] == "256"

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for ``tests/_workflow_exec.py``'s own ``run_step``.
+
+Bug class this closes, stated as an invariant rather than one reproducer:
+**a step's ``run:`` body length must not affect whether the harness can
+execute it.** ``run_step`` used to spawn ``bash -c <body>``, which put the
+whole body on the child's command line -- fine on POSIX, but Windows caps a
+command line at 32767 characters, so the moment
+``actions/check-target/action.yml``'s ``assurance_overlay`` step's body grew
+past that (it is ~50 KB today) every executing test in
+``tests/test_reusable_workflows_require_complete_analysis.py`` and its
+siblings failed on the windows-latest lane with ``FileNotFoundError:
+[WinError 206] The filename or extension is too long`` -- a harness spawn
+error, not a judgement about the step. The fix writes the body to a real
+script file, which is also what the runner itself does (``bash -e {0}``).
+
+The generalized test below therefore sweeps body sizes across and far past
+that ceiling, and separately pins the *largest real body in the repository*
+(so a future step that grows past a new platform limit is caught here, at
+the harness, instead of as an unexplained red lane), rather than asserting
+only that one 50 KB step now runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from _workflow_exec import REPO_ROOT, have_bash, make_workspace, run_step
+
+pytestmark = pytest.mark.skipif(not have_bash(), reason="bash not available")
+
+#: Windows' own ``CreateProcess`` command-line ceiling -- the boundary the
+#: sweep below is built around.
+_WINDOWS_COMMAND_LINE_LIMIT = 32767
+
+
+def _padded_body(total_length: int) -> str:
+    """A real, side-effect-visible step body padded to *total_length* chars.
+
+    The padding is trailing comment lines, so the body's *behavior* is
+    identical at every size and the only variable under test is its length.
+    """
+    head = 'printf "%s\\n" "size=$PADDED_SIZE" >> "$GITHUB_OUTPUT"\n'
+    if total_length <= len(head):
+        return head
+    filler = "# padding\n"
+    pad = (total_length - len(head)) // len(filler) + 1
+    return head + filler * pad
+
+
+def _real_run_bodies() -> list[str]:
+    """Every ``run:`` body in the repo's workflows and composite actions."""
+    bodies: list[str] = []
+    documents = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    documents += sorted((REPO_ROOT / "actions").glob("*/action.yml"))
+    for path in documents:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
+        step_lists = []
+        for job in (data.get("jobs") or {}).values():
+            if isinstance(job, dict):
+                step_lists.append(job.get("steps") or [])
+        runs = data.get("runs")
+        if isinstance(runs, dict):
+            step_lists.append(runs.get("steps") or [])
+        for steps in step_lists:
+            for step in steps:
+                if isinstance(step, dict) and isinstance(step.get("run"), str):
+                    bodies.append(step["run"])
+    return bodies
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        64,
+        4_096,
+        _WINDOWS_COMMAND_LINE_LIMIT - 1,
+        _WINDOWS_COMMAND_LINE_LIMIT,
+        _WINDOWS_COMMAND_LINE_LIMIT + 1,
+        64_000,
+        250_000,
+    ],
+)
+def test_run_step_executes_a_body_of_any_length(tmp_path: Path, size: int) -> None:
+    workspace = make_workspace(tmp_path)
+    result = run_step(
+        {"run": _padded_body(size)},
+        workspace=workspace,
+        env={"PADDED_SIZE": str(size)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.outputs["size"] == str(size)
+
+
+def test_largest_real_step_body_is_executable_by_the_harness(tmp_path: Path) -> None:
+    """The repository's own longest ``run:`` body, at its real length.
+
+    Padded to that length rather than executed verbatim (a real body needs
+    its own inputs, which is its own module's job): what this pins is that
+    the harness can *spawn* a body that big, which is exactly what broke.
+    """
+    bodies = _real_run_bodies()
+    assert bodies, "no run: steps discovered — the sweep above would be vacuous"
+    longest = max(len(body) for body in bodies)
+    workspace = make_workspace(tmp_path)
+    result = run_step(
+        {"run": _padded_body(longest)},
+        workspace=workspace,
+        env={"PADDED_SIZE": str(longest)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.outputs["size"] == str(longest)
+
+
+def test_step_body_script_is_not_left_inside_the_workspace(tmp_path: Path) -> None:
+    """The script file must not show up in what the step itself produced.
+
+    ``StepResult.tree()`` and several ``$RUNNER_TEMP`` assertions in the
+    workflow tests enumerate the workspace, so the harness's own scratch
+    file living there would silently change what those tests see.
+    """
+    workspace = make_workspace(tmp_path)
+    result = run_step(
+        {"run": _padded_body(40_000)},
+        workspace=workspace,
+        env={"PADDED_SIZE": "40000"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert not [name for name in result.tree() if "_step_body" in name]

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -145,3 +145,32 @@ def test_step_body_script_is_not_left_inside_the_workspace(tmp_path: Path) -> No
     )
     assert result.returncode == 0, result.stderr
     assert not [name for name in result.tree() if "_step_body" in name]
+
+
+def test_body_reaches_bash_byte_for_byte(tmp_path: Path) -> None:
+    """No newline translation between the YAML body and bash.
+
+    Codex review (PR #1230): writing the script with `Path.write_text` used
+    Python's default `newline=None`, which rewrites every ``\\n`` to
+    ``\\r\\n`` on Windows. Git Bash keeps that carriage return inside shell
+    tokens, so a heredoc delimiter line becomes ``EOF\\r`` and never
+    terminates the heredoc -- a real body like the ``assurance_overlay``
+    step's would fail differently rather than run. The oracle here is the
+    shell's own heredoc/quoting behavior, not the harness's notion of a
+    newline: this body cannot succeed under CRLF.
+    """
+    workspace = make_workspace(tmp_path)
+    run = (
+        "cat <<'MARKER_EOF' >> \"$GITHUB_OUTPUT\"\n"
+        "marker=intact\n"
+        "MARKER_EOF\n"
+        'value="no-trailing-cr"\n'
+        'printf "%s\\n" "value=$value" >> "$GITHUB_OUTPUT"\n'
+    )
+    result = run_step({"run": run}, workspace=workspace)
+    assert result.returncode == 0, result.stderr
+    assert result.outputs["marker"] == "intact"
+    # A surviving CR would ride along at the end of the value rather than
+    # failing the shell, so assert the exact string, not a prefix.
+    assert result.outputs["value"] == "no-trailing-cr"
+    assert "\r" not in "".join(result.output_lines)

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -60,8 +60,18 @@ def _padded_body(total_length: int) -> str:
     if total_length <= len(head):
         return head
     filler = "# padding\n"
-    pad = (total_length - len(head)) // len(filler) + 1
-    return head + filler * pad
+    remaining = total_length - len(head)
+    whole, partial = divmod(remaining, len(filler))
+    body = head + filler * whole
+    if partial:
+        # A truncated final comment line, so the body is *exactly* the
+        # requested length rather than rounded up past it -- otherwise the
+        # `limit - 1` case in the sweep below silently ran at or above the
+        # limit and proved nothing about the boundary (CodeRabbit review,
+        # PR #1230). `partial >= 1`, and a comment line of any length is
+        # still a valid, no-op shell line, so this never changes behavior.
+        body += "#" * (partial - 1) + "\n"
+    return body
 
 
 def _real_run_bodies() -> list[str]:
@@ -101,8 +111,11 @@ def _real_run_bodies() -> list[str]:
 )
 def test_run_step_executes_a_body_of_any_length(tmp_path: Path, size: int) -> None:
     workspace = make_workspace(tmp_path)
+    body = _padded_body(size)
+    # The sweep is only about the boundary if the body really is that long.
+    assert len(body) == size
     result = run_step(
-        {"run": _padded_body(size)},
+        {"run": body},
         workspace=workspace,
         env={"PADDED_SIZE": str(size)},
     )
@@ -121,8 +134,10 @@ def test_largest_real_step_body_is_executable_by_the_harness(tmp_path: Path) -> 
     assert bodies, "no run: steps discovered — the sweep above would be vacuous"
     longest = max(len(body) for body in bodies)
     workspace = make_workspace(tmp_path)
+    padded = _padded_body(longest)
+    assert len(padded) == longest
     result = run_step(
-        {"run": _padded_body(longest)},
+        {"run": padded},
         workspace=workspace,
         env={"PADDED_SIZE": str(longest)},
     )
@@ -145,6 +160,20 @@ def test_step_body_script_is_not_left_inside_the_workspace(tmp_path: Path) -> No
     )
     assert result.returncode == 0, result.stderr
     assert not [name for name in result.tree() if "_step_body" in name]
+    # Nor left behind beside it: the script is deleted in a `finally`, so a
+    # caller whose workspace parent is not a pytest-managed temporary
+    # directory never accumulates one file per step (CodeRabbit review).
+    assert not list(workspace.parent.glob("_step_body_*.sh"))
+
+
+def test_step_body_script_is_cleaned_up_even_when_the_body_fails(
+    tmp_path: Path,
+) -> None:
+    """The cleanup is in a `finally`, so a non-zero exit is covered too."""
+    workspace = make_workspace(tmp_path)
+    result = run_step({"run": "exit 3\n"}, workspace=workspace)
+    assert result.returncode == 3
+    assert not list(workspace.parent.glob("_step_body_*.sh"))
 
 
 def test_body_reaches_bash_byte_for_byte(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Repair the windows-latest unit lane on `main`: the workflow-step execution harness could not spawn a `run:` body longer than Windows' command-line limit.

## Motivation

Run [11773 on `main`](https://github.com/abicheck/abicheck/actions/runs/34651668771) failed with 95 tests red, all in `tests/test_reusable_workflows_require_complete_analysis.py` and its siblings, all with the same error:

```
FileNotFoundError: [WinError 206] The filename or extension is too long
```

`tests/_workflow_exec.py`'s `run_step` spawned `bash -eo pipefail -c <body>`, putting the step's entire `run:` body on the child process's command line. Windows caps a command line at 32767 characters, so once `actions/check-target/action.yml`'s `assurance_overlay` step grew to ~50 KB (PR #1222), every executing test over that step failed before bash ever started — a harness spawn error, not a judgement about the step it models. Linux and macOS lanes were unaffected, which is why it landed.

## Changes

- `tests/_workflow_exec.py`: `run_step` writes the body to a real script file and invokes `bash -eo pipefail <script>`. This is also what the GitHub runner itself does (`bash -e {0}`), so the harness moved closer to what it models, and it has no length ceiling. The script is written beside the workspace, not inside it, so `StepResult.tree()` and the `$RUNNER_TEMP` assertions across the workflow tests keep seeing only what the step itself created. A per-invocation counter plus the pid keeps two calls sharing one `tmp_path` from colliding.
- `tests/test_workflow_exec_harness.py` (new): states the invariant generally — **a step body's length must not affect whether the harness can execute it** — rather than pinning the one 50 KB step. It sweeps body sizes across and far past the 32767 boundary (64, 4096, limit−1, limit, limit+1, 64000, 250000), separately pins the repository's own *longest real* `run:` body length (discovered from `.github/workflows/*.yml` and `actions/*/action.yml`, so a future oversized step is caught here instead of as an unexplained red lane), and asserts the harness's scratch file never appears in the workspace tree.

## Verification

- `pytest tests/test_reusable_workflows_require_complete_analysis.py` — 58 passed (the module whose 95 Windows failures this fixes; the count differs because the Windows lane counts parametrized siblings across the file's sibling modules too).
- `pytest tests/ -k "workflow or action_run_sh or check_target or assurance"` — 1704 passed, 1 skipped.
- `ruff check` / `ruff format --check` clean on both files; `python scripts/check_ai_readiness.py` — 0 errors.

No `abicheck/**/*.py` changes, so no changelog fragment is required.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — n/a, tests only
- [x] Docs updated if user-visible behaviour changed — n/a
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTBtMXAuuFYxRcfNSzh8Rr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTBtMXAuuFYxRcfNSzh8Rr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring workflow steps can execute successfully with scripts ranging from short to very long.
  * Added validation that temporary execution files do not appear in generated workspace contents.
  * Added checks using the repository’s largest workflow script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->