### PR TITLE
test: close two false-green paths and three sources of repeated CI work

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -129,6 +129,27 @@ finishes in ~45 seconds.
   `StepResult.output_lines` exposes the raw records, so an *injected extra*
   `$GITHUB_OUTPUT` line is visible and not just a wrong value. See
   `test_reusable_workflow_execution.py`.
+- `schema_validation.py` — `validate_instance(instance, schema)`, a drop-in
+  replacement for `jsonschema.validate` that checks the *schema* once per
+  distinct schema content instead of on every call (which is what the library
+  does, and what it documents against when the schema is already known good).
+  **Use it instead of `jsonschema.validate` in new tests**: this suite
+  validates many reports against a handful of packaged schemas, so the
+  per-call schema check is pure repeated work. The cache is keyed on the
+  schema's canonical JSON, never a path or a dict's identity, so a test that
+  edits a schema between calls is not served a stale validator.
+  `test_schema_validation_helper.py` states the equivalence against the real
+  library as the oracle.
+- `test_cross_platform_integration.py`'s `_require_compile_success` — the
+  three-state rule every fixture-building helper owes: platform/tool missing
+  is a marker-level skip, a *named* optional compiler feature may skip, and a
+  configured compiler that ran and failed is a **failure** with command, source
+  and stderr attached. A generic helper that turns any nonzero exit into
+  `pytest.skip` produces a green lane that proved less than it claims — the
+  `ABICHECK_MIN_EXECUTED` silent-skip guard cannot see it, because the sibling
+  fixtures that still build satisfy the floor. Bug class
+  `guard.absent_capability_vs_real_failure`; contract in
+  `test_compile_failure_contract.py`.
 ## What NOT to do
 
 - Don't change the marker scheme — CI gates depend on it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,7 +380,7 @@ def _materialize_generated_skill_trees() -> None:
     except gen.SkillGenerationError:
         return  # a skills-src authoring error; let the real gen/AI-readiness checks report it
 
-    def _write_if_stale() -> None:
+    def _is_stale() -> bool:
         # Content-keyed, not "have I already run": `check_trees` compares every
         # owned file's bytes against the render, so a tree that is already
         # correct is left untouched and a stale or partially-written one is
@@ -388,17 +388,30 @@ def _materialize_generated_skill_trees() -> None:
         # xdist workers sharing one checkout (the first writes, the rest
         # verify and no-op) and remote workers with their own filesystem
         # (each writes its own, because its own check fails).
-        if not gen.check_trees(rendered):
-            return
-        gen.write_trees(rendered)
+        try:
+            return bool(gen.check_trees(rendered))
+        except OSError:
+            # `check_trees` enumerates then reads, so a file that another
+            # process removes between those two steps raises here. That can
+            # only happen while a writer is mid-`write_trees`, which means the
+            # trees really are being rebuilt: answer "stale" and let the
+            # locked path settle it, rather than letting a transient
+            # FileNotFoundError abort pytest configuration outright
+            # (Codex review, PR #1252).
+            return True
+
+    def _write_if_stale() -> None:
+        if _is_stale():
+            gen.write_trees(rendered)
 
     # Unconditional rewriting was not merely redundant work: `write_trees`
     # removes each owned skill directory before restoring it, so every extra
     # writer reopened a window in which a concurrent reader -- another worker's
     # test, a parallel session, a restarted worker -- sees the tree absent.
     # Checking first closes that window in the common case; the lock still
-    # serializes the writers that remain.
-    if not gen.check_trees(rendered):
+    # serializes the writers that remain, and the re-check *inside* the lock is
+    # what decides, so this unlocked one can only ever cost a lock acquisition.
+    if not _is_stale():
         return
     if filelock is not None:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,34 @@ def _hypothesis_profile_for_mutmut() -> None:
 _hypothesis_profile_for_mutmut()
 
 
