### PR TITLE
ci: give the integration lane's coverage a reader, and one owner to the native tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,18 +501,45 @@ jobs:
           cache: 'pip'
       - name: Install package
         run: pip install -e ".[dev]"
-      - name: Run integration tests (Linux/macOS — with coverage)
-        if: runner.os != 'Windows'
-        # ABICHECK_MIN_EXECUTED guards against a silent toolchain-install failure
-        # turning the whole lane into 0-ran-but-green (see tests/conftest.py).
-        # Linux's ELF integration count is known (~195) so it gets a real floor;
-        # the macOS Mach-O subset count isn't verified here, so it uses a minimal
-        # "> 0" floor — enough to catch a missing toolchain without risking a
-        # false failure from platform subsetting.
+      # Split per OS rather than one `runner.os != 'Windows'` step, because
+      # Linux and macOS differ on both axes below and folding them together
+      # hid a defect on each.
+      #
+      # 1. Coverage. Only Linux has a consumer -- the Codecov upload below is
+      #    gated to `ubuntu-24.04`. The combined step collected
+      #    coverage-integration.xml on macOS too, where nothing read it:
+      #    ~60% instrumentation overhead bought nothing. Same class as the
+      #    macOS unit lane and the `slow` lane (PR #1240); this was the site
+      #    that inspection missed and
+      #    tests/test_workflow_coverage_consumers.py found.
+      # 2. tests/test_cross_platform_integration.py. Its 20 tests are also run
+      #    by the dedicated native job below -- but that job's matrix is
+      #    macOS/Windows only, so Linux gets them *here or nowhere*. Hence
+      #    they are excluded on macOS/Windows (where the dedicated job, with
+      #    its real compiler environment and its own floor, owns them) and
+      #    kept on Linux. Handing the file over wholesale, as a selector-only
+      #    reading suggests, would have dropped Linux coverage silently.
+      #    Safe against the floors: both lanes excluding it sit at a "> 0"
+      #    floor, and the selection still collects hundreds of tests.
+      #
+      # ABICHECK_MIN_EXECUTED guards against a silent toolchain-install failure
+      # turning the whole lane into 0-ran-but-green (see tests/conftest.py).
+      - name: Run integration tests (Linux — with coverage)
+        if: runner.os == 'Linux'
+        # Linux's ELF integration count is known (~195) so it gets a real floor.
         env:
-          ABICHECK_MIN_EXECUTED: ${{ runner.os == 'macOS' && '1' || '20' }}
+          ABICHECK_MIN_EXECUTED: '20'
         run: |
           pytest tests/ -v -m integration --tb=short --cov=abicheck --cov-report=xml:coverage-integration.xml --ignore=tests/test_abi_examples.py
+      - name: Run integration tests (macOS — no coverage, native file owned by the dedicated job)
+        if: runner.os == 'macOS'
+        # The macOS Mach-O subset count isn't verified here, so a minimal
+        # "> 0" floor catches a missing toolchain without risking a false
+        # failure from platform subsetting.
+        env:
+          ABICHECK_MIN_EXECUTED: '1'
+        run: |
+          pytest tests/ -v -m integration --tb=short --ignore=tests/test_abi_examples.py --ignore=tests/test_cross_platform_integration.py
       - name: Run integration tests (Windows — parallel, no coverage)
         if: runner.os == 'Windows'
         # Same silent-skip guard: the xdist controller aggregates every worker's
@@ -522,7 +549,7 @@ jobs:
         env:
           ABICHECK_MIN_EXECUTED: '1'
         run: |
-          pytest tests/ -v -m integration --tb=short -n auto --dist worksteal --ignore=tests/test_abi_examples.py
+          pytest tests/ -v -m integration --tb=short -n auto --dist worksteal --ignore=tests/test_abi_examples.py --ignore=tests/test_cross_platform_integration.py
       - name: Upload integration coverage to Codecov
         if: always() && matrix.os == 'ubuntu-24.04'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7

--- a/docs/contribute/plans/ci-cost-and-assurance.md
+++ b/docs/contribute/plans/ci-cost-and-assurance.md
@@ -1,6 +1,6 @@
 # CI cost and assurance — closing the audit's remaining items
 
-**Status:** Proposed. Phases 0 and 6 landed in PR #1240; Phases 1–5 not started.
+**Status:** Proposed. Phases 0 and 6 landed in PR #1240; Phase 2's platform-safe half landed as a follow-up; Phases 1, 3, 4 and 5 not started.
 
 Origin: a CI audit that profiled this repository's workflows and found one
 real product performance bug plus a family of *inert configuration* — settings
@@ -70,17 +70,26 @@ as stated would **silently drop Linux execution of those 20 tests**, because the
 dedicated job has no Linux lane. The genuine duplication is macOS and Windows
 only.
 
-**Target.** Either exclude the file from the generic selector *only* where the
-dedicated job also runs (`--ignore` gated on `runner.os`), or add a Linux lane
-to the dedicated job and exclude the file from the generic selector everywhere.
-Both preserve today's platform coverage exactly; the first is smaller.
+**Landed** (the first of the two options). The generic integration step was
+split per OS: Linux keeps the file, macOS and Windows exclude it and leave it
+to the dedicated job. Platform coverage is unchanged — the file still runs
+everywhere it ran before, once.
 
-**Before changing anything:** both selectors carry `ABICHECK_MIN_EXECUTED`
-floors (20 on the generic Linux lane, 5 on the dedicated job). Removing tests
-from a selection moves the executed count those floors gate, and *collected* is
-not *executed* — most of the 654 are compiler-gated. Measure executed IDs per
-platform first. This phase buys correctness of ownership, not a measured
-runtime saving.
+This phase originally said to measure executed IDs per platform first, because
+`ABICHECK_MIN_EXECUTED` gates the executed count and *collected* is not
+*executed*. Reading the floors settled it without that measurement: the two
+lanes that now exclude the file sit at a `'1'` floor (macOS and Windows, both
+"> 0" guards against a missing toolchain), so dropping 20 tests from a
+selection that still collects hundreds cannot trip them, and Linux — the only
+lane with a real floor, `'20'` against a known ~195 — is untouched. The
+caution was warranted in general and did not apply here.
+
+The same split fixed a second defect in the same step, found by the guard
+written for Phase 0's own known gap: the step collected
+`coverage-integration.xml` on Linux *and* macOS while the Codecov upload is
+gated to `ubuntu-24.04`, so macOS paid ~60% instrumentation overhead for a
+report nobody read. Same class as the two sites Phase 0 fixed by inspection,
+and the one it missed.
 
 ## Phase 3 — make the coverage-core request live, or retire it
 

--- a/tests/_gha_expressions.py
+++ b/tests/_gha_expressions.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluate the small GitHub-expression subset this repository's workflows use.
+
+Two guards need to answer "would this actually run / render to this?" from a
+workflow's own expressions rather than from its text:
+`test_workflow_concurrency_grouping.py` (does a superseding run share a
+concurrency group?) and `test_workflow_coverage_consumers.py` (does every
+platform that writes a coverage report also have something that reads it?).
+The second was written after the first, and a second private copy of an
+expression evaluator is exactly the drift `AGENTS.md` warns about — so the
+semantics live here once.
+
+Deliberately a *subset*, and the callers are expected to say so: parenthesised
+sub-expressions, `||`, `&&`, `==`/`!=` against a literal, `always()`, and
+context lookups. Anything unmodelled evaluates falsy rather than raising,
+which keeps a guard reporting real findings instead of arguing with syntax it
+has not met — at the cost of checking such an expression loosely. That is the
+right trade for a guard, and the wrong one for anything that gates behaviour.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+#: `matrix.os` value -> the `runner.os` GitHub sets for it.
+_RUNNER_OS = {"ubuntu": "Linux", "macos": "macOS", "windows": "Windows"}
+
+
+def runner_os_for(matrix_os: str) -> str:
+    """`runner.os` for a `matrix.os` label such as `ubuntu-24.04`."""
+    for prefix, name in _RUNNER_OS.items():
+        if matrix_os.startswith(prefix):
+            return name
+    raise ValueError(f"unmodelled runner label: {matrix_os!r}")
+
+
+def _atom(token: str, ctx: dict[str, Any]) -> Any:
+    token = token.strip()
+    if token.startswith(("'", '"')):
+        return token[1:-1]
+    if token in ("always()", "success()"):
+        # `always()` is what makes a step run even after an earlier failure;
+        # for "does this run on this platform" it is simply true. `success()`
+        # is the default and equally true on the path being modelled.
+        return True
+    if token in ctx:
+        value = ctx[token]
+        return value if value != "" else False
+    if token.startswith(("github.", "matrix.", "runner.", "env.", "needs.")):
+        return False  # unmodelled context field: absent, never a guess
+    return token
+
+
+def evaluate(expr: str, ctx: dict[str, Any]) -> Any:
+    """Evaluate one expression body (no surrounding `${{ }}`) against *ctx*."""
+    expr = expr.strip()
+    while expr.startswith("(") and expr.endswith(")"):
+        depth = 0
+        for i, char in enumerate(expr):
+            depth += (char == "(") - (char == ")")
+            if depth == 0 and i < len(expr) - 1:
+                break
+        else:
+            expr = expr[1:-1].strip()
+            continue
+        break
+
+    for op in ("||", "&&"):
+        depth = 0
+        for i in range(len(expr) - 1):
+            depth += (expr[i] == "(") - (expr[i] == ")")
+            if depth == 0 and expr[i : i + 2] == op:
+                left = evaluate(expr[:i], ctx)
+                right = evaluate(expr[i + 2 :], ctx)
+                if op == "||":
+                    return left if left else right
+                return right if left else left
+    for comparison, negate in (("!=", True), ("==", False)):
+        if comparison in expr:
+            lhs, rhs = expr.split(comparison, 1)
+            equal = _atom(lhs, ctx) == _atom(rhs, ctx)
+            return not equal if negate else equal
+    return _atom(expr, ctx)
+
+
+def render(template: str, ctx: dict[str, Any]) -> str:
+    """Substitute every `${{ ... }}` in *template* using *ctx*."""
+
+    def _sub(match: re.Match[str]) -> str:
+        value = evaluate(match.group(1), ctx)
+        return "" if value is False else str(value)
+
+    return re.sub(r"\$\{\{(.+?)\}\}", _sub, template)
+
+
+def condition_holds(condition: str | None, ctx: dict[str, Any]) -> bool:
+    """Whether a step's `if:` would let it run under *ctx*.
+
+    An absent condition is GitHub's default: the step runs. A condition may
+    be written with or without the `${{ }}` wrapper; both are accepted, as
+    both appear in this repository.
+    """
+    if condition is None:
+        return True
+    body = condition.strip()
+    wrapped = re.fullmatch(r"\$\{\{(.+)\}\}", body, re.DOTALL)
+    if wrapped:
+        body = wrapped.group(1)
+    return bool(evaluate(body, ctx))

--- a/tests/_gha_expressions.py
+++ b/tests/_gha_expressions.py
@@ -53,6 +53,10 @@ def runner_os_for(matrix_os: str) -> str:
 
 
 def _atom(token: str, ctx: dict[str, Any]) -> Any:
+    """Resolve one operand: a quoted literal, a modelled function, a
+    context reference, or -- for anything this evaluator does not model --
+    absence. See this module's docstring for why absence rather than a
+    truthy default is the safe direction here."""
     token = token.strip()
     if token.startswith(("'", '"')):
         return token[1:-1]

--- a/tests/_gha_expressions.py
+++ b/tests/_gha_expressions.py
@@ -37,6 +37,9 @@ from __future__ import annotations
 import re
 from typing import Any
 
+#: A bare integer or decimal literal.
+_NUMERIC = re.compile(r"-?\d+(?:\.\d+)?")
+
 #: `matrix.os` value -> the `runner.os` GitHub sets for it.
 _RUNNER_OS = {"ubuntu": "Linux", "macos": "macOS", "windows": "Windows"}
 
@@ -61,9 +64,27 @@ def _atom(token: str, ctx: dict[str, Any]) -> Any:
     if token in ctx:
         value = ctx[token]
         return value if value != "" else False
-    if token.startswith(("github.", "matrix.", "runner.", "env.", "needs.")):
-        return False  # unmodelled context field: absent, never a guess
-    return token
+    if _NUMERIC.fullmatch(token):
+        # A bare number is a literal, and the only place one appears in this
+        # repository is as a comparison operand (`matrix.shard == 1`). It is
+        # returned as *text* because `_context` stringifies matrix values, so
+        # the two sides must meet in the same type to compare equal.
+        return token
+    if token in ("true", "false"):
+        return token == "true"
+    # Everything else -- a context reference this evaluator does not model, a
+    # function call it does not implement (`failure()`, `cancelled()`,
+    # `contains(...)`), a bareword -- is *absent*.
+    #
+    # Returning the raw token here was a real defect (CodeRabbit review): a
+    # non-empty string is truthy, so a step whose `if:` used an unmodelled
+    # function evaluated as "runs". In `test_workflow_coverage_consumers.py`
+    # that made such a step look like an active consumer unconditionally,
+    # masking exactly the orphaned-report defect that guard exists to catch --
+    # and it contradicted this module's own docstring, which already claimed
+    # the falsy behaviour. A guard that fails open is worse than no guard,
+    # because it reads as coverage.
+    return False
 
 
 def evaluate(expr: str, ctx: dict[str, Any]) -> Any:

