### PR TITLE
fix(action): recognize every Click spelling of --output

### DIFF
--- a/action/AGENTS.md
+++ b/action/AGENTS.md
@@ -310,6 +310,16 @@ Two predicates close that without weakening anything above:
   earlier one. **Add a consumer of the output path and resolve it through
   `_EFFECTIVE_OUTPUT_FILE`**, never `$OUTPUT_FILE`.
 
+  **Every spelling Click accepts for `--output` names the destination**, and
+  `_attached_output_value` is what recognizes the ones `_extra_args_options`
+  leaves opaque: `-oPATH`, `-voPATH`, `-vvoPATH`. It strips leading `v`s one at a
+  time rather than globbing `-v*o?*`, because that glob also accepts `-vHofoo` —
+  which Click reads as `-v -Hofoo`, a *header* value whose text merely contains
+  an `o`. Confirm a new spelling against the installed Click parser before
+  relying on it; the help text is not the parser. Two of these were separate
+  findings, which is why the tests state the whole spelling set rather than the
+  reported input.
+
   **`-oPATH` counts as naming the destination.** `_extra_args_options` leaves an
   *attached* short option an opaque bare token deliberately — that form consumes
   no following token, so "unexpanded" is the right answer for every other

--- a/action/run.sh
+++ b/action/run.sh
@@ -2216,6 +2216,30 @@ _effective_format() {
   printf '%s' "$_found"
 }
 
+# The attached `-o` value in an opaque bare token, or failure when it holds none.
+#
+# The forms Click accepts and this recognizes: `-oPATH`, and a cluster of
+# leading boolean `-v`s before it (`-voPATH`, `-vvoPATH`). Leading `v`s are
+# stripped one at a time rather than matched with `-v*o?*`, because that glob
+# also accepts `-vHofoo` -- which Click reads as `-v -Hofoo`, a *header* value
+# whose text merely happens to contain `o`. `-v` is the only boolean short
+# option across every command this Action invokes, which is the same fact
+# `_extra_args_expand_short_clusters` relies on.
+#
+# Fails (prints nothing, returns 1) for a bare `-o` or `-vo`, whose value is the
+# *next* token: the cluster expander already turns those into a pending option
+# that `_extra_args_options` pairs with its value, so they never arrive here.
+_attached_output_value() {
+  local _token="${1:-}" _rest
+  _rest="${_token#-}"
+  [[ "$_rest" != "$_token" ]] || return 1
+  while [[ "$_rest" == v* ]]; do
+    _rest="${_rest#v}"
+  done
+  [[ "$_rest" == o?* ]] || return 1
+  printf '%s' "${_rest#o}"
+}
+
 # The real `--output` path `abicheck` writes to, accounting for `extra-args`
 # overriding this script's own `-o "$OUTPUT_FILE"` flag -- the exact sibling of
 # `_effective_format` above, and for the same reason: `CMD` carries this
@@ -2238,16 +2262,26 @@ _effective_output_file() {
   while IFS=$'\t' read -r _name _value; do
     case "$_name" in
       --output | -o) _found="$_value" ;;
-      # Click's *attached* short form, `-oPATH`. `_extra_args_options` leaves it
-      # an opaque bare token on purpose -- that form consumes no following
-      # token, so for every other consumer "unexpanded" is already the right
-      # answer -- but here the attached value IS the answer, and dropping it
-      # sent a file-writing run down the stdout path (Codex review, P2;
-      # confirmed against the installed Click parser, which resolves
-      # `-oreport.json` to `--output`). Matched with a literal `-o` prefix and a
-      # non-empty remainder, so a bare `-o` (whose value is the next token, and
-      # which the case above already handled) cannot fall in here.
-      -o?*) _found="${_name#-o}" ;;
+      # Click's *attached* short forms, bare (`-oPATH`) or clustered
+      # (`-voPATH`, `-vvoPATH`). `_extra_args_options` leaves these opaque bare
+      # tokens on purpose -- an attached value consumes no following token, so
+      # for every other consumer "unexpanded" is already the right answer -- but
+      # here the attached value IS the answer, and dropping it sent a
+      # file-writing run down the stdout path (Codex review, P2 twice: first the
+      # bare form, then the clustered one, both confirmed directly against the
+      # installed Click parser).
+      #
+      # Delegated to `_attached_output_value` rather than matched with a glob:
+      # `-v*o?*` would also swallow `-vHofoo`, which Click reads as `-v -Hofoo`
+      # -- a header value, not an output path. Recognizing the form needs the
+      # same knowledge of which short options exist that
+      # `_extra_args_expand_short_clusters` already encodes, so it gets a named
+      # function instead of a third ad-hoc pattern.
+      -*)
+        if _value="$(_attached_output_value "$_name")"; then
+          _found="$_value"
+        fi
+        ;;
     esac
   done <<<"$(_extra_args_options)"
   printf '%s' "$_found"