+_SNAPSHOT_CACHE_BUCKETS: dict[Path, Path] = {}
+
+
+def _snapshot_cache_bucket(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The one directory this process's per-test cache directories live in.
+
+    Allocating them *directly* in pytest's basetemp fixed half the cost and
+    left the other half in place: ``tmp_path`` still uses pytest's numbered
+    allocator, which enumerates every sibling of basetemp to pick the next
+    number -- so every ordinary ``tmp_path`` request kept paying for the
+    thousands of cache directories this autouse fixture had deposited next to
+    it, directories whose names it can never collide with anyway. Keeping them
+    in one randomly-named bucket restores basetemp to roughly one entry per
+    test while preserving the guarantee that matters: each test still gets its
+    own distinct, empty, test-owned directory under pytest's retention policy,
+    and no mutable state is shared between tests.
+
+    Allocated once per process (each xdist worker has its own basetemp, so the
+    key keeps a worker from ever reading another's entry).
+    """
+    basetemp = tmp_path_factory.getbasetemp()
+    bucket = _SNAPSHOT_CACHE_BUCKETS.get(basetemp)
+    if bucket is None or not bucket.is_dir():
+        bucket = Path(tempfile.mkdtemp(prefix="snapshot-caches-", dir=basetemp))
+        _SNAPSHOT_CACHE_BUCKETS[basetemp] = bucket
+    return bucket
+
+
 @pytest.fixture(autouse=True)
 def _isolate_snapshot_cache(tmp_path_factory: pytest.TempPathFactory, monkeypatch):
     """Redirect the whole-snapshot cache (``snapshot_cache.py``) to a fresh
@@ -96,7 +124,7 @@ def _isolate_snapshot_cache(tmp_path_factory: pytest.TempPathFactory, monkeypatc
     cache_dir = Path(
         tempfile.mkdtemp(
             prefix="snapshot_cache-",
-            dir=tmp_path_factory.getbasetemp(),
+            dir=_snapshot_cache_bucket(tmp_path_factory),
         )
     )
     monkeypatch.setattr(snapshot_cache, "_CACHE_DIR", cache_dir)
@@ -325,12 +353,16 @@ def _materialize_generated_skill_trees() -> None:
     `pytest tests/` — not just in whichever CI job happens to run
     `gen_agent_skills.py --check` first. Deterministic and reruns cheaply
     (see that script's docstring: pure-Python, sub-second, no network), so
-    doing it unconditionally here rather than only when the trees are
-    missing keeps them from silently drifting stale mid-session too.
+    the render itself is recomputed every time rather than trusting the
+    trees to still be what `skills-src/` says -- that is what keeps them
+    from silently drifting stale mid-session.
 
-    Under pytest-xdist every worker calls `pytest_configure` independently;
-    a file lock keyed on skills-src's own module serializes them so no two
-    workers race `write_trees()`'s own rm-then-rewrite against each other.
+    The *write*, though, happens only when the render and the trees actually
+    disagree. Under pytest-xdist every worker calls `pytest_configure`
+    independently, so an unconditional write meant N+1 destructive rewrites
+    per session; a file lock keyed on skills-src's own module serializes the
+    writers that remain, so no two race `write_trees()`'s rm-then-rewrite
+    against each other.
     """
     scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
     if str(scripts_dir) not in sys.path:
@@ -343,21 +375,39 @@ def _materialize_generated_skill_trees() -> None:
     lock_path = scripts_dir.parent / ".pytest_cache" / "gen_agent_skills.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def _write() -> None:
-        try:
-            rendered = gen.render_all()
-        except gen.SkillGenerationError:
-            return  # a skills-src authoring error; let the real gen/AI-readiness checks report it
+    try:
+        rendered = gen.render_all()
+    except gen.SkillGenerationError:
+        return  # a skills-src authoring error; let the real gen/AI-readiness checks report it
+
+    def _write_if_stale() -> None:
+        # Content-keyed, not "have I already run": `check_trees` compares every
+        # owned file's bytes against the render, so a tree that is already
+        # correct is left untouched and a stale or partially-written one is
+        # still repaired. That is what makes this safe for both topologies --
+        # xdist workers sharing one checkout (the first writes, the rest
+        # verify and no-op) and remote workers with their own filesystem
+        # (each writes its own, because its own check fails).
+        if not gen.check_trees(rendered):
+            return
         gen.write_trees(rendered)
 
+    # Unconditional rewriting was not merely redundant work: `write_trees`
+    # removes each owned skill directory before restoring it, so every extra
+    # writer reopened a window in which a concurrent reader -- another worker's
+    # test, a parallel session, a restarted worker -- sees the tree absent.
+    # Checking first closes that window in the common case; the lock still
+    # serializes the writers that remain.
+    if not gen.check_trees(rendered):
+        return
     if filelock is not None:
         try:
             with filelock.FileLock(str(lock_path), timeout=120):
-                _write()
+                _write_if_stale()
         except filelock.Timeout:
             pass  # another worker is already materializing; proceed, it'll be done shortly
     else:
-        _write()
+        _write_if_stale()
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -205,4 +205,46 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="guard.absent_capability_vs_real_failure",
+        invariant=(
+            "A test-support helper may report 'skipped' only for a capability "
+            "that is genuinely absent (no platform, no tool, an explicitly "
+            "named optional feature). A tool that is present, was configured, "
+            "was actually run, and then failed is a test FAILURE with the "
+            "command, input and stderr attached -- for every nonzero exit "
+            "status, signal-kill included, and whatever the stderr's encoding. "
+            "The rule generalizes past compilers: the failure mode is any "
+            "helper that widens 'this environment cannot do X' to cover "
+            "'doing X went wrong', because the silent-skip guard "
+            "(ABICHECK_MIN_EXECUTED) cannot see it -- the sibling fixtures "
+            "that still build satisfy the floor while the broken ones vanish."
+        ),
+        fixed_by=(),
+        seed_tests=("tests/test_compile_failure_contract.py",),
+        public_surfaces=(),
+        axes={
+            "exit_status": ("zero", "nonzero", "signal"),
+            "optional_feature": ("named", "absent"),
+            "stderr": ("empty", "large", "non_utf8"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Only `tests/test_cross_platform_integration.py`'s two "
+                    "fixture-building helpers are migrated to the contract. "
+                    "A repo-wide grep finds roughly thirty other "
+                    "`if result.returncode != 0: pytest.skip(...)` sites "
+                    "across the integration/parity suites; each needs its own "
+                    "reading (several are genuine optional-feature probes -- "
+                    "a -gdwarf-5 or BTF-capable toolchain -- where a skip is "
+                    "the right answer), so they are not converted "
+                    "mechanically. No structural gate rejects a new site yet; "
+                    "the structural half of the seed test pins only the two "
+                    "migrated helpers."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+        ),
+    ),
 )

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -220,7 +220,7 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             "(ABICHECK_MIN_EXECUTED) cannot see it -- the sibling fixtures "
             "that still build satisfy the floor while the broken ones vanish."
         ),
-        fixed_by=(),
+        fixed_by=(1252,),
         seed_tests=("tests/test_compile_failure_contract.py",),
         public_surfaces=(),
         axes={

--- a/tests/schema_validation.py
+++ b/tests/schema_validation.py
@@ -35,6 +35,7 @@ place (both are things this suite really does — see
 """
 from __future__ import annotations
 
+import copy
 import json
 from typing import Any
 
@@ -56,9 +57,17 @@ def validator_for(schema: Any, format_checker: Any = None) -> Any:
     key = (json.dumps(schema, sort_keys=True, default=str), id(format_checker))
     validator = _VALIDATORS.get(key)
     if validator is None:
-        cls = jsonschema.validators.validator_for(schema)
-        cls.check_schema(schema)  # raises SchemaError, exactly as validate() does
-        validator = cls(schema, format_checker=format_checker)
+        # Deep-copy before handing the schema to the validator: a validator
+        # keeps a reference to the mapping it was built from, so a caller that
+        # later mutates its own schema in place would silently change what the
+        # entry stored under the *old* content key enforces -- and the next
+        # caller presenting an unmutated schema of that original content would
+        # be served it. Keyed on content, so the cached copy must be the
+        # content the key names, forever (Codex review, PR #1252).
+        frozen = copy.deepcopy(schema)
+        cls = jsonschema.validators.validator_for(frozen)
+        cls.check_schema(frozen)  # raises SchemaError, exactly as validate() does
+        validator = cls(frozen, format_checker=format_checker)
         _VALIDATORS[key] = validator
     return validator
 

--- a/tests/schema_validation.py
+++ b/tests/schema_validation.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One prepared JSON-Schema validator per distinct schema, for the tests.
+
+`jsonschema.validate(instance=..., schema=...)` re-validates the *schema*
+itself on every call before it looks at the instance — the library's own
+documentation says to reuse a validator once the schema is known good. The
+suite validates many reports against a handful of packaged schemas, so that
+per-call schema check is repeated work with no signal in it.
+
+`validate_instance` keeps exactly the semantics of `jsonschema.validate` —
+same `ValidationError` (the library's `best_match` choice, not merely the
+first error encountered), same `format_checker` handling, same
+`SchemaError` for a genuinely malformed schema — and differs only in
+checking the schema once per distinct schema *content*.
+
+The cache key is the schema's canonical JSON text, deliberately: keying on a
+file path would serve a stale validator after a test edits a schema, and
+keying on a dict's identity would do the same after a test mutates one in
+place (both are things this suite really does — see
+`tests/test_schema_validation_helper.py`, which states those as invariants).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["validate_instance", "validator_for"]
+
+_VALIDATORS: dict[tuple[str, int], Any] = {}
+
+
+def validator_for(schema: Any, format_checker: Any = None) -> Any:
+    """Return a validator for `schema`, checking the schema once per content.
+
+    `format_checker` is part of the key: two validators over the same schema
+    with and without one are not interchangeable.
+    """
+    import jsonschema  # imported lazily: an optional dependency several
+    # suites skip cleanly without, so importing it at module scope would turn
+    # their clean skip into a collection error.
+
+    key = (json.dumps(schema, sort_keys=True, default=str), id(format_checker))
+    validator = _VALIDATORS.get(key)
+    if validator is None:
+        cls = jsonschema.validators.validator_for(schema)
+        cls.check_schema(schema)  # raises SchemaError, exactly as validate() does
+        validator = cls(schema, format_checker=format_checker)
+        _VALIDATORS[key] = validator
+    return validator
+
+
+def validate_instance(instance: Any, schema: Any, format_checker: Any = None) -> None:
+    """Drop-in replacement for `jsonschema.validate(instance, schema)`."""
+    from jsonschema.exceptions import best_match
+
+    error = best_match(validator_for(schema, format_checker).iter_errors(instance))
+    if error is not None:
+        raise error

--- a/tests/schema_validation.py
+++ b/tests/schema_validation.py
@@ -36,10 +36,32 @@ place (both are things this suite really does — see
 from __future__ import annotations
 
 import copy
+import importlib.util
 import json
 from typing import Any
 
-__all__ = ["validate_instance", "validator_for"]
+import pytest
+
+__all__ = [
+    "jsonschema_available",
+    "requires_jsonschema",
+    "validate_instance",
+    "validator_for",
+]
+
+
+def jsonschema_available() -> bool:
+    """Whether the optional `jsonschema` dependency is installed."""
+    return importlib.util.find_spec("jsonschema") is not None
+
+
+#: The one spelling of "skip this structural-validation test when `jsonschema`
+#: is absent". Each consumer used to carry its own four-line
+#: `try: import jsonschema / except ImportError: jsonschema = None` preamble
+#: purely to feed a `skipif`; that boilerplate has one owner now.
+requires_jsonschema = pytest.mark.skipif(
+    not jsonschema_available(), reason="jsonschema not installed"
+)
 
 _VALIDATORS: dict[tuple[str, int], Any] = {}
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -42,13 +42,7 @@ from abicheck.aggregate import (
     target_id_from_path,
 )
 from abicheck.change_registry_types import Verdict
-
-try:
-    import jsonschema
-except ImportError:  # pragma: no cover - exercised only when jsonschema absent
-    jsonschema = None
-
-from tests.schema_validation import validate_instance
+from tests.schema_validation import requires_jsonschema, validate_instance
 
 LINUX = "linux-x86_64"
 WINDOWS = "windows-x86_64"
@@ -1348,7 +1342,7 @@ class TestJsonSchema:
         assert schema["$id"].endswith("aggregate_report.schema.json")
         assert "aggregate_schema_version" in schema["properties"]
 
-    @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+    @requires_jsonschema
     def test_real_output_validates_against_schema(self, tmp_path: Path):
         from abicheck.schemas import load_aggregate_report_schema
 
@@ -1371,7 +1365,7 @@ class TestJsonSchema:
         assert d["aggregate_schema_version"] == AGGREGATE_SCHEMA_VERSION
         assert d["unexpected_targets"]
 
-    @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+    @requires_jsonschema
     def test_discovered_only_output_validates(self, tmp_path: Path):
         from abicheck.schemas import load_aggregate_report_schema
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -48,6 +48,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 LINUX = "linux-x86_64"
 WINDOWS = "windows-x86_64"
 MACOS = "macos-arm64"
@@ -1365,7 +1367,7 @@ class TestJsonSchema:
         )
         _write_report(tmp_path, MACOS, "BREAKING")  # unexpected
         d = aggregate_reports_dir(tmp_path, expected=_expect(LINUX, WINDOWS)).to_dict()
-        jsonschema.validate(d, load_aggregate_report_schema())
+        validate_instance(d, load_aggregate_report_schema())
         assert d["aggregate_schema_version"] == AGGREGATE_SCHEMA_VERSION
         assert d["unexpected_targets"]
 
@@ -1375,7 +1377,7 @@ class TestJsonSchema:
 
         _write_report(tmp_path, LINUX, "API_BREAK")
         d = aggregate_reports_dir(tmp_path, discovered_only=True).to_dict()
-        jsonschema.validate(d, load_aggregate_report_schema())
+        validate_instance(d, load_aggregate_report_schema())
 
 
 class TestWarnAcceptanceProvenance:

--- a/tests/test_aggregate_effective_config_digest.py
+++ b/tests/test_aggregate_effective_config_digest.py
@@ -49,6 +49,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 LINUX = "linux-x86_64"
 
 #: A well-formed digest -- the exact ``"sha256:<64 lowercase hex chars>"``
@@ -198,5 +200,5 @@ def test_digest_bearing_report_validates_against_the_schema(tmp_path: Path) -> N
         effective_config_digest=_VALID_DIGEST,
     )
     d = aggregate_reports_dir(tmp_path, expected=_expect(LINUX)).to_dict()
-    jsonschema.validate(d, load_aggregate_report_schema())
+    validate_instance(d, load_aggregate_report_schema())
     assert d["targets"][0]["effective_config_digest"] == _VALID_DIGEST

--- a/tests/test_aggregate_findings.py
+++ b/tests/test_aggregate_findings.py
@@ -52,13 +52,7 @@ from abicheck.workflows.aggregate.reconcile import (
     resolve_cross_abi_identity,
     resolve_report_change_identity,
 )
-
-try:
-    import jsonschema
-except ImportError:  # pragma: no cover - exercised only when jsonschema absent
-    jsonschema = None
-
-from tests.schema_validation import validate_instance
+from tests.schema_validation import requires_jsonschema, validate_instance
 
 LINUX = "linux-x86_64"
 
@@ -455,7 +449,7 @@ class TestFindingMatrix:
         assert entry["undetermined_profiles"] == []
         assert entry["identity_tier"] in {"canonical", "normalized", "reduced"}
 
-    @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+    @requires_jsonschema
     def test_matrix_output_validates_against_schema(self, tmp_path: Path) -> None:
         from abicheck.schemas import load_aggregate_report_schema
 
@@ -1522,7 +1516,7 @@ class TestProfileContractState:
         assert entry.unaffected_profiles == ("clang",)
         assert {p.profile for p in entry.profile_contract} == {"gcc"}
 
-    @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+    @requires_jsonschema
     def test_matrix_output_validates_against_schema(self, tmp_path: Path) -> None:
         from abicheck.schemas import load_aggregate_report_schema
 
@@ -1533,7 +1527,7 @@ class TestProfileContractState:
         (entry,) = d["finding_matrix"]
         assert entry["profile_contract"]
 
-    @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
+    @requires_jsonschema
     def test_matrix_output_without_any_contract_evaluation_still_validates(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_aggregate_findings.py
+++ b/tests/test_aggregate_findings.py
@@ -58,6 +58,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 LINUX = "linux-x86_64"
 
 
@@ -465,7 +467,7 @@ class TestFindingMatrix:
         d = aggregate_reports_dir(
             tmp_path, expected=_expect(GCC, CLANG, MSVC)
         ).to_dict()
-        jsonschema.validate(d, load_aggregate_report_schema())
+        validate_instance(d, load_aggregate_report_schema())
         assert d["finding_matrix"]
 
 
@@ -1527,7 +1529,7 @@ class TestProfileContractState:
         _write_findings_report(tmp_path, GCC, "BREAKING", [_SIZE_CHANGED_IN_CONTRACT])
         _write_findings_report(tmp_path, CLANG, "BREAKING", [_SIZE_CHANGED_UNRESOLVED])
         d = aggregate_reports_dir(tmp_path, expected=_expect(GCC, CLANG)).to_dict()
-        jsonschema.validate(d, load_aggregate_report_schema())
+        validate_instance(d, load_aggregate_report_schema())
         (entry,) = d["finding_matrix"]
         assert entry["profile_contract"]
 
@@ -1539,6 +1541,6 @@ class TestProfileContractState:
 
         _write_findings_report(tmp_path, GCC, "BREAKING", [_SIZE_CHANGED])
         d = aggregate_reports_dir(tmp_path, expected=_expect(GCC)).to_dict()
-        jsonschema.validate(d, load_aggregate_report_schema())
+        validate_instance(d, load_aggregate_report_schema())
         (entry,) = d["finding_matrix"]
         assert "profile_contract" not in entry

--- a/tests/test_aggregate_scope_completeness.py
+++ b/tests/test_aggregate_scope_completeness.py
@@ -34,6 +34,7 @@ from pathlib import Path
 import pytest
 
 from abicheck.aggregate import ExpectedTargets, aggregate_reports_dir
+from tests.schema_validation import validate_instance
 
 LINUX = "linux-x86_64"
 
@@ -223,7 +224,6 @@ class TestScopeCompletenessAxis:
         reason="jsonschema not installed",
     )
     def test_the_output_validates_against_the_schema(self, tmp_path: Path) -> None:
-        import jsonschema
 
         from abicheck.schemas import load_aggregate_report_schema
 
@@ -231,7 +231,7 @@ class TestScopeCompletenessAxis:
             tmp_path, LINUX, "NO_CHANGE", **_exit(incomplete_scope_contribution=1)
         )
         payload = aggregate_reports_dir(tmp_path, expected=_expect(LINUX)).to_dict()
-        jsonschema.validate(payload, load_aggregate_report_schema())
+        validate_instance(payload, load_aggregate_report_schema())
 
 
 class TestScopeCompletenessFromARealRelease:

--- a/tests/test_cli_compare_audit_suppressions.py
+++ b/tests/test_cli_compare_audit_suppressions.py
@@ -40,6 +40,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 _requires_jsonschema = pytest.mark.skipif(
     jsonschema is None, reason="jsonschema not installed"
 )
@@ -223,7 +225,7 @@ class TestJsonReport:
         payload = json.loads(result.stdout)
         assert "suppression_audit" in payload
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
         assert "suppression_audit" in schema["properties"]
 
     def test_label_falls_back_to_selector_not_bucket_index(self, tmp_path):

--- a/tests/test_cli_compare_contract_evaluation.py
+++ b/tests/test_cli_compare_contract_evaluation.py
@@ -41,6 +41,7 @@ from abicheck.checker import DiffResult, Verdict
 from abicheck.cli import main
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
+from tests.schema_validation import validate_instance
 
 # ADR-049 Phase 3 -- app-usage scoping requires real library binaries (not
 # JSON snapshots), so --used-by tests stub `dumper.dump` the same way
@@ -172,7 +173,7 @@ class TestEndToEndJsonReport:
         accepted-but-undeclared one -- the exact gap that let the
         ``suppression_audit`` key ship undeclared (schema 2.24).
         """
-        jsonschema = pytest.importorskip("jsonschema")
+        pytest.importorskip("jsonschema")
         from abicheck.schemas import load_compare_report_schema
 
         old_p, new_p = _write_pair(tmp_path)
@@ -191,7 +192,7 @@ class TestEndToEndJsonReport:
         assert result.exit_code == 4, result.output
         payload = json.loads(result.output)
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
         assert "contract_context" in schema["properties"]
         assert "contract_evidence_refs" in schema["$defs"]["change"]["properties"]
 

--- a/tests/test_compile_failure_contract.py
+++ b/tests/test_compile_failure_contract.py
@@ -101,6 +101,13 @@ def test_oracle_is_not_a_constant() -> None:
 @pytest.mark.parametrize(
     "stderr",
     [b"", b"x" * 100_000, b"\xff\xfe not utf-8", "жёсткая ошибка".encode()],
+    # Explicit ids: pytest derives one from the value otherwise, and it exports
+    # the full node id in `PYTEST_CURRENT_TEST`. A 100 KB parameter therefore
+    # produced a 100 KB environment variable, which Windows rejects outright
+    # ("the environment variable is longer than 32767 characters") -- an error
+    # at setup, on that platform only. Any parametrized value large enough to
+    # matter as a test input is large enough to need an id of its own.
+    ids=["empty", "100kb", "not_utf8", "non_ascii"],
 )
 def test_failure_diagnostics_survive_any_stderr(stderr: bytes) -> None:
     """The failure message carries command, source and stderr for *every*
@@ -162,3 +169,30 @@ def test_real_compiler_error_fails_the_test(tmp_path: Path) -> None:
     # above is the compiler's verdict and not a broken helper.
     out = _compile_dll(_SRC, "good.dll", tmp_path)
     assert out.exists()
+
+
+def test_every_parametrized_id_in_this_module_stays_short() -> None:
+    """Guard for the platform-specific setup error the 100 KB stderr case hit.
+
+    pytest exports the whole node id in `PYTEST_CURRENT_TEST`, and Windows caps
+    an environment variable at 32767 characters, so a large parameter used as
+    its own implicit id turns into a collection-time `ValueError` on one
+    platform and passes everywhere else. The bound below is far under that cap;
+    the point is that a value big enough to be an interesting input must be
+    given an id, not that 200 is special.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", __file__, "--collect-only", "-q", "--no-header"],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).resolve().parent.parent),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    ids = [line for line in result.stdout.splitlines() if "::" in line]
+    assert ids, "collection produced no test ids — the guard would be vacuous"
+    too_long = [(line[:60], len(line)) for line in ids if len(line) > 200]
+    assert not too_long

--- a/tests/test_compile_failure_contract.py
+++ b/tests/test_compile_failure_contract.py
@@ -124,6 +124,12 @@ def test_failure_diagnostics_survive_any_stderr(stderr: bytes) -> None:
     assert "clang -shared -o x.so" in message
     assert _SRC in message
     assert "exited 1" in message
+    # The stderr itself, which is the whole point of the promise and the one
+    # thing the earlier version of this test did not check (Codex review,
+    # PR #1252): without this, a helper that dropped or truncated stderr
+    # passed every parameter above. Compared against an independent decode of
+    # the same bytes, not against whatever the helper produced.
+    assert stderr.decode(errors="replace") in message
 
 
 def test_skip_reason_names_the_optional_feature() -> None:

--- a/tests/test_compile_failure_contract.py
+++ b/tests/test_compile_failure_contract.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A *configured* compiler's failure must fail the test, never skip it.
+
+Bug class `guard.compiler_failure_masquerades_as_skip`
+(`tests/regressions/manifest_guards.py`). The escape this closes is the one
+the silent-skip guard (`tests/conftest.py`'s `ABICHECK_MIN_EXECUTED`) cannot
+see: a lane where the compiler *is* present, some fixtures build and satisfy
+the minimum-executed floor, and the fixtures that stopped building vanish as
+skips — a green run that proved less than it claims.
+
+These tests state the contract as invariants over the whole failure domain
+(every nonzero exit status, empty/huge/undecodable stderr, present and absent
+optional-feature label), not against the one flag that happened to break —
+AGENTS.md, "A bug fix's regression test targets the bug *class*".
+"""
+from __future__ import annotations
+
+import ast
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.test_cross_platform_integration import (
+    _compile_dll,
+    _require_compile_success,
+)
+
+_SRC = "int fn(void) { return 0; }"
+Failed = pytest.fail.Exception
+
+
+def _completed(returncode: int, stderr: bytes = b"boom") -> subprocess.CompletedProcess[bytes]:
+    return subprocess.CompletedProcess(args=["cc"], returncode=returncode, stdout=b"", stderr=stderr)
+
+
+# The oracle is deliberately *not* the implementation's own branch: "a nonzero
+# exit is a failure unless a named optional feature was being probed" is
+# restated here from the contract, so a mutation of the helper's condition
+# cannot pass by agreeing with itself.
+def _expected(returncode: int, optional_feature: str | None) -> str:
+    if returncode == 0:
+        return "return"
+    return "skip" if optional_feature is not None else "fail"
+
+
+@pytest.mark.parametrize(
+    "returncode",
+    # The whole small domain, not the one observed status: every POSIX exit
+    # code a compiler can plausibly produce, plus the negative values
+    # subprocess reports for a signal-killed compiler (OOM-killed cc1 is a
+    # real, recurring CI event and must not read as "feature unavailable").
+    [0, 1, 2, 4, 33, 64, 126, 127, 128, 139, 255, -9, -11],
+)
+@pytest.mark.parametrize("optional_feature", [None, "-fsanitize=address"])
+def test_outcome_over_the_whole_exit_status_domain(returncode: int, optional_feature: str | None) -> None:
+    expected = _expected(returncode, optional_feature)
+    result = _completed(returncode)
+
+    if expected == "return":
+        assert (
+            _require_compile_success(
+                "cc", ["cc", "-shared"], _SRC, result, optional_feature=optional_feature
+            )
+            is None
+        )
+        return
+
+    raises = pytest.raises(pytest.skip.Exception if expected == "skip" else Failed)
+    with raises:
+        _require_compile_success(
+            "cc", ["cc", "-shared"], _SRC, result, optional_feature=optional_feature
+        )
+
+
+def test_oracle_is_not_a_constant() -> None:
+    """Vacuity guard: an oracle reduced to one answer makes the sweep vacuous."""
+    answers = {
+        _expected(rc, feature)
+        for rc in (0, 1)
+        for feature in (None, "x")
+    }
+    assert answers == {"return", "skip", "fail"}
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [b"", b"x" * 100_000, b"\xff\xfe not utf-8", "жёсткая ошибка".encode()],
+)
+def test_failure_diagnostics_survive_any_stderr(stderr: bytes) -> None:
+    """The failure message carries command, source and stderr for *every*
+    stderr shape — including one that is not valid UTF-8, which a naive
+    `.decode()` would turn into a `UnicodeDecodeError` masking the real
+    compiler error."""
+    with pytest.raises(Failed) as excinfo:
+        _require_compile_success(
+            "clang", ["clang", "-shared", "-o", "x.so"], _SRC, _completed(1, stderr), optional_feature=None
+        )
+
+    message = str(excinfo.value)
+    assert "clang" in message
+    assert "clang -shared -o x.so" in message
+    assert _SRC in message
+    assert "exited 1" in message
+
+
+def test_skip_reason_names_the_optional_feature() -> None:
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        _require_compile_success(
+            "gcc", ["gcc"], _SRC, _completed(1), optional_feature="-Wl,--no-undefined"
+        )
+    assert "-Wl,--no-undefined" in str(excinfo.value)
+
+
+def test_no_compile_helper_skips_on_a_bare_returncode() -> None:
+    """Structural half: neither fixture-building helper may reach `pytest.skip`
+    on its own, which is how the original defect was spelled. The helpers must
+    route every nonzero status through the one place that decides."""
+    module = Path(__file__).with_name("test_cross_platform_integration.py")
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+    helpers = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in {"_compile_dylib", "_compile_dll"}
+    ]
+    assert {h.name for h in helpers} == {"_compile_dylib", "_compile_dll"}
+
+    for helper in helpers:
+        calls = [
+            ast.unparse(node.func)
+            for node in ast.walk(helper)
+            if isinstance(node, ast.Call)
+        ]
+        assert "pytest.skip" not in calls, f"{helper.name} still skips on a compiler error"
+        assert "_require_compile_success" in calls, f"{helper.name} does not enforce the contract"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("gcc") is None, reason="Requires gcc")
+def test_real_compiler_error_fails_the_test(tmp_path: Path) -> None:
+    """Executable half: drive the *real* helper against a real compiler that
+    really rejects the build, rather than asserting the helper's text."""
+    with pytest.raises(Failed):
+        _compile_dll("int fn(void) { return ", "broken.dll", tmp_path)
+
+    # ... and the same helper still builds a good fixture, so the failure
+    # above is the compiler's verdict and not a broken helper.
+    out = _compile_dll(_SRC, "good.dll", tmp_path)
+    assert out.exists()