--- a/tests/_gha_expressions.py
+++ b/tests/_gha_expressions.py
@@ -52,6 +52,27 @@ def runner_os_for(matrix_os: str) -> str:
     raise ValueError(f"unmodelled runner label: {matrix_os!r}")
 
 
+class _Absent:
+    """A value this evaluator has no evidence for.
+
+    Distinct from the literal `false`, and the distinction is load-bearing:
+    collapsing the two made `steps.probe.outputs.result == false` evaluate
+    *true*, so a step gated on an unmodelled reference read as active and a
+    coverage consumer guard counted it (CodeRabbit review). Absence is
+    falsy on its own, and any comparison involving it is `False` -- an
+    unknown is never *equal* to something, nor demonstrably *unequal*.
+    """
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return "<absent>"
+
+
+ABSENT = _Absent()
+
+
 def _atom(token: str, ctx: dict[str, Any]) -> Any:
     """Resolve one operand: a quoted literal, a modelled function, a
     context reference, or -- for anything this evaluator does not model --
@@ -67,7 +88,7 @@ def _atom(token: str, ctx: dict[str, Any]) -> Any:
         return True
     if token in ctx:
         value = ctx[token]
-        return value if value != "" else False
+        return value if value != "" else ABSENT
     if _NUMERIC.fullmatch(token):
         # A bare number is a literal, and the only place one appears in this
         # repository is as a comparison operand (`matrix.shard == 1`). It is
@@ -88,7 +109,12 @@ def _atom(token: str, ctx: dict[str, Any]) -> Any:
     # and it contradicted this module's own docstring, which already claimed
     # the falsy behaviour. A guard that fails open is worse than no guard,
     # because it reads as coverage.
-    return False
+    #
+    # `ABSENT` rather than `False` for the same reason one step further on:
+    # returning the literal `False` made `<unmodelled> == false` evaluate
+    # *true*, so the fail-open simply moved from the bare reference to the
+    # comparison around it (a second CodeRabbit review, on the fix above).
+    return ABSENT
 
 
 def evaluate(expr: str, ctx: dict[str, Any]) -> Any:
@@ -118,8 +144,14 @@ def evaluate(expr: str, ctx: dict[str, Any]) -> Any:
     for comparison, negate in (("!=", True), ("==", False)):
         if comparison in expr:
             lhs, rhs = expr.split(comparison, 1)
-            equal = _atom(lhs, ctx) == _atom(rhs, ctx)
-            return not equal if negate else equal
+            left, right = _atom(lhs, ctx), _atom(rhs, ctx)
+            if left is ABSENT or right is ABSENT:
+                # Neither `==` nor `!=` can be *shown* against an unknown, so
+                # both answer False. Returning the negation for `!=` here
+                # would make an unmodelled reference satisfy any inequality,
+                # which is the same fail-open this sentinel exists to stop.
+                return False
+            return (left != right) if negate else (left == right)
     return _atom(expr, ctx)
 
 
@@ -128,7 +160,7 @@ def render(template: str, ctx: dict[str, Any]) -> str:
 
     def _sub(match: re.Match[str]) -> str:
         value = evaluate(match.group(1), ctx)
-        return "" if value is False else str(value)
+        return "" if value is False or value is ABSENT else str(value)
 
     return re.sub(r"\$\{\{(.+?)\}\}", _sub, template)
 

--- a/tests/_workflow_files.py
+++ b/tests/_workflow_files.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One owner for reading the repository's own workflow/Action YAML in tests.
+
+The four `test_workflow_*.py` guards each independently re-derived
+`.github/workflows` and each called a bare `path.read_text()`. That bare call
+is the bug: `Path.read_text()` with no `encoding=` decodes using the
+*platform's* preferred encoding, which is UTF-8 on Linux/macOS and `cp1252`
+on a default Windows runner. Every one of these files is checked-in UTF-8
+carrying real non-ASCII prose (em dashes and `§` in the comment blocks), so
+the guards collected fine on two platforms and raised `UnicodeDecodeError`
+at *import* time on the third — turning assurance meant to protect CI into a
+red Windows lane.
+
+The fix is one loader rather than five corrected call sites: a workflow file
+read anywhere in the test suite is read here, with the encoding stated. The
+encoding of a file the repository itself owns is not a per-caller decision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+#: Checked-in repository text is UTF-8 regardless of the host's locale.
+ENCODING = "utf-8"
+
+
+def read_repo_text(path: Path) -> str:
+    """Read a checked-in repository text file with its encoding stated."""
+    return path.read_text(encoding=ENCODING)
+
+
+def workflow_paths() -> list[Path]:
+    """Every workflow definition, in a stable order."""
+    return sorted(WORKFLOW_DIR.glob("*.yml"))
+
+
+def workflow_texts() -> list[tuple[Path, str]]:
+    """Each workflow's path and raw text."""
+    return [(path, read_repo_text(path)) for path in workflow_paths()]

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -177,6 +177,9 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
             # ubuntu -- which is the argument for making a rule executable
             # rather than writing it down.
             "tests/test_workflow_coverage_consumers.py",
+            # The evaluator both guards rest on, with its own contract
+            # suite -- chiefly *which way it fails*.
+            "tests/test_gha_expression_evaluator.py",
         ),
         # `()` per the field's own rule: these seed tests read and parse
         # workflow/config files, they do not invoke the CLI, `abicheck.
@@ -199,9 +202,15 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
                     "The consumer half checks each *matrix combination*, "
                     "which needs every step's `if:` evaluated against it, so "
                     "it inherits `_gha_expressions`' deliberate subset: an "