@@ -4524,7 +4558,7 @@ _resolve_clean_exit_verdict() {
       _reject_unusable_report "$_dest_validity" "$_dest" || return
       if _assurance_axis_contradictory_at "$_dest"; then
         VERDICT="REPORT_UNREADABLE"
-        echo "::error::abicheck exited 0, but the JSON report requested at $(_sanitize_annotation "$_dest") claims a schema version carrying analysis_assurance_exit_contribution and omits it while reporting an analysis_assurance block -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
+        echo "::error::abicheck exited 0, but the JSON report requested at $(_sanitize_annotation "$_dest") reports an analysis_assurance block and omits the analysis_assurance_exit_contribution it owes -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
         return
       fi
     done <<<"$(_caller_json_destinations)"
@@ -4558,7 +4592,7 @@ _resolve_clean_exit_verdict() {
       _reject_unusable_report "$_validity" "format: json on stdout" || return
       if _assurance_axis_contradictory_at "$_STDOUT_JSON_FILE"; then
         VERDICT="REPORT_UNREADABLE"
-        echo "::error::abicheck exited 0, but the JSON report it printed on stdout claims a schema version carrying analysis_assurance_exit_contribution and omits it while reporting an analysis_assurance block -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
+        echo "::error::abicheck exited 0, but the JSON report it printed on stdout reports an analysis_assurance block and omits the analysis_assurance_exit_contribution it owes -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
         return
       fi
     fi
@@ -4576,7 +4610,7 @@ _resolve_clean_exit_verdict() {
   # correct direction for a gate.
   if _assurance_axis_contradictory; then
     VERDICT="REPORT_UNREADABLE"
-    echo "::error::abicheck exited 0, but its JSON report claims a schema version carrying analysis_assurance_exit_contribution and omits it while reporting an analysis_assurance block -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
+    echo "::error::abicheck exited 0, but its JSON report reports an analysis_assurance block and omits the analysis_assurance_exit_contribution it owes -- so whether the analysis-assurance gate fired cannot be established from it. That is an invalid report, not a passing assurance check, and this step will not report a compatibility result from it."
     return
   fi
   # A report that reports an *operational* outcome rather than a compatibility

--- a/changelog.d/20260912_claude_action_report_reader_truthfulness.md
+++ b/changelog.d/20260912_claude_action_report_reader_truthfulness.md
@@ -35,6 +35,9 @@
   emitted an empty value or, worse, a stale pre-existing file at the superseded
   path — which `action.yml`'s SARIF-upload step gates on and consuming workflows
   read. It now resolves the effective path and requires the file to be fresh.
+- **Every Click spelling of `--output` is recognized**, including the clustered
+  attached forms (`-voPATH`, `-vvoPATH`) that the short-option expander leaves
+  opaque by design.
 - **Click's attached `-oPATH` form is recognized as the report destination**, so
   a run writing to a file is no longer judged as the stdout shape (or judged at
   the superseded input path).

--- a/tests/regressions/manifest_report.py
+++ b/tests/regressions/manifest_report.py
@@ -289,7 +289,17 @@ REPORT_BUG_CLASSES: tuple[BugClass, ...] = (
             # on. Six findings on #1246 were this one shape, each fixed for
             # itself; the axis exists so the next admission rule without a
             # consumer fails a test instead of publishing COMPATIBLE.
-            "answerability": ("answered", "admitted_but_unanswerable"),
+            #
+            # Only these two states are *reachable*, which is the point rather
+            # than a gap (CodeRabbit review): on correct code no document is
+            # admitted-and-unanswerable, so naming that as a third state to
+            # exercise would describe a seed the matrix cannot contain. It is
+            # the state the invariant forbids, and it is reached only under
+            # mutation -- re-introducing three of the six historical findings
+            # produces it in 46, 48 and 8 generated documents respectively,
+            # which is how `TestAdmissionImpliesAnswerability` was verified to
+            # generalize rather than merely to pass.
+            "answerability": ("admitted_and_answered", "rejected"),
         },
         known_gaps=(
             KnownGap(

--- a/tests/test_action_report_destinations.py
+++ b/tests/test_action_report_destinations.py
@@ -1096,6 +1096,13 @@ class TestEveryOutputSpellingNamesTheDestination:
         )
         assert outputs.get("verdict") == "BREAKING", outputs
         assert outputs.get("report-path") == str(dest), outputs
+        # Side-effect absence, not only the published value: a misread would
+        # make `foo` the effective destination, and the freshness check would
+        # then fingerprint -- and on a rewrite trust -- a path the caller never
+        # named. Asserting the published value alone cannot see that, which is
+        # the #705 -> #758 lesson applied to this boundary.
+        assert not (tmp_path / "foo").exists(), "misread as an output path"
+        assert not list(tmp_path.glob("**/ofoo")), "misread as an output path"
 
     def test_a_header_value_containing_o_with_no_real_output(
         self, tmp_path: Path
@@ -1111,3 +1118,10 @@ class TestEveryOutputSpellingNamesTheDestination:
         outputs = _run_action(tmp_path, env, bindir)
         assert outputs.get("verdict") == "BREAKING", outputs
         assert outputs.get("report-path") == str(dest), outputs
+        # Side-effect absence, not only the published value: a misread would
+        # make `foo` the effective destination, and the freshness check would
+        # then fingerprint -- and on a rewrite trust -- a path the caller never
+        # named. Asserting the published value alone cannot see that, which is
+        # the #705 -> #758 lesson applied to this boundary.
+        assert not (tmp_path / "foo").exists(), "misread as an output path"
+        assert not list(tmp_path.glob("**/ofoo")), "misread as an output path"

--- a/tests/test_action_report_destinations.py
+++ b/tests/test_action_report_destinations.py
@@ -986,3 +986,128 @@ class TestReportPathPublishesTheEffectiveDestination:
         bindir = self._stub(tmp_path, dest)
         outputs = _run_action(tmp_path, self._env(tmp_path, "", dest), bindir)
         assert outputs.get("report-path") == str(dest), outputs
+
+
+#: Every spelling Click accepts for `--output`, each verified directly against
+#: the installed parser before being relied on here. The clustered attached
+#: forms are the ones that were missed: `_extra_args_expand_short_clusters`
+#: deliberately leaves a cluster ending in an attached value unexpanded, so the
+#: token arrives opaque and a naive `-o` prefix test does not see it.
+OUTPUT_SPELLINGS = (
+    "--output {dest}",
+    "--output={dest}",
+    "-o {dest}",
+    "-o{dest}",
+    "-vo{dest}",
+    "-vvo{dest}",
+    "-vo {dest}",
+)
+
+
+class TestEveryOutputSpellingNamesTheDestination:
+    """One spelling missed is a working run reported as `REPORT_UNREADABLE`.
+
+    The bare attached form (`-oPATH`) was the first finding here and the
+    clustered attached form (`-voPATH`) the second, which is why this is stated
+    over the whole spelling set rather than per reported input. Each entry was
+    confirmed against the installed Click parser, not assumed from the help text.
+
+    `_attached_output_value` is what recognizes them, and it strips leading `v`s
+    one at a time rather than globbing `-v*o?*` — that glob also accepts
+    `-vHofoo`, which Click reads as `-v -Hofoo`: a *header* value whose text
+    merely contains an `o`. `test_a_header_value_containing_o_is_not_an_output`
+    is the guard.
+    """
+
+    def _stub(self, tmp_path: Path, dest: Path) -> Path:
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        blob = tmp_path / "payload.json"
+        blob.write_text(
+            json.dumps({"report_schema_version": "4.4", "verdict": "BREAKING"}),
+            encoding="utf-8",
+        )
+        stub = bindir / "abicheck"
+        stub.write_text(
+            f'#!/usr/bin/env bash\ncp "{blob}" "{dest}"\nexit 0\n', encoding="utf-8"
+        )
+        stub.chmod(0o755)
+        return bindir
+
+    def _env(self, tmp_path: Path, extra: str) -> dict[str, str]:
+        return {
+            "INPUT_MODE": "compare",
+            "INPUT_OLD_LIBRARY": _lib(tmp_path, "libold.so"),
+            "INPUT_NEW_LIBRARY": _lib(tmp_path, "libnew.so"),
+            "INPUT_FORMAT": "json",
+            "INPUT_EXTRA_ARGS": extra,
+        }
+
+    @pytest.mark.parametrize("spelling", OUTPUT_SPELLINGS)
+    def test_the_report_is_found_and_read(self, tmp_path: Path, spelling: str) -> None:
+        dest = tmp_path / "out.json"
+        bindir = self._stub(tmp_path, dest)
+        outputs = _run_action(
+            tmp_path, self._env(tmp_path, spelling.format(dest=dest)), bindir
+        )
+        assert outputs.get("verdict") == "BREAKING", (spelling, outputs)
+
+    @pytest.mark.parametrize("spelling", OUTPUT_SPELLINGS)
+    def test_the_effective_path_is_published(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        dest = tmp_path / "out.json"
+        bindir = self._stub(tmp_path, dest)
+        outputs = _run_action(
+            tmp_path, self._env(tmp_path, spelling.format(dest=dest)), bindir
+        )
+        assert outputs.get("report-path") == str(dest), (spelling, outputs)
+
+    @pytest.mark.parametrize("spelling", OUTPUT_SPELLINGS)
+    def test_a_missing_destination_is_still_caught(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        # Recognizing a spelling must not stop requiring what it names.
+        dest = tmp_path / "out.json"
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        stub = bindir / "abicheck"
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        stub.chmod(0o755)
+        outputs = _run_action(
+            tmp_path, self._env(tmp_path, spelling.format(dest=dest)), bindir
+        )
+        assert outputs.get("verdict") == "REPORT_UNREADABLE", (spelling, outputs)
+
+    def test_a_header_value_containing_o_is_not_an_output(self, tmp_path: Path) -> None:
+        # `-vHofoo` is `-v -Hofoo` to Click: a header value, not a destination.
+        # A "strip everything before the first o" rule would take `foo` as the
+        # output path.
+        #
+        # The trap comes *after* the real `-o`, deliberately. Written the other
+        # way round this test is vacuous: the resolver is last-wins, so a real
+        # `-o` following the trap overwrites the bad value and the assertion
+        # passes either way. Mutation-testing this very assertion is what caught
+        # that -- the loose rule survived the first version of it.
+        dest = tmp_path / "real.json"
+        bindir = self._stub(tmp_path, dest)
+        outputs = _run_action(
+            tmp_path, self._env(tmp_path, f"-o{dest} -vHofoo"), bindir
+        )
+        assert outputs.get("verdict") == "BREAKING", outputs
+        assert outputs.get("report-path") == str(dest), outputs
+
+    def test_a_header_value_containing_o_with_no_real_output(
+        self, tmp_path: Path
+    ) -> None:
+        # The same trap with no `-o` to shadow it, so a misread cannot be masked
+        # by ordering at all: the run genuinely writes `output-file`, and if the
+        # header value were read as a destination the effective path would move
+        # to `foo` and the run would report REPORT_UNREADABLE.
+        dest = tmp_path / "declared.json"
+        bindir = self._stub(tmp_path, dest)
+        env = self._env(tmp_path, "-vHofoo")
+        env["INPUT_OUTPUT_FILE"] = str(dest)
+        outputs = _run_action(tmp_path, env, bindir)
+        assert outputs.get("verdict") == "BREAKING", outputs
+        assert outputs.get("report-path") == str(dest), outputs


### PR DESCRIPTION
## Summary

Follow-up to [#1246](https://github.com/abicheck/abicheck/pull/1246): the clustered attached forms of `--output` (`-voPATH`, `-vvoPATH`) were still unrecognized, so a working run reported `REPORT_UNREADABLE`. Plus two accuracy corrections that #1246's own changes made necessary.

This commit was pushed a few minutes after #1246 merged, so it is a new pull request rather than an addition to that one.

## Motivation

#1246 taught `_effective_output_file` about the bare attached form `-oPATH`. Click also accepts the *clustered* attached form, which `_extra_args_expand_short_clusters` deliberately leaves unexpanded — a cluster ending in an attached value consumes no following token, so "unexpanded" is the right answer for every other consumer. The `-o?*` test added for the bare form therefore never saw `-vo/report.json`, and with `format: json` and no `output-file` the Action judged a file-writing run as the stdout shape and published `REPORT_UNREADABLE` for a successful comparison.

Verified against the installed Click parser rather than inferred from the help text: `-vo/report.json` and `-vvo/report.json` both resolve to verbose plus that output path.

## Changes

- **`_attached_output_value`** replaces the inline `-o?*` glob. It strips leading `v`s one at a time rather than matching `-v*o?*`, because that glob also accepts `-vHofoo` — which Click reads as `-v -Hofoo`, a *header* value whose text merely contains an `o`. Naming the function also puts the "which short options exist" knowledge beside `_extra_args_expand_short_clusters`, which already depends on the same fact.
- **Tests state the whole spelling set** (`--output X`, `--output=X`, `-o X`, `-oX`, `-voX`, `-vvoX`, `-vo X`) across three properties each — the report is found and read, the effective path is published as `report-path`, and a missing destination is still `REPORT_UNREADABLE` — since this is the second spelling to be missed.
- **Three contradictory-report diagnostics** no longer claim the report "claims a schema version": the unversioned `mode: bundle_facts` shape can now be contradictory too, so they state only what is established — an `analysis_assurance` block with the contribution it owes omitted.
- **The bug class's `answerability` axis** now names the two states the seed matrix reaches. `admitted_but_unanswerable` is unreachable on correct code — that is what the invariant asserts — and is reached only under mutation, which the axis comment now records.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `report.unestablished_result_reads_as_success` (`tests/regressions/manifest_report.py`) — this instance is its inverse direction: a valid run reported as unreadable.
- Publicly observable failure: `extra-args: -vo/report.json` with `format: json` and no `output-file` publishes `verdict: REPORT_UNREADABLE` and exit 1 for a comparison that completed and wrote a valid report.
- Regression test fails on base: yes — `TestEveryOutputSpellingNamesTheDestination`; reverting `_attached_output_value` to the `-o?*` glob fails 4 cases (`-voX`, `-vvoX` × found-and-read, published-as-report-path).
- Negative control: `test_a_missing_destination_is_still_caught` (all seven spellings) — recognizing a spelling must not stop requiring what it names.
- Public-surface test: yes — every case runs the whole of `action/run.sh` through `tests/_action_run_sh_harness.py` with a real `$GITHUB_OUTPUT`, asserting the published `verdict` and `report-path` outputs.
- Axes covered: `requested_destination` (primary output file, stdout, `extra-args --write json=`) across all seven `--output` spellings; `answerability`.
- General invariant: *every spelling Click accepts for `--output` names the effective destination, and nothing else does.* Exercised over the full seven-form set × three properties (21 cases) plus two adversarial non-destination traps, against the installed Click parser as the oracle — not against the same string-matching the implementation uses.
- Malicious fixture + side-effect absence: `test_a_header_value_containing_o_is_not_an_output` and `test_a_header_value_containing_o_with_no_real_output` execute `-vHofoo` through the real `run.sh` (a PR-controlled `extra-args` value, per `action/AGENTS.md`'s threat model) and assert **no `foo`/`ofoo` file was created** alongside the published verdict and `report-path`. The published value alone cannot see a misread that made `foo` the effective destination, where the freshness check would then fingerprint — and on a rewrite trust — a path the caller never named.

One test-quality note worth recording, because mutation-testing my own work caught it: the first version of the `-vHofoo` trap test was **vacuous**. It placed the trap *before* a real `-o`, and the resolver is last-wins, so the real path overwrote the misread value and the assertion passed whether or not the rule was correct — the loose "strip everything before the first `o`" mutation survived it. The trap now comes after the real `-o`, with a second case carrying no `-o` at all so ordering cannot mask a misread; both fail against that mutation.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — extends the existing `20260912_claude_action_report_reader_truthfulness.md` fragment; no `abicheck/**/*.py` change in this PR
- [x] Docs updated if user-visible behaviour changed — `action/AGENTS.md`
- [x] `pre-commit run --all-files` passes locally — `ruff check` clean, `bash -n` clean, `check_architecture.py` 0 errors, `check_ai_readiness.py` reports only the pre-existing ADR-049 `**Verified:**` receipt error that is red on `main` too
- [x] No new `mypy` or `ruff` errors introduced

Local verification on `47625787`: `-k action` 3856 passed / 0 failed; `bugfix-test-contract` passes locally with this description via `BUGFIX_CONTRACT_BODY_FILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4iSrvcQHGa8A6spobjNAq