--- a/tests/test_conftest_cache_isolation.py
+++ b/tests/test_conftest_cache_isolation.py
@@ -95,3 +95,38 @@ def test_ast_memo_slot_starts_cleared(occurrence: int) -> None:
     left by one test is otherwise still visible to the next."""
     assert dumper_cache._ast_memo_slot.get() is None
     dumper_cache._ast_memo_slot.set({"poisoned": occurrence})
+
+
+@pytest.mark.parametrize("occurrence", range(6))
+def test_cache_directories_do_not_accumulate_in_pytest_basetemp(
+    occurrence: int, tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
+) -> None:
+    """The *cost* half of the same contract, stated as an invariant so the
+    next "make this faster" round cannot quietly undo it.
+
+    ``tmp_path`` is allocated by pytest's numbered allocator, which enumerates
+    basetemp's children to choose the next number. An autouse fixture that
+    deposits one directory per test *directly* in basetemp therefore charges
+    every later ``tmp_path`` request for a scan over its own leftovers. The
+    per-test cache directory must live one level down, in a single bucket, so
+    basetemp holds roughly one entry per test and no cache directory of its
+    own.
+    """
+    basetemp = tmp_path_factory.getbasetemp()
+    cache_dir = _current_cache_dir()
+
+    # Still a real, distinct, empty, test-owned directory under basetemp...
+    assert basetemp in cache_dir.parents
+    assert list(cache_dir.iterdir()) == []
+    # ... but never a direct child of it.
+    assert cache_dir.parent != basetemp
+    assert cache_dir.parent.name.startswith("snapshot-caches-")
+
+    # And basetemp itself carries no per-test cache entry at all, however many
+    # tests have run before this one.
+    assert [p.name for p in basetemp.iterdir() if p.name.startswith("snapshot_cache-")] == []
+
+    # The bucket is shared, the directories in it are not: this occurrence's
+    # directory is distinct from every earlier one even though they are
+    # siblings now.
+    assert cache_dir not in _SEEN

--- a/tests/test_conftest_skill_materialization.py
+++ b/tests/test_conftest_skill_materialization.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`tests/conftest.py`'s skill-tree materialization must write only when the
+published trees actually disagree with `skills-src/`.
+
+The cost is secondary here. The correctness point is that
+`gen_agent_skills.write_trees` *removes* each owned skill directory before
+restoring it, so every superfluous writer reopens a window in which a
+concurrent reader — another xdist worker's test, a parallel session, a
+restarted worker — observes the tree absent. Under xdist the old hook ran
+that rewrite once per worker plus once in the controller.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import gen_agent_skills as gen  # noqa: E402
+
+from tests.conftest import _materialize_generated_skill_trees  # noqa: E402
+
+
+def test_no_write_when_the_trees_already_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The steady state of every worker after the first, and of every rerun."""
+    writes: list[dict[str, str]] = []
+    monkeypatch.setattr(gen, "write_trees", lambda rendered, *a, **k: writes.append(rendered))
+
+    # The session's own conftest hook already materialized the trees, so this
+    # call sees them current.
+    _materialize_generated_skill_trees()
+    assert writes == []
+
+
+def test_repeated_calls_never_write_more_than_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Idempotence over repeated invocations, whatever the starting state:
+    the first call may or may not need to write, every later one must not."""
+    real_write = gen.write_trees
+    writes: list[int] = []
+
+    def counting_write(rendered: dict[str, str], *args: object, **kwargs: object) -> None:
+        writes.append(1)
+        real_write(rendered, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(gen, "write_trees", counting_write)
+    for _ in range(4):
+        _materialize_generated_skill_trees()
+    assert len(writes) <= 1
+
+
+def test_the_staleness_oracle_is_content_keyed_not_existence_keyed(tmp_path: Path) -> None:
+    """The decision rests on `check_trees`, which compares bytes. Exercised
+    over every way a tree can be wrong — missing, truncated, byte-modified,
+    carrying an extra generated file — not just the absent case, so a
+    regression to an existence check ("the directory is there, skip") fails
+    here."""
+    rendered = gen.render_all()
+    assert rendered, "the render must not be empty or this test is vacuous"
+    root = tmp_path / "skills"
+    roots = (root,)
+
+    assert gen.check_trees(rendered, roots)  # nothing written yet
+    gen.write_trees(rendered, roots)
+    assert gen.check_trees(rendered, roots) == []
+
+    some_rel = sorted(rendered)[0]
+    target = root / some_rel
+
+    original = target.read_text(encoding="utf-8")
+    for corruption in ("", original + "\ndrift\n", original.replace("a", "b", 1)):
+        if corruption == original:
+            continue
+        target.write_text(corruption, encoding="utf-8")
+        assert gen.check_trees(rendered, roots), f"byte drift not detected: {corruption[:40]!r}"
+        target.write_text(original, encoding="utf-8")
+        assert gen.check_trees(rendered, roots) == []
+
+    target.unlink()
+    assert gen.check_trees(rendered, roots)
+    gen.write_trees(rendered, roots)
+    assert gen.check_trees(rendered, roots) == []
+
+    stray = target.parent / "stray-generated-file.md"
+    stray.write_text("not from the render\n", encoding="utf-8")
+    assert gen.check_trees(rendered, roots), "an extra owned file is drift too"

--- a/tests/test_conftest_skill_materialization.py
+++ b/tests/test_conftest_skill_materialization.py
@@ -99,3 +99,75 @@ def test_the_staleness_oracle_is_content_keyed_not_existence_keyed(tmp_path: Pat
     stray = target.parent / "stray-generated-file.md"
     stray.write_text("not from the render\n", encoding="utf-8")
     assert gen.check_trees(rendered, roots), "an extra owned file is drift too"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileNotFoundError(2, "No such file or directory"),
+        NotADirectoryError(20, "Not a directory"),
+        OSError(5, "Input/output error"),
+    ],
+    ids=["missing", "not_a_dir", "generic"],
+)
+def test_a_concurrent_writer_does_not_abort_pytest_configuration(
+    monkeypatch: pytest.MonkeyPatch, error: OSError
+) -> None:
+    """`check_trees` enumerates the tree and then reads each file, so a file
+    another process removes in between raises. That can only happen while a
+    writer is mid-`write_trees` (it removes each owned directory before
+    restoring it) — and this runs from `pytest_configure`, so letting it
+    escape aborts the whole session.
+
+    Stated over several `OSError` shapes rather than the one the race
+    produces: the distinction that matters is "the tree is being rebuilt
+    underneath us", not which errno the filesystem reported.
+    """
+    calls: list[str] = []
+
+    def exploding_check(rendered: dict[str, str], *args: object, **kwargs: object):
+        calls.append("check")
+        if len(calls) == 1:  # only the unlocked fast path races
+            raise error
+        return []
+
+    monkeypatch.setattr(gen, "check_trees", exploding_check)
+    monkeypatch.setattr(gen, "write_trees", lambda *a, **k: calls.append("write"))
+
+    _materialize_generated_skill_trees()  # must not raise
+
+    # It treated the race as "possibly stale" and went to the lock, where the
+    # re-check found the tree settled — so no redundant destructive rewrite.
+    assert calls == ["check", "check"]
+
+
+def test_a_real_interleaving_is_survived(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The same property against the real `check_trees` walking a tree that is
+    genuinely disappearing under it, rather than a raised stand-in."""
+    rendered = gen.render_all()
+    root = tmp_path / "skills"
+    gen.write_trees(rendered, (root,))
+    owned = sorted(p for p in root.rglob("*") if p.is_file())
+    assert owned, "fixture must contain files or this test is vacuous"
+
+    real_check = gen.check_trees
+    state = {"n": 0}
+
+    def racing_check(r: dict[str, str], *args: object, **kwargs: object):
+        state["n"] += 1
+        if state["n"] == 1:
+            # Stand in for a concurrent `write_trees`: enumerate, then delete.
+            victim = owned[0]
+            original = victim.read_bytes()
+            victim.unlink()
+            try:
+                return real_check(r, (root,))
+            finally:
+                victim.write_bytes(original)
+        return []
+
+    monkeypatch.setattr(gen, "check_trees", racing_check)
+    monkeypatch.setattr(gen, "write_trees", lambda *a, **k: None)
+
+    _materialize_generated_skill_trees()  # must not raise
+    assert state["n"] >= 1

