### PR TITLE
docs: refresh the stripped-headers validation status after the removal-axis fix

### DIFF
--- a/catalog/README.md
+++ b/catalog/README.md
@@ -101,7 +101,7 @@ Commands below use `PYTHONPATH=.`.
 | Default/debug verdicts | `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1 PYTHONPATH=. python tests/validate_examples.py --toolchain {gcc,clang} --json` | CI Linux, gcc/clang | 208 catalog cases | gcc: 164 PASS / 5 XFAIL / 39 SKIP; clang: 165 PASS / 5 XFAIL / 38 SKIP | Green default/debug verdict lane. Without the env var, 7 `source_smoke: {mode: run}` cases SKIP instead of running |
 | Runtime smoke | `PYTHONPATH=. python validation/scripts/run_example_runtime_smoke.py --json` | Linux proof run | 208 catalog cases | 90 DEMONSTRATED / 78 NO_RUNTIME_SIGNAL / 1 BASELINE_SIGNAL / 39 SKIP | Passing; no BUILD_ERROR. The runner now compares each app's baseline exit code against a per-case `runtime_baseline_exit` in `ground_truth.json` (default 0) instead of hardcoding zero, so apps that deliberately return a computed value (e.g. case111's `ets(42).local()` returning `42`) are no longer misread as a broken baseline. `case06_visibility` is the one remaining, intentionally-unwhitelisted case — see "Known validation gaps" below |
 | Release headers | `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1 python tests/validate_examples.py --artifact-variant release-headers --json` | CI Linux artifact | 208 catalog cases | 164 PASS / 5 XFAIL / 39 SKIP | Informational; the false-risk regression on `case61_var_added` (`exported_object_alignment_reduced`) is fixed — CastXML now resolves a variable's natural type alignment as declared-alignment corroboration even without an explicit `alignas` override. Without the env var, the same 7 cases SKIP instead |
-| Stripped headers | `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1 python tests/validate_examples.py --artifact-variant stripped-headers --json` | CI Linux artifact | 208 catalog cases | 158 PASS / 6 FAIL / 5 XFAIL / 39 SKIP | Informational; reduced-evidence signal-loss backlog (below). Without the env var, the same 7 cases SKIP instead |
+| Stripped headers | `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1 python tests/validate_examples.py --artifact-variant stripped-headers --json` | CI Linux artifact | 208 catalog cases | 159 PASS / 5 FAIL / 5 XFAIL / 39 SKIP | Informational; reduced-evidence signal-loss backlog (below). Without the env var, the same 7 cases SKIP instead |
 | Build/source proof | `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1 python tests/validate_examples.py case01 case04 case98 case105 case122 case129 case130 case131 case132 case133 --artifact-variant build-source --json` | CI Linux artifact | 10 representative cases | 10 PASS | Required release proof; includes L3 C++ floor and L4 concept/template regressions. Not full L3-L5 catalog coverage — see "Known validation gaps" |
 
 Counts above are from the most recent full catalog run this table was refreshed against; re-run
@@ -228,7 +228,7 @@ success means one `COVERED` row per current ground-truth entry, with no
 
 Current stripped-header signal-loss cases: `case103_toolchain_flag_drift`,
 `case117_no_unique_address`, `case129_struct_return_convention`,
-`case60_base_class_position_changed`, `case69_trivial_to_nontrivial`, and
+`case60_base_class_position_changed`, and
 `case89_inline_accessor_renamed_pimpl_member` (downgrades `BREAKING` to
 `API_BREAK` — a reduced-evidence signal loss consistent with this lane's
 existing pattern, not a new detector bug).


### PR DESCRIPTION
## Summary

Two lines in `catalog/README.md`. This is the whole of what keeps **`Full example matrix` red on `main`**.

## Motivation

`1e5da80d3` ("fix: three main-CI failures — removal axis, …") changed a verdict in the stripped-headers lane but left the checked-in validation-status table recording the pre-fix numbers. `check_examples_validation_status_sync.py --check` has failed on every `main` run since:

```
catalog/README.md's validation-status table is stale.

Stripped headers:
  was: 158 PASS / 6 FAIL / 5 XFAIL / 39 SKIP
  now: 159 PASS / 5 FAIL / 5 XFAIL / 39 SKIP
```

That step is the **only** failing step of the job. The matrix itself is clean — `Full example matrix: {"COVERED": 208}`, no failed case, no `ARTIFACT ERROR` — and every per-toolchain shard job (gcc and clang, all shards) is green. One stale row is the entire redness.

## Changes

**1. The table row**, regenerated by running the script exactly as CI does, minus `--check`, against the result JSONs published by **`main`'s own run [34708904160](https://github.com/abicheck/abicheck/actions/runs/34708904160)** (head `1d8f4f03d`) — not hand-edited. `catalog/README.md` is a generated table; editing it by hand is what this gate exists to catch.

**2. The prose beneath it**, which did not say what I expected. It listed **six** "stripped-header signal-loss cases"; only **five** still fail, and the one that now passes is **`case69_trivial_to_nontrivial`** — *not* the hidden-friend case that motivated the removal-axis fix, which does not appear among this lane's failures at all. I diffed the prose list against the artifact's own `FAIL` set; they now match exactly:

```
case103_toolchain_flag_drift        expected=COMPATIBLE got=NO_CHANGE
case117_no_unique_address           expected=BREAKING   got=NO_CHANGE
case129_struct_return_convention    expected=BREAKING   got=COMPATIBLE
case60_base_class_position_changed  expected=BREAKING   got=NO_CHANGE
case89_inline_accessor_renamed_...  expected=BREAKING   got=API_BREAK
```

The sync gate checks only the table row, so that prose would have gone stale silently — worth noting as a small gap in the gate itself, though I have not widened it here.

## Verification

- The gate **reproduces the CI failure** on a clean checkout before the change (exit 1, identical diff text), and reports `catalog/README.md validation-status table is in sync.` after (exit 0).
- Prose list vs. artifact `FAIL` set: verified equal programmatically.
- `python scripts/check_ai_readiness.py` — 0 errors.
- `ARCHITECTURE_BASE=<main> python scripts/check_architecture.py` — 0 errors.
- `pytest tests/test_ai_readiness.py` — 86 passed; the 4 catalog/validation-status tests pass.

No changelog fragment — documentation only, no `abicheck/**/*.py` change.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, regenerated generated content
- [x] Changelog fragment — n/a, no `abicheck/**/*.py` change
- [x] Docs updated if user-visible behaviour changed
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173q5kUcC63nkVmJao2AGjV

---
_Generated by [Claude Code](https://claude.ai/code/session_0173q5kUcC63nkVmJao2AGjV)_