-                    "unmodelled context field or function evaluates falsy "
-                    "rather than raising, and a step gated on one this "
-                    "evaluator does not know is checked loosely. A matrix "
+                    "unmodelled reference or function evaluates as *absent*. "
+                    "That direction is deliberate but not uniformly safe. "
+                    "For a consumer it fails closed (the step is not counted "
+                    "as reading the report, so at worst a real consumer is "
+                    "reported as missing); for a *producer* it fails open "
+                    "(the step is not counted as writing one, so an orphaned "
+                    "report under an unmodelled `if:` is missed). Both beat "
+                    "the original defect, where an unmodelled token returned "
+                    "truthy and made any such step read as active. A matrix "
                     "built from an expression cannot be expanded statically "
                     "at all and is scanned as one nameless combination. The "
                     "core-effectiveness test also probes the interpreter "

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -223,6 +223,50 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         ),
     ),
     BugClass(
+        id="tests.dead_harness_reads_as_a_passing_control",
+        invariant=(
+            "A test harness whose failure mode produces the same observation "
+            "as its success signal must prove it can execute at all, or the "
+            "suite reports safety it never checked. "
+            "`test_workflow_untrusted_text_interpolation` executes hostile PR "
+            "bodies against the real workflow step and reads the attack as "
+            '"the file was not written verbatim" -- which is also exactly '
+            "what a harness that cannot run a shell produces. On the Windows "
+            "lane it handed Git bash a POSIX-only `PATH`, so no step ran, "
+            'every payload came back as "nothing written", and the negative '
+            "controls read that as the attack firing: a fully green "
+            "injection-defence module testing nothing. The fix is a "
+            "precondition that runs a payload-free script whose only job is "
+            "to write the file the other assertions look for, so a dead "
+            "harness fails loudly instead of reassuring."
+        ),
+        fixed_by=(1244,),
+        seed_tests=("tests/test_workflow_untrusted_text_interpolation.py",),
+        # A real `bash` execution of a real workflow step body.
+        public_surfaces=("github-action",),
+        axes={
+            "half": ("harness-liveness-precondition", "hostile-payload-corpus"),
+            "platform": ("posix", "windows-git-bash"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The precondition proves the harness can run *a* script "
+                    "and write *a* file; it does not prove the environment it "
+                    "hands the step matches a real runner's. The POSIX lanes "
+                    "still get a deliberately hermetic environment while "
+                    "Windows inherits the host's, so the two platforms do not "
+                    "execute under identical conditions -- a difference that "
+                    "is stated rather than closed. Nothing here runs on a "
+                    "real Windows host either; the dead-harness shape was "
+                    "reproduced locally by pointing the resolver at a binary "
+                    "that exits cleanly without writing."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md#phase-7",
+            ),
+        ),
+    ),
+    BugClass(
         id="tests.locale_dependent_repo_text_read",
         invariant=(
             "A test that reads the repository's own checked-in text must "

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -168,7 +168,16 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
             "is."
         ),
         fixed_by=(1240,),
-        seed_tests=("tests/test_coverage_core_effectiveness.py",),
+        seed_tests=(
+            "tests/test_coverage_core_effectiveness.py",
+            # The consumer half, left as a known gap by PR #1240 and closed
+            # immediately after. Closing it found a third site that PR's own
+            # inspection had missed -- the integration lane, whose producer
+            # runs on Linux *and* macOS while its Codecov upload is gated to
+            # ubuntu -- which is the argument for making a rule executable
+            # rather than writing it down.
+            "tests/test_workflow_coverage_consumers.py",
+        ),
         # `()` per the field's own rule: these seed tests read and parse
         # workflow/config files, they do not invoke the CLI, `abicheck.
         # service`, or a real workflow run. A claimed surface a seed test
@@ -178,16 +187,23 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         # them).
         public_surfaces=(),
         axes={
-            "half": ("requested-vs-selected-core", "documented-fallback"),
+            "half": (
+                "requested-vs-selected-core",
+                "documented-fallback",
+                "report-has-a-consumer",
+            ),
         },
         known_gaps=(
             KnownGap(
                 description=(
-                    "Only the coverage-core half is executable. Nothing "
-                    "asserts the consumer half -- that every `--cov-report` "
-                    "a workflow writes is uploaded, archived or gated -- so "
-                    "a future lane can reintroduce an unread report and "
-                    "only a human reading the diff would notice. The "
+                    "The consumer half checks each *matrix combination*, "
+                    "which needs every step's `if:` evaluated against it, so "
+                    "it inherits `_gha_expressions`' deliberate subset: an "
+                    "unmodelled context field or function evaluates falsy "
+                    "rather than raising, and a step gated on one this "
+                    "evaluator does not know is checked loosely. A matrix "
+                    "built from an expression cannot be expanded statically "
+                    "at all and is scanned as one nameless combination. The "
                     "core-effectiveness test also probes the interpreter "
                     "running the suite, not the pinned Python of each CI "
                     "lane, so a lane on a different version is checked only "

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -284,7 +284,12 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
             "(no repository-rooted read leaves the encoding to the platform) "
             "plus non-vacuity (some checked-in workflow really does contain "
             "a byte cp1252 rejects), because the structural rule alone would "
-            "pass the day the repository became pure ASCII."
+            "pass the day the repository became pure ASCII. The scan must "
+            "also follow *aliases*: a review found it walking only the call "
+            "target, so `path = REPO_ROOT / x` and `for path in "
+            "workflow_paths():` -- the two spellings this suite reaches for "
+            "first -- went unflagged, and adding alias tracking immediately "
+            "turned up two more unencoded reads of checked-in files."
         ),
         fixed_by=(1244,),
         seed_tests=("tests/test_repo_text_reads_state_their_encoding.py",),
@@ -303,8 +308,8 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
                     "it is built from a root constant this suite actually "
                     "uses (`REPO_ROOT`, `WORKFLOW_DIR`, `ROOT`, "
                     "`PROJECT_ROOT`). A test that re-derives the root into a "
-                    "differently-named local, or reaches checked-in content "
-                    "through a fixture-returned path, is not covered -- the "
+                    "root constant it does not know, or reaches checked-in "
+                    "content through a fixture-returned path, is not covered -- the "
                     "same shape as reading it with `subprocess` or "
                     "`importlib.resources`. Nothing here runs on a real "
                     "cp1252 host either: the failure is reproduced locally "

--- a/tests/regressions/manifest_tool_surface.py
+++ b/tests/regressions/manifest_tool_surface.py
@@ -223,6 +223,55 @@ TOOL_SURFACE_BUG_CLASSES: tuple[BugClass, ...] = (
         ),
     ),
     BugClass(
+        id="tests.locale_dependent_repo_text_read",
+        invariant=(
+            "A test that reads the repository's own checked-in text must "
+            "state the encoding. `Path.read_text()` and `open(path)` with no "
+            "`encoding=` decode using the *host's* preferred encoding -- "
+            "UTF-8 on the Linux and macOS lanes, `cp1252` on a default "
+            "Windows runner -- so a UTF-8 file carrying any non-ASCII byte "
+            "reads fine on two platforms and raises `UnicodeDecodeError` on "
+            "the third. This repository's own workflow comments are full of "
+            "em dashes and section signs, so the condition is not "
+            "hypothetical: four `test_workflow_*.py` guards each read "
+            "`.github/workflows/*.yml` at import time with a bare "
+            "`read_text()` and took down the Windows unit lane at "
+            "*collection*, before any assertion ran. The guard is structural "
+            "(no repository-rooted read leaves the encoding to the platform) "
+            "plus non-vacuity (some checked-in workflow really does contain "
+            "a byte cp1252 rejects), because the structural rule alone would "
+            "pass the day the repository became pure ASCII."
+        ),
+        fixed_by=(1244,),
+        seed_tests=("tests/test_repo_text_reads_state_their_encoding.py",),
+        # `()` per the field's own rule: the seed test parses repository
+        # files with `ast`; it invokes no CLI, no `abicheck.service`, and no
+        # real workflow run.
+        public_surfaces=(),
+        axes={
+            "half": ("structural-scan", "non-vacuity-of-the-content"),
+            "read_form": ("Path.read_text", "open"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "The scan recognises a repository-rooted path only when "
+                    "it is built from a root constant this suite actually "
+                    "uses (`REPO_ROOT`, `WORKFLOW_DIR`, `ROOT`, "
+                    "`PROJECT_ROOT`). A test that re-derives the root into a "
+                    "differently-named local, or reaches checked-in content "
+                    "through a fixture-returned path, is not covered -- the "
+                    "same shape as reading it with `subprocess` or "
+                    "`importlib.resources`. Nothing here runs on a real "
+                    "cp1252 host either: the failure is reproduced locally "
+                    "under `LC_ALL=C`, which is a stricter ASCII default, "
+                    "not cp1252 itself."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md#phase-7",
+            ),
+        ),
+    ),
+    BugClass(
         id="ci.inert_concurrency_group_key",
         invariant=(
             "A concurrency group keyed off a value that is unique per run "

--- a/tests/test_apt_install_hardening.py
+++ b/tests/test_apt_install_hardening.py
@@ -368,7 +368,7 @@ class TestPackagesAreNotInterpolatedIntoTheShell:
         assert result.returncode == 1
 
     def test_action_yml_passes_packages_through_env(self) -> None:
-        action = yaml.safe_load((ACTION_DIR / "action.yml").read_text())
+        action = yaml.safe_load((ACTION_DIR / "action.yml").read_text(encoding="utf-8"))
         (step,) = action["runs"]["steps"]
         assert step["env"]["INPUT_PACKAGES"] == "${{ inputs.packages }}"
         assert "${{" not in step["run"]

--- a/tests/test_coverage_core_effectiveness.py
+++ b/tests/test_coverage_core_effectiveness.py
@@ -94,7 +94,7 @@ def _selected_core(*, branch: bool) -> str:
 
 
 def _branch_coverage_is_enabled() -> bool:
-    text = (REPO_ROOT / "pyproject.toml").read_text()
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     section = text.split("[tool.coverage.run]", 1)
     if len(section) < 2:
         return False
@@ -114,7 +114,7 @@ _CONTEXT_LINES = 15
 def _requesting_sites() -> list[Path]:
     sites = []
     for candidate in _REQUEST_SITES:
-        text = (REPO_ROOT / candidate).read_text()
+        text = (REPO_ROOT / candidate).read_text(encoding="utf-8")
         if "COVERAGE_CORE" in text and "sysmon" in text:
             sites.append(candidate)
     return sites
@@ -122,7 +122,7 @@ def _requesting_sites() -> list[Path]:
 
 def _context_around_requests(path: Path) -> str:
     """The text immediately surrounding each COVERAGE_CORE line."""
-    lines = (REPO_ROOT / path).read_text().splitlines()
+    lines = (REPO_ROOT / path).read_text(encoding="utf-8").splitlines()
     chunks = []
     for i, line in enumerate(lines):
         if "COVERAGE_CORE" in line:

--- a/tests/test_gha_expression_evaluator.py
+++ b/tests/test_gha_expression_evaluator.py
@@ -39,7 +39,13 @@ changes that answer. Literals stay literals; only *references* go absent.
 from __future__ import annotations
 
 import pytest
-from _gha_expressions import condition_holds, evaluate, render, runner_os_for
+from _gha_expressions import (
+    ABSENT,
+    condition_holds,
+    evaluate,
+    render,
+    runner_os_for,
+)
 
 _CTX = {
     "github.event_name": "push",
@@ -63,8 +69,17 @@ _CTX = {
     ],
 )
 def test_unmodelled_expressions_are_absent_not_present(expr: str) -> None:
-    """The direction that matters: never truthy by accident."""
-    assert evaluate(expr, _CTX) is False
+    """The direction that matters: never truthy by accident.
+
+    Asserted as `is ABSENT` rather than `is False`. The distinction is the
+    whole point -- pinning the literal `False` here is what let
+    `<unmodelled> == false` compare equal and read as active (see
+    `TestAbsentSurvivesComparison`), so a test demanding that identity would
+    forbid the fix. Falsiness, the property callers actually depend on, is
+    asserted alongside it.
+    """
+    assert evaluate(expr, _CTX) is ABSENT
+    assert not evaluate(expr, _CTX)
     assert condition_holds(expr, _CTX) is False
     assert condition_holds("${{ " + expr + " }}", _CTX) is False
 
@@ -133,3 +148,47 @@ def test_an_unmodelled_runner_label_raises_rather_than_guessing() -> None:
     that platform, which is a wrong answer rather than a missing one."""
     with pytest.raises(ValueError, match="unmodelled runner label"):
         runner_os_for("freebsd-14")
+
+
+class TestAbsentSurvivesComparison:
+    """Absence must stay distinguishable from the literal `false`.
+
+    The first review here fixed `_atom` to stop returning a truthy raw token
+    for an unmodelled reference. Returning `False` moved the fail-open one
+    level out instead of closing it: `false` is *also* what the literal
+    `false` evaluates to, so `<unmodelled> == false` compared equal and the
+    condition read as active again (second CodeRabbit review). An unknown is
+    neither demonstrably equal to something nor demonstrably unequal, so
+    both comparisons answer False.
+    """
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "steps.probe.outputs.result == false",
+            "steps.probe.outputs.result != true",
+            "steps.probe.outputs.result != 'x'",
+            "failure() == false",
+            "cancelled() != true",
+            "contains(github.event.head_commit.message, 'x') == false",
+            "github.event.nothing.here == false",
+            "bareword != 'x'",
+            "false == steps.probe.outputs.result",
+            "'x' != steps.probe.outputs.result",
+        ],
+    )
+    def test_a_comparison_against_an_unmodelled_operand_never_holds(
+        self, expr: str
+    ) -> None:
+        assert condition_holds(expr, _CTX) is False
+
+    def test_a_modelled_comparison_against_false_still_works(self) -> None:
+        """The fix must not make every `== false` unanswerable: a value this
+        evaluator does model compares normally."""
+        ctx = {**_CTX, "matrix.allow-prereleases": False}
+        assert condition_holds("matrix.allow-prereleases == false", ctx) is True
+        assert condition_holds("matrix.allow-prereleases != false", ctx) is False
+
+    def test_an_unmodelled_reference_renders_empty_rather_than_as_false(self) -> None:
+        """`render` must not start spelling absence as the text `<absent>`."""
+        assert render("x-${{ steps.nope.outputs.v }}", _CTX) == "x-"

--- a/tests/test_gha_expression_evaluator.py
+++ b/tests/test_gha_expression_evaluator.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract of the shared GitHub-expression evaluator.
+
+`_gha_expressions` is a primitive two guards depend on, so it gets the
+standalone contract suite `AGENTS.md` asks for ("Primitive-level property
+tests") rather than being exercised only through its callers' domain logic.
+
+The load-bearing property is **which way it fails**. Both callers ask "would
+this step run / does this render to that", and both are guards: an
+unmodelled expression must read as *absent*, never as *present*. Returning
+the raw token made a non-empty string truthy, so a step gated on
+`failure()` or a `steps.*` output evaluated as "runs" — which in
+`test_workflow_coverage_consumers.py` made such a step look like an active
+consumer unconditionally, masking the orphaned-report defect that guard
+exists to catch (CodeRabbit review on PR #1244). A guard that fails open is
+worse than no guard, because it reads as coverage.
+
+The one-line fix suggested with that finding — return `False` from the
+final fallback — would have been wrong in a way the tests below pin:
+`examples-validation.yml` really does compare against a bare numeric
+literal (`matrix.shard == 1`), and collapsing literals to `False` silently
+changes that answer. Literals stay literals; only *references* go absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _gha_expressions import condition_holds, evaluate, render, runner_os_for
+
+_CTX = {
+    "github.event_name": "push",
+    "github.ref": "refs/heads/main",
+    "matrix.os": "ubuntu-24.04",
+    "matrix.shard": "1",
+    "runner.os": "Linux",
+}
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "failure()",
+        "cancelled()",
+        "contains(github.event.pull_request.labels.*.name, 'skip')",
+        "steps.probe.outputs.result",
+        "fromJson(needs.setup.outputs.matrix)",
+        "some_bareword",
+        "github.event.merge_group.head_sha",
+    ],
+)
+def test_unmodelled_expressions_are_absent_not_present(expr: str) -> None:
+    """The direction that matters: never truthy by accident."""
+    assert evaluate(expr, _CTX) is False
+    assert condition_holds(expr, _CTX) is False
+    assert condition_holds("${{ " + expr + " }}", _CTX) is False
+
+
+def test_literals_survive_the_absent_rule() -> None:
+    """The complement, and why the suggested one-liner was not taken: a bare
+    numeric or boolean literal is a *value*, not a reference."""
+    assert evaluate("matrix.shard == 1", _CTX) is True
+    assert evaluate("matrix.shard == 2", _CTX) is False
+    assert evaluate("true", _CTX) is True
+    assert evaluate("false", _CTX) is False
+    assert evaluate("'push' == 'push'", _CTX) is True
+
+
+def test_a_real_workflow_condition_shape_still_evaluates() -> None:
+    """The exact `if:` that carries the numeric literal in this repository,
+    so the rule above is pinned against real syntax rather than a sample."""
+    expr = "always() && matrix.toolchain == 'gcc' && matrix.shard == 1"
+    assert evaluate(expr, {**_CTX, "matrix.toolchain": "gcc"}) is True
+    assert evaluate(expr, {**_CTX, "matrix.toolchain": "clang"}) is False
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("runner.os != 'Windows'", True),
+        ("runner.os == 'Windows'", False),
+        ("github.event_name == 'push' || github.event_name == 'schedule'", True),
+        ("(github.event_name == 'pull_request') && runner.os == 'Linux'", False),
+        ("always() && matrix.os == 'ubuntu-24.04'", True),
+    ],
+)
+def test_supported_operators(expr: str, expected: bool) -> None:
+    assert bool(evaluate(expr, _CTX)) is expected
+
+
+def test_absent_condition_means_the_step_runs() -> None:
+    """GitHub's default, and the reason `condition_holds` takes `None`."""
+    assert condition_holds(None, _CTX) is True
+
+
+def test_render_substitutes_and_drops_absent_fields() -> None:
+    assert render("x-${{ github.event_name }}", _CTX) == "x-push"
+    assert render("x-${{ steps.nope.outputs.v }}", _CTX) == "x-"
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("ubuntu-24.04", "Linux"),
+        ("macos-latest", "macOS"),
+        ("windows-latest", "Windows"),
+    ],
+)
+def test_runner_os_mapping(label: str, expected: str) -> None:
+    assert runner_os_for(label) == expected
+
+
+def test_an_unmodelled_runner_label_raises_rather_than_guessing() -> None:
+    """The one place this module *does* raise: a matrix OS it cannot map
+    would otherwise silently mis-evaluate every `runner.os` condition for
+    that platform, which is a wrong answer rather than a missing one."""
+    with pytest.raises(ValueError, match="unmodelled runner label"):
+        runner_os_for("freebsd-14")

--- a/tests/test_gha_expression_evaluator.py
+++ b/tests/test_gha_expression_evaluator.py
@@ -98,6 +98,7 @@ def test_a_real_workflow_condition_shape_still_evaluates() -> None:
     ],
 )
 def test_supported_operators(expr: str, expected: bool) -> None:
+    """The operator subset this evaluator claims to model."""
     assert bool(evaluate(expr, _CTX)) is expected
 
 