--- a/tests/test_contract_coverage_ledger.py
+++ b/tests/test_contract_coverage_ledger.py
@@ -57,6 +57,7 @@ from abicheck.model import (
     Visibility,
 )
 from abicheck.serialization import snapshot_to_json
+from tests.schema_validation import validate_instance
 
 
 def _fn(name: str, mangled: str) -> Function:
@@ -656,11 +657,11 @@ class TestCoverageFailuresValidateAgainstTheSchema:
         return json.loads(to_json(result))
 
     def _validate(self, report: dict) -> None:
-        jsonschema = pytest.importorskip("jsonschema")
+        pytest.importorskip("jsonschema")
 
         from abicheck.schemas import load_compare_report_schema
 
-        jsonschema.validate(report, load_compare_report_schema())
+        validate_instance(report, load_compare_report_schema())
 
     def test_a_report_carrying_failures_validates(self) -> None:
         report = self._report(contract_mode="exports")

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -63,6 +63,7 @@ from abicheck.cli_compare_release import (
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
+from tests.schema_validation import validate_instance
 
 # ── snapshot helpers (mirror tests/test_compare_release.py) ───────────────────
 
@@ -2556,7 +2557,6 @@ class TestUsedByScoping:
         "consumer_proven" added alongside the four public-surface-walk
         values it already had."""
         pytest.importorskip("jsonschema")
-        import jsonschema
 
         from abicheck.schemas import load_compare_report_schema
 
@@ -2578,7 +2578,7 @@ class TestUsedByScoping:
             c for c in data["changes"] if c["kind"] == "consumer_required_symbol_removed"
         )
         assert entry["reachability_kind"] == "consumer_proven"
-        jsonschema.validate(instance=data, schema=load_compare_report_schema())
+        validate_instance(data, load_compare_report_schema())
 
     def test_json_missing_symbol_respects_show_only(
         self, tmp_path, monkeypatch
@@ -2651,13 +2651,10 @@ class TestUsedByScoping:
         # scoped-only payload validates against the packaged
         # compare_report.schema.json, not just that reading it by hand
         # looks right.
-        try:
-            import jsonschema
-        except ImportError:
-            pytest.skip("jsonschema not installed")
+        pytest.importorskip("jsonschema")
         from abicheck.schemas import load_compare_report_schema
 
-        jsonschema.validate(instance=data, schema=load_compare_report_schema())
+        validate_instance(data, load_compare_report_schema())
 
     # test_stat_json_summary_reflects_scoped_only_and_missing_findings removed
     # (CLI cleanup phase two, PR 1): it exercised `--format json --stat`

--- a/tests/test_cross_platform_integration.py
+++ b/tests/test_cross_platform_integration.py
@@ -43,8 +43,45 @@ skip_unless_windows = pytest.mark.skipif(
 )
 
 
+def _require_compile_success(
+    tool: str,
+    cmd: list[str],
+    src: str,
+    result: subprocess.CompletedProcess[bytes],
+    *,
+    optional_feature: str | None,
+) -> None:
+    """Turn a *configured* compiler's failure into a test failure, not a skip.
+
+    Three states are deliberately kept apart (see AGENTS.md, "Decision-making
+    principles" — a generic helper must not launder a real error into an
+    absence of capability):
+
+    * the platform or the compiler is missing  -> the module-level
+      ``skip_unless_*`` markers already skip, before any process is spawned;
+    * a *named* optional compiler feature is being probed -> the individual
+      test passes ``optional_feature=...`` and accepts a skip;
+    * the configured compiler ran and rejected the build -> **failure**, with
+      the full command, source and stderr, because that is a broken fixture or
+      a broken toolchain configuration and it must not be green.
+    """
+    if result.returncode == 0:
+        return
+    stderr = result.stderr.decode(errors="replace")
+    detail = (
+        f"{tool} exited {result.returncode}\n"
+        f"command: {' '.join(cmd)}\n"
+        f"source:\n{src}\n"
+        f"stderr:\n{stderr}"
+    )
+    if optional_feature is not None:
+        pytest.skip(f"optional compiler feature {optional_feature!r} unavailable: {detail}")
+    pytest.fail(f"{tool} failed to build the test fixture:\n{detail}")
+
+
 def _compile_dylib(src: str, name: str, tmp: Path,
-                   extra_flags: list[str] | None = None) -> Path:
+                   extra_flags: list[str] | None = None,
+                   optional_feature: str | None = None) -> Path:
     """Compile C source to a macOS dynamic library (.dylib)."""
     out = tmp / name
     cmd = [
@@ -53,13 +90,13 @@ def _compile_dylib(src: str, name: str, tmp: Path,
         *(extra_flags or []),
     ]
     result = subprocess.run(cmd, input=src.encode(), capture_output=True)
-    if result.returncode != 0:
-        pytest.skip(f"clang failed: {result.stderr.decode()[:200]}")
+    _require_compile_success("clang", cmd, src, result, optional_feature=optional_feature)
     return out
 
 
 def _compile_dll(src: str, name: str, tmp: Path,
-                 extra_flags: list[str] | None = None) -> Path:
+                 extra_flags: list[str] | None = None,
+                 optional_feature: str | None = None) -> Path:
     """Compile C source to a Windows DLL using MinGW gcc."""
     out = tmp / name
     cmd = [
@@ -68,8 +105,7 @@ def _compile_dll(src: str, name: str, tmp: Path,
         *(extra_flags or []),
     ]
     result = subprocess.run(cmd, input=src.encode(), capture_output=True)
-    if result.returncode != 0:
-        pytest.skip(f"gcc failed: {result.stderr.decode()[:200]}")
+    _require_compile_success("gcc", cmd, src, result, optional_feature=optional_feature)
     return out
 
 

--- a/tests/test_effective_config_digest.py
+++ b/tests/test_effective_config_digest.py
@@ -53,6 +53,7 @@ from abicheck.policy_file import PolicyFile
 from abicheck.reclassify import ReclassifyRule
 from abicheck.reporter import to_json
 from abicheck.severity import resolve_severity_config
+from tests.schema_validation import validate_instance
 
 
 def _identity(
@@ -704,7 +705,6 @@ class TestCompatReportOmitsTheDigest:
         required field is genuinely populated the way to_json's real
         callers produce it."""
         pytest.importorskip("jsonschema")
-        import jsonschema
 
         from abicheck.model import AbiSnapshot, Function, Visibility
         from abicheck.schemas import load_compare_report_schema
@@ -729,7 +729,7 @@ class TestCompatReportOmitsTheDigest:
         result = compare(old, new)
         report = json.loads(to_json(result, include_exit_decision=False))
         assert "effective_config_digest" not in report
-        jsonschema.validate(report, load_compare_report_schema())
+        validate_instance(report, load_compare_report_schema())
 
 
 def _scoped_result(**dynamic_attrs) -> DiffResult:

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -67,6 +67,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 _requires_jsonschema = pytest.mark.skipif(
     jsonschema is None, reason="jsonschema not installed"
 )
@@ -1143,6 +1145,6 @@ class TestIncludeExitDecisionFlag:
         result = compare(old, new)
         report = json.loads(to_json(result, include_exit_decision=False))
         assert "exit" not in report
-        jsonschema.validate(report, load_compare_report_schema())
+        validate_instance(report, load_compare_report_schema())
 
 

--- a/tests/test_presentation_analysis_separation.py
+++ b/tests/test_presentation_analysis_separation.py
@@ -159,21 +159,36 @@ class TestF19OutputFormatInvariance:
     """F-19: the canonical result is byte-identical across --format/--write/
     --view/rendering-filter permutations; the exit code is identical too."""
 
-    def test_exit_code_identical_across_every_rendering_permutation(
-        self, tmp_path: Path
+    #: The one expected exit code for `_write_pair`'s fixture: it removes a
+    #: public function, which is a real ABI break. Stated as an exact oracle
+    #: rather than "all 192 permutations agree", because agreement alone is
+    #: satisfied by a CLI that returns 0 everywhere -- the sweep then compares
+    #: the bug with itself and passes (AGENTS.md, "A matrix test needs an
+    #: oracle, not just a type check"). A constant expectation across every
+    #: item is also strictly stronger than the old cross-permutation equality
+    #: it replaces, which is what lets the sweep be split across items.
+    _EXPECTED_EXIT_CODE = 4
+
+    #: Split on --format only: the 192 combinations below are unchanged, but
+    #: they run as six pytest items of 32 CLI invocations instead of one
+    #: indivisible item, so xdist can spread the most expensive block in this
+    #: module instead of serializing it behind one worker.
+    @pytest.mark.parametrize(
+        "fmt", ("json", "markdown", "sarif", "html", "junit", "review")
+    )
+    def test_exit_code_is_the_breaking_verdict_for_every_rendering_permutation(
+        self, tmp_path: Path, fmt: str
     ) -> None:
         old_p, new_p = _write_pair(tmp_path)
         suppress = _write_suppression(tmp_path)
 
-        exit_codes: set[int] = set()
+        seen: list[tuple[tuple[str, ...], int]] = []
         for (
-            fmt,
             view_demangle,
             audit_flag,
             view_patterns,
             view_mode,
         ) in itertools.product(
-            ("json", "markdown", "sarif", "html", "junit", "review"),
             ("demangle", "no-demangle"),
             (True, False),
             (True, False),
@@ -197,13 +212,14 @@ class TestF19OutputFormatInvariance:
             if view_patterns:
                 args += ["--view", "patterns"]
             result = CliRunner().invoke(main, args)
-            assert result.exit_code in (0, 4), (fmt, result.output)
-            exit_codes.add(result.exit_code)
+            seen.append((tuple(args[3:]), result.exit_code))
 
-        # One real BREAKING removal: every permutation above must agree on
-        # the same exit code -- none of format/--view tokens/
-        # audit-suppressions may change *whether* the run gates.
-        assert len(exit_codes) == 1, exit_codes
+        # Batched: a disagreement names every offending permutation at once
+        # rather than stopping at the first.
+        wrong = [entry for entry in seen if entry[1] != self._EXPECTED_EXIT_CODE]
+        assert not wrong, wrong
+        # Vacuity guard: the loop really ran its whole 32-permutation share.
+        assert len(seen) == 32
 
     def test_json_canonical_facts_identical_across_demangle_audit_explain(
         self, tmp_path: Path

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -59,6 +59,8 @@ try:
 except ImportError:  # pragma: no cover - exercised only when jsonschema absent
     jsonschema = None
 
+from tests.schema_validation import validate_instance
+
 _requires_jsonschema = pytest.mark.skipif(
     jsonschema is None, reason="jsonschema not installed"
 )
@@ -212,7 +214,7 @@ class TestAnalysisAssuranceSchemaNamesTheConfigKeyNotTheRetiredFlag:
 class TestReportValidatesAgainstSchema:
     def _validate(self, payload: dict) -> None:
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
 
     def test_no_change_report_validates(self):
         f = _fn("api", "_Z3apiv")
@@ -790,7 +792,7 @@ class TestNotComparableReportSchema:
 
     def _validate(self, payload: dict) -> None:
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
 
     def test_not_comparable_report_with_reason_validates(self):
         payload = {
@@ -832,7 +834,7 @@ class TestCheckTargetSyntheticReportsValidateAgainstSchema:
 
     def _validate(self, payload: dict) -> None:
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
 
     def test_operational_error_report_validates(self):
         from abicheck.buildsource.check_report import build_operational_error_report
@@ -924,7 +926,7 @@ class TestReportIdentityEnvelope:
         result.effective_depth = "headers"
         result.baseline_channel = "accepted-main"
         payload = json.loads(reporter.to_json(result))
-        jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+        validate_instance(payload, load_compare_report_schema())
         assert payload["check_id"] == "libfoo@linux-x86_64-gcc13#accepted-main@source"
         assert payload["profile_id"] == "linux-x86_64-gcc13"
         assert payload["requested_depth"] == "source"
@@ -979,11 +981,11 @@ class TestReportIdentityEnvelope:
         schema = load_compare_report_schema()
 
         payload["check_id"] = "libfoo@profile#channel@source"
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
 
         payload["check_id"] = "libfoo@profile#channel@source\n"
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(instance=payload, schema=schema)
+            validate_instance(payload, schema)
 
     def test_environment_id_starting_with_punctuation_is_rejected(self):
         """Codex review, fresh evidence: build_check_id's own
@@ -1007,10 +1009,10 @@ class TestReportIdentityEnvelope:
         schema = load_compare_report_schema()
         payload["check_id"] = "libfoo@profile#channel@source!_prod"
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(instance=payload, schema=schema)
+            validate_instance(payload, schema)
 
         payload["check_id"] = "libfoo@profile#channel@source!prod"
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)
 
     def test_explicit_id_qualified_check_id_round_trips_and_validates(self):
         """G42 'Explicit check identifiers': the full construct
@@ -1032,7 +1034,7 @@ class TestReportIdentityEnvelope:
             explicit_id="l4-plugin-rhel8",
         )
         payload = json.loads(reporter.to_json(result))
-        jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+        validate_instance(payload, load_compare_report_schema())
         assert (
             payload["check_id"]
             == "libfoo@linux-x86_64-gcc13#accepted-main@source~l4-plugin-rhel8"
@@ -1170,4 +1172,4 @@ class TestGateFailOnRemovedLibraryDigestField:
         payload = json.loads(reporter.to_json(compare(old, new)))
         assert "gate.fail_on_removed_library" in payload["effective_config_fields"]
         schema = load_compare_report_schema()
-        jsonschema.validate(instance=payload, schema=schema)
+        validate_instance(payload, schema)

--- a/tests/test_run_outcome.py
+++ b/tests/test_run_outcome.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import copy
 import json
 
-import jsonschema
 import pytest
 
 from abicheck.buildsource.check_report import (
@@ -47,6 +46,7 @@ from abicheck.policy.outcome import (
     run_outcome_for_scan_fields,
 )
 from abicheck.workflows.aggregate.gate import GateInfo
+from tests.schema_validation import validate_instance
 
 # ---------------------------------------------------------------------------
 # RunOutcome / PolicyGateDecision / OperationalStatus domain behavior
@@ -1014,7 +1014,7 @@ class TestRunOutcomeSchemaValidation:
             / "compare_report.schema.json"
         )
         schema = json.loads(schema_path.read_text())
-        jsonschema.validate(data, schema)
+        validate_instance(data, schema)
 
     def test_fresh_compare_report_validates_against_the_published_schema_mirror(self):
         from pathlib import Path
@@ -1047,4 +1047,4 @@ class TestRunOutcomeSchemaValidation:
             / "compare_report.schema.json"
         )
         schema = json.loads(schema_path.read_text())
-        jsonschema.validate(data, schema)
+        validate_instance(data, schema)

--- a/tests/test_schema_validation_helper.py
+++ b/tests/test_schema_validation_helper.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`tests/schema_validation.validate_instance` must be indistinguishable from
+`jsonschema.validate` except for how often it checks the schema.
+
+An optimization inside a *test* helper is uniquely dangerous: if it weakens
+validation, every suite that depends on it goes green for the wrong reason and
+nothing else is watching. So the contract is stated against the real library as
+the oracle — the same instance/schema pair is put through both, and the two
+must agree on verdict and on which error is raised — over a domain of
+schema/instance pairs chosen to include the cases a caching bug would break
+(a schema mutated in place after its first use, a bool-vs-int instance, a
+malformed schema, a `format_checker`).
+"""
+from __future__ import annotations
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+from tests.schema_validation import validate_instance, validator_for  # noqa: E402
+
+_SCHEMAS: list[dict] = [
+    {"type": "object"},
+    {"type": "object", "required": ["a"], "properties": {"a": {"type": "integer"}}},
+    {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    {"type": "integer", "minimum": 0, "maximum": 10},
+    {"type": "boolean"},
+    {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+    {"type": "object", "additionalProperties": False, "properties": {"a": {"const": 1}}},
+    {"type": "string", "format": "date-time"},
+]
+
+_INSTANCES: list[object] = [
+    {},
+    {"a": 1},
+    {"a": "1"},
+    {"a": True},
+    {"a": 1, "b": 2},
+    [],
+    ["x"],
+    [1],
+    0,
+    11,
+    True,
+    1,
+    "x",
+    "2026-09-12T00:00:00Z",
+    "not-a-date",
+    None,
+]
+
+
+def _reference(instance: object, schema: dict, format_checker=None) -> str:
+    """The oracle: the library's own `validate`, reduced to a comparable token."""
+    try:
+        jsonschema.validate(instance=instance, schema=schema, format_checker=format_checker)
+    except jsonschema.ValidationError as exc:
+        return f"ValidationError:{exc.message}"
+    return "ok"
+
+
+def _under_test(instance: object, schema: dict, format_checker=None) -> str:
+    try:
+        validate_instance(instance, schema, format_checker)
+    except jsonschema.ValidationError as exc:
+        return f"ValidationError:{exc.message}"
+    return "ok"
+
+
+def test_agrees_with_the_library_across_the_whole_cross_product() -> None:
+    """128 pairs, batched so a disagreement names every one at once."""
+    disagreements = [
+        (schema, instance, _reference(instance, schema), _under_test(instance, schema))
+        for schema in _SCHEMAS
+        for instance in _INSTANCES
+        if _reference(instance, schema) != _under_test(instance, schema)
+    ]
+    assert not disagreements
+
+
+def test_the_sweep_is_not_vacuous() -> None:
+    """Guard against a domain that happens to be all-passing or all-failing:
+    an agreement sweep over one verdict proves nothing about the other."""
+    verdicts = {_reference(i, s) == "ok" for s in _SCHEMAS for i in _INSTANCES}
+    assert verdicts == {True, False}
+
+
+def test_a_malformed_schema_still_raises_schema_error() -> None:
+    for bad in ({"type": 123}, {"required": "not-a-list"}, {"minimum": "x", "type": "integer"}):
+        with pytest.raises(jsonschema.SchemaError):
+            validate_instance({}, bad)
+
+
+def test_a_schema_mutated_in_place_is_not_served_a_stale_validator() -> None:
+    """The reason the cache is keyed on content and not on the dict's identity
+    or a file path: a caller that edits its schema between calls must get the
+    new behaviour."""
+    schema = {"type": "object", "properties": {"a": {"type": "integer"}}}
+    validate_instance({"a": 1}, schema)
+
+    schema["properties"]["a"] = {"type": "string"}
+    with pytest.raises(jsonschema.ValidationError):
+        validate_instance({"a": 1}, schema)
+
+    schema["properties"]["a"] = {"type": "integer"}
+    validate_instance({"a": 1}, schema)
+
+
+def test_bool_is_not_accepted_where_an_integer_is_required() -> None:
+    """Python's `bool` is an `int` subclass; jsonschema deliberately does not
+    treat `True` as an integer. A reimplementation that lost that distinction
+    would pass the sweep above only if this case were in it — it is."""
+    with pytest.raises(jsonschema.ValidationError):
+        validate_instance(True, {"type": "integer"})
+    validate_instance(1, {"type": "integer"})
+
+
+def test_format_checker_is_honoured_and_is_part_of_the_cache_key() -> None:
+    # "ipv4" is checked by jsonschema's own built-in checker, with no optional
+    # format dependency to install -- unlike "date-time", whose checker is a
+    # no-op unless `rfc3339-validator` is present, which would make this test
+    # pass for the wrong reason.
+    schema = {"type": "string", "format": "ipv4"}
+    checker = jsonschema.FormatChecker()
+    assert "ipv4" in checker.checkers, "the built-in ipv4 checker is required here"
+
+    validate_instance("999.999.999.999", schema)  # formats are annotations by default
+    with pytest.raises(jsonschema.ValidationError):
+        validate_instance("999.999.999.999", schema, checker)
+    # ... and the strict validator must not have displaced the lenient one.
+    validate_instance("999.999.999.999", schema)
+
+
+def test_the_cache_actually_caches() -> None:
+    """Output equivalence alone cannot tell a working cache from an absent
+    one, so assert the reuse directly."""
+    schema = {"type": "object", "properties": {"zz": {"type": "integer"}}}
+    first = validator_for(dict(schema))
+    second = validator_for(dict(schema))  # equal content, different object
+    assert first is second
+    assert validator_for(dict(schema), jsonschema.FormatChecker()) is not first
+
+
+def test_the_real_packaged_schemas_round_trip(
+) -> None:
+    """Not only toy schemas: the packaged documents this helper exists for
+    must themselves check clean and validate a real report shape."""
+    from abicheck.schemas import (
+        load_aggregate_report_schema,
+        load_compare_report_schema,
+    )
+
+    for loader in (load_compare_report_schema, load_aggregate_report_schema):
+        schema = loader()
+        assert validator_for(schema) is validator_for(loader())
+        with pytest.raises(jsonschema.ValidationError):
+            validate_instance("not an object at all", schema)

--- a/tests/test_schema_validation_helper.py
+++ b/tests/test_schema_validation_helper.py
@@ -27,6 +27,8 @@ malformed schema, a `format_checker`).
 """
 from __future__ import annotations
 
+import copy
+
 import pytest
 
 jsonschema = pytest.importorskip("jsonschema")
@@ -118,6 +120,49 @@ def test_a_schema_mutated_in_place_is_not_served_a_stale_validator() -> None:
 
     schema["properties"]["a"] = {"type": "integer"}
     validate_instance({"a": 1}, schema)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        # Every shape of in-place edit a caller can make to its own schema:
+        # tightening, loosening, adding a constraint, removing one, and
+        # rewriting a nested subschema.
+        lambda s: s["properties"].__setitem__("a", {"type": "string"}),
+        lambda s: s.__setitem__("required", ["a"]),
+        lambda s: s["properties"]["a"].__setitem__("minimum", 100),
+        lambda s: s.__setitem__("additionalProperties", False),
+        lambda s: s["properties"].clear(),
+    ],
+    ids=["retype", "add_required", "add_bound", "close", "empty"],
+)
+def test_a_later_caller_is_never_served_a_validator_a_mutation_changed(mutate) -> None:
+    """The sibling case of the test above, and the one that actually escaped
+    (Codex review, PR #1252): a validator keeps a reference to the mapping it
+    was built from, so mutating that mapping changed what the entry stored
+    under the *original* content key enforced. The mutating caller then got
+    correct answers (its new content is a new key) while an unrelated later
+    caller presenting an equal, unmutated schema got the mutated behaviour.
+
+    The oracle is the library over the original content, and the check is
+    made for every mutation shape rather than the one that was reported."""
+    original = {"type": "object", "properties": {"a": {"type": "integer"}}}
+    probes: list[object] = [{"a": 1}, {"a": "x"}, {"a": 1, "b": 2}, {}]
+
+    live = copy.deepcopy(original)
+    validate_instance({"a": 1}, live)  # populate the cache from this dict
+    mutate(live)
+    validate_instance({"a": 1} if _reference({"a": 1}, live) == "ok" else {}, live)
+
+    # A different caller, an equal but never-mutated schema: must behave
+    # exactly as the library does for that content.
+    fresh = copy.deepcopy(original)
+    disagreements = [
+        (probe, _reference(probe, original), _under_test(probe, fresh))
+        for probe in probes
+        if _reference(probe, original) != _under_test(probe, fresh)
+    ]
+    assert not disagreements
 
 
 def test_bool_is_not_accepted_where_an_integer_is_required() -> None:


### PR DESCRIPTION
## Summary

Close two paths where a test could report green while proving less than it claims, and remove three sources of repeated work in the test session.

## Motivation

Follow-up on the CI-optimization pass. The two correctness items come first deliberately: after the native matrix and the lanes are trimmed, whatever survives has to actually be checking something. A cheaper suite that is green for the wrong reason is worse than the one it replaced.

## Changes

- **A configured compiler's failure now fails the test.** `tests/test_cross_platform_integration.py`'s `_compile_dylib`/`_compile_dll` turned *any* nonzero compiler exit into `pytest.skip`. A missing platform or compiler is already handled by the module's `skipif` markers, so that branch only ever fired when the compiler was present, ran, and rejected the build — a broken fixture or toolchain configuration, silently removed from the run. The `ABICHECK_MIN_EXECUTED` silent-skip guard cannot see this: the sibling fixtures that still build satisfy its floor. `_require_compile_success` now keeps three states apart — platform/tool absent (marker-level skip), a *named* optional compiler feature (skip, per-test opt-in), a configured compiler that failed (**failure**, with command, source and stderr attached).
- **F-19's 192-permutation sweep gets a real oracle.** `test_exit_code_identical_across_every_rendering_permutation` accepted any exit code in `(0, 4)` and asserted only that they agreed — so a CLI returning `0` for everything passed all 192 invocations against a fixture that removes a public function. It now asserts the exact breaking verdict (strictly stronger than agreement), which is what allows the sweep to split on `--format` into six pytest items of 32 invocations each: xdist can spread the module's most expensive block instead of serializing it behind one worker. All 192 combinations are unchanged, and each item carries a vacuity guard that its 32 really ran.
- **Per-test snapshot-cache directories move into one bucket.** They were allocated directly in pytest's basetemp, which left `tmp_path`'s *numbered* allocator enumerating thousands of unrelated cache directories on every request — the second half of the cost the earlier `mkdtemp` change addressed. Same guarantee as before (a distinct, empty, test-owned directory under pytest's retention policy, no shared mutable state).
- **`tests/schema_validation.validate_instance` replaces `jsonschema.validate`** at the suite's schema call sites (12 modules). `jsonschema.validate` re-validates the *schema* on every call; this suite validates many reports against a handful of packaged schemas. The cache is keyed on the schema's canonical JSON — never a file path or a dict's identity — so a test that edits a schema between calls is not served a stale validator.
- **The skill-tree materialization hook writes only when the trees actually disagree with the render.** Under xdist it ran once per worker plus once in the controller, and `write_trees` removes each owned skill directory before restoring it, so every superfluous writer reopened a window in which a concurrent reader sees the tree absent. The render is still recomputed on every call, so mid-session drift is still repaired.
- Documented the compile-helper rule and the schema helper in `tests/CLAUDE.md`; registered `guard.absent_capability_vs_real_failure` in `tests/regressions/manifest_guards.py`, with its residual (≈30 unmigrated `returncode != 0 → skip` sites across the integration/parity suites, several of which are genuine optional-feature probes) recorded as a `KnownGap` rather than left as prose.

## Bug-fix test contract

- Bug class: `guard.absent_capability_vs_real_failure` (new entry in `tests/regressions/manifest_guards.py`) — a test-support helper widening "this environment cannot do X" to cover "doing X went wrong".
- Publicly observable failure: on a lane where the compiler is present but a fixture no longer builds, the affected tests report `skipped` and the job is green; the minimum-executed guard is satisfied by the fixtures that still build, so nothing anywhere reports that the checks did not run.
- Regression test fails on base: yes — `tests/test_compile_failure_contract.py::test_no_compile_helper_skips_on_a_bare_returncode` and the whole `test_outcome_over_the_whole_exit_status_domain` sweep fail against the pre-change helpers (`_require_compile_success` does not exist; the helpers call `pytest.skip`).
- Negative control: `test_real_compiler_error_fails_the_test` builds a *good* fixture through the same helper right after the broken one, so the failure is the compiler's verdict and not a helper that now rejects everything; `test_oracle_is_not_a_constant` guards the sweep's oracle against collapsing to one answer.
- Public-surface test: none — this is test-infrastructure behaviour, exercised through the real helper and a real `gcc`, not through a documented abicheck entry point. `public_surfaces` is `()` in the registry entry accordingly.
- Axes covered: exit status (zero / every plausible nonzero / signal-kill negative values), optional-feature label (named / absent), stderr shape (empty / 100 KB / non-UTF-8 / non-ASCII).
- General invariant: a helper may report "skipped" only for a capability that is genuinely absent; a tool that was configured, run, and failed is a test failure with its diagnostics attached. Exercised over the whole small domain above rather than the one flag that broke, with the expectation restated independently of the implementation's own branch (`_expected`), plus an executable half that drives the real helper against a real compiler that really rejects the build.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added — n/a, no `abicheck/**/*.py` change
- [x] Docs updated if user-visible behaviour changed — `tests/CLAUDE.md` (contributor-facing)
- [x] No new `mypy` or `ruff` errors introduced (`ruff check tests/ abicheck/` clean)

## Verification

- `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 4592 passed at the point of the one pre-existing failure below; a full run without `-x` is in progress and will be reported in this thread.
- `tests/test_ai_readiness.py::test_adr_status_sync_holds` fails **on a clean checkout in this container** (ADR-049's `**Verified:**` sha is unreachable from the container's stale `origin/main` ref). Verified by stashing every change and re-running it — unrelated to this PR.
- The F-19 block (`-k F19`) passes as 12 items in 182 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vediWrjpFbUp5UJU4UjkA

---
_Generated by [Claude Code](https://claude.ai/code/session_011vediWrjpFbUp5UJU4UjkA)_