### PR TITLE
chore: regenerate the harbor tasks and skill-eval pack after slice 7m

### DIFF
--- a/agent-evals/skills/harbor/tasks/changed-signature/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/changed-signature/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/changed-signature/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/changed-signature/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/compatible-addition/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/compatible-addition/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/compatible-addition/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/compatible-addition/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/constant-value-changed/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/constant-value-changed/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/constant-value-changed/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/constant-value-changed/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/consumer-actually-affected/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/consumer-actually-affected/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/consumer-actually-affected/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/consumer-actually-affected/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/consumer-unaffected-despite-break/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/consumer-unaffected-despite-break/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/consumer-unaffected-despite-break/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/consumer-unaffected-despite-break/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/contract-coverage-incomplete/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/contract-coverage-incomplete/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/contract-coverage-incomplete/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/contract-coverage-incomplete/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/enum-value-change/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/enum-value-change/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/enum-value-change/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/enum-value-change/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/evidence-too-shallow/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/evidence-too-shallow/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/evidence-too-shallow/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/evidence-too-shallow/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/not-comparable-pair/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/not-comparable-pair/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/not-comparable-pair/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/not-comparable-pair/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/plugin-required-symbol-loss/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/plugin-required-symbol-loss/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/plugin-required-symbol-loss/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/plugin-required-symbol-loss/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/removed-export/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/removed-export/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/removed-export/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/removed-export/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/runtime-floor-raised/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/runtime-floor-raised/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/runtime-floor-raised/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/runtime-floor-raised/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/struct-layout-drift/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/struct-layout-drift/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/struct-layout-drift/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/struct-layout-drift/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/harbor/tasks/vtable-change/environment/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/vtable-change/environment/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # real fix (vendoring the runtime sources directly, or a published
 # release tag) is a bigger, cross-cutting change than this generator's
 # own scope; see agent-evals/skills/harbor/CLAUDE.md.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 # ^ content digest of `_RUNTIME_RELEVANT_PATHS` at generation time -- what
 # `--check` (scripts/gen_harbor_tasks.py) actually compares to detect real
 # staleness, independent of whether ABICHECK_REF above is still a

--- a/agent-evals/skills/harbor/tasks/vtable-change/tests/Dockerfile
+++ b/agent-evals/skills/harbor/tasks/vtable-change/tests/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # each exists. `_normalize_pinned_ref`/`_DIGEST_LINE` in this generator are
 # file-path-agnostic, so the identical two-line convention here is picked up
 # by `--check` without any further changes to that comparison machinery.
-ARG ABICHECK_REF=db2c4fa834a0384e5db700a24942c4b6f31fa9b6
-# ABICHECK_RUNTIME_DIGEST=19dc1c438c140b985df2ae47295d67c481fe434374de7b50b1d97516c3d8593f
+ARG ABICHECK_REF=ae27d9f6ad51eca8774670afe43e7f80e02301f2
+# ABICHECK_RUNTIME_DIGEST=ac7309bc74818692711788921db32a4920a27c1792dc58c742e70a53403af2a1
 RUN git clone https://github.com/abicheck/abicheck.git /opt/abicheck-src \
     && cd /opt/abicheck-src \
     && (git checkout "$ABICHECK_REF" 2>/dev/null \

--- a/agent-evals/skills/skill-eval-pack.json
+++ b/agent-evals/skills/skill-eval-pack.json
@@ -481,7 +481,7 @@
       "affects": [
         "check-abi-compatibility"
       ],
-      "digest": "sha256:b9f42cd5daa289caf499a006d542724499dc5b20ebf5cd3bf9f8ab54cacb1ac4",
+      "digest": "sha256:64bcdefa72b3fcc717d2b684311bc784d7da2d3379442ffef0c58ce28fd45069",
       "roots": [
         "agent-evals/skills/grade_bundle.py",
         "agent-evals/skills/graders",


### PR DESCRIPTION
## Summary

Regenerate the two drift-gated agent-eval trees after #1257 merged.

## Motivation

#1257 changed runtime-relevant paths, so `agent-evals/skills/harbor/tasks/` and `agent-evals/skills/skill-eval-pack.json` now carry a stale content digest. On `main` today that makes `gen_harbor_tasks.py --check` and `gen_skill_eval_pack.py --check` fail, and with them three steps of the PR gate: `harbor-tasks`, `skill-eval-pack`, and `unit-pr` (via `tests/test_gen_harbor_tasks.py` and `tests/test_skill_eval_pack.py`).

Found by running `python scripts/verify.py --profile pr` against the merged content.

## Changes

- `python scripts/gen_harbor_tasks.py` and `python scripts/gen_skill_eval_pack.py`, committed as generated. No hand edits.

The pinned `ABICHECK_REF` necessarily lags by one commit — it records the HEAD the generator saw — which is exactly why `--check` compares the recorded content digest rather than the ref.

## Verification

- `python scripts/gen_harbor_tasks.py --check` → up to date
- `python scripts/gen_skill_eval_pack.py --check` → up to date
- `pytest tests/test_gen_harbor_tasks.py tests/test_skill_eval_pack.py` → 191 passed, 14 skipped

## Checklist

- [x] Tests added / updated for new behaviour — n/a, generated-output refresh; the existing drift tests are the coverage
- [x] Changelog fragment — n/a, no change under `abicheck/**/*.py`
- [x] Docs updated — n/a
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Me97yiuVnJqN2J7KAfhXo

---
_Generated by [Claude Code](https://claude.ai/code/session_017Me97yiuVnJqN2J7KAfhXo)_