### PR TITLE
feat: one `project validate INPUT`, and the external CLI audit reconciled (Phase 7l/7p)

### DIFF
--- a/.github/workflows/check-project.yml
+++ b/.github/workflows/check-project.yml
@@ -781,7 +781,7 @@ jobs:
                   # claim is actually trustworthy (e.g. two targets
                   # sharing one pack, or a pack whose own manifest.library
                   # names a different target). validate_build_output() is
-                  # the same check 'project validate-build' runs, and
+                  # the same check 'project validate' runs on a build output, and
                   # 'project plan' never calls it -- run it here, before
                   # this target's evidence is treated as scoped to it,
                   # rather than inferring validity from path confinement

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1217,8 +1217,10 @@ already thinks in terms of this operand" bar (#2) on its own** — validating a
 project's `.abicheck.yml`, a `build-output.json`, or generating a run-plan —
 it almost certainly belongs as a new subcommand of the existing `project`
 group (`abicheck/cli_project.py`), not a new root command. `project` exists
-precisely to hold this class of operation: `project validate`,
-`project validate-build`, `project plan` are all "read one project-integration
+precisely to hold this class of operation: `project validate` (one command
+over a project config, a build-output directory, or a use-case manifest,
+dispatched on the document's own schema — never its filename),
+`project plan`, `project history` are all "read one project-integration
 artifact, report on it" operations that share one advanced/opt-in namespace
 instead of each claiming root. Add `@project_group.command("your-verb")`
 there and extend `tests/test_cli_root_surface.py`'s existing assertions

--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -376,16 +376,31 @@ def is_build_output_dir(path: Path | str) -> bool:
     return isinstance(data, dict) and data.get("schema") == BUILD_OUTPUT_SCHEMA
 
 
-def load_build_output(root: Path | str) -> BuildOutput:
-    """Load and parse ``<root>/build-output.json``.
+def resolve_build_output_manifest(path: Path | str) -> tuple[Path, Path]:
+    """``(root, manifest_path)`` for a build output named either way.
 
-    Raises ``FileNotFoundError`` if absent, ``ValueError`` if *root* carries a
-    ``build-output.json`` that does not declare
-    ``schema: abicheck.build-output/v1`` — matching
-    :func:`~.inputs_pack.load_inputs_manifest`'s same two-exception contract.
+    A caller may name the *directory* (the usual ``abicheck-build/``) or the
+    manifest file, which need not be called ``build-output.json``: the
+    ``schema:`` tag makes a document one, not its name (a CI job's
+    ``artifacts/run-42.json``, which ``project validate`` routes by shape).
+    Re-deriving the conventional name from a named manifest's parent turns
+    that valid input into "no manifest here". *root* — where relative paths resolve from — is its directory either way.
     """
-    root = Path(root)
-    manifest_path = root / BUILD_OUTPUT_MANIFEST_NAME
+    p = Path(path)
+    if p.is_file():
+        return p.parent, p
+    return p, p / BUILD_OUTPUT_MANIFEST_NAME
+
+
+def load_build_output(root: Path | str) -> BuildOutput:
+    """Load and parse a build output's manifest.
+
+    *root* is a directory or a manifest file under any name
+    (:func:`resolve_build_output_manifest`). Raises ``FileNotFoundError``
+    if absent, ``ValueError`` if it does not declare
+    ``schema: abicheck.build-output/v1`` — :func:`~.inputs_pack.load_inputs_manifest`'s two-exception contract.
+    """
+    _, manifest_path = resolve_build_output_manifest(root)
     if not manifest_path.is_file():
         raise FileNotFoundError(
             f"No build-output manifest at {manifest_path}. Expected an "
@@ -743,16 +758,16 @@ def _declared_evidence_sharing_issues(
 
 
 def validate_build_output(root: Path | str) -> BuildOutputValidationReport:
-    """Validate one ``build-output.json`` + its referenced artifacts (ADR-047 §11.1).
+    """Validate one build output + its referenced artifacts (ADR-047 §11.1).
 
-    Never raises for a structurally-readable ``build-output.json`` — problems
-    are reported, not thrown. Raises ``FileNotFoundError``/``ValueError`` only
-    when *root* is not a readable ``abicheck-build/`` directory at all,
-    matching :func:`load_build_output`.
+    *root* is a directory or a manifest file under any name
+    (:func:`resolve_build_output_manifest`). Never raises for a
+    structurally-readable manifest — problems are reported, not thrown;
+    ``FileNotFoundError``/``ValueError`` only when *root* is not a readable build output at all, matching :func:`load_build_output`.
     """
-    root = Path(root)
+    root, manifest_path = resolve_build_output_manifest(root)
     report = BuildOutputValidationReport(root=str(root))
-    build_output = load_build_output(root)
+    build_output = load_build_output(manifest_path)
 
     if not build_output.targets:
         report.warnings.append("build-output.json declares no targets[].")
@@ -778,6 +793,8 @@ def validate_build_output(root: Path | str) -> BuildOutputValidationReport:
         report.errors.extend(_evidence_projection_issues(target))
 
     report.errors.extend(_declared_evidence_sharing_issues(root, build_output.targets))
-    report.errors.extend(_inferred_evidence_projection_issues(root, build_output.targets))
+    report.errors.extend(
+        _inferred_evidence_projection_issues(root, build_output.targets)
+    )
 
     return report

--- a/abicheck/buildsource/validation_input.py
+++ b/abicheck/buildsource/validation_input.py
@@ -89,10 +89,11 @@ class ValidationInputError(ValueError):
 def classify_validation_input(path: Path) -> tuple[ValidationInputKind, Path]:
     """Classify *path*, returning its kind and the path its validator wants.
 
-    The second element differs from *path* only for a build-output
-    manifest named directly (``abicheck-build/build-output.json``), whose
-    validator takes the containing directory — so a caller never has to
-    know which of the two spellings this build's tooling produced.
+    The second element is the path that kind's validator should be given.
+    It is *path* itself in every case today; it stays in the return type
+    because the two build-output spellings (a directory, or a manifest
+    file under any name) are both legal operands and a future kind may
+    need the same freedom.
 
     Raises :class:`ValidationInputError` with a message naming what was
     found and what the three recognized shapes are. It never raises for a
@@ -124,9 +125,14 @@ def classify_validation_input(path: Path) -> tuple[ValidationInputKind, Path]:
         return ValidationInputKind.USE_CASE_MANIFEST, path
     if isinstance(document, dict):
         if document.get("schema") == BUILD_OUTPUT_SCHEMA:
-            # A build-output manifest named directly; its validator reads
-            # the directory around it.
-            return ValidationInputKind.BUILD_OUTPUT, path.parent
+            # A build-output manifest named directly, under any name. The
+            # path is passed through rather than replaced by its parent:
+            # substituting the directory makes the validator look for the
+            # conventional ``build-output.json`` beside it, which turns a
+            # valid ``artifacts/run-42.json`` into "no manifest here" —
+            # a filename dependency re-introduced one layer down from the
+            # dispatch that just refused to make one.
+            return ValidationInputKind.BUILD_OUTPUT, path
         return ValidationInputKind.PROJECT_CONFIG, path
 
     raise ValidationInputError(

--- a/abicheck/buildsource/validation_input.py
+++ b/abicheck/buildsource/validation_input.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which validator does one ``project validate INPUT`` operand want?
+
+The dispatch behind the single ``project validate`` command (plan
+`one-comparison-product.md` Phase 7p): ``project validate``,
+``validate-build`` and ``validate-use-cases`` were one question — "is this
+project-integration document well formed?" — asked over three input
+schemas, each with its own subcommand and its own copy of
+``--format``/``-o``/``-v``.
+
+Two rules govern this dispatch, and both exist because the obvious
+implementation violates them:
+
+1. **Dispatch on a validated schema discriminator or a recognized
+   directory contract — never on a filename.** ``build-output.json``,
+   ``.abicheck.yml`` and ``impact-use-cases.yaml`` are conventions, not
+   contracts: a caller may hold any of the three under any name (a CI job
+   writing ``artifacts/run-42.json``, a repository with several candidate
+   configs), and a name-based guess would route it to the wrong validator
+   and report confident nonsense about a document of a different kind.
+   Every branch below reads the document's own shape.
+2. **Recognizing a document never authorizes anything.** Classification
+   answers *which validator*, nothing else. ``--toolchain-bindings``
+   stays an explicit, separately-supplied operand precisely because an
+   untrusted project config must not be able to nominate the executables
+   its own validation probes (``ProfileCompileSpec.binding``'s trust
+   boundary).
+
+The three shapes are mutually exclusive by construction, which is what
+makes a discriminator possible at all:
+
+* a **directory** is a build output, and only when it carries a
+  ``build-output.json`` declaring ``schema: abicheck.build-output/v1``
+  (:func:`~abicheck.buildsource.build_output.is_build_output_dir`, the
+  same contract every other build-output consumer routes on);
+* a **sequence** document is a use-case manifest — the only one of the
+  three whose top level is a list;
+* an **empty** document is vacuously valid under all three, and is
+  reported as such rather than assigned to one of them;
+* a **mapping** is a build-output manifest when it carries the explicit
+  ``schema:`` discriminator, and a project config otherwise. Project
+  configs are the one shape with no self-describing tag, so they are the
+  mapping default rather than a key sniff: ``targets:``/``bundles:``/
+  ``profiles:``/``baseline:`` are all optional in a config that is
+  otherwise legitimately empty, and demanding one would reject a document
+  today's ``project validate`` accepts.
+"""
+
+from __future__ import annotations
+
+import enum
+from pathlib import Path
+from typing import Any
+
+from .build_output import (
+    BUILD_OUTPUT_MANIFEST_NAME,
+    BUILD_OUTPUT_SCHEMA,
+    is_build_output_dir,
+)
+
+
+class ValidationInputKind(enum.Enum):
+    """Which validator a ``project validate`` operand resolves to."""
+
+    EMPTY_DOCUMENT = "empty-document"
+    PROJECT_CONFIG = "project-config"
+    BUILD_OUTPUT = "build-output"
+    USE_CASE_MANIFEST = "use-case-manifest"
+
+
+class ValidationInputError(ValueError):
+    """*INPUT* is not a recognizable project-integration document."""
+
+
+def classify_validation_input(path: Path) -> tuple[ValidationInputKind, Path]:
+    """Classify *path*, returning its kind and the path its validator wants.
+
+    The second element differs from *path* only for a build-output
+    manifest named directly (``abicheck-build/build-output.json``), whose
+    validator takes the containing directory — so a caller never has to
+    know which of the two spellings this build's tooling produced.
+
+    Raises :class:`ValidationInputError` with a message naming what was
+    found and what the three recognized shapes are. It never raises for a
+    *valid-but-failing* document: "malformed" is the validator's answer,
+    not this function's.
+    """
+    if path.is_dir():
+        if is_build_output_dir(path):
+            return ValidationInputKind.BUILD_OUTPUT, path
+        raise ValidationInputError(
+            f"{path} is a directory but not an abicheck-build/ build output: "
+            f"expected a {BUILD_OUTPUT_MANIFEST_NAME} declaring "
+            f"schema: {BUILD_OUTPUT_SCHEMA}."
+        )
+
+    document = _parse_document(path)
+
+    if document is None:
+        # An empty document is the one genuinely ambiguous shape: an empty
+        # mapping and an empty list are indistinguishable in YAML, and
+        # *both* superseded commands accepted one as valid (an empty
+        # ``.abicheck.yml`` declaring no targets; an empty manifest
+        # declaring no use cases). It is therefore reported as its own
+        # kind rather than silently assigned to one validator — picking
+        # either would answer a question the document does not settle,
+        # and rejecting it would lose a capability both old commands had.
+        return ValidationInputKind.EMPTY_DOCUMENT, path
+    if isinstance(document, list):
+        return ValidationInputKind.USE_CASE_MANIFEST, path
+    if isinstance(document, dict):
+        if document.get("schema") == BUILD_OUTPUT_SCHEMA:
+            # A build-output manifest named directly; its validator reads
+            # the directory around it.
+            return ValidationInputKind.BUILD_OUTPUT, path.parent
+        return ValidationInputKind.PROJECT_CONFIG, path
+
+    raise ValidationInputError(
+        f"{path} is not a recognized project-integration document "
+        f"(found {_describe(document)}). Expected a project config (a YAML "
+        f"mapping), a use-case manifest (a YAML list), or a build output (a "
+        f"directory, or a {BUILD_OUTPUT_MANIFEST_NAME} declaring "
+        f"schema: {BUILD_OUTPUT_SCHEMA})."
+    )
+
+
+def _parse_document(path: Path) -> Any:
+    """Parse *path* as YAML (which subsumes the JSON manifest shape).
+
+    Only the document's top-level shape is read here; every validator
+    re-parses under its own strict loader, so a permissive read at this
+    step cannot let a malformed document through as valid.
+    """
+    import yaml
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValidationInputError(f"cannot read {path}: {exc}") from exc
+    try:
+        return yaml.safe_load(text)
+    except (yaml.YAMLError, ValueError) as exc:
+        raise ValidationInputError(f"cannot parse {path}: {exc}") from exc
+
+
+def _describe(document: Any) -> str:
+    if document is None:
+        return "an empty document"
+    return f"a {type(document).__name__}"

--- a/abicheck/buildsource/validation_input.py
+++ b/abicheck/buildsource/validation_input.py
@@ -164,6 +164,9 @@ def _parse_document(path: Path) -> Any:
 
 
 def _describe(document: Any) -> str:
-    if document is None:
-        return "an empty document"
+    """Name the shape a document turned out to have, for the error message.
+
+    ``None`` never reaches here — an empty document is its own kind — so
+    only the genuinely unroutable shapes (a scalar) are described.
+    """
     return f"a {type(document).__name__}"

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
 from . import (  # noqa: E402  — must run after `main` is defined
     cli_aggregate,  # noqa: F401  — registers aggregate
     cli_buildsource,  # noqa: F401  — buildsource internals (no command of its own)
-    cli_project,  # noqa: F401  — registers project (validate, validate-build, plan)
+    cli_project,  # noqa: F401  — registers project (validate, plan, history)
     cli_stack,  # noqa: F401  — registers deps (tree, compare)
 )
 from .cli_options import variant_options  # noqa: E402

--- a/abicheck/cli_project.py
+++ b/abicheck/cli_project.py
@@ -27,8 +27,10 @@ artifact, and grouping the three under one advanced-integration namespace is
 how that bar is satisfied here without losing any of the three checks:
 
 \b
-  project validate        was: project-targets validate
-  project validate-build  was: build-output validate
+  project validate        was: project-targets validate, build-output
+                          validate, and project validate-use-cases —
+                          one command over three input schemas (plan
+                          Phase 7p)
   project plan            was: run-plan generate
 
 Two former subcommands are **not** carried forward as public CLI surface:
@@ -62,6 +64,11 @@ from .buildsource.project_targets import (
     validate_project_targets,
 )
 from .buildsource.run_plan import generate_run_plan
+from .buildsource.validation_input import (
+    ValidationInputError,
+    ValidationInputKind,
+    classify_validation_input,
+)
 from .cli import _safe_write_output, _setup_verbosity, main
 from .cli_options import output_options, verbose_option
 from .workflows.extraction import (
@@ -80,8 +87,9 @@ def project_group() -> None:
 
     \b
     Subcommands:
-      validate         Check .abicheck.yml's targets/bundles/profiles/channels block.
-      validate-build   Check a project-produced abicheck-build/ directory.
+      validate         Check one project-integration document: a project
+                       config, an abicheck-build/ directory, or an
+                       impact-use-cases.yaml manifest.
       plan             Derive run-plan.json from .abicheck.yml + build-output.json.
       history          Derive lifecycle events + coverage from N stored snapshots (ADR-066 S1).
 
@@ -101,14 +109,24 @@ def project_group() -> None:
 
 
 # --------------------------------------------------------------------------
-# project validate  (was: project-targets validate)
+# --------------------------------------------------------------------------
+# project validate — one command, three input schemas (plan Phase 7p)
+#
+# Was three subcommands (``validate``, ``validate-build``,
+# ``validate-use-cases``): one question over three schemas, each with its
+# own copy of --format/-o/-v. Dispatch is by validated schema discriminator
+# or recognized directory contract, never by filename — buildsource/
+# validation_input.py owns it and says why that distinction is
+# load-bearing. Recognizing a document authorizes nothing:
+# --toolchain-bindings stays explicitly supplied.
 # --------------------------------------------------------------------------
 
 
 @project_group.command("validate")
 @click.argument(
-    "config",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    "input_path",
+    metavar="INPUT",
+    type=click.Path(exists=True, path_type=Path),
     default=".abicheck.yml",
 )
 @output_options(
@@ -128,49 +146,140 @@ def project_group() -> None:
         "declared — that the resolved executable's probed identity actually "
         "matches. Loaded only from this explicit path — never auto-"
         "discovered, per the untrusted-config trust boundary "
-        "ProfileCompileSpec.binding documents."
+        "ProfileCompileSpec.binding documents. Applies to a project config; "
+        "supplying it with any other INPUT is a usage error."
     ),
 )
 @verbose_option
 def project_validate_cmd(
-    config: Path,
+    input_path: Path,
     fmt: str,
     output: Path | None,
     toolchain_bindings: Path | None,
     verbose: bool,
 ) -> None:
-    """Validate CONFIG's targets:/bundles:/profiles:/baseline: block (ADR-047 §3).
+    """Validate INPUT, a project-integration document (ADR-047, ADR-057).
 
-    CONFIG defaults to ``.abicheck.yml`` in the current directory. Checks:
-    every target's ``kind``-specific required fields are set (and no
-    kind-inappropriate field is); ``app-consumer``/``plugin-contract``
-    targets' ``library`` resolves to a real ``kind: library`` target; every
-    ``bundle:`` reference and bundle membership resolves and agrees; every
-    ``checks[].channel`` resolves to a declared baseline channel (or is the
-    ``"none"`` no-baseline sentinel); ``checks[].depth``/``gate_mode`` are
-    valid; every ``checks[].profiles`` entry resolves to a declared profile;
-    every id is a valid, ``check_id``-embeddable identifier. With
-    ``--toolchain-bindings``, also checks every declared
-    ``profiles.<id>.compile.binding``/``consumer_compile.binding`` resolves
-    against that file, and that a resolved binding's probed compiler
-    identity matches any declared
-    ``compiler_family``/``compiler_version``/``target``
-    (G34 Phase A; MSVC bindings are skipped — see
-    ``abicheck.buildsource.toolchain_probe``'s module docstring).
-
-    Structural/type errors in the YAML itself (unknown key, wrong type) fail
-    immediately as a usage error; this command's own validation report only
-    covers cross-reference/semantic issues on an already-well-formed block.
+    INPUT defaults to ``.abicheck.yml``. Which validation runs is decided by
+    INPUT's own shape, never by its name:
 
     \b
-    Exit codes:
-      0   Valid — no errors (warnings may still be present).
-      1   One or more validation errors.
-      64  Usage error (CONFIG is not readable YAML, or fails strict parsing).
+      a YAML mapping           -> a project config's targets:/bundles:/
+                                  profiles:/baseline: block (ADR-047 §3)
+      a directory, or a
+      build-output.json        -> that build output (ADR-047 §11.1)
+      a YAML list              -> an impact-use-cases.yaml manifest
+                                  (G29 Phase 4, ADR-057 amendment)
+
+    **Project config.** Every target's ``kind``-specific required fields are
+    set (and no kind-inappropriate field is); ``app-consumer``/
+    ``plugin-contract`` targets' ``library`` resolves to a real
+    ``kind: library`` target; every ``bundle:`` reference and bundle
+    membership resolves and agrees; every ``checks[].channel`` resolves to a
+    declared baseline channel (or is the ``"none"`` no-baseline sentinel);
+    ``checks[].depth``/``gate_mode`` are valid; every ``checks[].profiles``
+    entry resolves to a declared profile; every id is a valid,
+    ``check_id``-embeddable identifier. With ``--toolchain-bindings``, also
+    checks every declared ``profiles.<id>.compile.binding``/
+    ``consumer_compile.binding`` resolves against that file, and that a
+    resolved binding's probed compiler identity matches any declared
+    ``compiler_family``/``compiler_version``/``target`` (G34 Phase A; MSVC
+    bindings are skipped — see ``abicheck.buildsource.toolchain_probe``'s
+    module docstring). Structural/type errors in the YAML itself fail
+    immediately as a usage error; the validation report covers
+    cross-reference/semantic issues on an already-well-formed block.
+
+    **Build output.** Every declared public/generated header root is
+    non-empty; every target's binary exists and matches its digests[] entry;
+    ``evidence.projection`` is 'declared' for every target that has evidence
+    ('inferred' is schema-reserved for a future attribution mechanism and is
+    always rejected); no evidence pack is referenced by more than one
+    target, and a referenced pack's own identity (manifest.library or a
+    tagged TU's target_id) agrees with the specific target using it.
+
+    **Use-case manifest.** Structure only: a well-formed YAML list of use
+    cases, where a non-mapping entry, an unrecognized field, or a
+    missing/blank ``use_case`` name is a usage error. Attributing a real
+    comparison's findings to the use cases that reach them is
+    ``abicheck compare --use-cases MANIFEST`` — reported beside every
+    other finding, not a second diffing surface inside a validator.
+
+    \b
+    Exit codes: 0 valid (warnings may still be present) · 1 validation
+    errors · 64 usage error (INPUT unreadable, not a recognizable
+    project-integration document, or failing strict parsing).
     """
     _setup_verbosity(verbose)
 
-    parsed = _load_project_targets_config(config)
+    try:
+        kind, target = classify_validation_input(input_path)
+    except ValidationInputError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if (
+        toolchain_bindings is not None
+        and kind is not ValidationInputKind.PROJECT_CONFIG
+    ):
+        raise click.UsageError(
+            "--toolchain-bindings applies to a project config; "
+            f"{input_path} is a {kind.value}."
+        )
+
+    if kind is ValidationInputKind.EMPTY_DOCUMENT:
+        ok, payload, text = _validate_empty_document(target, toolchain_bindings)
+    elif kind is ValidationInputKind.PROJECT_CONFIG:
+        ok, payload, text = _validate_project_config(target, toolchain_bindings)
+    elif kind is ValidationInputKind.BUILD_OUTPUT:
+        ok, payload, text = _validate_build_output(target)
+    else:
+        ok, payload, text = _validate_use_case_manifest(target)
+
+    rendered = json.dumps(payload, indent=2) if fmt == "json" else text
+
+    if output is not None:
+        _safe_write_output(output, rendered)
+    else:
+        click.echo(rendered)
+
+    sys.exit(0 if ok else 1)
+
+
+def _report_lines(header: str, report: object) -> list[str]:
+    """Render a validation report's errors/warnings — shared by the two
+    report-producing kinds, which had byte-identical copies of this."""
+    errors = list(getattr(report, "errors", []))
+    warnings = list(getattr(report, "warnings", []))
+    lines = [header]
+    if not errors:
+        lines.append("OK — no errors.")
+    else:
+        lines.append(f"FAILED — {len(errors)} error(s):")
+        lines.extend(f"  - {e}" for e in errors)
+    if warnings:
+        lines.append(f"{len(warnings)} warning(s):")
+        lines.extend(f"  - {w}" for w in warnings)
+    return lines
+
+
+def _validate_project_config(
+    config: Path,
+    toolchain_bindings: Path | None,
+) -> tuple[bool, dict[str, object], str]:
+    try:
+        parsed = _load_project_targets_config(config)
+    except click.UsageError as exc:
+        # A mapping is read as a project config, since that is the one
+        # shape with no self-describing tag. Say so when the read fails:
+        # the likeliest cause is a document of another kind that lost its
+        # discriminating shape (a use-case manifest whose entries stopped
+        # being a list), and a bare "unknown key" message would send the
+        # user looking for a typo instead.
+        raise click.UsageError(
+            f"{exc.format_message()}\n"
+            f"({config} was read as a project config — a YAML mapping with "
+            "no schema: tag. A use-case manifest is a YAML list; a build "
+            "output is a directory or a build-output.json.)"
+        ) from exc
     report = validate_project_targets(parsed)
 
     if toolchain_bindings is not None:
@@ -185,26 +294,74 @@ def project_validate_cmd(
             check_profile_toolchain_identity(parsed.profiles, bindings_file)
         )
 
-    if fmt == "json":
-        text = json.dumps(report.to_dict(), indent=2)
-    else:
-        lines = [f"project validation: {config}"]
-        if report.ok:
-            lines.append("OK — no errors.")
-        else:
-            lines.append(f"FAILED — {len(report.errors)} error(s):")
-            lines.extend(f"  - {e}" for e in report.errors)
-        if report.warnings:
-            lines.append(f"{len(report.warnings)} warning(s):")
-            lines.extend(f"  - {w}" for w in report.warnings)
-        text = "\n".join(lines)
+    text = "\n".join(_report_lines(f"project validation: {config}", report))
+    return report.ok, report.to_dict(), text
 
-    if output is not None:
-        _safe_write_output(output, text)
-    else:
-        click.echo(text)
 
-    sys.exit(0 if report.ok else 1)
+def _validate_build_output(directory: Path) -> tuple[bool, dict[str, object], str]:
+    try:
+        report = validate_build_output(directory)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    text = "\n".join(_report_lines(f"build-output validation: {directory}", report))
+    return report.ok, report.to_dict(), text
+
+
+def _validate_use_case_manifest(manifest: Path) -> tuple[bool, dict[str, object], str]:
+    from .errors import UseCaseManifestError
+    from .impact.use_cases import load_use_case_manifest
+
+    try:
+        definitions = load_use_case_manifest(manifest)
+    except (UseCaseManifestError, OSError) as exc:
+        # OSError alongside the manifest-specific error (Codex review, fresh
+        # evidence): load_use_case_manifest() deliberately leaves a missing/
+        # unreadable MANIFEST unwrapped (its own docstring) — Click's
+        # exists=True check only guarantees the path was there at argument
+        # parsing time, not at the read a moment later (permissions change,
+        # the file disappearing), so an unhandled OSError here would exit 1
+        # with a bare traceback instead of the documented usage-error path.
+        raise click.UsageError(str(exc)) from exc
+
+    payload = {
+        "manifest": str(manifest),
+        "ok": True,
+        "use_case_count": len(definitions),
+    }
+    text = "\n".join(
+        [
+            f"use-case manifest validation: {manifest}",
+            f"OK — {len(definitions)} use case(s), structurally well-formed.",
+        ]
+    )
+    return True, payload, text
+
+
+def _validate_empty_document(
+    path: Path,
+    toolchain_bindings: Path | None,
+) -> tuple[bool, dict[str, object], str]:
+    """An empty document — validated under every reading, not assigned to one.
+
+    YAML cannot distinguish an empty mapping from an empty list, and both
+    superseded commands accepted one: an ``.abicheck.yml`` declaring no
+    targets (whose *config* validation still has warnings worth printing —
+    "no targets declared" is the whole point of running it) and a manifest
+    declaring zero use cases. So the config validation actually runs, and
+    the other readings are stated beside it. Picking one silently would
+    lose whichever the caller meant.
+    """
+    ok, payload, text = _validate_project_config(path, toolchain_bindings)
+    payload = {**payload, "kind": "empty-document", "use_case_count": 0}
+    text = "\n".join(
+        [
+            text,
+            "Note: this document is empty, so it is also a vacuously valid "
+            "use-case manifest (0 use cases).",
+        ]
+    )
+    return ok, payload, text
 
 
 def _load_project_targets_config(config: Path) -> ProjectTargetsConfig:
@@ -223,156 +380,6 @@ def _load_project_targets_config(config: Path) -> ProjectTargetsConfig:
         return ProjectTargetsConfig.from_dict(raw)
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
-
-
-# --------------------------------------------------------------------------
-# project validate-build  (was: build-output validate)
-# --------------------------------------------------------------------------
-
-
-@project_group.command("validate-build")
-@click.argument(
-    "directory",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-)
-@output_options(
-    ["text", "json"],
-    default="text",
-    format_help="Output format for the validation report.",
-)
-@verbose_option
-def project_validate_build_cmd(
-    directory: Path,
-    fmt: str,
-    output: Path | None,
-    verbose: bool,
-) -> None:
-    """Validate DIRECTORY's build-output.json (ADR-047 §11.1).
-
-    Checks: every declared public/generated header root is non-empty; every
-    target's binary exists and matches its digests[] entry; evidence.projection
-    is 'declared' for every target that has evidence ('inferred' is
-    schema-reserved for a future attribution mechanism and is always
-    rejected); no evidence pack is referenced by more than one target, and a
-    referenced pack's own identity (manifest.library or a tagged TU's
-    target_id) agrees with the specific target using it.
-
-    \b
-    Exit codes:
-      0   Valid — no errors (warnings may still be present).
-      1   One or more validation errors.
-      64  Usage error (DIRECTORY is not a readable build-output.json).
-    """
-    _setup_verbosity(verbose)
-
-    try:
-        report = validate_build_output(directory)
-    except (FileNotFoundError, ValueError) as exc:
-        raise click.UsageError(str(exc)) from exc
-
-    if fmt == "json":
-        text = json.dumps(report.to_dict(), indent=2)
-    else:
-        lines = [f"build-output validation: {directory}"]
-        if report.ok:
-            lines.append("OK — no errors.")
-        else:
-            lines.append(f"FAILED — {len(report.errors)} error(s):")
-            lines.extend(f"  - {e}" for e in report.errors)
-        if report.warnings:
-            lines.append(f"{len(report.warnings)} warning(s):")
-            lines.extend(f"  - {w}" for w in report.warnings)
-        text = "\n".join(lines)
-
-    if output is not None:
-        _safe_write_output(output, text)
-    else:
-        click.echo(text)
-
-    sys.exit(0 if report.ok else 1)
-
-
-# --------------------------------------------------------------------------
-# project validate-use-cases  (G29 Phase 4, ADR-057 amendment)
-# --------------------------------------------------------------------------
-
-
-@project_group.command("validate-use-cases")
-@click.argument(
-    "manifest",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
-)
-@output_options(
-    ["text", "json"],
-    default="text",
-    format_help="Output format for the validation report.",
-)
-@verbose_option
-def project_validate_use_cases_cmd(
-    manifest: Path,
-    fmt: str,
-    output: Path | None,
-    verbose: bool,
-) -> None:
-    """Validate MANIFEST, an ``impact-use-cases.yaml`` file (G29 Phase 4,
-    ADR-057 amendment; see docs/contribute/use-case-impact.md).
-
-    Checks the manifest is a well-formed YAML list of use cases: a
-    non-mapping entry, an unrecognized field, or a missing/blank
-    ``use_case`` name is a usage error.
-
-    Structure only. Resolving a manifest's entrypoints against a real
-    library, and attributing a real comparison's findings to the use cases
-    that reach them, is ``abicheck compare --use-cases MANIFEST`` -- one
-    comparison, reported in the same place as every other finding, rather
-    than a second snapshot-diffing surface grown inside a validator (the
-    ``--against``/``--against-new`` pair that used to live here).
-
-    \b
-    Exit codes:
-      0   Valid — the manifest is well-formed.
-      64  Usage error (MANIFEST is malformed or unreadable).
-    """
-    _setup_verbosity(verbose)
-
-    from .errors import UseCaseManifestError
-    from .impact.use_cases import load_use_case_manifest
-
-    try:
-        definitions = load_use_case_manifest(manifest)
-    except (UseCaseManifestError, OSError) as exc:
-        # OSError alongside the manifest-specific error (Codex review, fresh
-        # evidence): load_use_case_manifest() deliberately leaves a missing/
-        # unreadable MANIFEST unwrapped (its own docstring) — Click's
-        # exists=True check only guarantees the path was there at argument
-        # parsing time, not at the read a moment later (permissions change,
-        # the file disappearing), so an unhandled OSError here would exit 1
-        # with a bare traceback instead of the documented usage-error path.
-        raise click.UsageError(str(exc)) from exc
-
-    if fmt == "json":
-        text = json.dumps(
-            {
-                "manifest": str(manifest),
-                "ok": True,
-                "use_case_count": len(definitions),
-            },
-            indent=2,
-        )
-    else:
-        text = "\n".join(
-            [
-                f"use-case manifest validation: {manifest}",
-                f"OK — {len(definitions)} use case(s), structurally well-formed.",
-            ]
-        )
-
-    if output is not None:
-        _safe_write_output(output, text)
-    else:
-        click.echo(text)
-
-    sys.exit(0)
 
 
 # --------------------------------------------------------------------------

--- a/abicheck/cli_project.py
+++ b/abicheck/cli_project.py
@@ -116,9 +116,9 @@ def project_group() -> None:
 # ``validate-use-cases``): one question over three schemas, each with its
 # own copy of --format/-o/-v. Dispatch is by validated schema discriminator
 # or recognized directory contract, never by filename — buildsource/
-# validation_input.py owns it and says why that distinction is
-# load-bearing. Recognizing a document authorizes nothing:
-# --toolchain-bindings stays explicitly supplied.
+# validation_input.py owns it and says why that is load-bearing.
+# Recognizing a document authorizes nothing: --toolchain-bindings stays
+# explicitly supplied.
 # --------------------------------------------------------------------------
 
 
@@ -144,8 +144,7 @@ def project_group() -> None:
         "declared profiles.<id>.compile.binding (and consumer_compile.binding) "
         "resolves, and — when compiler_family/compiler_version/target is also "
         "declared — that the resolved executable's probed identity actually "
-        "matches. Loaded only from this explicit path — never auto-"
-        "discovered, per the untrusted-config trust boundary "
+        "matches. Loaded only from this explicit path — never auto-discovered, per the untrusted-config trust boundary "
         "ProfileCompileSpec.binding documents. Applies to a project config; "
         "supplying it with any other INPUT is a usage error."
     ),
@@ -200,9 +199,9 @@ def project_validate_cmd(
     **Use-case manifest.** Structure only: a well-formed YAML list of use
     cases, where a non-mapping entry, an unrecognized field, or a
     missing/blank ``use_case`` name is a usage error. Attributing a real
-    comparison's findings to the use cases that reach them is
-    ``abicheck compare --use-cases MANIFEST`` — reported beside every
-    other finding, not a second diffing surface inside a validator.
+    comparison's findings to the use cases that reach them is ``abicheck
+    compare --use-cases MANIFEST`` — reported beside every other finding,
+    not a second diffing surface inside a validator.
 
     \b
     Exit codes: 0 valid (warnings may still be present) · 1 validation
@@ -265,6 +264,7 @@ def _validate_project_config(
     config: Path,
     toolchain_bindings: Path | None,
 ) -> tuple[bool, dict[str, object], str]:
+    """Validate a project config's targets/bundles/profiles/baseline block."""
     try:
         parsed = _load_project_targets_config(config)
     except click.UsageError as exc:
@@ -299,6 +299,7 @@ def _validate_project_config(
 
 
 def _validate_build_output(directory: Path) -> tuple[bool, dict[str, object], str]:
+    """Validate a build output: a directory, or a manifest under any name."""
     try:
         report = validate_build_output(directory)
     except (FileNotFoundError, ValueError) as exc:
@@ -309,6 +310,7 @@ def _validate_build_output(directory: Path) -> tuple[bool, dict[str, object], st
 
 
 def _validate_use_case_manifest(manifest: Path) -> tuple[bool, dict[str, object], str]:
+    """Validate an impact-use-cases.yaml manifest's own structure."""
     from .errors import UseCaseManifestError
     from .impact.use_cases import load_use_case_manifest
 
@@ -346,11 +348,10 @@ def _validate_empty_document(
 
     YAML cannot distinguish an empty mapping from an empty list, and both
     superseded commands accepted one: an ``.abicheck.yml`` declaring no
-    targets (whose *config* validation still has warnings worth printing —
-    "no targets declared" is the whole point of running it) and a manifest
-    declaring zero use cases. So the config validation actually runs, and
-    the other readings are stated beside it. Picking one silently would
-    lose whichever the caller meant.
+    targets (whose config validation still has warnings worth printing) and
+    a manifest declaring zero use cases. So the config validation actually
+    runs and the other readings are stated beside it; picking one silently
+    would lose whichever the caller meant.
     """
     ok, payload, text = _validate_project_config(path, toolchain_bindings)
     payload = {**payload, "kind": "empty-document", "use_case_count": 0}

--- a/abicheck/frontends/cli/commands/compare.py
+++ b/abicheck/frontends/cli/commands/compare.py
@@ -753,7 +753,7 @@ def _embed_inline_source_side(
                    "-- an unattributed finding is an absence of proof, not proof "
                    "the finding is harmless, so this never moves a verdict or an "
                    "exit code. Validate a manifest on its own with "
-                   "`abicheck project validate-use-cases`.")
+                   "`abicheck project validate`.")
 @verbose_option
 @click.pass_context
 def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:

--- a/abicheck/impact/use_case_impact.py
+++ b/abicheck/impact/use_case_impact.py
@@ -85,7 +85,7 @@ class UseCaseImpact:
 
     *resolutions* is the manifest's own entrypoint resolution, unioned
     across both sides' graphs the same way the attribution below is (what
-    ``project validate-use-cases`` reports against one graph on its own);
+    ``project validate`` reports a manifest's own structure);
     *by_use_case* is this comparison's findings attributed to the use cases
     whose entrypoints reach them; *unattributed_changes* is how many
     findings no declared entrypoint could be shown to reach.

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -47,7 +47,7 @@ any *report-schema* ``Change.affected_use_cases`` field or
 drive-by extension here).
 
 :func:`explain_use_case_impact` (G29 Phase 4, added alongside the
-``project validate-use-cases --against-new`` CLI mode) is a narrower, real
+``project validate-use-cases --against-new`` CLI mode, both now retired) is a narrower, real
 step past graph-building alone: given a real two-snapshot diff's changed
 symbols, it answers *which declared use case(s)' own entrypoints reach
 each one* — but it is a **read-only report view**, not a `Change`
@@ -439,7 +439,7 @@ class UseCaseResolution:
     docstring), which is correct for graph construction but leaves a
     manifest author with zero visibility into *which* of their declared
     entrypoints actually matched anything. This dataclass is that missing
-    visibility, for a caller (``project validate-use-cases``) that wants to
+    visibility, for a caller (``project validate``) that wants to
     report it without changing what the graph itself records.
     """
 

--- a/changelog.d/project-validate-one-command.md
+++ b/changelog.d/project-validate-one-command.md
@@ -7,10 +7,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
 - **`abicheck project validate INPUT` is now one command over all three
   project-integration documents**, replacing `project validate` /
   `project validate-build` / `project validate-use-cases`. Which validation
-  runs is decided by INPUT's own shape — a directory (or a
-  `build-output.json`) declaring `schema: abicheck.build-output/v1` is a
-  build output, a YAML list is an `impact-use-cases.yaml` manifest, and a
-  YAML mapping is a project config — never by its filename, so a document
+  runs is decided by INPUT's own shape — an `abicheck-build/`-shaped
+  directory, or any mapping document declaring
+  `schema: abicheck.build-output/v1` under any name, is a build output; a
+  YAML list is an `impact-use-cases.yaml` manifest; any other YAML mapping
+  is a project config — never by its filename, so a document
   held under any name is routed correctly and one held under a *misleading*
   name is not routed confidently wrong. `--toolchain-bindings` still applies
   only to a project config and is a usage error elsewhere: recognizing a

--- a/changelog.d/project-validate-one-command.md
+++ b/changelog.d/project-validate-one-command.md
@@ -1,0 +1,18 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Changed
+
+- **`abicheck project validate INPUT` is now one command over all three
+  project-integration documents**, replacing `project validate` /
+  `project validate-build` / `project validate-use-cases`. Which validation
+  runs is decided by INPUT's own shape — a directory (or a
+  `build-output.json`) declaring `schema: abicheck.build-output/v1` is a
+  build output, a YAML list is an `impact-use-cases.yaml` manifest, and a
+  YAML mapping is a project config — never by its filename, so a document
+  held under any name is routed correctly and one held under a *misleading*
+  name is not routed confidently wrong. `--toolchain-bindings` still applies
+  only to a project config and is a usage error elsewhere: recognizing a
+  document authorizes nothing. The two retired spellings exit `64` with no
+  alias.

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -1699,14 +1699,51 @@ mechanism* first and an option count second:
   `root-cause` **with a measurement**, not declared redundant. Net option
   count: **0** — which is the point: this slice reduces decisions, not
   strings beginning with `--`.
-- **7p — `project validate` consolidation.** `project validate`,
-  `validate-build` and `validate-use-cases` are one question over three
-  input schemas. Target: `abicheck project validate INPUT`, dispatching on
-  a validated schema discriminator or a recognized directory contract —
-  **never on a filename guess**, and recognizing a project file never
-  authorizes its nominated toolchain (`--toolchain-bindings` stays the
-  explicit authorization). **Net −2 subcommands**, −4 duplicated output
-  options once 7m's export request is shared.
+- **7p — `project validate` consolidation. Done.** `project validate`,
+  `validate-build` and `validate-use-cases` were one question over three
+  input schemas. Now `abicheck project validate INPUT`, dispatching on a
+  validated schema discriminator or a recognized directory contract —
+  never on a filename guess, and recognizing a project file never
+  authorizes its nominated toolchain (`--toolchain-bindings` applies to a
+  project config and is a usage error elsewhere, rather than being
+  silently ignored). **−2 subcommands**, −4 duplicated output options;
+  the remaining `--format`/`-o` pair folds with 7m like every other
+  command's.
+
+  The classifier is `buildsource/validation_input.py` — beside the
+  build-output contract it routes on, since ADR-061 classifies
+  `frontends/` as `may_import: [model, workflows, report]` and routing on
+  anything but that real contract would be the filename guess this slice
+  rules out. A directory (or a `build-output.json` named directly, which resolves to
+  its directory) declaring `schema: abicheck.build-output/v1` is a build
+  output, reusing `is_build_output_dir` — the same contract every other
+  build-output consumer routes on; a top-level list is a use-case
+  manifest; a mapping is a project config, as the one shape carrying no
+  self-describing tag. Its property test is exhaustive over
+  shape × filename, with each shape's *conventional* name among the
+  misleading ones, so a filename-based implementation fails rather than
+  coincidentally passing — AGENTS.md's primitive-level rule, and the
+  reason this is a separate module rather than a branch inside the
+  command.
+
+  **Three consequences worth not rediscovering**, each a real behavior
+  change the consolidation forces, none of them a capability loss:
+
+  1. **An empty document is validated under every reading, not assigned
+     to one.** YAML cannot tell an empty mapping from an empty list, and
+     both superseded commands accepted one. So the project-config
+     validation still runs (its "no targets declared" warning is the
+     whole reason to run it) and the vacuous manifest reading is stated
+     beside it. Silently picking either would have dropped whichever the
+     caller meant — the empty config's warnings, or the manifest's `0
+     use cases` answer.
+  2. **A mapping that was meant to be a manifest is read as a config**,
+     because shape is the discriminator. Exit code is unchanged (`64`)
+     and the message now names the reading applied, so the user is not
+     sent hunting for a typo in a document of the wrong kind.
+  3. **Unparseable YAML fails at classification**, ahead of every
+     validator, rather than inside the project-config loader. Same exit
+     code, same named file.
 - **7q — `aggregate --run-plan` into `--manifest`.** A run plan is a
   second schema for the same "expected set" input; the projection is
   validated internally. `--discovered-only` stays **explicit** — it states
@@ -1827,10 +1864,10 @@ listed beside it so the gap is legible rather than averaged away:
 | `deps compare` | 8 | **7** | 7 | — (7m) |
 | `project history` | 5 | **4** | 4 | — (7m) |
 | `project plan` | 8 | **6** | 6 | — (7r + 7m) |
-| `project validate` | 4 | **3** | 3 | — (7m) |
-| `project validate-build` | 3 | **0** | folded | 7p |
-| `project validate-use-cases` | 3 | **0** | folded | 7p |
-| **Native total** | **109** | **87** | 68 | **19 options, all of them `compare`'s 15 and `dump`'s 4** |
+| `project validate` | 4 | **3** | 3 | — (7m); **7p landed**, so this row is now one command over all three schemas |
+| `project validate-build` | 3 | **0** | folded | **done (7p)** |
+| `project validate-use-cases` | 3 | **0** | folded | **done (7p)** |
+| **Native total** | **109** (103 after 7p) | **87** | 68 | **19 options, all of them `compare`'s 15 and `dump`'s 4** |
 | `compat check` / `compat dump` | 75 (22 hidden) / 19 (5 hidden) | frozen | frozen | ADR-068 D7 — excluded from every count |
 
 Read the last column as this phase's actual position: **on six of the ten

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -407,8 +407,8 @@ The number is a consequence of the model, not the goal.
 > state.** Phase 7i re-derived both live counts by Click introspection and
 > itemized, per flag, every option standing between them and the targets —
 > see its own table in §6 Phase 7. Read that, not this, for where the
-> surface actually is: as of that slice `compare` is at **50** (from 78 at
-> the original audit, 56 at the start of the slice) and `dump` at **21**
+> surface actually is: as of that slice `compare` was at **50** (from 78 at
+> the original audit, 56 at the start of the slice) and `dump` at **21**; live today, after Phase 6, **47** and **18** (Phase 7l)
 > (from 39 / 24). Both targets remain reachable, and every residual option
 > has a named owner and a named blocker; two of them are *deliberate keeps*
 > that the targets below predate.
@@ -1596,7 +1596,10 @@ now recorded where the check runs.
 changes; no machine contract changes, so no schema bump. It is a
 documentation-and-enforcement slice whose whole product is that the surface
 can no longer grow unruled. **Counts after 7k: `compare` 50, `dump` 21**
-(unchanged from 7j).
+(unchanged from 7j). Both numbers are the *pre-Phase-6* surface: `scan`'s
+retirement took `--env-matrix`, `--require-complete-analysis` and
+`--build-target` with it, so the live, Click-introspected counts are
+**`compare` 47, `dump` 18** — see Phase 7l.
 
 Only now, with one analysis path: the CONFIG/AUTO/MERGE/REMOVE rows of §4,
 in small PRs grouped by concept —
@@ -1625,6 +1628,187 @@ Every PR in this phase meets the merge criteria recorded in
 `64` with no hidden alias, front-end parity in the same PR, schema bump where
 a machine contract changes, and verdict/gate/exit/coverage/assurance asserted
 separately. That list is carried forward unchanged; it is not restated here.
+
+### Phase 7l — external CLI audit (2026-09-12), reconciled
+
+An external, static source/reference audit of the whole CLI surface at
+`31cbd4a` was reviewed against this phase's existing rulings. Its counts
+reproduce exactly (`compare` **47** visible, `dump` **18**, Click-
+introspected — the "50/21" in 7i/7j/7k is the pre-Phase-6 surface, before
+`scan`'s retirement took `--env-matrix`, `--require-complete-analysis` and
+`--build-target` off `compare`/`dump` with it), so the two surfaces are
+talking about the same CLI and the disagreements below are about *rulings*,
+not about state.
+
+Its central claim is one this phase should adopt explicitly, because 7i/7k
+did not state it: **a necessary capability does not require a dedicated
+flag, and a removal that costs the user three commands or an invented
+manifest is not a simplification.** Its corollary matters equally — "there
+is no replacement today" is a *migration prerequisite*, not permanent
+ownership, which is exactly what a `deferred` ruling already says, and
+several of our `per_run_operand` rulings would be honestly re-read as
+`deferred` under it.
+
+**Adopted — new work this phase did not have.** Each becomes a numbered
+slice below rather than a flag row, because each is a *replacement
+mechanism* first and an option count second:
+
+- **7m — one export request.** `--format`/`-o/--output`/`--write`/
+  `--output-dir`/`--max-findings-per-library` are four mechanisms for
+  "which artifacts does this analysis produce". Target: one repeatable
+  `-o FORMAT=DESTINATION` with `-` for stdout (Click already supports `-`
+  in its file handling, so 7k's own decline of the `--write` merge — "a
+  path-less `--write` value would be one flag carrying two grammars" —
+  does not survive this framing: it is one grammar, and `-` is the
+  stdout spelling). `--output-dir`'s per-component fan-out and
+  `--max-findings-per-library`'s summary cap are then consequences of the
+  export set, not separate escape routes: complete machine data is never
+  truncated, and a human summary is bounded automatically. **Net −4**,
+  and the first removal on this surface that reduces what a user must
+  *decide*, not just what they must type. Blocked on: ADR-061 gap C (one
+  document, several projections) — already this plan's Phase 5
+  prerequisite — plus collision detection, Windows path handling, and
+  F-19's output-format invariance holding across the new grammar.
+- **7n — evidence transports, one input per evidence *role*.**
+  `--debug-root` merges into `--debug-info` (a detached debug file, a
+  directory of them, and a debug package are three transports of one
+  role); `--devel-pkg` merges into `-H` (a development package is a
+  carrier of header evidence); `--probe-matrix` merges into a typed
+  `--build-info` (probe observations and compile context stay distinct
+  *internally* and may be supplied together). **Net −3.** The bar for
+  each is that the merged input keeps the schema, side ownership, and
+  binary/debug identity validation it has today — accepting more filename
+  extensions is not the deliverable. **Explicitly not merged:
+  `--sources` and `--build-info`** — a checkout and the context it was
+  built under are independent inputs that are routinely supplied
+  together; an `--evidence` grammar there would trade a flag for a type
+  vocabulary the user must learn and for harder ambiguity diagnosis. That
+  boundary is the audit's own, and this plan endorses it.
+- **7o — `--view`'s internal grammar.** 7i/7k ruled `--view` a keep and
+  never looked inside it. It now carries report mode, a
+  severity/entity/action display filter with its own AND/OR rules across
+  repeated groups, demangle toggles, pattern explanation, filtered-finding
+  display and suppression audit — the four flags Phase 5 merged, still
+  four decisions. Target: `patterns`, `filtered` and `suppressions` become
+  unconditional disclosure (compact counts always, detail in the canonical
+  result — which is ADR-067's accounting rule, not a display preference);
+  `demangle`/`no-demangle` become automatic once human output carries a
+  copyable exact symbol and machine output carries both names; the display
+  dimensions derive from the canonical finding model rather than a second
+  `ChangeKind`-name interpretation. `leaf` is re-examined against
+  `root-cause` **with a measurement**, not declared redundant. Net option
+  count: **0** — which is the point: this slice reduces decisions, not
+  strings beginning with `--`.
+- **7p — `project validate` consolidation.** `project validate`,
+  `validate-build` and `validate-use-cases` are one question over three
+  input schemas. Target: `abicheck project validate INPUT`, dispatching on
+  a validated schema discriminator or a recognized directory contract —
+  **never on a filename guess**, and recognizing a project file never
+  authorizes its nominated toolchain (`--toolchain-bindings` stays the
+  explicit authorization). **Net −2 subcommands**, −4 duplicated output
+  options once 7m's export request is shared.
+- **7q — `aggregate --run-plan` into `--manifest`.** A run plan is a
+  second schema for the same "expected set" input; the projection is
+  validated internally. `--discovered-only` stays **explicit** — it states
+  that the operator has no expected inventory, and inferring that from an
+  empty manifest is how a CI matrix silently goes green with missing jobs.
+  **Net −1.**
+- **7r — `project plan --allow-empty` retired** once a legitimately empty
+  selection produces an *explained skipped plan* rather than needing a
+  bypass switch, and bootstrap validation routes to `project validate`.
+  **Net −1.** Its other four inputs (`--build-output`, `--project`,
+  `--head-sha`, `--toolchain-bindings`) are ruled keeps here for the
+  audit's reason, which this plan adopts as a general rule:
+  **auto-detection is a useful default, not proof that an explicit
+  override is unnecessary** (a Git origin may describe a fork or mirror;
+  the planner's checkout is not necessarily the candidate revision).
+
+**Adopted as re-rulings of existing entries** (`rulings.py` changes from
+`per_run_operand` to `deferred`, with the named blocker, when the slice
+above lands — not before, since a deferral needs a real prerequisite):
+`--format`, `--write`, `--output-dir`, `--max-findings-per-library`
+(7m) · `--debug-root`, `--devel-pkg`, `--probe-matrix` (7n).
+
+**Declined, with the reason recorded** — each was already measured or
+already decided, and the audit did not have the measurement:
+
+- **`dump --compression` → retire.** Declined; 7k already ruled this
+  against §4.2's AUTO row, and the audit concedes the counterexample
+  itself (`-o build/abi.json --compression zstd`: the publishing job owns
+  the encoding, and the suffix cannot express it). "Retire it through a
+  storage preference or an external re-compression step" is a capability
+  trade the audit labels a "conscious convenience tradeoff"; this plan's
+  Non-goals rule it out — we do not shorten the CLI by making a supported
+  workflow require an extra step.
+- **`--dry-run` → `--plan`.** Declined, and it is not a neutral rename:
+  ADR-054 folded a `plan` *command* back into `dump --dump-manifest
+  --dry-run` precisely to stop a second "preflight" vocabulary growing
+  next to the established one. Re-introducing `--plan` as a flag spelling
+  re-opens that drift for a stated zero option-count gain. (`project
+  plan` is a different noun — a run plan artifact — and is unaffected.)
+- **`--used-by-manifest` → `--used-by @FILE`.** Declined again, same
+  reason as 7k: a manifest carries digest/platform/profile provenance and
+  a required-vs-advisory distinction a consumer path cannot express, so
+  the collapse either drops content or overloads one flag with two value
+  grammars. The audit's own `@`-prefix proposal is the second of those.
+  (Its ruling that `--required-symbol` stays *distinct* from `--used-by`
+  — a host contract is not an observed import table — matches ours.)
+- **`--severity-preset` merged into policy selection.** Declined *for
+  now*, not on the merits: the audit itself names the real blocker
+  (gate activation must be consistent across pairwise, bundle and
+  no-baseline execution first), and this plan will not merge a gate
+  selector into a policy document while a no-baseline run still describes
+  the preset as what arms its audit gate. Re-examine after that
+  convergence; the audit's constraint that acceptance, classification and
+  suppression stay *separate meanings* under one resolved selection is
+  adopted verbatim as the design bar.
+- **`--select-required` merged into an expected inventory.** Already this
+  plan's ADR-065 dependency (P5), not a new finding; `--select-required`
+  stays until package component inventories land, and 7k's own decline
+  (it declares a completeness *obligation* feeding the scope exit axis)
+  stands until then.
+- **`--follow-deps`/`--search-path`/`--ld-library-path` → one
+  `--environment old=|new=` operand.** Not declined, but **not adopted as
+  a reduction**: it is a *new* operand, the audit counts it as such, and
+  7i's measurement (the dependency walk embeds absolute host paths, so it
+  may never become unconditional) plus 7k's measurement (the two path
+  flags insert at different loader steps and record different
+  `resolution_reason` values, so collapsing them changes which library
+  resolves) both survive it. Recorded as **future direction, owned by
+  G42** (named deployment environments and provider resolution), where an
+  environment is a real named object rather than a flag rename. The
+  audit's two constraints are carried into G42's own acceptance bar: the
+  replacement must keep the *same-run* enrichment of a comparison or
+  snapshot (telling the user to "run `deps` separately" is not parity),
+  and removing `--follow-deps` must never mean resolving against the
+  current host by default.
+
+**Noted, no change here.** `compat`'s 94 logical options (27 hidden) are
+frozen by ADR-068 D7 and excluded from every count — the audit agrees and
+proposes nothing there. `abicheck-cc` and the Clang plugin take compiler
+arguments and `ABICHECK_*` variables, not abicheck flags; the audit's
+useful point is that wrapper, plugin and `dump` capture settings should be
+*generated from one capture specification* rather than maintained three
+times, which is G34's territory, and that `ABICHECK_CC_DISABLE` treating
+`"0"` as "disable" is a real defect worth fixing on its own. Its warning
+that environment variables must not become the new hidden CLI is adopted
+as a standing constraint on every CONFIG demotion in this phase: a
+demoted flag lands in `.abicheck.yml`, never in an undocumented variable.
+
+**The acceptance bar for every slice above**, stated once (it is the
+audit's, and it is stricter than "the old spelling exits 64"):
+
+> The old user task still has a simple, supported invocation, with the
+> same relevant evidence and a truthful result.
+
+A test asserting only that a removed flag now errors proves deletion, not
+simplification, and does not satisfy 7m–7r.
+
+**Counts if 7m–7r land:** `compare` 47 → **40** (7m −4, 7n −3), which is
+§4.5's target reached without touching the five `deferred` entries;
+`dump` 18 → **17** (7n's `--debug-root` merge), with `--build-target`
+already gone with `scan` and §4.5's ≤16 target reachable only through one
+further ruling, not through this audit.
 
 ### Phase 8 — `deps` convergence (ADR-068 D6) — done
 

--- a/docs/contribute/plans/one-comparison-product.md
+++ b/docs/contribute/plans/one-comparison-product.md
@@ -1810,6 +1810,85 @@ simplification, and does not satisfy 7m–7r.
 already gone with `scan` and §4.5's ≤16 target reachable only through one
 further ruling, not through this audit.
 
+**The whole-surface count, verified and re-derived.** 7i/7k only ever
+counted `compare` and `dump`; the audit counts every command, and every one
+of its twelve numbers reproduces exactly by Click introspection on this
+branch (one logical option once, short aliases and `--no-` spellings
+collapsed, `--help`/`--help-all` excluded). The "adopted" column is what
+7m–7r above actually deliver — not the audit's own end state, which is
+listed beside it so the gap is legible rather than averaged away:
+
+| Command | Today | After 7m–7r | Audit's end state | The gap, named |
+|---|---|---|---|---|
+| `compare` | 47 | **40** | 25 | The five `deferred` rulings + the CONFIG demotions this plan declines or gates (`--dump-manifest`, `--include-system-declarations`, `--abi3`, `--severity-preset`, `--select-required`) + the `--environment` collapse (G42) |
+| `dump` | 18 | **17** | 13 | `--dump-manifest`/`--include-system-declarations` to capture config, `--compression` (ruled a keep, 7k), `--environment` (G42) |
+| `aggregate` | 6 | **4** | 4 | — (7q + 7m's shared export) |
+| `deps tree` | 7 | **6** | 6 | — (7m) |
+| `deps compare` | 8 | **7** | 7 | — (7m) |
+| `project history` | 5 | **4** | 4 | — (7m) |
+| `project plan` | 8 | **6** | 6 | — (7r + 7m) |
+| `project validate` | 4 | **3** | 3 | — (7m) |
+| `project validate-build` | 3 | **0** | folded | 7p |
+| `project validate-use-cases` | 3 | **0** | folded | 7p |
+| **Native total** | **109** | **87** | 68 | **19 options, all of them `compare`'s 15 and `dump`'s 4** |
+| `compat check` / `compat dump` | 75 (22 hidden) / 19 (5 hidden) | frozen | frozen | ADR-068 D7 — excluded from every count |
+
+Read the last column as this phase's actual position: **on six of the ten
+native commands the audit's end state and ours are identical**, and the
+entire 87-vs-68 difference is the contract/capture-config question this
+plan has already gated (Phase 9, G42, P5) or ruled against with a
+measurement. There is no third, unexamined bucket. `--format`/`-o`
+converging on one export request is what moves every command except
+`compare`/`dump`, which is why 7m is sequenced first: it is one mechanism
+that closes eight rows.
+
+**Six smaller audit items, ruled here rather than left unrecorded** —
+these were in the audit and absent from the first pass of this section:
+
+- **`--abi3` → declared floor activates the check.** Adopted *in part*: an
+  `.abicheck.yml`-declared `abi3` floor should arm the applicable check
+  without a second enable flag. The flag itself stays until that key
+  exists, and the audit's own guard is adopted with it — **an arbitrary
+  CPython extension must never be assumed to promise `abi3`**, so the
+  check arms from a declaration, never from sniffing the binary. Owner:
+  G26 (`--abi3`'s own workstream), not this phase.
+- **`--dump-manifest`, `--include-system-declarations` → capture
+  contract.** The audit argues both are properties of *how this project
+  captures evidence*, against our `per_run_operand` rulings. Recorded as a
+  live disagreement rather than settled: it is the same question 7p/7n
+  cannot answer alone, and it needs the capture-specification work
+  (below) to have a home at all. Neither ruling changes until then, and
+  the plan states why on each: a multi-TU recipe and a dependency-surface
+  selector both vary per invocation today because no capture spec exists
+  to carry them.
+- **`--bundle-facts-out`: the blocker is a task, not a property.** 7d
+  ruled it a keep because "`dump` has no directory/package fan-out to hold
+  this". The audit is right that this is a *missing implementation*, not a
+  reason the flag belongs on `compare` forever. Re-recorded as a keep
+  **with a named owner** — bundle capture in `dump` — so it reads as
+  deferred-by-absence rather than settled. `rulings.py` keeps
+  `per_run_operand` until that capture exists (a `deferred` ruling needs a
+  blocker that is actually being built).
+- **`deps`: the default `/` root must be visible in the resolved plan.**
+  Adopted, and it is a correctness point rather than a CLI one: an
+  unspecified `--sysroot`/`--old-root`/`--new-root` currently reads in the
+  output like a deliberately chosen deployment environment. No flag
+  changes; the resolved plan and report state that the root was defaulted.
+  Owner: Phase 8's `ReportDocument` projection, which already renders the
+  stack report.
+- **`ABICHECK_CC_DISABLE` treats `"0"` as disable.** A real defect
+  (any non-empty value disables capture), not a CLI-surface item. Fix
+  separately with a regression test over the *class* — truthy/falsey
+  string parsing across every `ABICHECK_*` boolean, not just this one
+  variable — per AGENTS.md's bug-class rule.
+- **One capture specification for `dump`, `abicheck-cc` and the Clang
+  plugin.** The audit's strongest structural point outside `compare`:
+  public roots, library identity and version are configured three times in
+  three vocabularies (`-H`/`ABICHECK_CC_HEADERS`/`public-roots=`). Not
+  this plan's to own — recorded as G34's, and as the prerequisite that
+  makes the two `per_run_operand` rulings above answerable.
+
+
 ### Phase 8 — `deps` convergence (ADR-068 D6) — done
 
 `StackVerdict` → `ExitDecision`: `stack_checker.exit_decision_for_stack_compare`/

--- a/docs/contribute/use-case-impact.md
+++ b/docs/contribute/use-case-impact.md
@@ -19,7 +19,7 @@ generated: false
 > text/markdown report. It genuinely answers "was this use case affected",
 > but it is read-only: no `Change` field, no exit-code contribution, and
 > still no `USE_CASE_IMPACT_CONFIRMED` finding kind (see "What this does
-> not cover yet" below). `abicheck project validate-use-cases` checks a
+> not cover yet" below). `abicheck project validate` checks a
 > manifest's structure on its own.
 
 An optional `impact-use-cases.yaml` manifest lets you declare a project's own
@@ -34,7 +34,7 @@ amending [ADR-057](../contribute/adr/057-consumer-graph-and-impact-join.md).
 `abicheck.impact.use_cases` parses the manifest, builds/joins the graph
 facts, and (`explain_use_case_impact`) answers which declared use case(s)
 reach a given changed symbol. Two CLI surfaces use it:
-`abicheck project validate-use-cases <manifest>` checks the manifest's own
+`abicheck project validate <manifest>` checks the manifest's own
 structure, and `abicheck compare --use-cases <manifest> OLD NEW` resolves
 each use case's entrypoints against the comparison's own snapshots and
 reports which of its findings each use case reaches
@@ -45,7 +45,7 @@ reports which of its findings each use case reaches
 ## Checking a manifest with the CLI
 
 ```console
-$ abicheck project validate-use-cases impact-use-cases.yaml
+$ abicheck project validate impact-use-cases.yaml
 use-case manifest validation: impact-use-cases.yaml
 OK — 2 use case(s), structurally well-formed.
 
@@ -60,7 +60,7 @@ Use-case impact (impact-use-cases.yaml):
   proof of absence).
 ```
 
-`project validate-use-cases` checks only the manifest's own structure (a
+`project validate` checks only the manifest's own structure (a
 non-mapping entry, an unrecognized field, or a missing `use_case` name is a
 usage error, exit 64).
 

--- a/docs/integration/scenarios/existing-build-artifact.md
+++ b/docs/integration/scenarios/existing-build-artifact.md
@@ -28,7 +28,7 @@ abicheck-build-linux-x86_64-gcc13-release/
 > `build-output.json` by hand, or generate it from your build system's own
 > `install`/manifest step. See the
 > [schema reference](../../reference/build-output-schema.md) for the exact
-> shape and validation rules (`abicheck project validate-build` checks it
+> shape and validation rules (`abicheck project validate` checks it
 > before anything consumes it).
 
 ## The check

--- a/docs/reference/build-output-schema.md
+++ b/docs/reference/build-output-schema.md
@@ -7,7 +7,7 @@ system, or an `install` step, populates an `abicheck-build/` directory that
 downstream tooling then validates and consumes.
 
 > **Status.** This page documents the schema and the
-> `abicheck project validate-build` command shipped in G30 P1.1. The
+> `abicheck project validate` command (`validate-build` until plan Phase 7p) shipped in G30 P1.1. The
 > consumers that read a validated `build-output.json` to resolve a
 > baseline or run a check — `resolve-baseline`/`check-target` (G30
 > P1.2/P1.3) and `abicheck project plan`/[`check-project.yml`](reusable-workflows.md)
@@ -70,7 +70,7 @@ as-installed header root — see [Validation rules](#validation-rules) below.
 
 Every field is optional and defaulted (the `buildsource` package-wide
 forward-compatibility convention) — a hand-written or partially-populated
-manifest never aborts a load. `abicheck project validate-build` is what turns
+manifest never aborts a load. `abicheck project validate` is what turns
 missing/inconsistent fields into an actionable report.
 
 ### Top-level fields
@@ -131,7 +131,7 @@ means the build itself asserted this evidence pack belongs to exactly this
 target (e.g. per-target compile-DB filtering, or a wrapper invoked once per
 link step). `"inferred"` would mean abicheck derived the association from a
 build-wide pack via TU→link-unit→DSO attribution — that attribution
-mechanism is G30 P2, not built yet, so `abicheck project validate-build`
+mechanism is G30 P2, not built yet, so `abicheck project validate`
 treats `"inferred"` (and any value other than `"declared"`) as a **hard
 validation failure**, not a lower-confidence warning. Until P2 ships, a
 build-wide evidence pack may only feed a build-wide source audit or a
@@ -142,7 +142,9 @@ for the practical consequence of this rule).
 
 ## Validation rules
 
-`abicheck project validate-build DIRECTORY` checks, per ADR-047 §11.1:
+`abicheck project validate DIRECTORY` checks, per ADR-047 §11.1 (the
+directory is recognized by its own `build-output.json` schema tag, not by
+its name):
 
 1. **Every declared header root is non-empty.** Each `public_header_roots`/
    `generated_header_roots` entry must resolve to an existing, non-empty
@@ -179,11 +181,11 @@ principle ADR-047 §11 states for every G30 validator.
 ### CLI
 
 ```console
-$ abicheck project validate-build abicheck-build/
+$ abicheck project validate abicheck-build/
 build-output validation: abicheck-build/
 OK — no errors.
 
-$ abicheck project validate-build abicheck-build/ --format json
+$ abicheck project validate abicheck-build/ --format json
 {
   "root": "abicheck-build/",
   "ok": true,

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -94,7 +94,7 @@ Compare two ABI surfaces and report changes.
 | `--diagnostic-comparison` | no | `False` | ADR-050 D2's sanctioned escape hatch: when OLD and NEW were extracted under a genuinely incomparable profile/scope (ExtractionContract mismatch), downgrade the default hard failure (exit 16, no verdict) into a tentative diff instead, stamped assurance: "none" everywhere in the report so a reader knows not to trust it the way an ordinary comparable diff is trusted. Not needed, and does nothing, on a comparable pair. |
 | `--contract` | no | — | Which evidence domain each finding is judged against (ADR-049 Phase 6), and the flag that turns the contract evaluator on -- omit it and nothing about the run changes. 'public': the header-derived declared surface. 'exports': the binary's own export table (ELF .dynsym / PE export directory / Mach-O export trie) plus the raw type closure reachable from it -- a private-header type reached from a real export is inside this contract, an unexported public-header declaration is not. 'all': every entity, no root or closure evidence required. 'auto': evaluate, but let the domain be chosen by the D7 precedence chain below an explicit CLI value -- the --scope-public-headers/--no-scope-public-headers legacy alias, then .abicheck.yml. Each finding is stamped with a contract\_relevance (IN\_CONTRACT/PROVEN\_OUT\_OF\_CONTRACT/UNKNOWN\_UNPROVEN/UNKNOWN\_UNRESOLVED/NOT\_APPLICABLE), a contract\_reason\_code and -- when resolved -- a contract\_assurance, rendered per finding in --format json/markdown, in sarif/junit properties, and as an html badge; --format review's compact digest renders it only in the --used-by/--required-symbol scoped-gate appendix. --format json additionally carries contract\_evidence\_refs per finding (which evidence records the decision rests on) and a top-level contract\_context block (observed provider evidence, resolved evaluation context, decision receipt), so a decision can be replayed or re-evaluated later without re-reading the binaries. **The decisions are authoritative** (ADR-049 Phase 7): relevance is classified before compatibility policy, and policy scores only IN\_CONTRACT/NOT\_APPLICABLE findings -- so this changes verdicts and exit codes. Nothing is hidden: an excluded finding stays in the report with the relevance and reason that explain why it did not gate. Uncertainty is not treated as compatible either -- if the selected domain's required evidence is incomplete, the orthogonal contract-coverage ledger contributes exit 1, folded with max so it never lowers an ABI break's 2/4. Set contract.unresolved=warn (e.g. via a `kind: contract` --pack) to accept incomplete coverage: that zeroes the contribution while still reporting every failure. The coverage floor itself applies to a directory/package (release) comparison too -- each library's own floor is max()-folded into the release's exit code the same way, and a pack-supplied contract.unresolved applies there too (see --pack's own help). Choices: `public`, `exports`, `all`, `auto`. |
 | `--pack` | no | — | Select an ADR-049 D8 pack manifest (repeatable). A pack is a small versioned YAML document (id/version/kind/assignments) carrying one reusable piece of configuration. 'kind: policy' assigns ChangeKind slugs to break/warn/risk/ignore, exactly as --policy's overrides do; 'kind: contract' assigns surface.internal\_namespaces and contract.unresolved (the latter needs --contract, which is what computes the coverage it configures); 'kind: gate' assigns gate.severity.<category> (gate.exit\_code\_scheme was removed along with --exit-code-scheme, CLI cleanup phase two PR G2 -- the one automatic gate algorithm is fully determined by whether a severity setting is in effect, so a pack asserting it is rejected at load time). Composition is D8's: an explicitly stated value (--policy, --severity-preset, or .abicheck.yml) always outranks a pack, and two selected packs assigning different values to the same field are a usage error unless something else already states it. A manifest assigning a field this build resolves but does not yet apply is rejected rather than silently recorded. On a directory/package (release) comparison, a 'kind: policy'/'kind: contract'/'kind: gate' pack's policy.overrides/surface.internal\_namespaces/contract.unresolved/gate.severity.<category> all apply to every library uniformly (folded into the release's own resolved GateOptions); contract.unresolved still needs --contract on that release comparison, same as everywhere else. On `scan` this requires --against (a pack's only application there is the baseline comparison), and a 'kind: gate' pack's gate.severity.<category> applies to the baseline comparison's exit code the same way --severity-preset given directly already does. |
-| `--use-cases` | no | — | An impact-use-cases.yaml manifest (G29 Phase 4, ADR-057 amendment) whose declared use cases this comparison's own findings are attributed to: for each use case, which changes its resolved entrypoints can be shown to reach. Needs a source graph on at least one side (dump --sources/--build-info, or the always-on header-only graph). Read-only -- an unattributed finding is an absence of proof, not proof the finding is harmless, so this never moves a verdict or an exit code. Validate a manifest on its own with `abicheck project validate-use-cases`. |
+| `--use-cases` | no | — | An impact-use-cases.yaml manifest (G29 Phase 4, ADR-057 amendment) whose declared use cases this comparison's own findings are attributed to: for each use case, which changes its resolved entrypoints can be shown to reach. Needs a source graph on at least one side (dump --sources/--build-info, or the always-on header-only graph). Read-only -- an unattributed finding is an absence of proof, not proof the finding is harmless, so this never moves a verdict or an exit code. Validate a manifest on its own with `abicheck project validate`. |
 | `--verbose`, `-v` | no | `False` | Enable verbose/debug output. |
 | `--variant` | no | — | Which build variant to compare when an operand is a stored ProjectSnapshot package directory declaring more than one. Scope to one side with an 'old='/'new=' prefix, repeating the flag per side (e.g. --variant old=v1 --variant new=v2); a bare value applies to both. Defaults to the package's only variant when it declares exactly one; a usage error otherwise. No-op for a live directory/archive/single-file operand. |
 
@@ -320,13 +320,13 @@ Generate run-plan.json from CONFIG's targets:/bundles:/profiles: block.
 
 ### `project validate`
 
-Validate CONFIG's targets:/bundles:/profiles:/baseline: block (ADR-047 §3).
+Validate INPUT, a project-integration document (ADR-047, ADR-057).
 
 **Arguments**
 
 | Name | Required | Description |
 |---|:--:|---|
-| `config` | no |  |
+| `input_path` | no |  |
 
 **Options**
 
@@ -334,41 +334,5 @@ Validate CONFIG's targets:/bundles:/profiles:/baseline: block (ADR-047 §3).
 |---|:--:|---|---|
 | `--format` | no | `text` | Output format for the validation report. Choices: `text`, `json`. |
 | `--output`, `-o` | no | — | Write output to this path (default: stdout). |
-| `--toolchain-bindings` | no | — | Path to a trusted toolchain-bindings file (schema abicheck.toolchain-bindings/v1) to additionally check every declared profiles.<id>.compile.binding (and consumer\_compile.binding) resolves, and — when compiler\_family/compiler\_version/target is also declared — that the resolved executable's probed identity actually matches. Loaded only from this explicit path — never auto-discovered, per the untrusted-config trust boundary ProfileCompileSpec.binding documents. |
-| `--verbose`, `-v` | no | `False` | Enable verbose/debug output. |
-
-### `project validate-build`
-
-Validate DIRECTORY's build-output.json (ADR-047 §11.1).
-
-**Arguments**
-
-| Name | Required | Description |
-|---|:--:|---|
-| `directory` | yes |  |
-
-**Options**
-
-| Option | Required | Default | Description |
-|---|:--:|---|---|
-| `--format` | no | `text` | Output format for the validation report. Choices: `text`, `json`. |
-| `--output`, `-o` | no | — | Write output to this path (default: stdout). |
-| `--verbose`, `-v` | no | `False` | Enable verbose/debug output. |
-
-### `project validate-use-cases`
-
-Validate MANIFEST, an ``impact-use-cases.yaml`` file (G29 Phase 4, ADR-057 amendment; see docs/contribute/use-case-impact.md).
-
-**Arguments**
-
-| Name | Required | Description |
-|---|:--:|---|
-| `manifest` | yes |  |
-
-**Options**
-
-| Option | Required | Default | Description |
-|---|:--:|---|---|
-| `--format` | no | `text` | Output format for the validation report. Choices: `text`, `json`. |
-| `--output`, `-o` | no | — | Write output to this path (default: stdout). |
+| `--toolchain-bindings` | no | — | Path to a trusted toolchain-bindings file (schema abicheck.toolchain-bindings/v1) to additionally check every declared profiles.<id>.compile.binding (and consumer\_compile.binding) resolves, and — when compiler\_family/compiler\_version/target is also declared — that the resolved executable's probed identity actually matches. Loaded only from this explicit path — never auto-discovered, per the untrusted-config trust boundary ProfileCompileSpec.binding documents. Applies to a project config; supplying it with any other INPUT is a usage error. |
 | `--verbose`, `-v` | no | `False` | Enable verbose/debug output. |

--- a/docs/use/companion-commands.md
+++ b/docs/use/companion-commands.md
@@ -116,7 +116,7 @@ Some of the old companion functionality survives as a **command**:
 The CLI surface today has five core per-library analysis commands
 (`compare`, `compat`, `deps`, `dump`, `scan`) plus project-orchestration
 commands — `aggregate` and the `project` group (`project plan`/`project
-validate`/`project validate-build`, ADR-054) — that compose those five
+validate`, ADR-054) — that compose those five
 across a multi-target project — neither group is part of the
 companion-command consolidation this page describes; see the
 [CLI Reference](../reference/cli-reference.md) for the full command tree.

--- a/scripts/retired_surfaces.py
+++ b/scripts/retired_surfaces.py
@@ -297,6 +297,25 @@ RETIRED_SURFACES: tuple[tuple[str, tuple[str, ...], frozenset[str]], ...] = (
         frozenset({"AGENTS.md"}),
     ),
     (
+        "project validate-build / project validate-use-cases (plan Phase 7p"
+        " folded both into one project validate INPUT, dispatching on the"
+        " document's own schema discriminator or directory contract rather"
+        " than on its filename)",
+        ("validate-build", "validate-use-cases"),
+        frozenset(
+            {
+                "AGENTS.md",
+                # Historical record: the plan that ordered the fold and the
+                # ADRs/plan sections that describe the surface as it was.
+                "contribute/plans",
+                "contribute/adr",
+                # Migration note naming the retired spelling beside the
+                # replacement, which is the point of the note.
+                "reference/build-output-schema.md",
+            }
+        ),
+    ),
+    (
         "project validate-use-cases --against/--against-new (resolving a"
         " manifest against a real library, and attributing a comparison's"
         " findings to the use cases that reach them, is compare --use-cases)",

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -652,4 +652,47 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="cli_surface.name_independent_dispatch_undone_downstream",
+        invariant=(
+            "When a front end decides what an operand *is* from its own "
+            "content -- a schema discriminator, a directory contract -- "
+            "every consumer it then hands that operand to must accept it "
+            "as given. Re-deriving a conventional filename from it (taking "
+            "a named manifest's parent directory and looking for the usual "
+            "name beside it) re-introduces, one layer down, exactly the "
+            "name dependency the dispatch just refused, and turns a valid "
+            "input into 'not found'. The corollary is where this class "
+            "actually escapes: proving the *classifier* is name-independent "
+            "proves nothing about the pipeline behind it, so the "
+            "generalized test must run the whole public invocation under "
+            "the non-conventional name, not just the classification step."
+        ),
+        fixed_by=(1242,),
+        seed_tests=(
+            "tests/test_cli_project_validate_dispatch.py",
+            "tests/test_build_output.py",
+        ),
+        # Earned: the seed's name-independence matrix runs real `CliRunner`
+        # invocations of `abicheck project validate` end to end, which is
+        # the half that was missing when the defect shipped.
+        public_surfaces=("cli",),
+        axes={
+            "input_kind": (
+                "project-config",
+                "build-output",
+                "use-case-manifest",
+                "empty-document",
+            ),
+            "operand_shape": ("directory", "named-manifest-file"),
+            "filename": (
+                ".abicheck.yml",
+                "impact-use-cases.yaml",
+                "build-output.json",
+                "run-42.json",
+                "config.yaml",
+                "NOTES",
+            ),
+        },
+    ),
 )

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -1271,12 +1271,17 @@ class TestDeclaredEvidenceSharingScope:
 
 
 class TestBuildOutputCLI:
-    """``abicheck project validate-build DIRECTORY`` (G30 P1.1, ADR-054)."""
+    """``abicheck project validate DIRECTORY`` (G30 P1.1, ADR-054).
+
+    Since plan Phase 7p one ``project validate`` covers all three
+    project-integration documents; a build output is recognized by its own
+    ``build-output.json`` schema tag, not by a dedicated subcommand.
+    """
 
     def _run(self, args):
         from abicheck.cli import main
 
-        return CliRunner().invoke(main, ["project", "validate-build", *args])
+        return CliRunner().invoke(main, ["project", "validate", *args])
 
     def _valid_dir(self, tmp_path: Path) -> Path:
         root = tmp_path / "abicheck-build"

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -1271,12 +1271,7 @@ class TestDeclaredEvidenceSharingScope:
 
 
 class TestBuildOutputCLI:
-    """``abicheck project validate DIRECTORY`` (G30 P1.1, ADR-054).
-
-    Since plan Phase 7p one ``project validate`` covers all three
-    project-integration documents; a build output is recognized by its own
-    ``build-output.json`` schema tag, not by a dedicated subcommand.
-    """
+    """``abicheck project validate DIRECTORY`` (G30 P1.1, ADR-054; one command over all three kinds since Phase 7p, routed by ``schema:``)."""
 
     def _run(self, args):
         from abicheck.cli import main

--- a/tests/test_build_output_manifest_resolution.py
+++ b/tests/test_build_output_manifest_resolution.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Either spelling of a build-output operand (PR #1242).
+
+Split out of ``test_build_output.py``, which is at its
+``architecture/debt.yaml`` no-growth baseline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.build_output import (
+    BUILD_OUTPUT_SCHEMA,
+    load_build_output,
+    resolve_build_output_manifest,
+    validate_build_output,
+)
+
+
+class TestResolveBuildOutputManifest:
+    """Either spelling of a build-output operand, and the root each gives.
+
+    A build output may be named as its directory or as the manifest file
+    itself -- under any name, since the ``schema:`` tag is what makes a
+    document one. Relative artifact paths must resolve against the
+    directory *holding the manifest* in both cases; re-deriving the
+    conventional filename from a named manifest's parent is the defect
+    registered as ``cli_surface.name_independent_dispatch_undone_
+    downstream``.
+    """
+
+    @pytest.mark.parametrize(
+        "name", ["build-output.json", "run-42.json", "artifacts.json", "OUT"]
+    )
+    def test_a_named_manifest_keeps_its_name_and_yields_its_directory(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        manifest = tmp_path / name
+        manifest.write_text(json.dumps({"schema": BUILD_OUTPUT_SCHEMA}))
+        assert resolve_build_output_manifest(manifest) == (tmp_path, manifest)
+
+    def test_a_directory_yields_the_conventional_manifest(self, tmp_path: Path) -> None:
+        assert resolve_build_output_manifest(tmp_path) == (
+            tmp_path,
+            tmp_path / "build-output.json",
+        )
+
+    @pytest.mark.parametrize("name", ["build-output.json", "run-42.json"])
+    def test_load_and_validate_accept_a_named_manifest(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        (tmp_path / name).write_text(
+            json.dumps({"schema": BUILD_OUTPUT_SCHEMA, "targets": []})
+        )
+        assert load_build_output(tmp_path / name).schema == BUILD_OUTPUT_SCHEMA
+        assert validate_build_output(tmp_path / name).ok

--- a/tests/test_cli_project_validate_dispatch.py
+++ b/tests/test_cli_project_validate_dispatch.py
@@ -155,6 +155,24 @@ class TestClassifierProperties:
             classify_validation_input(directory)
         assert "build-output.json" in str(exc.value)
 
+    def test_an_unreadable_document_is_a_classification_error(
+        self, tmp_path: Path
+    ) -> None:
+        # Click's exists=True only proves the path was there at argument
+        # parsing time. A file that cannot be *read as text* (here, bytes
+        # that are not UTF-8) has to surface as a usage error naming the
+        # file, not as a bare UnicodeDecodeError traceback.
+        path = tmp_path / "binary.yml"
+        path.write_bytes(b"\xff\xfe\x00not utf-8 at all\x80\x81")
+        with pytest.raises(ValidationInputError) as exc:
+            classify_validation_input(path)
+        assert "cannot read" in str(exc.value)
+        assert str(path) in str(exc.value)
+
+        res = _run(str(path))
+        assert res.exit_code == 64
+        assert "cannot read" in res.output
+
     def test_unparseable_yaml_is_a_classification_error_not_a_crash(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_cli_project_validate_dispatch.py
+++ b/tests/test_cli_project_validate_dispatch.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``project validate INPUT``'s one-command, three-schema dispatch (Phase 7p).
+
+Two levels, deliberately: the classifier's contract stated as invariants
+over generated inputs (it is a reusable dispatch primitive, so AGENTS.md's
+"primitive-level property tests" rule applies — a fixed-example test only
+forecloses the filenames it happens to name), and the CLI end to end.
+
+The invariant that matters, and the one a filename-based implementation
+would fail: **classification depends only on a document's content, never
+on its name or extension.** That is what makes the consolidation safe —
+the three superseded commands each trusted the caller to pick the right
+validator, and this one has to derive it.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+from abicheck.buildsource.build_output import BUILD_OUTPUT_SCHEMA
+from abicheck.buildsource.validation_input import (
+    ValidationInputError,
+    ValidationInputKind,
+    classify_validation_input,
+)
+from abicheck.cli import main
+
+#: One representative document per recognized shape, with the kind it must
+#: classify to. Content only — no filename appears here on purpose.
+DOCUMENTS: dict[ValidationInputKind, str] = {
+    ValidationInputKind.PROJECT_CONFIG: (
+        "targets:\n  lib:\n    kind: library\n    binary_pattern: lib*.so\n"
+    ),
+    ValidationInputKind.USE_CASE_MANIFEST: "- use_case: training\n  entrypoints: [train]\n",
+    ValidationInputKind.BUILD_OUTPUT: json.dumps({"schema": BUILD_OUTPUT_SCHEMA}),
+    ValidationInputKind.EMPTY_DOCUMENT: "",
+}
+
+#: Names deliberately chosen to disagree with the content they will hold —
+#: including each shape's *conventional* name, so a filename-based
+#: implementation fails rather than coincidentally passing.
+MISLEADING_NAMES = (
+    ".abicheck.yml",
+    "impact-use-cases.yaml",
+    "build-output.json",
+    "run-42.json",
+    "config.yaml",
+    "NOTES",
+)
+
+
+def _run(*args: str) -> Result:
+    return CliRunner().invoke(main, ["project", "validate", *args])
+
+
+class TestClassifierProperties:
+    """The classifier's contract, over every (shape, name) combination."""
+
+    @pytest.mark.parametrize(
+        ("kind", "name"), list(itertools.product(DOCUMENTS, MISLEADING_NAMES))
+    )
+    def test_classification_is_content_only(
+        self, tmp_path: Path, kind: ValidationInputKind, name: str
+    ) -> None:
+        # Exhaustive over the product, not a sampled pair: the oracle is
+        # the shape the content was *written* as, stated independently of
+        # the implementation's own branch order.
+        path = tmp_path / name
+        path.write_text(DOCUMENTS[kind], encoding="utf-8")
+        assert classify_validation_input(path)[0] is kind
+
+    @pytest.mark.parametrize("name", MISLEADING_NAMES)
+    def test_a_build_output_directory_is_recognized_under_any_name(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / "build-output.json").write_text(
+            json.dumps({"schema": BUILD_OUTPUT_SCHEMA}), encoding="utf-8"
+        )
+        kind, target = classify_validation_input(directory)
+        assert kind is ValidationInputKind.BUILD_OUTPUT
+        assert target == directory
+
+    def test_a_named_build_output_manifest_resolves_to_its_directory(
+        self, tmp_path: Path
+    ) -> None:
+        # The one case where the returned path differs from the input:
+        # the build-output validator takes the directory around the
+        # manifest, so a caller may name either.
+        directory = tmp_path / "abicheck-build"
+        directory.mkdir()
+        manifest = directory / "build-output.json"
+        manifest.write_text(
+            json.dumps({"schema": BUILD_OUTPUT_SCHEMA}), encoding="utf-8"
+        )
+        assert classify_validation_input(manifest) == (
+            ValidationInputKind.BUILD_OUTPUT,
+            directory,
+        )
+
+    def test_the_schema_tag_outranks_a_mapping_default(self, tmp_path: Path) -> None:
+        # A document carrying both a build-output schema tag and
+        # config-looking keys follows its explicit discriminator — the
+        # mapping default is only for documents that declare nothing.
+        path = tmp_path / "ambiguous.yml"
+        path.write_text(
+            json.dumps({"schema": BUILD_OUTPUT_SCHEMA, "targets": []}),
+            encoding="utf-8",
+        )
+        assert classify_validation_input(path)[0] is ValidationInputKind.BUILD_OUTPUT
+
+    @pytest.mark.parametrize("content", ["42", "just a string", "true"])
+    def test_a_scalar_document_is_rejected_by_shape(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        path = tmp_path / "scalar.yml"
+        path.write_text(content, encoding="utf-8")
+        with pytest.raises(ValidationInputError) as exc:
+            classify_validation_input(path)
+        # The message must name all three recognized shapes: a user who
+        # got here does not yet know which one their document should be.
+        assert "mapping" in str(exc.value)
+        assert "list" in str(exc.value)
+        assert BUILD_OUTPUT_SCHEMA in str(exc.value)
+
+    def test_a_plain_directory_is_rejected_naming_the_contract(
+        self, tmp_path: Path
+    ) -> None:
+        directory = tmp_path / "not-a-build"
+        directory.mkdir()
+        with pytest.raises(ValidationInputError) as exc:
+            classify_validation_input(directory)
+        assert "build-output.json" in str(exc.value)
+
+    def test_unparseable_yaml_is_a_classification_error_not_a_crash(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "broken.yml"
+        path.write_text("targets: [unclosed\n", encoding="utf-8")
+        with pytest.raises(ValidationInputError):
+            classify_validation_input(path)
+
+
+class TestValidateCli:
+    """The command itself, once per kind, through the public entry point."""
+
+    def test_a_config_validates(self, tmp_path: Path) -> None:
+        path = tmp_path / "anything.yml"
+        path.write_text(DOCUMENTS[ValidationInputKind.PROJECT_CONFIG], encoding="utf-8")
+        res = _run(str(path))
+        assert res.exit_code == 0, res.output
+        assert "project validation" in res.output
+
+    def test_a_use_case_manifest_validates(self, tmp_path: Path) -> None:
+        path = tmp_path / "anything.yml"
+        path.write_text(
+            DOCUMENTS[ValidationInputKind.USE_CASE_MANIFEST], encoding="utf-8"
+        )
+        res = _run(str(path))
+        assert res.exit_code == 0, res.output
+        assert "use-case manifest validation" in res.output
+
+    def test_a_build_output_directory_validates(self, tmp_path: Path) -> None:
+        directory = tmp_path / "abicheck-build"
+        directory.mkdir()
+        (directory / "build-output.json").write_text(
+            json.dumps({"schema": BUILD_OUTPUT_SCHEMA, "targets": []}),
+            encoding="utf-8",
+        )
+        res = _run(str(directory))
+        assert res.exit_code == 0, res.output
+        assert "build-output validation" in res.output
+
+    def test_an_empty_document_names_every_reading(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.yml"
+        path.write_text("", encoding="utf-8")
+        res = _run(str(path))
+        assert res.exit_code == 0, res.output
+        # Both readings survive: the project-config validation actually
+        # runs (its "no targets declared" warning is the reason to run it
+        # at all) and the manifest reading is stated beside it.
+        assert "project validation" in res.output
+        assert "warning(s)" in res.output
+        assert "0 use case" in res.output
+
+    def test_an_unrecognizable_input_is_a_usage_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "scalar.yml"
+        path.write_text("42", encoding="utf-8")
+        res = _run(str(path))
+        assert res.exit_code == 64
+        assert "not a recognized project-integration document" in res.output
+
+    def test_toolchain_bindings_outside_a_project_config_is_a_usage_error(
+        self, tmp_path: Path
+    ) -> None:
+        # Recognizing a document never authorizes anything: the bindings
+        # file stays an explicit operand of the one validation that uses
+        # it, rather than being silently ignored elsewhere.
+        manifest = tmp_path / "uc.yml"
+        manifest.write_text(
+            DOCUMENTS[ValidationInputKind.USE_CASE_MANIFEST], encoding="utf-8"
+        )
+        bindings = tmp_path / "bindings.json"
+        bindings.write_text("{}", encoding="utf-8")
+        res = _run(str(manifest), "--toolchain-bindings", str(bindings))
+        assert res.exit_code == 64
+        assert "--toolchain-bindings" in res.output
+
+    @pytest.mark.parametrize("retired", ["validate-build", "validate-use-cases"])
+    def test_the_retired_spellings_are_gone(self, tmp_path: Path, retired: str) -> None:
+        res = CliRunner().invoke(main, ["project", retired, str(tmp_path)])
+        assert res.exit_code == 64
+
+
+class TestDispatchConsequences:
+    """Behavior changes the shape dispatch forces — moved here from
+    ``test_project_targets.py``, whose subject is the config parser rather
+    than which validator an operand resolves to."""
+
+    def test_a_list_named_like_a_config_is_read_as_a_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        config_path = tmp_path / ".abicheck.yml"
+        config_path.write_text("- just\n- a\n- list\n")
+        result = _run(str(config_path))
+        assert result.exit_code == 64, result.output
+        # Phase 7p dispatches on shape, not filename: a top-level list is read
+        # as a use-case manifest and still rejected (its entries are strings).
+        assert "impact-use-cases" in result.output.lower()

--- a/tests/test_cli_project_validate_dispatch.py
+++ b/tests/test_cli_project_validate_dispatch.py
@@ -101,21 +101,24 @@ class TestClassifierProperties:
         assert kind is ValidationInputKind.BUILD_OUTPUT
         assert target == directory
 
-    def test_a_named_build_output_manifest_resolves_to_its_directory(
+    def test_a_named_build_output_manifest_is_passed_through(
         self, tmp_path: Path
     ) -> None:
-        # The one case where the returned path differs from the input:
-        # the build-output validator takes the directory around the
-        # manifest, so a caller may name either.
+        # The manifest path is handed to the validator as given, never
+        # swapped for its parent directory: the validator resolves a
+        # build output from either spelling, and substituting the
+        # directory would send it looking for the conventional
+        # `build-output.json` beside a manifest that is legitimately
+        # called something else.
         directory = tmp_path / "abicheck-build"
         directory.mkdir()
-        manifest = directory / "build-output.json"
+        manifest = directory / "run-42.json"
         manifest.write_text(
             json.dumps({"schema": BUILD_OUTPUT_SCHEMA}), encoding="utf-8"
         )
         assert classify_validation_input(manifest) == (
             ValidationInputKind.BUILD_OUTPUT,
-            directory,
+            manifest,
         )
 
     def test_the_schema_tag_outranks_a_mapping_default(self, tmp_path: Path) -> None:
@@ -230,6 +233,71 @@ class TestValidateCli:
     def test_the_retired_spellings_are_gone(self, tmp_path: Path, retired: str) -> None:
         res = CliRunner().invoke(main, ["project", retired, str(tmp_path)])
         assert res.exit_code == 64
+
+
+class TestNameIndependenceEndToEnd:
+    """The whole invocation, not just the classification step.
+
+    This class exists because proving the classifier is name-independent
+    proved nothing about the pipeline behind it: the first revision
+    resolved an explicitly named manifest to its *parent directory*, and
+    `validate_build_output` then looked for the conventional
+    `build-output.json` beside it — so a valid `run-42.json` exited 64
+    while every classifier test passed (CodeRabbit review, PR #1242).
+    Registered as `cli_surface.name_independent_dispatch_undone_downstream`
+    in `tests/regressions/manifest.py`.
+
+    The oracle is the document's content, stated independently: a
+    well-formed document of each kind validates (exit 0) under *any*
+    name, and reaches the validator its content names.
+    """
+
+    #: The header each kind's validator prints — the evidence that the
+    #: right one ran, not merely that something exited 0.
+    EXPECTED_HEADER = {
+        ValidationInputKind.PROJECT_CONFIG: "project validation",
+        ValidationInputKind.USE_CASE_MANIFEST: "use-case manifest validation",
+        ValidationInputKind.BUILD_OUTPUT: "build-output validation",
+        ValidationInputKind.EMPTY_DOCUMENT: "project validation",
+    }
+
+    @pytest.mark.parametrize(
+        ("kind", "name"), list(itertools.product(DOCUMENTS, MISLEADING_NAMES))
+    )
+    def test_a_valid_document_validates_under_any_name(
+        self, tmp_path: Path, kind: ValidationInputKind, name: str
+    ) -> None:
+        path = tmp_path / name
+        path.write_text(DOCUMENTS[kind], encoding="utf-8")
+        res = _run(str(path))
+        assert res.exit_code == 0, res.output
+        assert self.EXPECTED_HEADER[kind] in res.output
+
+    @pytest.mark.parametrize("name", MISLEADING_NAMES)
+    def test_a_named_manifest_resolves_its_own_artifacts(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        # The parent-directory substitution also decided where relative
+        # artifact paths resolve from, so the fix has to keep that right:
+        # the root is the directory holding the manifest, whatever the
+        # manifest is called.
+        directory = tmp_path / "out"
+        directory.mkdir()
+        binary = directory / "libfoo.so"
+        binary.write_bytes(b"\x7fELF fake")
+        (directory / name).write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [{"id": "foo", "binary": "libfoo.so"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        res = _run(str(directory / name))
+        # The binary resolves (no "does not exist" error); whatever else
+        # the validator reports about it is not this test's subject.
+        assert "does not exist" not in res.output, res.output
 
 
 class TestDispatchConsequences:

--- a/tests/test_cli_project_validate_use_cases.py
+++ b/tests/test_cli_project_validate_use_cases.py
@@ -15,7 +15,9 @@
 
 """``impact-use-cases.yaml``'s two CLI front doors (G29 Phase 4, ADR-057).
 
-``abicheck project validate-use-cases`` checks a manifest's own structure;
+``abicheck project validate`` checks a manifest's own structure (one
+command over three input schemas since plan Phase 7p — the manifest is
+recognized by its top-level list shape, not by its filename);
 ``abicheck compare --use-cases`` folds it into a real comparison and reports
 which of that comparison's findings each declared use case reaches. (The
 ``--against``/``--against-new`` pair that used to diff two snapshots from
@@ -43,7 +45,7 @@ from abicheck.serialization import save_snapshot
 
 
 def _run(args: list[str]) -> Result:
-    return CliRunner().invoke(main, ["project", "validate-use-cases", *args])
+    return CliRunner().invoke(main, ["project", "validate", *args])
 
 
 def _compare(manifest: Path, old: Path, new: Path, *extra: str) -> Result:
@@ -193,10 +195,16 @@ class TestStructuralValidationOnly:
         assert "0 use case" in res.output
 
     def test_malformed_manifest_is_a_usage_error(self, tmp_path: Path) -> None:
+        # A mapping is not a manifest at all under Phase 7p's shape
+        # dispatch — it is read as a project config, the one shape with no
+        # self-describing tag. Still exit 64, and the message says which
+        # reading was applied rather than sending the user hunting for a
+        # typo in a document of the wrong kind.
         manifest = _write_manifest(tmp_path, "not_a_list: true\n")
         res = _run([str(manifest)])
         assert res.exit_code == 64
-        assert "top-level document" in res.output
+        assert "read as a project config" in res.output
+        assert "a YAML list" in res.output
 
     def test_unknown_field_is_a_usage_error(self, tmp_path: Path) -> None:
         manifest = _write_manifest(tmp_path, "- use_case: x\n  entrypoint: [train]\n")

--- a/tests/test_cli_root_surface.py
+++ b/tests/test_cli_root_surface.py
@@ -25,7 +25,10 @@ existed, the root surface had drifted back into mirroring an internal
 pipeline (config -> build-output -> run-plan -> aggregate) instead of
 user-facing operations, the exact failure mode ADR-043 reset the CLI to
 avoid. ADR-054 consolidates those four into one ``project`` group
-(``project validate``/``validate-build``/``plan``) and folds the standalone
+(``project validate``/``validate-build``/``plan``; plan Phase 7p then
+folded ``validate-build`` and ``validate-use-cases`` into a single
+``project validate INPUT`` dispatching on each document's own schema)
+and folds the standalone
 ``plan --dump-manifest`` diagnostic into ``dump --dump-manifest --dry-run``;
 ``build-output baseline-libraries`` and ``run-plan to-aggregate-manifest``
 are dropped from the public CLI entirely (the former stays a library

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -1919,28 +1919,12 @@ def test_cli_validate_empty_file_is_ok(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
 
 
-def test_cli_validate_non_mapping_yaml_is_usage_error(tmp_path: Path) -> None:
-    config_path = tmp_path / ".abicheck.yml"
-    config_path.write_text("- just\n- a\n- list\n")
-    result = CliRunner().invoke(main, ["project", "validate", str(config_path)])
-    assert result.exit_code == 64, result.output
-    assert "must contain a yaml mapping" in result.output.lower()
-
-
 def test_cli_validate_with_warnings_shown_in_text_output(tmp_path: Path) -> None:
     config_path = tmp_path / ".abicheck.yml"
     config_path.write_text("")
     result = CliRunner().invoke(main, ["project", "validate", str(config_path)])
     assert result.exit_code == 0, result.output
     assert "warning(s)" in result.output
-
-
-def test_cli_validate_malformed_yaml_raises_usage_error(tmp_path: Path) -> None:
-    config_path = tmp_path / ".abicheck.yml"
-    config_path.write_text("targets: [this is not: valid: yaml: at: all\n")
-    result = CliRunner().invoke(main, ["project", "validate", str(config_path)])
-    assert result.exit_code == 64, result.output
-    assert "cannot read" in result.output.lower()
 
 
 def test_cli_validate_writes_to_output_file(tmp_path: Path) -> None:

--- a/tests/test_reusable_workflows_project_evidence.py
+++ b/tests/test_reusable_workflows_project_evidence.py
@@ -499,7 +499,7 @@ def test_resolver_rejects_evidence_shared_across_targets(tmp_path: Path) -> None
     *points* somewhere safe -- it says nothing about whether the
     build-output.json making a 'declared' claim is actually trustworthy.
     Two targets sharing one evidence pack is exactly the shape
-    validate_build_output() (the same check `project validate-build` runs,
+    validate_build_output() (the same check `project validate` runs on a build output,
     which `project plan` never calls) already rejects; the resolver must
     run it before treating this target's evidence as scoped to it.
     """


### PR DESCRIPTION
## Summary

Two halves of the same CLI-cleanup step: **Phase 7l** records the 2026-09-12 external CLI surface audit, ruled item by item against this phase's existing 7d/7i/7k rulings, and **Phase 7p** implements the first slice it agreed on — `project validate`, `validate-build` and `validate-use-cases` collapse into one `project validate INPUT`.

## Motivation

The audit's counts reproduce exactly by Click introspection, so its disagreements with the plan are about *rulings*, not state. Its central principle is one 7i/7k never stated: a necessary capability does not require a dedicated flag, but a removal that costs the user three commands or an invented manifest is not simplification. Its corollary — "there is no replacement today" is a migration prerequisite, not permanent ownership — is what `deferred` already means in `rulings.py`, and it re-reads several `per_run_operand` entries honestly.

## Changes

### Phase 7p — one `project validate INPUT` (code)

Which validation runs is decided by INPUT's own shape, **never by its filename**:

| INPUT | Validator |
|---|---|
| an `abicheck-build/`-shaped directory, or any mapping declaring `schema: abicheck.build-output/v1` under any name | build output (ADR-047 §11.1) |
| a YAML list | `impact-use-cases.yaml` manifest (G29 Phase 4) |
| any other YAML mapping | project config (ADR-047 §3) |

- The classifier is `abicheck/buildsource/validation_input.py`, beside the build-output contract it routes on (`is_build_output_dir` — the same contract every other consumer uses); ADR-061 classifies `frontends/` as `may_import: [model, workflows, report]`, so routing on the real contract could not live there.
- **Recognizing a document authorizes nothing:** `--toolchain-bindings` applies to a project config and is a usage error elsewhere, rather than being silently ignored.
- `resolve_build_output_manifest()` accepts either spelling of a build output (directory, or manifest file under any name); `load_build_output`/`validate_build_output` route through it, so *every* consumer handed a manifest path works, not just this CLI. Relative artifact paths resolve against the manifest's directory in both spellings.
- Both retired spellings exit `64` with no alias, registered in `scripts/retired_surfaces.py`. Front-end parity in the same PR: reusable workflow comment, `compare --use-cases` help text, docs, regenerated CLI reference, `AGENTS.md`.

**Three behavior changes the consolidation forces**, each handled rather than glossed: an empty document is validated under *every* reading (both superseded commands accepted one, and YAML cannot tell an empty mapping from an empty list, so the config validation still runs and the vacuous manifest reading is stated beside it); a mapping meant as a manifest is read as a config, exit `64` unchanged with the reading named; unparseable YAML fails at classification, ahead of every validator.

**Tests.** `tests/test_cli_project_validate_dispatch.py` states the classifier's contract as invariants, exhaustive over shape × filename with each shape's *conventional* name among the misleading ones. Its `TestNameIndependenceEndToEnd` class exists because the first revision passed every classifier test while the pipeline behind it still re-derived `build-output.json` from a named manifest's parent — registered as bug class `cli_surface.name_independent_dispatch_undone_downstream`.

Native CLI surface: **109 → 103 options, 10 → 8 native commands.**

### Phase 7l — the audit, ruled (docs)

- **Adopted as slices 7m–7r**: one repeatable `-o FORMAT=DESTINATION` export request replacing `--format`/`-o`/`--write`/`--output-dir`/`--max-findings-per-library`; evidence-transport convergence (`--debug-root` → `--debug-info`, `--devel-pkg` → `-H`, `--probe-matrix` → typed `--build-info`) while keeping `--sources` and `--build-info` deliberately distinct; `--view`'s internal grammar reduced to unconditional disclosure; **7p (done, this PR)**; `aggregate --run-plan` into `--manifest` with `--discovered-only` staying explicit; `project plan --allow-empty` retired behind an explained skipped plan.
- **Declined with reasons recorded**: `dump --compression` (7k's measured keep — the audit concedes the counterexample), `--dry-run` → `--plan` (ADR-054 folded a `plan` command back into `dump --dry-run` for exactly this drift), `--used-by-manifest` → `--used-by @FILE`, `--severity-preset` into policy selection (blocked on gate-activation convergence, which the audit names itself), `--select-required` (ADR-065 P5), and the `--environment` operand (recorded as G42 direction, carrying the audit's two parity constraints).
- **Whole-surface accounting**, verified by Click introspection: 109 today → 87 after 7m–7r, against the audit's 68 — with the entire 19-option difference named as `compare`'s 15 and `dump`'s 4, every one already gated or ruled against with a measurement. On six of the ten native commands the two end states are identical.
- Corrects the stale `compare` 50 / `dump` 21 figures (pre-Phase-6, before `scan`'s retirement).

## Known CI state — every red lane is inherited, not introduced

| Lane | Cause | Evidence |
|---|---|---|
| `Validate examples (gcc/clang, shard 1/3)` · `integration-tests (ubuntu/macos/windows)` | `test_example_source_smoke[case96_hidden_friend_removed]` — `expected='API_BREAK' got='BREAKING'`. Bisected to **`2591ae40`** (PR #1235), which reached `main` before this PR branched; this PR's base `851b1bd4` already fails it. The CI integration lane's *only* failure is this same test. | [comment](https://github.com/abicheck/abicheck/pull/1242#issuecomment-5645129202) |
| `unit-tests (windows-latest, 3.13)` | `bash` resolving to the WSL stub on the runner; red on `main` with the same signature (69 failures there, the only non-green job in that run). | [comment](https://github.com/abicheck/abicheck/pull/1242#issuecomment-5644876673) |
| earlier `docs-pr` / `test-action` / `integration-tests` reds | Superseded heads whose runs were cancelled by a later push (their logs contain no test body, and `test-action summary` reads `"result": "cancelled"` for every dependency). | — |

`main` still *looks* green on the examples lane only because its last completed run predates the regression; every newer main run is queued behind today's runner backlog.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`changelog.d/project-validate-one-command.md`)
- [x] Docs updated (CLI reference regenerated, `AGENTS.md`, build-output schema, use-case-impact)
- [x] No new `mypy` or `ruff` errors introduced; `check_architecture.py` clean (new tests moved to their own file rather than raising a no-growth baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8p3eDgqwTU2AQ35bjLc5g