### PR TITLE
fix: ambiguous marker basenames withhold the move claim

### DIFF
--- a/abicheck/analysis_assurance.py
+++ b/abicheck/analysis_assurance.py
@@ -1273,6 +1273,9 @@ def compute_analysis_assurance(
     returns (``layer_coverage`` in the native ``compare`` CLI path -- see
     ``cli_compare_helpers._report_compare_result``).
 
+    Prefer ``workflows.gate.attach_analysis_assurance``, which wires
+    *same_content* for you (see ``workflows/analysis_assurance_attach``).
+
     *old_pack*/*new_pack* are the ``BuildSourcePack`` that actually backed
     this comparison's build/source findings -- **not** implicitly re-read
     from ``old.build_source``/``new.build_source`` internally (finding, P1

--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -120,6 +120,7 @@ from .graph_reconcile_outcome import (  # re-exported: the public outcome vocabu
     _classify_outcome,
     _project_relative_path,
     coordinate_evidence,
+    move_evidence_established,
 )
 
 if TYPE_CHECKING:
@@ -756,6 +757,24 @@ def diff_graph_reconciliation_findings(
         old_label = pair.old_node.label or pair.old_node.id
         new_label = pair.new_node.label or pair.new_node.id
         prose = _OUTCOME_PROSE.get(pair.outcome, "identity-reconciled")
+        # OUTCOME_RECONCILED's prose asserts that location evidence
+        # CHANGED, which is false for a pair that reached it because the
+        # location could not be determined at all -- an ambiguous marker
+        # basename, a kind mismatch, a permutation, a declaring file
+        # contradicting its own markers (Codex review, PR #1232). Those
+        # are exactly the cases where the move claim was withheld for
+        # being unsupported, so rendering it back in the description
+        # re-made the claim the classifier had just declined. Same
+        # outcome, same ChangeKind, same severity -- only the sentence
+        # stops over-claiming, and says which dimension is unresolved.
+        if pair.outcome == OUTCOME_RECONCILED and not move_evidence_established(
+            pair.old_identity, pair.new_identity
+        ):
+            prose = (
+                "identity-reconciled (no clean split: the available "
+                "evidence does not establish whether the declaring "
+                "location changed)"
+            )
         # State the weaker evidence rather than hiding it (Codex review, PR
         # #1228): a coordinate-only pair with no declaring-file evidence on
         # either side read its coordinate shift out of the qualified name,

--- a/abicheck/buildsource/graph_reconcile.py
+++ b/abicheck/buildsource/graph_reconcile.py
@@ -117,10 +117,10 @@ from .graph_reconcile_outcome import (  # re-exported: the public outcome vocabu
     OUTCOME_MOVED,
     OUTCOME_RECONCILED,
     OUTCOME_RENAMED,
-    _classify_outcome,
+    _classify_outcome,  # noqa: F401  # re-export: imported from here by tests/callers
     _project_relative_path,
+    classify,
     coordinate_evidence,
-    move_evidence_established,
 )
 
 if TYPE_CHECKING:
@@ -155,6 +155,16 @@ class ReconciledPair:
     #: every other outcome. See ``graph_reconcile_outcome.
     #: coordinate_evidence`` for why this is recorded rather than gated on.
     coordinate_evidence: str | None = None
+    #: Whether the classification actually ESTABLISHED a declaring-file
+    #: move. Recorded rather than recomputed at render time (Codex review,
+    #: PR #1232): the declaring paths can come from incoming
+    #: ``SOURCE_DECLARES`` edges rather than from the identities, and a
+    #: recomputation that sees only ``old_identity``/``new_identity``
+    #: silently loses that evidence -- under-claiming on exactly the real
+    #: header-graph ``source_decl`` nodes whose ``source_relative`` is
+    #: empty. The outcome and this flag are two halves of one answer and
+    #: must come from one call.
+    move_established: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         d = {
@@ -399,7 +409,7 @@ class _Reconciler:
         new_node = next(n for n in kind_pass.new_list if n.id == new_id)
         old_declaring = self.old_declaring_files.get(oid, "")
         new_declaring = self.new_declaring_files.get(new_id, "")
-        outcome = _classify_outcome(
+        classification = classify(
             kind_pass.old_ident[oid],
             kind_pass.new_ident[new_id],
             old_declaring_file=old_declaring,
@@ -416,10 +426,11 @@ class _Reconciler:
                 old_node,
                 new_node,
                 match_kind,
-                outcome,
+                classification.outcome,
                 kind_pass.old_ident[oid],
                 kind_pass.new_ident[new_id],
                 evidence,
+                classification.move_established,
             )
         )
         self.matched_old.add(oid)
@@ -767,9 +778,7 @@ def diff_graph_reconciliation_findings(
         # re-made the claim the classifier had just declined. Same
         # outcome, same ChangeKind, same severity -- only the sentence
         # stops over-claiming, and says which dimension is unresolved.
-        if pair.outcome == OUTCOME_RECONCILED and not move_evidence_established(
-            pair.old_identity, pair.new_identity
-        ):
+        if pair.outcome == OUTCOME_RECONCILED and not pair.move_established:
             prose = (
                 "identity-reconciled (no clean split: the available "
                 "evidence does not establish whether the declaring "

--- a/abicheck/buildsource/graph_reconcile_outcome.py
+++ b/abicheck/buildsource/graph_reconcile_outcome.py
@@ -191,8 +191,8 @@ def _classify_outcome(
     old_declaring_file: str = "",
     new_declaring_file: str = "",
 ) -> str:
-    """The reconciliation outcome for this pair. See :func:`_classify`."""
-    return _classify(
+    """The reconciliation outcome for this pair. See :func:`classify`."""
+    return classify(
         old_identity,
         new_identity,
         old_declaring_file=old_declaring_file,
@@ -200,44 +200,31 @@ def _classify_outcome(
     ).outcome
 
 
-def move_evidence_established(
-    old_identity: CanonicalIdentity,
-    new_identity: CanonicalIdentity,
-    *,
-    old_declaring_file: str = "",
-    new_declaring_file: str = "",
-) -> bool:
-    """Whether this pair's evidence actually established a declaring-file
-    MOVE, as opposed to reaching its outcome some other way.
-
-    ``OUTCOME_RECONCILED`` is the case that matters: it is produced both
-    by a genuine rename-and-move and by a pair whose move claim was
-    withheld as unsupported, and its prose asserts the former. Shares
-    :func:`_classify`'s computation rather than re-deriving it, so the
-    prose a finding renders cannot drift from the outcome it renders
-    (Codex review, PR #1232).
-    """
-    return _classify(
-        old_identity,
-        new_identity,
-        old_declaring_file=old_declaring_file,
-        new_declaring_file=new_declaring_file,
-    ).move_established
-
-
 @dataclass(frozen=True)
-class _Classification:
+class Classification:
+    """One pair's outcome together with whether a MOVE was established.
+
+    Two halves of one answer: ``OUTCOME_RECONCILED`` is reached both by a
+    genuine rename-and-move and by a pair whose move claim was withheld as
+    unsupported, and only ``move_established`` tells them apart. Returned
+    together so a consumer cannot end up deciding one half from different
+    inputs than the other was decided from -- the declaring paths can come
+    from incoming ``SOURCE_DECLARES`` edges rather than from the
+    identities, and a recomputation that sees only the identities silently
+    loses that evidence (Codex review, PR #1232).
+    """
+
     outcome: str
     move_established: bool
 
 
-def _classify(
+def classify(
     old_identity: CanonicalIdentity,
     new_identity: CanonicalIdentity,
     *,
     old_declaring_file: str = "",
     new_declaring_file: str = "",
-) -> _Classification:
+) -> Classification:
     old_qn = old_identity.qualified_name
     new_qn = new_identity.qualified_name
     # source_relative is file#scope#name; the file prefix says "did the
@@ -372,11 +359,11 @@ def _classify(
     # rendering it for the second re-makes in the user-facing sentence
     # exactly the claim this function just declined to make.
     if renamed and not moved:
-        return _Classification(OUTCOME_RENAMED, moved)
+        return Classification(OUTCOME_RENAMED, moved)
     if moved and not renamed:
-        return _Classification(OUTCOME_MOVED, moved)
+        return Classification(OUTCOME_MOVED, moved)
     if renamed and moved:
-        return _Classification(OUTCOME_RECONCILED, moved)
+        return Classification(OUTCOME_RECONCILED, moved)
     # Neither fired: coordinate-only needs the raw name differed (normalized
     # equal), an agreeing signature tail, AND a type-shaped kind -- a real
     # source_decl producer tracks no param_types/mangled_name (Codex
@@ -419,7 +406,7 @@ def _classify(
         and not markers_reordered
         and old_identity.kind in _COORDINATE_ONLY_KINDS
     )
-    return _Classification(
+    return Classification(
         OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED,
         moved,
     )

--- a/abicheck/buildsource/graph_reconcile_outcome.py
+++ b/abicheck/buildsource/graph_reconcile_outcome.py
@@ -30,6 +30,7 @@ A leaf: nothing here reaches back into the matching module.
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
 
 from ..model.graph_identity import (
     closure_location_free_identity,
@@ -190,6 +191,53 @@ def _classify_outcome(
     old_declaring_file: str = "",
     new_declaring_file: str = "",
 ) -> str:
+    """The reconciliation outcome for this pair. See :func:`_classify`."""
+    return _classify(
+        old_identity,
+        new_identity,
+        old_declaring_file=old_declaring_file,
+        new_declaring_file=new_declaring_file,
+    ).outcome
+
+
+def move_evidence_established(
+    old_identity: CanonicalIdentity,
+    new_identity: CanonicalIdentity,
+    *,
+    old_declaring_file: str = "",
+    new_declaring_file: str = "",
+) -> bool:
+    """Whether this pair's evidence actually established a declaring-file
+    MOVE, as opposed to reaching its outcome some other way.
+
+    ``OUTCOME_RECONCILED`` is the case that matters: it is produced both
+    by a genuine rename-and-move and by a pair whose move claim was
+    withheld as unsupported, and its prose asserts the former. Shares
+    :func:`_classify`'s computation rather than re-deriving it, so the
+    prose a finding renders cannot drift from the outcome it renders
+    (Codex review, PR #1232).
+    """
+    return _classify(
+        old_identity,
+        new_identity,
+        old_declaring_file=old_declaring_file,
+        new_declaring_file=new_declaring_file,
+    ).move_established
+
+
+@dataclass(frozen=True)
+class _Classification:
+    outcome: str
+    move_established: bool
+
+
+def _classify(
+    old_identity: CanonicalIdentity,
+    new_identity: CanonicalIdentity,
+    *,
+    old_declaring_file: str = "",
+    new_declaring_file: str = "",
+) -> _Classification:
     old_qn = old_identity.qualified_name
     new_qn = new_identity.qualified_name
     # source_relative is file#scope#name; the file prefix says "did the
@@ -315,12 +363,20 @@ def _classify_outcome(
         if has_two_sided_files
         else (markers_differ and marker_fallback_usable)
     )
+    # `moved` is also what the PROSE may claim (Codex review, PR #1232).
+    # A pair reaches OUTCOME_RECONCILED two ways: because both dimensions
+    # genuinely changed, or because coordinate-only was disqualified while
+    # the move claim was withheld -- an ambiguous marker basename, a
+    # permutation, a declaring file contradicting its own markers. The
+    # outcome cannot tell them apart, and its prose asserts the first, so
+    # rendering it for the second re-makes in the user-facing sentence
+    # exactly the claim this function just declined to make.
     if renamed and not moved:
-        return OUTCOME_RENAMED
+        return _Classification(OUTCOME_RENAMED, moved)
     if moved and not renamed:
-        return OUTCOME_MOVED
+        return _Classification(OUTCOME_MOVED, moved)
     if renamed and moved:
-        return OUTCOME_RECONCILED
+        return _Classification(OUTCOME_RECONCILED, moved)
     # Neither fired: coordinate-only needs the raw name differed (normalized
     # equal), an agreeing signature tail, AND a type-shaped kind -- a real
     # source_decl producer tracks no param_types/mangled_name (Codex
@@ -363,7 +419,10 @@ def _classify_outcome(
         and not markers_reordered
         and old_identity.kind in _COORDINATE_ONLY_KINDS
     )
-    return OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED
+    return _Classification(
+        OUTCOME_COORDINATES_ONLY if coordinate_only else OUTCOME_RECONCILED,
+        moved,
+    )
 
 
 def coordinate_evidence(

--- a/abicheck/buildsource/graph_reconcile_outcome.py
+++ b/abicheck/buildsource/graph_reconcile_outcome.py
@@ -167,8 +167,19 @@ def _declaration_marker_is_among_the_changed(
     """
     if not declaring_file or not own_files:
         return True
-    changed = Counter(own_files) - Counter(other_files)
     base = path_basename(declaring_file)
+    matching = [marker for marker in own_files if marker[1] == base]
+    if len(matching) != 1:
+        # Ambiguous rather than absent (Codex review, PR #1229): several
+        # markers naming the recorded file give no way to tell WHICH one
+        # is the declaration's, so one of them changing is equally
+        # consistent with an unmoved declaration whose nested argument
+        # moved. `W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4)>`
+        # declared in `include/wrapper.h` is exactly that. Answering False
+        # withholds the move claim; `markers_differ` stays true, so the
+        # real difference is still reported.
+        return False
+    changed = Counter(own_files) - Counter(other_files)
     return any(marker_base == base for _kind, marker_base in changed.elements())
 
 
@@ -281,10 +292,7 @@ def _classify_outcome(
     # does not reorder, and its full multiset differs.
     markers_reordered = bool(old_markers) and (
         (old_files != new_files and sorted(old_files) == sorted(new_files))
-        or (
-            old_markers != new_markers
-            and sorted(old_markers) == sorted(new_markers)
-        )
+        or (old_markers != new_markers and sorted(old_markers) == sorted(new_markers))
     )
     has_two_sided_files = bool(old_file) and bool(new_file)
     # A recorded declaring file that names NONE of its side's markers

--- a/abicheck/workflows/gate.py
+++ b/abicheck/workflows/gate.py
@@ -140,6 +140,7 @@ from ..policy.severity import (
     resolve_severity_config,
 )
 from ..storage.snapshot_encode import same_persisted_content
+from .analysis_assurance_attach import attach_analysis_assurance
 
 if TYPE_CHECKING:
     from ..model import AbiSnapshot
@@ -166,6 +167,7 @@ __all__ = [
     "assurance_floor_diagnostic",
     "categorize_changes",
     "classify_change_object",
+    "attach_analysis_assurance",
     "compute_analysis_assurance",
     "same_persisted_content",
     "compute_exit_code",

--- a/changelog.d/20260912_014500_ambiguous_marker_basename.md
+++ b/changelog.d/20260912_014500_ambiguous_marker_basename.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- A declaration whose recorded declaring file is named by more than one of
+  its closure markers no longer reports `declaration_moved` when one of them
+  changes: with several candidates there is no way to tell which marker is
+  the declaration's, so the move claim is withheld.

--- a/changelog.d/20260912_020000_reconciled_prose_no_overclaim.md
+++ b/changelog.d/20260912_020000_reconciled_prose_no_overclaim.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- A `declaration_identity_reconciled` finding whose declaring-file move was
+  withheld as unsupported no longer describes itself as "both name and
+  location evidence changed": the text now says the available evidence does
+  not establish whether the declaring location changed. The finding's kind
+  and severity are unchanged.

--- a/changelog.d/20260912_021500_edge_derived_move_evidence.md
+++ b/changelog.d/20260912_021500_edge_derived_move_evidence.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- A reconciled rename-and-move whose declaring files come from
+  `SOURCE_DECLARES` edges rather than the declarations' own recorded paths
+  again describes itself as "both name and location evidence changed",
+  instead of reporting the location as unestablished.

--- a/tests/test_analysis_assurance_content_identity.py
+++ b/tests/test_analysis_assurance_content_identity.py
@@ -339,3 +339,46 @@ def test_the_persisted_projection_is_not_reimplemented_outside_storage() -> None
         and "RUNTIME_ONLY_FIELDS" in p.read_text(encoding="utf-8")
     ]
     assert not offenders, offenders
+
+
+def test_the_supported_entry_point_wires_the_projection_itself() -> None:
+    """Codex review (PR #1229): the content-identity answer has to be
+    passed in, so a caller reaching for `compute_analysis_assurance`
+    directly and omitting it gets the narrower object-identity check —
+    `status="partial"` for one stale snapshot file loaded twice.
+
+    It cannot be defaulted here: the answer is the storage codec's and
+    `policy` has no `storage` edge (`architecture/modules.yaml`), which
+    `scripts/check_architecture.py` enforces. So there is ONE entry point
+    that wires it, and this pins that it does — a programmatic caller
+    following the docstring gets the same answer the CLI does, rather than
+    having to discover the helper.
+    """
+    from abicheck.checker_types import DiffResult
+    from abicheck.workflows.gate import attach_analysis_assurance
+
+    a = _load("v4.json", schema_version=25, from_headers=True)
+    b = _load("v4.json", schema_version=25, from_headers=True)
+    assert degraded_reliability_facts(a), "fixture must be genuinely degraded"
+
+    result = DiffResult(library="libcompat.so.1", old_version="1.0", new_version="1.0")
+    attach_analysis_assurance(result, a, b)
+    assert result.analysis_assurance is not None
+    assert result.analysis_assurance.schema_staleness_status == "clean"
+    # A bare `DiffResult` carries none of the evidence a real run does, so
+    # the rollup is `not_requested` here rather than `complete`; what this
+    # pins is that staleness does not drag it to `partial`, which is the
+    # regression shape (`test_self_compare_of_stored_stale_snapshot_is_
+    # complete_end_to_end` covers `complete` through the real CLI).
+    assert result.analysis_assurance.status != "partial"
+
+    # The must-stay-distinct half: the same entry point still taints a
+    # genuinely differing pair, so wiring the projection is not the same
+    # as switching the check off.
+    other = _load("v4.json", schema_version=45, from_headers=True)
+    differing = DiffResult(
+        library="libcompat.so.1", old_version="1.0", new_version="1.0"
+    )
+    attach_analysis_assurance(differing, a, other)
+    assert differing.analysis_assurance is not None
+    assert differing.analysis_assurance.schema_staleness_status == "degraded"

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -634,6 +634,104 @@ class TestCoordinateEvidenceIsStated:
         assert "on either side" not in text, text
         assert "on one side but not the other" in text, text
 
+    def test_reconciled_text_does_not_claim_a_location_it_could_not_read(
+        self,
+    ) -> None:
+        """Codex review (PR #1232): withholding an unsupported move but
+        then rendering `OUTCOME_RECONCILED`'s "both name and location
+        evidence changed" re-makes, in the user-facing sentence, exactly
+        the claim the classifier just declined.
+
+        Over every shape that reaches the outcome with the location
+        dimension unresolved -- an ambiguous marker basename, a marker
+        permutation, and a declaring file contradicting its own marker --
+        the description must not assert a changed location, and must say
+        the dimension is unresolved. (A kind mismatch lands on
+        `OUTCOME_RENAMED`, whose prose claims nothing about location, so
+        it needs no wording of its own.)"""
+        from abicheck.buildsource.graph_reconcile import (
+            GraphReconciliation,
+            diff_graph_reconciliation_findings,
+        )
+
+        unresolved = {
+            "ambiguous_basename": (
+                "W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4)>",
+                "include/wrapper.h",
+                "W<(lambda at wrapper.h:1:2),(lambda at nested_new.h:3:4)>",
+                "",
+            ),
+            "marker_permutation": (
+                "P<(lambda at a.h:1:2),(lambda at b.h:3:4)>",
+                "",
+                "P<(lambda at b.h:7:8),(lambda at a.h:9:10)>",
+                "",
+            ),
+            "file_contradicts_its_marker": (
+                "W<(lambda at nested_old.h:1:2)>",
+                "include/wrapper.h",
+                "W<(lambda at nested_new.h:1:2)>",
+                "",
+            ),
+        }
+        for label, (old_qn, old_file, new_qn, new_file) in unresolved.items():
+            old_attrs = {"qualified_name": old_qn}
+            if old_file:
+                old_attrs["def_file"] = old_file
+            new_attrs = {"qualified_name": new_qn}
+            if new_file:
+                new_attrs["def_file"] = new_file
+            pair = _reconcile_one_pair(
+                GraphNode(
+                    id="type://old", kind="record_type", label=old_qn, attrs=old_attrs
+                ),
+                GraphNode(
+                    id="type://new", kind="record_type", label=new_qn, attrs=new_attrs
+                ),
+            )
+            findings = diff_graph_reconciliation_findings(
+                GraphReconciliation(reconciled=[pair])
+            )
+            assert len(findings) == 1, (label, findings)
+            text = findings[0].description
+            assert "both name and location evidence changed" not in text, (label, text)
+            assert (
+                "does not establish whether the declaring location changed" in text
+            ), (
+                label,
+                text,
+            )
+
+    def test_a_real_rename_and_move_still_says_both_changed(self) -> None:
+        """The must-stay-distinct half: when two-sided declaring files DO
+        establish the move, the combined claim is true and must still be
+        made, so the softened wording cannot spread to every reconciled
+        pair."""
+        from abicheck.buildsource.graph_reconcile import (
+            GraphReconciliation,
+            diff_graph_reconciliation_findings,
+        )
+
+        pair = _reconcile_one_pair(
+            GraphNode(
+                id="type://old",
+                kind="record_type",
+                label="Old",
+                attrs={"qualified_name": "Old", "def_file": "a.h"},
+            ),
+            GraphNode(
+                id="type://new",
+                kind="record_type",
+                label="New",
+                attrs={"qualified_name": "New", "def_file": "b.h"},
+            ),
+        )
+        findings = diff_graph_reconciliation_findings(
+            GraphReconciliation(reconciled=[pair])
+        )
+        assert len(findings) == 1, findings
+        assert "both name and location evidence changed" in findings[0].description
+
     def test_finding_description_discloses_the_weaker_evidence(self) -> None:
         """The field has a real consumer: the emitted finding's own text.
         A `qualified_name`-evidence pair must say a same-basename move

--- a/tests/test_graph_reconcile_closure_rename.py
+++ b/tests/test_graph_reconcile_closure_rename.py
@@ -702,6 +702,75 @@ class TestCoordinateEvidenceIsStated:
                 text,
             )
 
+    def test_edge_derived_move_evidence_reaches_the_prose(self) -> None:
+        """Codex review (PR #1232): the declaring paths can come from
+        incoming `SOURCE_DECLARES` edges rather than from the identities'
+        own `source_relative`, which is empty for real header-graph
+        `source_decl` nodes. Recomputing the move flag at render time from
+        the identities alone lost that evidence and softened the wording
+        on a pair whose move the edges HAD established -- the opposite
+        over-correction.
+
+        Both halves of the gap are asserted, because the defect lived
+        between them: `classify` must READ the edge-derived paths, and the
+        emission must render the flag it RECORDED rather than recomputing
+        one from the identities alone.
+        """
+        from abicheck.buildsource.entity_identity import (
+            IDENTITY_TIER_CANONICAL,
+            CanonicalIdentity,
+        )
+        from abicheck.buildsource.graph_reconcile import (
+            GraphReconciliation,
+            ReconciledPair,
+            diff_graph_reconciliation_findings,
+        )
+        from abicheck.buildsource.graph_reconcile_outcome import classify
+
+        def _identity(qn: str) -> CanonicalIdentity:
+            return CanonicalIdentity(
+                primary_id=f"id:{qn}",
+                tier=IDENTITY_TIER_CANONICAL,
+                qualified_name=qn,
+                source_relative="",
+                normalized_signature="sig\x1fs",
+                kind="source_decl",
+            )
+
+        old_identity = _identity("Old")
+        new_identity = _identity("New")
+        # Premise: nothing in the identities themselves says where either
+        # side lives, so only the edge-derived paths can establish a move.
+        assert not old_identity.source_relative
+        assert not new_identity.source_relative
+
+        classification = classify(
+            old_identity,
+            new_identity,
+            old_declaring_file="a.h",
+            new_declaring_file="b.h",
+        )
+        assert classification.outcome == OUTCOME_RECONCILED
+        assert classification.move_established
+
+        pair = ReconciledPair(
+            GraphNode(id="decl://old", kind="source_decl", label="Old"),
+            GraphNode(id="decl://new", kind="source_decl", label="New"),
+            "structural_context",
+            classification.outcome,
+            old_identity,
+            new_identity,
+            None,
+            classification.move_established,
+        )
+        findings = diff_graph_reconciliation_findings(
+            GraphReconciliation(reconciled=[pair])
+        )
+        assert len(findings) == 1, findings
+        text = findings[0].description
+        assert "both name and location evidence changed" in text, text
+        assert "no clean split" not in text, text
+
     def test_a_real_rename_and_move_still_says_both_changed(self) -> None:
         """The must-stay-distinct half: when two-sided declaring files DO
         establish the move, the combined claim is true and must still be

--- a/tests/test_graph_reconcile_coordinate_outcome.py
+++ b/tests/test_graph_reconcile_coordinate_outcome.py
@@ -501,6 +501,37 @@ class TestMarkerCarriedLocationEvidence:
                 )
                 assert outcome == OUTCOME_RECONCILED, (old_qn, old_file, outcome)
 
+    def test_several_markers_naming_the_recorded_file_are_ambiguous(self) -> None:
+        """Codex review (PR #1229): when more than one marker names the
+        recorded declaring file, nothing says WHICH is the declaration's.
+        `W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4)>` declared in
+        `include/wrapper.h` is consistent with an unmoved declaration whose
+        nested argument moved, so one `wrapper.h` entry appearing in the
+        marker difference cannot be read as the declaration moving.
+
+        Withholding the move claim, not the finding: `markers_differ` stays
+        true, so the real difference is still reported. Over both
+        orientations and both a 2- and a 3-marker name."""
+        pairs = (
+            (
+                "W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4)>",
+                "W<(lambda at wrapper.h:1:2),(lambda at nested_new.h:3:4)>",
+            ),
+            (
+                "W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4),"
+                "(lambda at n.h:5:6)>",
+                "W<(lambda at wrapper.h:1:2),(lambda at nested_new.h:3:4),"
+                "(lambda at n.h:5:6)>",
+            ),
+        )
+        for old_qn, new_qn in pairs:
+            for old_file, new_file in (("include/wrapper.h", ""), ("", "wrapper.h")):
+                outcome = _classify_outcome(
+                    _identity(old_qn, old_file, f"sig:{old_qn}\x1fs"),
+                    _identity(new_qn, new_file, f"sig:{new_qn}\x1fs"),
+                )
+                assert outcome == OUTCOME_RECONCILED, (old_qn, old_file, outcome)
+
     def test_the_declarations_own_marker_changing_is_still_a_move(self) -> None:
         """The must-stay-distinct half: when the recorded file's OWN marker
         is the one that changed, that is exactly the declaration moving, so


### PR DESCRIPTION
## Summary

One commit that missed #1229's merge by about a minute. It was pushed, reviewed and verified on that PR, but the merge took the previous head (`ebace472`), so the fix is not on `main`. Rebased onto current `main` unchanged.

## Changes

**An ambiguous marker basename no longer fabricates a declaration move.** When more than one of a side's closure markers names its recorded declaring file, nothing in the identity says *which* marker is the declaration's. `W<(lambda at wrapper.h:1:2),(lambda at wrapper.h:3:4)>` declared in `include/wrapper.h`, against a side spelling `nested_new.h` for the second marker, therefore reported `declaration_moved` — although the unchanged first marker is equally consistent with an unmoved declaration whose nested template argument moved. A non-unique basename association is now ambiguous rather than affirmative. `markers_differ` stays true, so the pair still reports `declaration_identity_reconciled` and the real difference remains visible; only the unsupported move claim is withheld.

**The content-identity projection gets one documented entry point.** `compute_analysis_assurance`/`schema_staleness_status` take "are these the same persisted content" as a parameter because `policy` may not import `storage`, so a caller that omits it silently falls back to Python object identity — reporting `status="partial"` for one stale snapshot file loaded twice. Defaulting it in place is not available: `scripts/check_architecture.py` rejects the `policy -> storage` edge (verified by trying it), and widening that is an ADR-level decision rather than a bug-fix edit. So `workflows.gate` now exports `attach_analysis_assurance` as the supported route — a layer that may import `storage`, and already what every in-repo caller uses — and both docstrings point at it.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `guard.proxy_predicate_overshoots_justification` (`tests/regressions/manifest_guards.py`) — a proxy predicate broader than the property it stands for. "The recorded declaring file appears among the markers that changed" stands for "the declaration's own marker changed", and the two diverge the moment the association is not unique.
- Publicly observable failure: A declaration with two closure markers from one header, where only an unrelated nested marker changes, is reported as `declaration_moved` (risk) instead of `declaration_identity_reconciled` — a move the evidence cannot support, on a pair where the only known declaration location did not change.
- Regression test fails on base: Yes. `TestMarkerCarriedLocationEvidence::test_several_markers_naming_the_recorded_file_are_ambiguous` returns `declaration_moved` on the parent commit; reproduced there before fixing.
- Negative control: `test_the_declarations_own_marker_changing_is_still_a_move` (a unique association, which must still be a move) and `test_a_lone_agreeing_declaring_file_still_lets_the_marker_speak` (every marker spelling, both orientations) are unchanged and pass on the parent too, so the new strictness cannot degrade into "a repeated basename never moves".
- Public-surface test: `test_the_supported_entry_point_wires_the_projection_itself` goes through `workflows.gate.attach_analysis_assurance` and asserts the resulting `AnalysisAssurance`; the marker half's production-path evidence is the real `reconcile_added_removed` fold (`test_coordinate_shift_without_any_declaring_file_evidence`).
- Axes covered: Linux / CPython 3.13; 2- and 3-marker names; both orientations of which side records the declaring file; unique vs non-unique basename association; snapshot schema vintages 25 and 45 for the assurance half.
- General invariant: `test_several_markers_naming_the_recorded_file_are_ambiguous` states it over both orientations and both name shapes rather than the one reported pair, and the existing `TestClassifyOutcomeProperties` (200-pair exhaustive enumeration against a dimension-level oracle) still holds unchanged — no returned label claims a dimension the inputs do not show changed. `test_every_compute_call_site_passes_the_storage_projection` remains the mechanical guard that every in-repo caller wires the projection.
- Real-dependency test: Yes for the assurance half — snapshots are loaded by the real decoder from committed fixtures and scored through the real `attach_analysis_assurance`/`compute_analysis_assurance` path, with the differing-vintage complement. The marker half touches no third-party boundary (a pure in-process classifier over already-parsed identities).
- Malicious fixture + side-effect absence: None — no Action, workflow, or composite-action file is touched, and neither change parses externally-supplied input. Recorded as not applicable rather than left silent.
- False-positive removed / real break preserved: Yes. The false positive removed is `declaration_moved` on an ambiguous association; the real signal preserved is a move where the declaration's own marker is the one that changed, pinned by the unchanged negative control above.
- Must-merge / must-not-merge pair: Yes. Must-not-claim: two markers sharing the recorded file's basename, one changing, must not be a move. Must-still-claim: a unique association whose marker changes must still be a move. Both asserted independently, and the second passes on the parent so it pins the rule rather than riding the fix. For the assurance half: a content-identical reload must not read `partial` through the supported entry point, while a differing-vintage pair must still read `degraded`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated if user-visible behaviour changed (changelog fragment)
- [x] `python scripts/verify.py --profile pr` run locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KX2nFo13igsXrqfp539Pg

---
_Generated by [Claude Code](https://claude.ai/code/session_014KX2nFo13igsXrqfp539Pg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a supported entry point for attaching analysis assurance when comparing independently loaded snapshots.

- **Bug Fixes**
  - Prevented declarations from being incorrectly reported as moved when multiple markers identify the same declaring file.
  - Preserved accurate reporting of genuine differences in ambiguous marker scenarios.

- **Documentation**
  - Added guidance on using the supported analysis-assurance entry point.

- **Tests**
  - Added coverage for snapshot content identity, schema differences, and ambiguous marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->