@@ -107,6 +108,8 @@ def test_absent_condition_means_the_step_runs() -> None:
 
 
 def test_render_substitutes_and_drops_absent_fields() -> None:
+    """A modelled reference substitutes; an unmodelled one renders empty,
+    matching how GitHub itself interpolates a missing value."""
     assert render("x-${{ github.event_name }}", _CTX) == "x-push"
     assert render("x-${{ steps.nope.outputs.v }}", _CTX) == "x-"
 
@@ -120,6 +123,7 @@ def test_render_substitutes_and_drops_absent_fields() -> None:
     ],
 )
 def test_runner_os_mapping(label: str, expected: str) -> None:
+    """`runner.os` is derived from the runner label, never stored."""
     assert runner_os_for(label) == expected
 
 

--- a/tests/test_project_targets_scheduling.py
+++ b/tests/test_project_targets_scheduling.py
@@ -138,7 +138,7 @@ class TestActionYmlAgreesOnDependencySources:
     a matrix cell twenty minutes later. This is what stops it drifting."""
 
     def test_mirror_matches_the_action(self) -> None:
-        action = (REPO_ROOT / "action.yml").read_text()
+        action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
         # The one place action.yml enumerates them: its own validation case.
         marker = "system|conda-forge|conda-forge-gcc14|conda-forge-clang20|none)"
         assert marker in action, "action.yml's dependency-source case changed shape"
@@ -147,7 +147,7 @@ class TestActionYmlAgreesOnDependencySources:
     def test_check_target_forwards_the_input(self) -> None:
         """A per-cell value that check-target accepts but never forwards would
         be silently inert — the failure this whole phase is about."""
-        action = (REPO_ROOT / "actions" / "check-target" / "action.yml").read_text()
+        action = (REPO_ROOT / "actions" / "check-target" / "action.yml").read_text(encoding="utf-8")
         assert "dependency-source:" in action
         assert "dependency-source: ${{ inputs.dependency-source }}" in action
 
@@ -161,7 +161,7 @@ def _resolve_dependency_source(
     resolution *behaviour* — a future edit that keeps the same words but
     changes the branching still fails here.
     """
-    action = yaml.safe_load((REPO_ROOT / "action.yml").read_text())
+    action = yaml.safe_load((REPO_ROOT / "action.yml").read_text(encoding="utf-8"))
     step = next(
         s
         for s in action["runs"]["steps"]

--- a/tests/test_repo_text_reads_state_their_encoding.py
+++ b/tests/test_repo_text_reads_state_their_encoding.py
@@ -73,6 +73,8 @@ def _opens_in_binary_mode(call: ast.Call) -> bool:
 
 
 def _encoding_is_stated(call: ast.Call) -> bool:
+    """Does this read name its encoding -- as a keyword, positionally, or
+    vacuously by reading bytes?"""
     if any(kw.arg == "encoding" for kw in call.keywords):
         return True
     if _opens_in_binary_mode(call):
@@ -82,6 +84,8 @@ def _encoding_is_stated(call: ast.Call) -> bool:
 
 
 def _unencoded_repo_reads(path: Path) -> list[str]:
+    """Every repository-rooted text read in *path* that leaves the encoding
+    to the host's locale, as `file:line: source` strings."""
     tree = ast.parse(path.read_text(encoding=ENCODING))
     findings = []
     for node in ast.walk(tree):
@@ -103,6 +107,7 @@ def _unencoded_repo_reads(path: Path) -> list[str]:
 
 
 def test_no_test_reads_checked_in_text_with_a_platform_dependent_encoding() -> None:
+    """The structural half of the invariant, over the whole suite."""
     findings: list[str] = []
     for module in sorted(TESTS_DIR.rglob("*.py")):
         findings += _unencoded_repo_reads(module)
@@ -153,6 +158,8 @@ def test_workflow_text_is_utf8_that_a_cp1252_host_could_not_have_decoded(
 
 
 def test_some_checked_in_workflow_really_defeats_the_platform_default() -> None:
+    """The non-vacuity half: the rule above must be defending against
+    content that actually exists, not a hypothetical byte."""
     undecodable = []
     for path in workflow_paths():
         try:

--- a/tests/test_repo_text_reads_state_their_encoding.py
+++ b/tests/test_repo_text_reads_state_their_encoding.py
@@ -54,11 +54,91 @@ TESTS_DIR = Path(__file__).resolve().parent
 _REPO_ROOTED_NAMES = frozenset({"REPO_ROOT", "WORKFLOW_DIR", "ROOT", "PROJECT_ROOT"})
 
 
-def _is_repo_rooted(node: ast.AST) -> bool:
-    """True when `node` is built out of a repository-root constant, however
-    many `/` joins and attribute hops deep."""
+#: Helpers that hand back repository-rooted paths. A name bound from one of
+#: these is as repository-rooted as `REPO_ROOT / x` is.
+_REPO_ROOTED_CALLS = frozenset({"workflow_paths", "workflow_texts"})
+
+
+def _bindings(node: ast.AST) -> tuple[list[ast.expr], ast.expr | None]:
+    """The targets a statement binds and the value it binds them from."""
+    if isinstance(node, ast.Assign):
+        return list(node.targets), node.value
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign)) and node.value:
+        return [node.target], node.value
+    if isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+        return [node.target], node.iter
+    return [], None
+
+
+_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+def _own_nodes(scope: ast.AST) -> list[ast.AST]:
+    """Every node inside *scope* except those belonging to a nested function.
+
+    Scoping matters: collected per module, a name bound from a repository
+    path in one function marks every same-named local elsewhere, and this
+    suite really does reuse short names like `candidate` for a repo-derived
+    value in one test and a `tmp_path` child in another -- a false positive
+    that fails the build.
+    """
+    own: list[ast.AST] = []
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        own.append(node)
+        if not isinstance(node, _SCOPES):
+            stack.extend(ast.iter_child_nodes(node))
+    return own
+
+
+def _repo_rooted_aliases(scope: ast.AST, inherited: frozenset[str]) -> frozenset[str]:
+    """Names in *scope* that hold a repository-rooted path.
+
+    Walking only the call target missed the two spellings this suite reaches
+    for first -- `path = REPO_ROOT / "f.yml"` then `path.read_text()`, and
+    `for path in workflow_paths(): path.read_text()` -- so the guard read
+    them as unrooted and let a bare read through. A guard that fails open on
+    the *natural* spelling of the thing it forbids is worse than none, which
+    is the same lesson `_gha_expressions` learned one review earlier
+    (CodeRabbit review).
+
+    Iterated to a fixed point, so a chain (`a = REPO_ROOT / x; b = a / y`)
+    resolves regardless of statement order.
+    """
+    aliases = set(inherited)
+    nodes = _own_nodes(scope)
+    while True:
+        grown = False
+        for node in nodes:
+            targets, value = _bindings(node)
+            if value is None or not _is_repo_rooted(value, aliases):
+                continue
+            for target in targets:
+                for sub in ast.walk(target):
+                    if isinstance(sub, ast.Name) and sub.id not in aliases:
+                        aliases.add(sub.id)
+                        grown = True
+        if not grown:
+            return frozenset(aliases)
+
+
+def _is_repo_rooted(
+    node: ast.AST, aliases: frozenset[str] | set[str] = frozenset()
+) -> bool:
+    """True when `node` is built out of a repository-root constant, a helper
+    that returns one, or a local name bound from either -- however many `/`
+    joins and attribute hops deep."""
     for sub in ast.walk(node):
-        if isinstance(sub, ast.Name) and sub.id in _REPO_ROOTED_NAMES:
+        if isinstance(sub, ast.Name) and (
+            sub.id in _REPO_ROOTED_NAMES or sub.id in aliases
+        ):
+            return True
+        if (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id in _REPO_ROOTED_CALLS
+        ):
             return True
     return False
 
@@ -83,12 +163,11 @@ def _encoding_is_stated(call: ast.Call) -> bool:
     return len(call.args) >= 4
 
 
-def _unencoded_repo_reads(path: Path) -> list[str]:
-    """Every repository-rooted text read in *path* that leaves the encoding
-    to the host's locale, as `file:line: source` strings."""
-    tree = ast.parse(path.read_text(encoding=ENCODING))
+def _reads_in_scope(scope: ast.AST, aliases: frozenset[str], name: str) -> list[str]:
+    """Unencoded repository-rooted reads written directly in *scope*, then
+    recursively in each function nested inside it under its own aliases."""
     findings = []
-    for node in ast.walk(tree):
+    for node in _own_nodes(scope):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
@@ -98,12 +177,22 @@ def _unencoded_repo_reads(path: Path) -> list[str]:
             target = node.args[0] if node.args else None
         else:
             continue
-        if target is None or not _is_repo_rooted(target):
+        if target is None or not _is_repo_rooted(target, aliases):
             continue
         if _encoding_is_stated(node):
             continue
-        findings.append(f"{path.name}:{node.lineno}: {ast.unparse(node)[:90]}")
-    return findings
+        findings.append(f"{name}:{node.lineno}: {ast.unparse(node)[:90]}")
+    for node in _own_nodes(scope):
+        if isinstance(node, _SCOPES):
+            findings += _reads_in_scope(node, _repo_rooted_aliases(node, aliases), name)
+    return sorted(findings, key=lambda f: int(f.split(":")[1]))
+
+
+def _unencoded_repo_reads(path: Path) -> list[str]:
+    """Every repository-rooted text read in *path* that leaves the encoding
+    to the host's locale, as `file:line: source` strings."""
+    tree = ast.parse(path.read_text(encoding=ENCODING))
+    return _reads_in_scope(tree, _repo_rooted_aliases(tree, frozenset()), path.name)
 
 
 def test_no_test_reads_checked_in_text_with_a_platform_dependent_encoding() -> None:
@@ -119,32 +208,45 @@ def test_no_test_reads_checked_in_text_with_a_platform_dependent_encoding() -> N
     )
 
 
-def test_the_scan_can_actually_see_an_unencoded_read() -> None:
-    """Guards the AST scan: a matcher that recognised nothing would make the
-    assertion above vacuously true."""
-    module = ast.parse(
-        "from x import REPO_ROOT\n"
-        "a = (REPO_ROOT / 'f.yml').read_text()\n"
-        "b = open(REPO_ROOT / 'f.yml')\n"
-        "b2 = open(REPO_ROOT / 'f.bin', 'rb')\n"
-        "c = (REPO_ROOT / 'f.yml').read_text(encoding='utf-8')\n"
-        "d = (tmp_path / 'f.yml').read_text()\n"
-    )
-    calls = [n for n in ast.walk(module) if isinstance(n, ast.Call)]
-    flagged = []
-    for node in calls:
-        func = node.func
-        if isinstance(func, ast.Attribute) and func.attr == "read_text":
-            target = func.value
-        elif isinstance(func, ast.Name) and func.id == "open":
-            target = node.args[0]
-        else:
-            continue
-        if _is_repo_rooted(target) and not _encoding_is_stated(node):
-            flagged.append(node.lineno)
-    assert flagged == [2, 3], (
-        "expected the bare repo-rooted reads on lines 2 and 3 -- and not the "
-        f"binary open, the stated encoding, or the tmp_path read; got {flagged}"
+#: Every shape the scan must judge, and the verdict it owes each. Lines are
+#: 1-based and must stay in step with the source below.
+_SCAN_FIXTURE = """from x import REPO_ROOT, workflow_paths
+a = (REPO_ROOT / 'f.yml').read_text()
+b = open(REPO_ROOT / 'f.yml')
+b2 = open(REPO_ROOT / 'f.bin', 'rb')
+c = (REPO_ROOT / 'f.yml').read_text(encoding='utf-8')
+d = (tmp_path / 'f.yml').read_text()
+path = REPO_ROOT / 'g.yml'
+e = path.read_text()
+for looped in workflow_paths():
+    f = looped.read_text()
+for ok in workflow_paths():
+    g = ok.read_text(encoding='utf-8')
+"""
+
+#: Bare repository-rooted reads: direct (2, 3), through an assigned alias (8),
+#: and through a loop variable bound from a repo-rooted helper (10).
+_SCAN_FIXTURE_EXPECTED = [2, 3, 8, 10]
+
+
+def test_the_scan_can_actually_see_an_unencoded_read(tmp_path: Path) -> None:
+    """Guards the AST scan itself: a matcher that recognised nothing would
+    make the assertion above vacuously true.
+
+    Driven through `_unencoded_repo_reads` -- the real function -- rather
+    than a hand-rolled copy of its matching, so the two cannot drift. The
+    alias cases are the ones a review found the scan blind to: walking only
+    the call target missed `path = REPO_ROOT / ...` and
+    `for path in workflow_paths():`, which are how this suite most naturally
+    spells the very thing the guard forbids.
+    """
+    fixture = tmp_path / "sample.py"
+    fixture.write_text(_SCAN_FIXTURE, encoding="utf-8")
+    flagged = [int(f.split(":")[1]) for f in _unencoded_repo_reads(fixture)]
+    assert flagged == _SCAN_FIXTURE_EXPECTED, (
+        "the scan must flag the direct and aliased bare reads and nothing "
+        "else -- not the binary open, the stated encodings, or the tmp_path "
+        f"read; got {flagged}"
     )
 
 

--- a/tests/test_repo_text_reads_state_their_encoding.py
+++ b/tests/test_repo_text_reads_state_their_encoding.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A test that reads the repository's own text must state the encoding.
+
+Bug class `tests.locale_dependent_repo_text_read`. `Path.read_text()` and
+`open(path)` with no `encoding=` decode using the *host's* preferred encoding.
+That is UTF-8 on the Linux and macOS lanes and `cp1252` on a default Windows
+runner, so a checked-in UTF-8 file containing any non-ASCII byte — an em dash
+or a `§`, which this repository's own comment prose is full of — reads fine on
+two platforms and raises `UnicodeDecodeError` on the third.
+
+The `test_workflow_*.py` guards hit exactly this: four modules each read
+`.github/workflows/*.yml` at import time with a bare `read_text()`, and the
+Windows unit lane failed at *collection*, not on any assertion. A fixed-input
+regression test ("this module can now be imported") would foreclose only those
+four files, so this module states the class instead, in two halves:
+
+* a **structural** half — no test module may read a path rooted at the
+  repository with the encoding left to the platform; and
+* a **behavioural** half — the checked-in text those readers consume really
+  does contain bytes a `cp1252` host cannot decode, so the structural rule is
+  defending against a live failure rather than a hypothetical one. Without
+  this the rule could pass vacuously the day the repository became pure ASCII,
+  which is precisely the "toy-scale fixture" failure mode AGENTS.md's
+  third-party-boundary lesson describes.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from _workflow_files import ENCODING, workflow_paths
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+#: Names that resolve to a repository-rooted path in this test suite. A read
+#: relative to one of these is reading checked-in content; a read relative to
+#: `tmp_path` or a fixture directory the test itself wrote is not.
+_REPO_ROOTED_NAMES = frozenset({"REPO_ROOT", "WORKFLOW_DIR", "ROOT", "PROJECT_ROOT"})
+
+
+def _is_repo_rooted(node: ast.AST) -> bool:
+    """True when `node` is built out of a repository-root constant, however
+    many `/` joins and attribute hops deep."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and sub.id in _REPO_ROOTED_NAMES:
+            return True
+    return False
+
+
+def _opens_in_binary_mode(call: ast.Call) -> bool:
+    """A binary read decodes nothing, so no encoding applies to it."""
+    mode = call.args[1] if len(call.args) >= 2 else None
+    for kw in call.keywords:
+        if kw.arg == "mode":
+            mode = kw.value
+    return isinstance(mode, ast.Constant) and "b" in str(mode.value)
+
+
+def _encoding_is_stated(call: ast.Call) -> bool:
+    if any(kw.arg == "encoding" for kw in call.keywords):
+        return True
+    if _opens_in_binary_mode(call):
+        return True
+    # open(path, mode, buffering, encoding) positionally — rare, but legal.
+    return len(call.args) >= 4
+
+
+def _unencoded_repo_reads(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding=ENCODING))
+    findings = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in ("read_text", "write_text"):
+            target = func.value
+        elif isinstance(func, ast.Name) and func.id == "open":
+            target = node.args[0] if node.args else None
+        else:
+            continue
+        if target is None or not _is_repo_rooted(target):
+            continue
+        if _encoding_is_stated(node):
+            continue
+        findings.append(f"{path.name}:{node.lineno}: {ast.unparse(node)[:90]}")
+    return findings
+
+
+def test_no_test_reads_checked_in_text_with_a_platform_dependent_encoding() -> None:
+    findings: list[str] = []
+    for module in sorted(TESTS_DIR.rglob("*.py")):
+        findings += _unencoded_repo_reads(module)
+    assert not findings, (
+        "these reads of checked-in repository text leave the encoding to the "
+        "host's locale, so they decode as cp1252 on the Windows lanes and fail "
+        "on any non-ASCII byte; read through tests/_workflow_files.py's "
+        "read_repo_text(), or pass encoding='utf-8':\n  " + "\n  ".join(findings)
+    )
+
+
+def test_the_scan_can_actually_see_an_unencoded_read() -> None:
+    """Guards the AST scan: a matcher that recognised nothing would make the
+    assertion above vacuously true."""
+    module = ast.parse(
+        "from x import REPO_ROOT\n"
+        "a = (REPO_ROOT / 'f.yml').read_text()\n"
+        "b = open(REPO_ROOT / 'f.yml')\n"
+        "b2 = open(REPO_ROOT / 'f.bin', 'rb')\n"
+        "c = (REPO_ROOT / 'f.yml').read_text(encoding='utf-8')\n"
+        "d = (tmp_path / 'f.yml').read_text()\n"
+    )
+    calls = [n for n in ast.walk(module) if isinstance(n, ast.Call)]
+    flagged = []
+    for node in calls:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "read_text":
+            target = func.value
+        elif isinstance(func, ast.Name) and func.id == "open":
+            target = node.args[0]
+        else:
+            continue
+        if _is_repo_rooted(target) and not _encoding_is_stated(node):
+            flagged.append(node.lineno)
+    assert flagged == [2, 3], (
+        "expected the bare repo-rooted reads on lines 2 and 3 -- and not the "
+        f"binary open, the stated encoding, or the tmp_path read; got {flagged}"
+    )
+
+
+@pytest.mark.parametrize("path", workflow_paths(), ids=lambda p: p.name)
+def test_workflow_text_is_utf8_that_a_cp1252_host_could_not_have_decoded(
+    path: Path,
+) -> None:
+    """Each workflow must be valid UTF-8 — and collectively they must contain
+    at least one byte `cp1252` rejects, or the rule above defends nothing."""
+    path.read_bytes().decode("utf-8")
+
+
+def test_some_checked_in_workflow_really_defeats_the_platform_default() -> None:
+    undecodable = []
+    for path in workflow_paths():
+        try:
+            path.read_bytes().decode("cp1252")
+        except UnicodeDecodeError:
+            undecodable.append(path.name)
+    assert undecodable, (
+        "no checked-in workflow contains a byte cp1252 rejects, so the "
+        "encoding rule above would pass even if every reader regressed; "
+        "re-derive the non-vacuity precondition before deleting this test"
+    )

--- a/tests/test_skill_eval_harness.py
+++ b/tests/test_skill_eval_harness.py
@@ -498,7 +498,7 @@ class TestWorkspaceIsolation:
         """The corpus itself, not a synthetic stand-in: three of the eight
         leaked before this — one naming the tool and the exact change kinds it
         reports."""
-        pack = json.loads((EVAL_DIR / "skill-eval-pack.json").read_text())
+        pack = json.loads((EVAL_DIR / "skill-eval-pack.json").read_text(encoding="utf-8"))
         ready = {s: e for s, e in pack["scenarios"].items() if e["status"] == "ready"}
         assert ready, "the pack lists no ready scenario to check"
         for sid, entry in ready.items():

--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -700,7 +700,7 @@ class TestUnitTestsPerPlatformTimeout:
     @staticmethod
     def _unit_tests_job() -> dict[str, Any]:
         yaml = pytest.importorskip("yaml")
-        data = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text())
+        data = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
         return dict(data["jobs"]["unit-tests"])
 
     @classmethod

--- a/tests/test_workflow_concurrency_grouping.py
+++ b/tests/test_workflow_concurrency_grouping.py
@@ -36,12 +36,12 @@ here rather than at the next congested merge queue.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
+from _gha_expressions import render
 
 WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
@@ -51,8 +51,13 @@ WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 _SUPERSEDABLE = ("pull_request", "push")
 
 
-def _context(event: str, *, pr: int | None = None, ref: str = "refs/heads/main",
-             run_id: str = "1") -> dict[str, Any]:
+def _context(
+    event: str,
+    *,
+    pr: int | None = None,
+    ref: str = "refs/heads/main",
+    run_id: str = "1",
+) -> dict[str, Any]:
     return {
         "github.workflow": "W",
         "github.event_name": event,
@@ -66,57 +71,16 @@ def _context(event: str, *, pr: int | None = None, ref: str = "refs/heads/main",
     }
 
 
-def _atom(token: str, ctx: dict[str, Any]) -> Any:
-    token = token.strip()
-    if token.startswith(("'", '"')):
-        return token[1:-1]
-    if token in ctx:
-        value = ctx[token]
-        return value if value != "" else False
-    if token.startswith("github."):
-        # An unmodelled context field: treat as absent rather than guessing.
-        return False
-    return token
-
-
-def _evaluate(expr: str, ctx: dict[str, Any]) -> Any:
-    """Evaluate the small GitHub-expression subset these groups use:
-    parenthesised sub-expressions, `||`, `&&`, and `==` against a literal.
-    Falsy follows GitHub: an empty string is falsy, so `a || b` yields b."""
-    expr = expr.strip()
-    while expr.startswith("(") and expr.endswith(")"):
-        depth = 0
-        for i, ch in enumerate(expr):
-            depth += (ch == "(") - (ch == ")")
-            if depth == 0 and i < len(expr) - 1:
-                break
-        else:
-            expr = expr[1:-1].strip()
-            continue
-        break
-
-    for op in ("||", "&&"):
-        depth = 0
-        for i in range(len(expr) - 1):
-            depth += (expr[i] == "(") - (expr[i] == ")")
-            if depth == 0 and expr[i : i + 2] == op:
-                left = _evaluate(expr[:i], ctx)
-                right = _evaluate(expr[i + 2 :], ctx)
-                if op == "||":
-                    return left if left else right
-                return right if left else left
-    if "==" in expr:
-        lhs, rhs = expr.split("==", 1)
-        return _atom(lhs, ctx) == _atom(rhs, ctx)
-    return _atom(expr, ctx)
-
-
 def _render(group: str, ctx: dict[str, Any]) -> str:
-    def sub(match: re.Match[str]) -> str:
-        value = _evaluate(match.group(1), ctx)
-        return "" if value is False else str(value)
+    """Render a concurrency-group expression.
 
-    return re.sub(r"\$\{\{(.+?)\}\}", sub, group)
+    A thin alias for the shared renderer: the expression semantics live in
+    `_gha_expressions` so this module and
+    `test_workflow_coverage_consumers.py` cannot drift apart on what `||`,
+    `&&` or an unmodelled context field mean. They were a private copy here
+    until the second guard needed them.
+    """
+    return render(group, ctx)
 
 
 def _cancelling_workflows() -> list[tuple[str, str, list[str]]]:

--- a/tests/test_workflow_concurrency_grouping.py
+++ b/tests/test_workflow_concurrency_grouping.py
@@ -36,14 +36,12 @@ here rather than at the next congested merge queue.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 from _gha_expressions import render
-
-WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+from _workflow_files import read_repo_text, workflow_paths
 
 # Events whose runs can legitimately supersede one another. A schedule or a
 # workflow_dispatch run is deliberately allowed (and expected) to key off
@@ -85,8 +83,8 @@ def _render(group: str, ctx: dict[str, Any]) -> str:
 
 def _cancelling_workflows() -> list[tuple[str, str, list[str]]]:
     found = []
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
-        doc = yaml.safe_load(path.read_text())
+    for path in workflow_paths():
+        doc = yaml.safe_load(read_repo_text(path))
         concurrency = (doc or {}).get("concurrency")
         if not isinstance(concurrency, dict):
             continue

--- a/tests/test_workflow_concurrency_grouping.py
+++ b/tests/test_workflow_concurrency_grouping.py
@@ -56,6 +56,8 @@ def _context(
     ref: str = "refs/heads/main",
     run_id: str = "1",
 ) -> dict[str, Any]:
+    """A synthesized GitHub context for one run of *event*, so a group
+    expression can be rendered the way the real runner would."""
     return {
         "github.workflow": "W",
         "github.event_name": event,
@@ -82,6 +84,8 @@ def _render(group: str, ctx: dict[str, Any]) -> str:
 
 
 def _cancelling_workflows() -> list[tuple[str, str, list[str]]]:
+    """Every workflow declaring `cancel-in-progress`, with its group
+    expression and the events that can produce a run in that group."""
     found = []
     for path in workflow_paths():
         doc = yaml.safe_load(read_repo_text(path))

--- a/tests/test_workflow_coverage_consumers.py
+++ b/tests/test_workflow_coverage_consumers.py
@@ -45,16 +45,31 @@ from typing import Any
 
 import yaml
 from _gha_expressions import condition_holds, runner_os_for
-from _workflow_files import read_repo_text, workflow_paths
+from _workflow_files import WORKFLOW_DIR, read_repo_text, workflow_paths
 
 #: `--cov-report=xml` writes `coverage.xml`; `--cov-report=xml:NAME` writes NAME.
 _COV_REPORT = re.compile(r"--cov-report=xml(?::([\w.\-]+))?")
 
 
 def _matrix_combinations(job: dict[str, Any]) -> list[dict[str, Any]]:
-    """Expand a job's matrix the way GitHub does: the cross product of its
-    list-valued keys, plus each `include` entry. A job with no matrix has one
-    nameless combination, so jobs are handled uniformly."""
+    """Expand a job's matrix the way GitHub does.
+
+    The cross product of the list-valued axes, then `exclude` applied as
+    *partial* match, then `include` — which is not simply "append". GitHub
+    merges an include entry into every existing combination it is compatible
+    with (it adds keys, or restates values already there) and appends it as a
+    new combination only when it would *overwrite* an original axis value.
+    Appending unconditionally, as this did, produced a standalone
+    `{'coverage': True}` leg for an include that should have merged, and
+    ignored `exclude` entirely (CodeRabbit review).
+
+    Neither shape exists in this repository today: `ci.yml`'s includes all
+    set `os` to a value outside the base axis, which GitHub does append, and
+    no workflow uses `exclude` — so the old code was accidentally right for
+    the current tree and would have gone wrong on the first compatible
+    include anyone added. A job with no matrix has one nameless combination,
+    so jobs are handled uniformly.
+    """
     matrix = (job.get("strategy") or {}).get("matrix") or {}
     if not isinstance(matrix, dict):
         # A matrix built from an expression (`matrix: ${{ fromJson(...) }}`)
@@ -70,8 +85,27 @@ def _matrix_combinations(job: dict[str, Any]) -> list[dict[str, Any]]:
         dict(zip(keys, values, strict=True))
         for values in itertools.product(*(matrix[k] for k in keys))
     ] or [{}]
+
+    for removed in matrix.get("exclude") or []:
+        if isinstance(removed, dict):
+            # A partial exclude removes every combination it matches on the
+            # keys it names, leaving the rest alone.
+            combos = [
+                c for c in combos if any(c.get(k) != v for k, v in removed.items())
+            ]
+
     for extra in matrix.get("include") or []:
-        if isinstance(extra, dict):
+        if not isinstance(extra, dict):
+            continue
+        # Compatible == does not overwrite any *original axis* value. An
+        # include key absent from the axes always merges; one that restates
+        # the axis value it already has merges too.
+        merged_into_any = False
+        for combo in combos:
+            if all(k not in keys or combo.get(k) == v for k, v in extra.items()):
+                combo.update(extra)
+                merged_into_any = True
+        if not merged_into_any:
             combos.append(dict(extra))
     return combos
 
@@ -180,3 +214,100 @@ def test_a_platform_scoped_consumer_does_not_cover_every_platform() -> None:
     macos = _context({"os": "macos-latest"})
     assert _has_consumer(steps, steps[0], "c.xml", linux)
     assert not _has_consumer(steps, steps[0], "c.xml", macos)
+
+
+class TestMatrixExpansionFollowsGitHub:
+    """`_matrix_combinations` decides which legs the guard above inspects, so
+    a leg it invents or loses is a finding invented or lost.
+
+    Stated as its own contract rather than only through the workflows this
+    repository happens to have today: neither `exclude` nor a *compatible*
+    `include` appears in the current tree, so every assertion here would be
+    unreachable from the real workflows -- which is precisely why the
+    behaviour was wrong and nothing noticed (CodeRabbit review).
+    """
+
+    def test_the_cross_product_is_every_axis_combination(self) -> None:
+        combos = _matrix_combinations(
+            {"strategy": {"matrix": {"os": ["a", "b"], "py": ["1", "2"]}}}
+        )
+        assert sorted(map(str, combos)) == sorted(
+            str({"os": o, "py": p}) for o in ("a", "b") for p in ("1", "2")
+        )
+
+    def test_a_job_without_a_matrix_is_one_nameless_combination(self) -> None:
+        assert _matrix_combinations({}) == [{}]
+
+    def test_an_include_adding_a_new_key_merges_into_every_combination(self) -> None:
+        """GitHub merges rather than appends here. Appending produced a
+        standalone `{'cov': True}` leg with no `os` at all, which the guard
+        would then evaluate every `if:` against."""
+        combos = _matrix_combinations(
+            {"strategy": {"matrix": {"os": ["a", "b"], "include": [{"cov": True}]}}}
+        )
+        assert combos == [{"os": "a", "cov": True}, {"os": "b", "cov": True}]
+
+    def test_an_include_restating_an_axis_value_merges_only_there(self) -> None:
+        combos = _matrix_combinations(
+            {
+                "strategy": {
+                    "matrix": {"os": ["a", "b"], "include": [{"os": "a", "cov": True}]}
+                }
+            }
+        )
+        assert combos == [{"os": "a", "cov": True}, {"os": "b"}]
+
+    def test_an_include_overwriting_an_axis_value_is_appended(self) -> None:
+        """The one shape this repository does use: `ci.yml` adds windows and
+        macOS legs to an `os: [ubuntu-latest]` axis."""
+        combos = _matrix_combinations(
+            {
+                "strategy": {
+                    "matrix": {"os": ["a"], "include": [{"os": "z", "cov": True}]}
+                }
+            }
+        )
+        assert combos == [{"os": "a"}, {"os": "z", "cov": True}]
+
+    def test_a_partial_exclude_removes_every_combination_it_matches(self) -> None:
+        combos = _matrix_combinations(
+            {
+                "strategy": {
+                    "matrix": {
+                        "os": ["a", "b"],
+                        "py": ["1", "2"],
+                        "exclude": [{"os": "a"}],
+                    }
+                }
+            }
+        )
+        assert combos == [{"os": "b", "py": "1"}, {"os": "b", "py": "2"}]
+
+    def test_exclude_is_applied_before_include(self) -> None:
+        """GitHub's documented order. Reversing it would let an include
+        resurrect a leg the author excluded."""
+        combos = _matrix_combinations(
+            {
+                "strategy": {
+                    "matrix": {
+                        "os": ["a", "b"],
+                        "exclude": [{"os": "a"}],
+                        "include": [{"cov": True}],
+                    }
+                }
+            }
+        )
+        assert combos == [{"os": "b", "cov": True}]
+
+    def test_the_real_unit_tests_matrix_still_expands_to_its_five_legs(self) -> None:
+        """The regression this must not cause: the live matrix is exactly the
+        shape the old append-everything code got right by luck."""
+        doc = yaml.safe_load(read_repo_text(WORKFLOW_DIR / "ci.yml"))
+        combos = _matrix_combinations(doc["jobs"]["unit-tests"])
+        assert [(c["os"], c["python-version"]) for c in combos] == [
+            ("ubuntu-latest", "3.12"),
+            ("ubuntu-latest", "3.13"),
+            ("ubuntu-latest", "3.14"),
+            ("windows-latest", "3.13"),
+            ("macos-latest", "3.13"),
+        ]

--- a/tests/test_workflow_coverage_consumers.py
+++ b/tests/test_workflow_coverage_consumers.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every coverage report a lane writes must have something that reads it.
+
+Bug class `ci.instrumentation_without_a_consumer`. Coverage instrumentation
+costs roughly 60% wall time on the lane carrying it, so a report nobody
+uploads, archives or gates is pure loss — and it reads as diligence, which
+is why it survives review.
+
+PR #1240 fixed the two sites it found by inspection (the macOS *unit* lane
+and the `slow` lane) and registered the class with an explicit known gap:
+"nothing asserts the consumer half, so a future lane can reintroduce an
+unread report and only a human reading the diff would notice." This module
+closes that gap — and closing it immediately found a third site the
+inspection had missed, in the *integration* lane, where the producer runs on
+`runner.os != 'Windows'` (Linux **and** macOS) while the Codecov upload is
+gated to `ubuntu-24.04`. That is the whole argument for making a rule
+executable rather than writing it down.
+
+The check is per *matrix combination*, not per file, because that is where
+the defect lives: a report can have a perfectly real consumer and still be
+orphaned on one platform of the same job. Each job's matrix is expanded, and
+both the producing step's and the consuming step's `if:` are evaluated
+against that combination through the shared `_gha_expressions` evaluator.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from _gha_expressions import condition_holds, runner_os_for
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+#: `--cov-report=xml` writes `coverage.xml`; `--cov-report=xml:NAME` writes NAME.
+_COV_REPORT = re.compile(r"--cov-report=xml(?::([\w.\-]+))?")
+
+
+def _matrix_combinations(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Expand a job's matrix the way GitHub does: the cross product of its
+    list-valued keys, plus each `include` entry. A job with no matrix has one
+    nameless combination, so jobs are handled uniformly."""
+    matrix = (job.get("strategy") or {}).get("matrix") or {}
+    if not isinstance(matrix, dict):
+        # A matrix built from an expression (`matrix: ${{ fromJson(...) }}`)
+        # cannot be expanded statically. Treated as one nameless combination
+        # so the job is still scanned, rather than skipped outright.
+        matrix = {}
+    keys = [
+        k
+        for k, v in matrix.items()
+        if k not in ("include", "exclude") and isinstance(v, list)
+    ]
+    combos = [
+        dict(zip(keys, values, strict=True))
+        for values in itertools.product(*(matrix[k] for k in keys))
+    ] or [{}]
+    for extra in matrix.get("include") or []:
+        if isinstance(extra, dict):
+            combos.append(dict(extra))
+    return combos
+
+
+def _context(combo: dict[str, Any]) -> dict[str, Any]:
+    ctx: dict[str, Any] = {f"matrix.{k}": str(v) for k, v in combo.items()}
+    if "os" in combo:
+        ctx["runner.os"] = runner_os_for(str(combo["os"]))
+    return ctx
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    return [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+
+
+def _orphaned_reports() -> list[str]:
+    findings = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        doc = yaml.safe_load(path.read_text())
+        for job_name, job in ((doc or {}).get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            steps = _steps(job)
+            for combo in _matrix_combinations(job):
+                ctx = _context(combo)
+                for step in steps:
+                    run = step.get("run")
+                    if not isinstance(run, str):
+                        continue
+                    if not condition_holds(step.get("if"), ctx):
+                        continue
+                    for match in _COV_REPORT.findall(run):
+                        report = match or "coverage.xml"
+                        if not _has_consumer(steps, step, report, ctx):
+                            findings.append(
+                                f"{path.name}::{job_name} {combo or '(no matrix)'} "
+                                f"writes {report} but nothing reads it here"
+                            )
+    return findings
+
+
+def _has_consumer(
+    steps: list[dict[str, Any]],
+    producer: dict[str, Any],
+    report: str,
+    ctx: dict[str, Any],
+) -> bool:
+    """Whether some *other* step that runs under *ctx* names *report*.
+
+    An upload action, an artifact upload, or any step referencing the file
+    all count — the rule is that the measurement is read, not how."""
+    for step in steps:
+        if step is producer:
+            continue
+        if not condition_holds(step.get("if"), ctx):
+            continue
+        if report in yaml.safe_dump(step):
+            return True
+    return False
+
+
+def test_every_written_coverage_report_has_a_consumer() -> None:
+    orphaned = _orphaned_reports()
+    assert not orphaned, (
+        "coverage instrumentation costs ~60% wall time on the lane carrying "
+        "it, so a report with no reader is pure loss. Either give it a "
+        "consumer (an upload, an artifact, a gate) or stop collecting it — "
+        f"keeping the tests either way: {orphaned}"
+    )
+
+
+def test_the_survey_actually_finds_coverage_producers() -> None:
+    """Guards the scan: a parsing change that matched no producer would make
+    the assertion above vacuously true."""
+    producers = 0
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        producers += len(_COV_REPORT.findall(path.read_text()))
+    assert producers >= 2, (
+        f"found {producers} coverage producers; expected the known lanes"
+    )
+
+
+def test_a_platform_scoped_consumer_does_not_cover_every_platform() -> None:
+    """The property that makes this check per-combination rather than per
+    file, pinned directly.
+
+    A file-level check — "some step somewhere names this report" — passes on
+    exactly the defect this module was written to catch: a real consumer,
+    gated to one platform, while the producer runs on two.
+    """
+    steps = [
+        {"if": "runner.os != 'Windows'", "run": "pytest --cov-report=xml:c.xml"},
+        {
+            "if": "matrix.os == 'ubuntu-24.04'",
+            "uses": "codecov/codecov-action",
+            "with": {"files": "c.xml"},
+        },
+    ]
+    linux = _context({"os": "ubuntu-24.04"})
+    macos = _context({"os": "macos-latest"})
+    assert _has_consumer(steps, steps[0], "c.xml", linux)
+    assert not _has_consumer(steps, steps[0], "c.xml", macos)

--- a/tests/test_workflow_coverage_consumers.py
+++ b/tests/test_workflow_coverage_consumers.py
@@ -77,6 +77,8 @@ def _matrix_combinations(job: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _context(combo: dict[str, Any]) -> dict[str, Any]:
+    """The expression context one matrix combination sees, including the
+    `runner.os` GitHub derives from the runner label rather than storing."""
     ctx: dict[str, Any] = {f"matrix.{k}": str(v) for k, v in combo.items()}
     if "os" in combo:
         ctx["runner.os"] = runner_os_for(str(combo["os"]))
@@ -84,10 +86,13 @@ def _context(combo: dict[str, Any]) -> dict[str, Any]:
 
 
 def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """A job's steps, skipping any malformed non-mapping entry."""
     return [s for s in (job.get("steps") or []) if isinstance(s, dict)]
 
 
 def _orphaned_reports() -> list[str]:
+    """Every (workflow, job, matrix combination) that writes a coverage
+    report no step in the same combination reads."""
     findings = []
     for path in workflow_paths():
         doc = yaml.safe_load(read_repo_text(path))
@@ -134,6 +139,7 @@ def _has_consumer(
 
 
 def test_every_written_coverage_report_has_a_consumer() -> None:
+    """The invariant itself: instrumentation must have a reader."""
     orphaned = _orphaned_reports()
     assert not orphaned, (
         "coverage instrumentation costs ~60% wall time on the lane carrying "

--- a/tests/test_workflow_coverage_consumers.py
+++ b/tests/test_workflow_coverage_consumers.py
@@ -41,13 +41,11 @@ from __future__ import annotations
 
 import itertools
 import re
-from pathlib import Path
 from typing import Any
 
 import yaml
 from _gha_expressions import condition_holds, runner_os_for
-
-WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+from _workflow_files import read_repo_text, workflow_paths
 
 #: `--cov-report=xml` writes `coverage.xml`; `--cov-report=xml:NAME` writes NAME.
 _COV_REPORT = re.compile(r"--cov-report=xml(?::([\w.\-]+))?")
@@ -91,8 +89,8 @@ def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _orphaned_reports() -> list[str]:
     findings = []
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
-        doc = yaml.safe_load(path.read_text())
+    for path in workflow_paths():
+        doc = yaml.safe_load(read_repo_text(path))
         for job_name, job in ((doc or {}).get("jobs") or {}).items():
             if not isinstance(job, dict):
                 continue
@@ -149,8 +147,8 @@ def test_the_survey_actually_finds_coverage_producers() -> None:
     """Guards the scan: a parsing change that matched no producer would make
     the assertion above vacuously true."""
     producers = 0
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
-        producers += len(_COV_REPORT.findall(path.read_text()))
+    for path in workflow_paths():
+        producers += len(_COV_REPORT.findall(read_repo_text(path)))
     assert producers >= 2, (
         f"found {producers} coverage producers; expected the known lanes"
     )

--- a/tests/test_workflow_path_filter_closure.py
+++ b/tests/test_workflow_path_filter_closure.py
@@ -42,13 +42,10 @@ moment it does — not when someone remembers to extend a list here.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import pytest
 import yaml
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+from _workflow_files import REPO_ROOT, read_repo_text, workflow_paths
 
 # A repo-relative script handed to an interpreter, or executed directly.
 _EXECUTED_FILE = re.compile(
@@ -122,14 +119,14 @@ def _required_paths(text: str) -> set[str]:
         action_yml = REPO_ROOT / action / "action.yml"
         required.add(f"{action}/action.yml")
         if action_yml.is_file():
-            required |= _executed_files(action_yml.read_text())
+            required |= _executed_files(read_repo_text(action_yml))
     return required
 
 
 def _filtered_workflows() -> list[tuple[str, str, list[str], set[str]]]:
     cases = []
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
-        text = path.read_text()
+    for path in workflow_paths():
+        text = read_repo_text(path)
         doc = yaml.safe_load(text)
         # PyYAML parses the bare `on:` key as the boolean True.
         triggers = (doc or {}).get("on", (doc or {}).get(True)) or {}

--- a/tests/test_workflow_path_filter_closure.py
+++ b/tests/test_workflow_path_filter_closure.py
@@ -118,11 +118,26 @@ def _required_paths(text: str) -> set[str]:
         # Every such job installs *this* package; its dependency bounds,
         # entry points and optional extras all live in pyproject.toml.
         required.add("pyproject.toml")
-    for action in _LOCAL_ACTION.findall(text):
-        action_yml = REPO_ROOT / action / "action.yml"
+    # To a fixed point, because a local action may itself use another one:
+    # scanning only the direct manifests would leave a nested action, and
+    # every file *it* executes, outside the filter (CodeRabbit review). No
+    # such nesting exists in this repository today -- which is exactly why
+    # the traversal has to be written now rather than when the first one
+    # appears and silently is not covered. The visited set makes a cycle
+    # terminate instead of recursing forever.
+    pending, visited = list(_LOCAL_ACTION.findall(text)), set()
+    while pending:
+        action = pending.pop()
+        if action in visited:
+            continue
+        visited.add(action)
         required.add(f"{action}/action.yml")
-        if action_yml.is_file():
-            required |= _executed_files(read_repo_text(action_yml))
+        action_yml = REPO_ROOT / action / "action.yml"
+        if not action_yml.is_file():
+            continue
+        action_text = read_repo_text(action_yml)
+        required |= _executed_files(action_text)
+        pending += _LOCAL_ACTION.findall(action_text)
     return required
 
 

--- a/tests/test_workflow_path_filter_closure.py
+++ b/tests/test_workflow_path_filter_closure.py
@@ -110,6 +110,9 @@ def _covers(globs: list[str], path: str) -> bool:
 
 
 def _required_paths(text: str) -> set[str]:
+    """Files a workflow's own jobs execute, so its paths filter must name
+    them: scripts it runs, `pyproject.toml` where it installs this
+    package, and the `action.yml` of each local action it uses."""
     required = _executed_files(text)
     if "pip install -e" in text:
         # Every such job installs *this* package; its dependency bounds,
@@ -124,6 +127,8 @@ def _required_paths(text: str) -> set[str]:
 
 
 def _filtered_workflows() -> list[tuple[str, str, list[str], set[str]]]:
+    """One case per (workflow, event) that restricts itself with `paths`,
+    carrying the declared globs and the paths it actually depends on."""
     cases = []
     for path in workflow_paths():
         text = read_repo_text(path)
@@ -157,6 +162,8 @@ def test_the_survey_found_filtered_workflows() -> None:
 def test_path_filter_covers_the_workflow_own_infrastructure(
     name: str, event: str, globs: list[str], required: set[str]
 ) -> None:
+    """A workflow that skips itself when its own machinery changes is a
+    gate that silently stops gating."""
     missing = sorted(p for p in required if not _covers(globs, p))
     assert not missing, (
         f"{name} [{event}]: the jobs depend on these files but the paths "

--- a/tests/test_workflow_untrusted_text_interpolation.py
+++ b/tests/test_workflow_untrusted_text_interpolation.py
@@ -41,11 +41,13 @@ that silently never executed anything would pass both other tests.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
+from _workflow_exec import bash_executable, have_bash
 from _workflow_files import WORKFLOW_DIR, read_repo_text, workflow_paths
 
 #: Contexts whose value is free text chosen by whoever opened the PR,
@@ -152,15 +154,28 @@ def _run_body_step(script: str, payload: str, workdir: Path) -> tuple[str | None
     raised `FileNotFoundError` there -- the harness crashed on exactly the
     case it exists to detect, reporting a test error instead of "the attack
     fired". Both outcomes are observations to return, not failures here.
+
+    The environment is replaced rather than extended, so a variable leaking
+    in from the developer's shell cannot change what the step does. On
+    Windows that replacement has to be partial: Git bash is a real POSIX
+    shell but it still needs the host's own `PATH` and `SystemRoot` to find
+    its utilities, and handing it the POSIX-only `PATH` below left the step
+    unable to run at all -- every payload then came back as "nothing was
+    written", which reads exactly like a passing negative control.
+    `test_the_harness_can_execute_a_trivial_step` is what makes that state
+    visible rather than silently reassuring.
     """
+    env = {
+        "PR_BODY": payload,
+        "RUNNER_TEMP": str(workdir),
+        "PATH": "/usr/bin:/bin",
+    }
+    if os.name == "nt":
+        env = {**os.environ, **env, "PATH": os.environ.get("PATH", "")}
     subprocess.run(
-        ["bash", "-c", script],
+        [bash_executable(), "-c", script],
         cwd=workdir,
-        env={
-            "PR_BODY": payload,
-            "RUNNER_TEMP": str(workdir),
-            "PATH": "/usr/bin:/bin",
-        },
+        env=env,
         capture_output=True,
         text=True,
         timeout=30,
@@ -182,6 +197,41 @@ def _real_pr_body_script() -> str:
     pytest.fail("bugfix-test-contract.yml no longer has a PR_BODY step")
 
 
+#: The executing half needs a real POSIX shell. On a Windows runner without
+#: Git for Windows, `bash` resolves to the WSL launcher stub, which prints
+#: its own UTF-16LE "no installed distributions" text and exits 1 -- so an
+#: unguarded run asserts against WSL's output rather than against the step,
+#: reporting a security regression that did not happen. The structural half
+#: above is pure YAML parsing and stays unconditional.
+_needs_bash = pytest.mark.skipif(not have_bash(), reason="needs a real bash")
+
+
+@_needs_bash
+def test_the_harness_can_execute_a_trivial_step(tmp_path: Path) -> None:
+    """Every other result in this module is uninterpretable without this.
+
+    `_run_body_step` reports "nothing was written" both when a payload
+    destroyed the redirect and when the shell never ran at all -- and the
+    negative controls below treat "nothing was written" as *the attack
+    fired*, so a harness that cannot execute anything makes this module
+    report a clean, fully-passing security check while testing nothing.
+    That is not hypothetical: handing Git bash a POSIX-only `PATH` on the
+    Windows lane produced precisely that state.
+
+    So prove the harness works against a script with no payload in it at
+    all, whose only job is to write the file the others look for.
+    """
+    written, pwned = _run_body_step(
+        'printf %s "$PR_BODY" > pr-body.md', "sentinel", tmp_path
+    )
+    assert written == "sentinel", (
+        "the harness could not execute a trivial step, so every other "
+        "result in this module is meaningless -- not evidence of safety"
+    )
+    assert not pwned
+
+
+@_needs_bash
 @pytest.mark.parametrize("payload", HOSTILE_PAYLOADS)
 def test_hostile_pr_body_is_data_not_commands(payload: str, tmp_path: Path) -> None:
     """Executes the attack against the real step rather than asserting the
@@ -191,6 +241,7 @@ def test_hostile_pr_body_is_data_not_commands(payload: str, tmp_path: Path) -> N
     assert written == payload, "the body must land verbatim, as data"
 
 
+@_needs_bash
 @pytest.mark.parametrize("payload", HOSTILE_PAYLOADS)
 def test_the_harness_detects_a_genuinely_unsafe_step(
     payload: str, tmp_path: Path
@@ -211,6 +262,7 @@ def test_the_harness_detects_a_genuinely_unsafe_step(
     pytest.skip(f"payload {payload!r} is inert in this unsafe shape")
 
 
+@_needs_bash
 def test_at_least_one_payload_fires_against_the_unsafe_script(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_workflow_untrusted_text_interpolation.py
+++ b/tests/test_workflow_untrusted_text_interpolation.py
@@ -46,9 +46,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+from _workflow_files import WORKFLOW_DIR, read_repo_text, workflow_paths
 
 #: Contexts whose value is free text chosen by whoever opened the PR,
 #: issue or comment. Numeric ids and SHAs (`pull_request.number`,
@@ -87,8 +85,8 @@ HOSTILE_PAYLOADS = (
 
 def _steps() -> list[tuple[str, str, int, dict]]:
     found = []
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
-        doc = yaml.safe_load(path.read_text())
+    for path in workflow_paths():
+        doc = yaml.safe_load(read_repo_text(path))
         for job_name, job in ((doc or {}).get("jobs") or {}).items():
             if not isinstance(job, dict):
                 continue
@@ -168,7 +166,7 @@ def _run_body_step(script: str, payload: str, workdir: Path) -> tuple[str | None
         timeout=30,
     )
     body = workdir / "pr-body.md"
-    written = body.read_text() if body.exists() else None
+    written = body.read_text(encoding="utf-8") if body.exists() else None
     return written, (workdir / "PWNED").exists()
 
 
@@ -176,7 +174,7 @@ def _run_body_step(script: str, payload: str, workdir: Path) -> tuple[str | None
 #: a file". Read from the workflow rather than retyped, so this cannot go
 #: on testing a string the workflow stopped using.
 def _real_pr_body_script() -> str:
-    doc = yaml.safe_load((WORKFLOW_DIR / "bugfix-test-contract.yml").read_text())
+    doc = yaml.safe_load(read_repo_text(WORKFLOW_DIR / "bugfix-test-contract.yml"))
     for job in doc["jobs"].values():
         for step in job.get("steps") or []:
             if isinstance(step, dict) and "PR_BODY" in (step.get("env") or {}):

--- a/tests/test_workflow_untrusted_text_interpolation.py
+++ b/tests/test_workflow_untrusted_text_interpolation.py
@@ -86,6 +86,7 @@ HOSTILE_PAYLOADS = (
 
 
 def _steps() -> list[tuple[str, str, int, dict]]:
+    """Every step of every workflow, tagged with where it came from."""
     found = []
     for path in workflow_paths():
         doc = yaml.safe_load(read_repo_text(path))
@@ -185,10 +186,13 @@ def _run_body_step(script: str, payload: str, workdir: Path) -> tuple[str | None
     return written, (workdir / "PWNED").exists()
 
 
-#: The real step, copied from bugfix-test-contract.yml's "Write PR body to
-#: a file". Read from the workflow rather than retyped, so this cannot go
-#: on testing a string the workflow stopped using.
 def _real_pr_body_script() -> str:
+    """The real step body from bugfix-test-contract.yml's "Write PR body to
+    a file".
+
+    Read out of the workflow rather than retyped, so this module cannot go
+    on testing a string the workflow itself stopped using.
+    """
     doc = yaml.safe_load(read_repo_text(WORKFLOW_DIR / "bugfix-test-contract.yml"))
     for job in doc["jobs"].values():
         for step in job.get("steps") or []:


### PR DESCRIPTION
## Summary

Follow-up to #1240: closes that PR's own recorded known gap, and closes Phase 2 of [the plan it landed](docs/contribute/plans/ci-cost-and-assurance.md). Both turn out to be the same two lines of `ci.yml`.

Seven further defects surfaced while driving this to green, across four review-and-CI rounds — two found by CI **in this PR's own new tests**, five by review. Each was traced to its cause and closed as a class rather than patched at the site; they are described under "What review and CI found" below.

## Motivation

**The known gap, and what closing it found.** #1240 registered `ci.instrumentation_without_a_consumer` — coverage instrumentation costs ~60% wall time, so a report nobody uploads, archives or gates is pure loss — fixed the two sites it found by inspection, and wrote down explicitly that nothing enforced the rule: *"a future lane can reintroduce an unread report and only a human reading the diff would notice."*

Making it executable immediately found a third site that the same inspection had missed:

| | Condition |
|---|---|
| Producer (`--cov-report=xml:coverage-integration.xml`) | `runner.os != 'Windows'` → Linux **and macOS** |
| Consumer (Codecov upload) | `matrix.os == 'ubuntu-24.04'` → Linux only |

So macOS paid the instrumentation cost for a report with no reader. That is the argument for making a rule executable rather than writing it down, and it shaped the check: it runs **per matrix combination**, not per file. A file-level "some step names this report" check passes on exactly this defect, because the consumer is real and merely narrower than the producer. `test_a_platform_scoped_consumer_does_not_cover_every_platform` pins that distinction directly.

**Phase 2.** `test_cross_platform_integration.py`'s 20 tests run in the generic `-m integration` selector *and* in the dedicated native job. The audit that started this work recommended handing the file to the dedicated jobs; #1240's plan recorded why that would be wrong — the matrices differ:

| Job | Matrix |
|---|---|
| `integration-tests` (generic) | ubuntu-24.04, macos-latest, windows-latest |
| Native PE/Mach-O compare workflows | macos-latest, windows-latest |

Linux gets those tests *here or nowhere*. They are now excluded on macOS/Windows, where the dedicated job owns them, and kept on Linux. Each runs once, everywhere it ran before.

The plan said to measure executed test IDs per platform first, because `ABICHECK_MIN_EXECUTED` gates the executed count and *collected* is not *executed*. Reading the floors settled it without that measurement: the two lanes that now exclude the file sit at a `'1'` floor (both "> 0" guards against a missing toolchain), so dropping 20 tests from a selection that still collects hundreds cannot trip them — and Linux, the only lane with a real floor (`'20'` against a known ~195), is untouched. The caution was right in general and did not apply here. The macOS lane has since confirmed it on a real runner: 233 executed against the `'1'` floor, with no `--cov` flags.

## Changes

- `.github/workflows/ci.yml`: the `runner.os != 'Windows'` integration step splits into Linux and macOS steps. Linux keeps coverage (it has a consumer) and keeps the native file; macOS drops both. Windows drops the file too. No test stops running anywhere.
- `tests/test_workflow_coverage_consumers.py`: the consumer guard, per matrix combination.
- `tests/_gha_expressions.py`: the GitHub-expression evaluator, extracted rather than copied a second time; `test_workflow_concurrency_grouping.py` now routes through it, so the two guards cannot drift on what `||`, `&&` or an unmodelled context field mean.
- `tests/_workflow_files.py`: one owner for reading the repository's own workflow YAML in tests, with the encoding stated (see below).
- `tests/test_repo_text_reads_state_their_encoding.py`, `tests/test_gha_expression_evaluator.py`: the two new guards described below.
- `tests/regressions/manifest_tool_surface.py`: three bug classes — the existing one gains the seed test and an honest known gap; two are new.
- The plan document records Phase 2 as landed and why the measurement it asked for was not needed.

No `abicheck/**/*.py` change, so no changelog fragment (the gate scopes to that tree).

## What review and CI found

**1. A guard that failed open** (`c8b38f5c`, CodeRabbit). `_atom` returned the raw token for an unmodelled expression, and a non-empty string is truthy — so an unmodelled `if:` made a step read as unconditionally active, silently masking the very "report with no reader" defect this PR exists to catch. I took the finding but not the suggested blanket `return False`: `examples-validation.yml:303` compares `matrix.shard == 1`, and collapsing every unrecognized token to `False` flips that comparison. Literals stay literals; only *references and calls* go absent. `tests/test_gha_expression_evaluator.py` is the primitive's standalone contract suite `AGENTS.md` asks for — restoring the old fallback fails 8 of its cases.

**2. Reading the repo's own text with the platform's encoding** (`98cbb4ef`). Four guards read `.github/workflows/*.yml` at import time through a bare `read_text()`. That decodes as `cp1252` on Windows, and `check-project.yml` is 78 KB of UTF-8 full of em dashes — so the Windows unit lane died at *collection*, before any assertion ran. Fixed as the class: one owner for the read, plus an AST scan rejecting any repository-rooted read that leaves the encoding to the host. That scan found **seven more latently Windows-red sites** beyond the four that failed. Paired with a non-vacuity half, so the rule cannot pass hollowly if the repository ever turns pure ASCII. Class `tests.locale_dependent_repo_text_read`. **Confirmed on the real runner: 12 collection errors → 0.**

**3. A dead injection harness reading as a passing control** (`3a3b675f`). `test_workflow_untrusted_text_interpolation` launched a bare `bash` with a POSIX-only `PATH`; on Windows the step never ran. The shallow half is the platform bug. The deep half is that this module reads an attack as *"the body did not land verbatim"* — indistinguishable from *"the shell never ran"* — and its negative controls treat that as the attack firing. A harness that can execute nothing makes the module report a clean, fully-passing injection defence while testing nothing. Demonstrated, not argued: pointing the resolver at a binary that exits cleanly without writing makes the old control report PASS. Fixed by routing through `_workflow_exec.bash_executable()` (whose docstring already predicted this exact mistake), keeping the hermetic `PATH` POSIX-only, and adding a payload-free liveness precondition so a dead harness fails loudly. Class `tests.dead_harness_reads_as_a_passing_control`.

**4. Four more fail-open gaps in the new guards** (`9d79b1ef`, CodeRabbit). Three of the four share the shape the guards exist to prevent — answering *"nothing to report"* for input they could not see. (a) The fix in (1) moved the fail-open out one level rather than closing it: returning `False` for an unmodelled token made it indistinguishable from the literal `false`, so `<unmodelled> == false` compared equal. An `ABSENT` sentinel now survives into the comparison. Note that `test_unmodelled_expressions_are_absent_not_present` had pinned `is False` — the very identity the correct fix must break. (b) The encoding scan walked only the call target, missing `path = REPO_ROOT / x` and `for path in workflow_paths():`, the two spellings this suite reaches for first; alias tracking (scoped per function, to avoid a cross-test false positive) found **two more** unencoded reads, both fixed. (c) Nested local actions were not traversed — latent, since none exist today. (d) Matrix expansion appended every `include` and ignored `exclude`; it was accidentally correct for this tree, since every `ci.yml` include overwrites `os`. All four now carry tests that fail against the old behaviour.

## Verification

| Check | Result |
|---|---|
| Full fast unit suite | 44,792 passed; 2 pre-existing failures (ADR-049 `**Verified:**` receipt names a commit unreachable from this container's shallow `origin/main` — reproduced identically on an unmodified `main` worktree, and the `ai-readiness` job passes in CI) |
| New consumer guard with the macOS producer reinstated | fails with the exact finding, passes once removed |
| Encoding failure, unfixed tree under `LC_ALL=C` | reproduces; green on the fixed tree |
| Encoding fix on the real `windows-latest` runner | 12 `charmap` collection errors → **0** |
| Injection-harness fix on the real `windows-latest` runner | 78 failures → 71; the 7 run and pass rather than skipping (skip count moved by 2, matching the local inert-payload controls) |
| Integration lanes on the current head | Linux/macOS/Windows each fail on `case96` only — nothing else |
| macOS integration lane command | no `--cov` flags, 233 executed against the `'1'` floor |
| `scripts/check_architecture.py` | 0 errors |
| `ruff check tests/`, `ruff format --check` (this diff) | clean |
| `mypy abicheck/` | Success, no issues in 793 source files |

## Not this PR's — four regressions already on `main`

Every remaining red check traces to a PR merged before this branch, each reproduced locally on `main` and commented on in the thread:

| From | Failure |
|---|---|
| #1234 | `test_action_run_sh_helpers.py` and siblings, ~71 Windows unit failures |
| #1235 | `case96_hidden_friend_removed` — `expected='API_BREAK' got='BREAKING'`, under both gcc and clang |
| #1237 | two `test_release_assurance_cli.py` failures on the ubuntu integration lane |
| `84d5e67b` | `mutmut` aborts on its **clean, unmutated** baseline test (`test_release_evidence_contract_axis`, `assert 8 == 7`), so the mutation gate has been reporting nothing at all — not "no survivors", but "never ran" |

## Bug-fix test contract

- Bug class: `ci.instrumentation_without_a_consumer` (existing; this PR closes its recorded known gap and adds the seed test). Also `tests.locale_dependent_repo_text_read` and `tests.dead_harness_reads_as_a_passing_control`, both new.
- Publicly observable failure: the macOS integration lane ran under coverage instrumentation — roughly 60% added wall time — writing `coverage-integration.xml` that no upload, artifact or gate ever read.
- Regression test fails on base: yes. The guard was written before the fix and reported exactly this site against the then-current tree; reinstating the producer reproduces the failure.
- Negative control: `test_the_survey_actually_finds_coverage_producers` (a parsing change matching nothing would make the main assertion vacuous) and `test_a_platform_scoped_consumer_does_not_cover_every_platform` (a file-level check would pass on this very defect).
- Public-surface test: not applicable for the coverage class — this is CI configuration, not library surface, so `public_surfaces` stays `()` per the registry's own rule. The harness class does claim `github-action`, since its seed test really executes a workflow step body under `bash`.
- Malicious fixture + side-effect absence: yes, and strengthened here. `test_workflow_untrusted_text_interpolation` executes seven hostile PR bodies (quote-breaking, `$(...)`, backticks, `${IFS}`, `::error::` newline forgery) against the **real** step body read out of `bugfix-test-contract.yml`, and asserts both that the payload lands verbatim as data and that no `PWNED` side effect exists — never that the YAML contains a quote, which is exactly the #705 → #758 failure. This PR adds the missing half: a liveness precondition, because "no side effect" is also what a harness that cannot execute anything produces, and the negative controls read that as the attack firing.
- Axes covered: producer/consumer gating across every matrix combination of every job in every workflow, on both `push` and `pull_request` shapes; the `half` axis gains `report-has-a-consumer`.
- General invariant: **a coverage report written on a platform must be read on that platform.** Checked by evaluating each step's real `if:` against each expanded matrix combination, not by matching text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uvfxucH1VxgJp4YTXQJ1H