### PR TITLE
fix(action): anchor the release-operand probe through the shared qualified-path predicate

### DIFF
--- a/action/run.sh
+++ b/action/run.sh
@@ -1749,10 +1749,14 @@ _is_release_style_operand() {
     # the package-only inputs for an operand `compare` does fan out
     # (Codex review, PR #1259). `$_PY_SAFE_DIR` exists to keep the
     # untrusted checkout off `sys.path`, not to relocate the operand.
-    # A drive-lettered path (`C:/...`) is already absolute on the Git Bash
-    # runners and must not be prefixed.
+    # Which spellings must NOT be prefixed is `_is_path_already_qualified`'s
+    # question, not a second regex's: it covers UNC (`\\server\share`),
+    # root-relative (`\pkg`) and drive-relative (`C:pkg`) forms this call
+    # site would otherwise mangle, and it gates every Windows-only form on
+    # actually running on Windows, so a POSIX file literally named `C:pkg`
+    # still anchors (Codex and CodeRabbit review, PR #1261).
     local _probe_path="$path"
-    if [[ "$_probe_path" != /* ]] && ! [[ "$_probe_path" =~ ^[A-Za-z]:[/\\] ]]; then
+    if ! _is_path_already_qualified "$_probe_path"; then
       _probe_path="$PWD/$_probe_path"
     fi
     local _probe_rc=0

--- a/action/run.sh
+++ b/action/run.sh
@@ -1742,6 +1742,19 @@ _is_release_style_operand() {
   # `$_PY_SAFE_DIR`/cleared-`PYTHONPATH` isolation as every other
   # abicheck-importing call here, for the same sys.path reason.
   if [[ "${_PY_BIN_HAS_ABICHECK:-false}" == "true" && -n "${_PY_SAFE_DIR:-}" && -n "${_PY_BIN:-}" ]]; then
+    # Anchor the operand BEFORE the `cd`. `old-library`/`new-library` are
+    # normally relative to the workflow directory, and the probe runs from
+    # `$_PY_SAFE_DIR` -- so a bare `Path(sys.argv[1])` there would stat a
+    # nonexistent path under the temp dir, answer "not a package", and skip
+    # the package-only inputs for an operand `compare` does fan out
+    # (Codex review, PR #1259). `$_PY_SAFE_DIR` exists to keep the
+    # untrusted checkout off `sys.path`, not to relocate the operand.
+    # A drive-lettered path (`C:/...`) is already absolute on the Git Bash
+    # runners and must not be prefixed.
+    local _probe_path="$path"
+    if [[ "$_probe_path" != /* ]] && ! [[ "$_probe_path" =~ ^[A-Za-z]:[/\\] ]]; then
+      _probe_path="$PWD/$_probe_path"
+    fi
     local _probe_rc=0
     # shellcheck disable=SC2016  # the inline script is deliberately unexpanded.
     (cd "$_PY_SAFE_DIR" && PYTHONPATH= "$_PY_BIN" -c '
@@ -1751,7 +1764,7 @@ from pathlib import Path
 from abicheck.package import is_package
 
 raise SystemExit(0 if is_package(Path(sys.argv[1])) else 3)
-' "$path") || _probe_rc=$?
+' "$_probe_path") || _probe_rc=$?
     [[ "$_probe_rc" -eq 0 ]] && return 0
     [[ "$_probe_rc" -eq 3 ]] && return 1
   fi

--- a/changelog.d/phase-7n-post-merge-review-fixes.md
+++ b/changelog.d/phase-7n-post-merge-review-fixes.md
@@ -1,0 +1,33 @@
+### Fixed
+
+- **A ZIP package carrying a permitted preamble is recognised again.** The
+  format allows arbitrary bytes before the first local file header — a
+  self-extracting stub — and every real zip reader accepts one, but Phase
+  7n's content detection checked for the magic at byte 0 and rejected such
+  wheels and conda packages outright. Detection now asks
+  `zipfile.is_zipfile`, which locates the central directory from the end of
+  the file.
+- **A debug artifact that no extraction path can read is refused with
+  accurate advice.** `--debug-info`'s rejection of a directly-named `.pdb`
+  or DWARF-package file previously suggested passing the directory holding
+  it, which is dropped just as silently (`_dump_pe` never receives
+  `debug_roots`, and the ELF dump reads only `DebugArtifact.dwarf_path`).
+  It now names `.abicheck.yml`'s `debug.pdb_path` for a PDB, and says
+  plainly that no input feeds a DWARF package to the dump path today. The
+  underlying gap is recorded in `docs/contribute/known-gaps.md`.
+- **Legacy-conda detection no longer reads a whole archive to decide.**
+  Since the detector stopped gating on the filename it runs for every
+  tar-shaped operand, and it listed every member before inspecting the
+  first few — so a large or adversarial archive could be fully walked
+  before the extraction limits applied. It stops at a bounded number of
+  members now.
+- **The GitHub Action forwards package-only inputs for a
+  content-detected release operand.** `action/run.sh` decided whether an
+  operand was a package from a filename-suffix table, which stopped
+  matching `abicheck`'s own `is_package()` when that became content-based:
+  a tar, conda or wheel archive staged under a nonconventional name was
+  compared as a release by the CLI while the Action withheld `devel-pkg1`/
+  `devel-pkg2` and `debug-info1`/`debug-info2`, quietly lowering the
+  evidence the comparison ran on. The Action now asks the installed
+  `abicheck`, keeping the table only for the genuinely pre-install
+  `validate-inputs.sh` position.

--- a/tests/test_action_release_operand_detection.py
+++ b/tests/test_action_release_operand_detection.py
@@ -56,7 +56,13 @@ def _function_source() -> str:
     return text[start:end]
 
 
-def _ask(path: Path, *, abicheck_available: bool, cwd: Path) -> bool:
+def _ask(
+    path: Path | str,
+    *,
+    abicheck_available: bool,
+    cwd: Path,
+    workdir: Path | None = None,
+) -> bool:
     """Run the extracted function over *path*, with the probe on or off.
 
     Shells out through `_workflow_exec`'s resolver and its guard, the one
@@ -76,6 +82,7 @@ def _ask(path: Path, *, abicheck_available: bool, cwd: Path) -> bool:
         capture_output=True,
         text=True,
         check=False,
+        cwd=None if workdir is None else str(workdir),
     )
     assert completed.returncode in (0, 1), completed.stderr
     return completed.returncode == 0
@@ -130,6 +137,59 @@ class TestAgreementWithTheRealPredicate:
         assert not is_package(d)
         assert _ask(d, abicheck_available=True, cwd=tmp_path)
         assert _ask(d, abicheck_available=False, cwd=tmp_path)
+
+
+class TestTheProbeResolvesTheOperandNotTheSafeDirectory:
+    """A relative operand is the *normal* Action spelling.
+
+    `old-library`/`new-library` usually arrive relative to the workflow
+    directory, and the probe runs from `$_PY_SAFE_DIR` (which exists to keep
+    the untrusted checkout off `sys.path`, not to relocate the operand). A
+    bare `Path(sys.argv[1])` inside that subshell stats a nonexistent path
+    under the temp dir, answers "not a package", and skips the package-only
+    inputs for an operand `compare` does fan out (Codex review, PR #1259).
+
+    The working directory and the safe directory are deliberately *distinct*
+    here: the first version of this module passed the same `tmp_path` as
+    both and used absolute operands, so it could not have caught this.
+    """
+
+    def test_a_relative_operand_resolves_from_the_working_directory(
+        self, tmp_path: Path
+    ) -> None:
+        workdir = tmp_path / "workspace"
+        workdir.mkdir()
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        _make_tar_mode(workdir / "operand", "w:gz")
+
+        assert is_package(workdir / "operand")
+        assert _ask(
+            "operand", abicheck_available=True, cwd=safe_dir, workdir=workdir
+        )
+
+    def test_a_relative_non_package_still_answers_no(self, tmp_path: Path) -> None:
+        """The control: anchoring must not make everything a package."""
+        workdir = tmp_path / "workspace"
+        workdir.mkdir()
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        (workdir / "libfoo.so").write_bytes(b"\x7fELF\x02\x01\x01" + b"\x00" * 64)
+
+        assert not _ask(
+            "libfoo.so", abicheck_available=True, cwd=safe_dir, workdir=workdir
+        )
+
+    def test_a_dotted_relative_operand_resolves_too(self, tmp_path: Path) -> None:
+        workdir = tmp_path / "workspace"
+        (workdir / "nested").mkdir(parents=True)
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        _make_tar_mode(workdir / "nested" / "operand", "w:gz")
+
+        assert _ask(
+            "./nested/operand", abicheck_available=True, cwd=safe_dir, workdir=workdir
+        )
 
 
 class TestThePreInstallFallback:

--- a/tests/test_action_release_operand_detection.py
+++ b/tests/test_action_release_operand_detection.py
@@ -37,6 +37,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from _package_fixtures import _make_conda_v2, _make_tar_mode, _make_wheel
 from _workflow_exec import bash_executable, require_bash
 
@@ -48,12 +49,23 @@ _FN_START = "_is_release_style_operand() {"
 _FN_END = "\n}\n"
 
 
-def _function_source() -> str:
-    """The real definition, parsed out of `run.sh` rather than restated."""
+def _named_function_source(name: str) -> str:
+    """The real definition of *name*, parsed out of `run.sh`, not restated."""
     text = RUN_SH.read_text(encoding="utf-8")
-    start = text.index(_FN_START)
+    start = text.index(f"{name}() {{")
     end = text.index(_FN_END, start) + len(_FN_END)
     return text[start:end]
+
+
+def _function_source() -> str:
+    """The real `_is_release_style_operand`, plus the helpers it calls."""
+    return "\n".join(
+        (
+            '_RUNNING_ON_WINDOWS="${_RUNNING_ON_WINDOWS:-false}"',
+            _named_function_source("_is_path_already_qualified"),
+            _named_function_source("_is_release_style_operand"),
+        )
+    )
 
 
 def _ask(
@@ -190,6 +202,119 @@ class TestTheProbeResolvesTheOperandNotTheSafeDirectory:
         assert _ask(
             "./nested/operand", abicheck_available=True, cwd=safe_dir, workdir=workdir
         )
+
+
+class TestTheProbeAnchorsExactlyWhatTheSharedPredicateSays:
+    """The anchoring decision has one owner, and it is not this call site.
+
+    The first version of the anchoring fix above carried its *own* regex
+    (`^[A-Za-z]:[/\\\\]` plus a POSIX-absolute test). That is the
+    `cli_surface.copied_option_table_went_stale` shape inside one file: a
+    second, narrower spelling of a question `_is_path_already_qualified`
+    already answers, which silently disagreed on UNC (`\\\\server\\share`),
+    root-relative (`\\pkg`) and drive-relative (`C:pkg`) paths -- each then
+    prefixed with `$PWD`, sending the probe at a path that does not exist
+    and withholding the package-only inputs (Codex P2 and CodeRabbit,
+    PR #1261).
+
+    So the oracle here is the predicate itself, asked of the same string,
+    and the observation is the argv the probe *actually* passes to Python
+    -- not the probe's verdict, which collapses two different paths onto
+    the same "not a package" answer and would have passed against the bug.
+    The spellings are swept from both sides of every branch the predicate
+    has, so a future narrowing at either site fails here.
+    """
+
+    SPELLINGS = (
+        "pkg",
+        "./nested/pkg",
+        "../pkg",
+        "/abs/pkg",
+        "C:/pkg",
+        "C:\\pkg",
+        "C:pkg",
+        "\\pkg",
+        "\\\\server\\share\\pkg",
+        "a:baseline.json",
+        "weird name/pkg",
+    )
+
+    @staticmethod
+    def _probe_argv(spelling: str, *, on_windows: bool, workdir: Path) -> str:
+        """The path the probe subprocess is actually handed."""
+        require_bash()
+        recorder = workdir / "recorded"
+        stub = workdir / "py-stub"
+        stub.write_text(
+            '#!/usr/bin/env bash\nprintf "%s" "${!#}" > "$RECORD"\nexit 3\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        script = "\n".join(
+            (
+                f'_RUNNING_ON_WINDOWS={"true" if on_windows else "false"}',
+                "_PY_BIN_HAS_ABICHECK=true",
+                f'_PY_BIN="{stub}"',
+                f'_PY_SAFE_DIR="{workdir}"',
+                f'RECORD="{recorder}"; export RECORD',
+                _function_source(),
+                '_is_release_style_operand "$1"',
+            )
+        )
+        subprocess.run(  # noqa: S603
+            [bash_executable(), "-c", script, "bash", spelling],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(workdir),
+        )
+        return recorder.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _predicate(spelling: str, *, on_windows: bool) -> bool:
+        """The oracle: `run.sh`'s own shared predicate, nothing restated."""
+        require_bash()
+        script = "\n".join(
+            (
+                f'_RUNNING_ON_WINDOWS={"true" if on_windows else "false"}',
+                _named_function_source("_is_path_already_qualified"),
+                '_is_path_already_qualified "$1"',
+            )
+        )
+        completed = subprocess.run(  # noqa: S603
+            [bash_executable(), "-c", script, "bash", spelling],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode in (0, 1), completed.stderr
+        return completed.returncode == 0
+
+    @pytest.mark.parametrize("on_windows", [False, True])
+    def test_the_probe_anchors_iff_the_predicate_says_unqualified(
+        self, tmp_path: Path, on_windows: bool
+    ) -> None:
+        disagreements = {}
+        for spelling in self.SPELLINGS:
+            workdir = tmp_path / f"w{len(disagreements)}-{abs(hash(spelling))}"
+            workdir.mkdir()
+            qualified = self._predicate(spelling, on_windows=on_windows)
+            argv = self._probe_argv(
+                spelling, on_windows=on_windows, workdir=workdir
+            )
+            anchored = argv != spelling
+            if anchored is qualified:
+                disagreements[spelling] = (qualified, argv)
+        assert not disagreements, disagreements
+
+    def test_the_sweep_covers_both_answers_on_each_platform(self) -> None:
+        """Vacuity guard: a sweep that is all-qualified or all-unqualified
+        would pass against a predicate reduced to a constant."""
+        for on_windows in (False, True):
+            answers = {
+                self._predicate(s, on_windows=on_windows) for s in self.SPELLINGS
+            }
+            assert answers == {True, False}, on_windows
 
 
 class TestThePreInstallFallback:

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -55,6 +55,12 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from _package_fixtures import (
+    _make_conda_v2,
+    _make_tar_mode,
+    _make_wheel,
+    _write_zstd_tar,
+)
 from _workflow_exec import HOSTILE_SCALAR_CORPUS, bash_executable, require_bash
 
 RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
@@ -213,14 +219,23 @@ def _bash_ansi_c_quote(value: str) -> str:
     return "$'" + "".join(out) + "'"
 
 
-def _run_predicate(call: str) -> bool:
+def _run_predicate(call: str, *, abicheck_available: bool = True) -> bool:
     """Source the real helper functions and evaluate a boolean-returning call
     (e.g. an ``_is_release_style_operand "path"`` invocation), returning
-    whether it exited zero (true) or non-zero (false)."""
+    whether it exited zero (true) or non-zero (false).
+
+    *abicheck_available* selects which half of `_is_release_style_operand`
+    answers: the default runs the real probe against the installed abicheck
+    (plan Phase 7n made `is_package()` content-based, and `run.sh` derives
+    from it rather than keeping a copy), while ``False`` forces the
+    suffix/magic fallback that `validate-inputs.sh`'s genuinely pre-install
+    position still uses. Both are real code paths, so both are addressable.
+    """
     require_bash()
     script = (
         _helpers_region()
         + _cli_introspection_prelude()
+        + ("" if abicheck_available else "\n_PY_BIN_HAS_ABICHECK=false\n")
         + f"\nif {call}; then exit 0; else exit 1; fi\n"
     )
     with tempfile.NamedTemporaryFile(
@@ -400,6 +415,36 @@ class TestAddSidedScalarFlag:
 
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+def _real_package(tmp_path: Path, suffix: str) -> Path:
+    """A file at ``libfoo<suffix>`` whose *content* is that format.
+
+    One place, so the sweep above cannot drift into fake fixtures again.
+    """
+    target = tmp_path / f"libfoo{suffix}"
+    if suffix == ".rpm":
+        target.write_bytes(b"\xed\xab\xee\xdb" + b"\x00" * 64)
+    elif suffix == ".deb":
+        target.write_bytes(b"!<arch>\n" + b"\x00" * 64)
+    elif suffix == ".conda":
+        _make_conda_v2(target, {})
+    elif suffix == ".whl":
+        _make_wheel(target, {"foo/__init__.py": b""})
+    elif suffix == ".tar.zst":
+        _write_zstd_tar(target)
+    else:
+        _make_tar_mode(
+            target,
+            {
+                ".tar": "w",
+                ".tar.gz": "w:gz",
+                ".tgz": "w:gz",
+                ".tar.xz": "w:xz",
+                ".tar.bz2": "w:bz2",
+            }[suffix],
+        )
+    return target
+
+
 class TestIsReleaseStyleOperand:
     """``compare`` mode now skips its --write optimization for
     directory/package operands, since the release fan-out engine rejects
@@ -436,15 +481,39 @@ class TestIsReleaseStyleOperand:
             ".whl",
         ],
     )
-    def test_package_extensions_are_release_style(self, tmp_path, suffix) -> None:
-        f = tmp_path / f"libfoo{suffix}"
-        f.write_text("", encoding="utf-8")
-        assert _run_predicate(f'_is_release_style_operand "{f}"')
+    def test_real_packages_are_release_style(self, tmp_path, suffix) -> None:
+        """Every supported format, with content that really is that format.
 
-    def test_package_extension_matched_case_insensitively(self, tmp_path) -> None:
+        These fixtures were empty files carrying a package suffix, which
+        stopped being release operands when plan Phase 7n made `is_package()`
+        content-based and `run.sh` started deriving from it: a zero-byte
+        `libfoo.rpm` is not a package, and `compare` would not fan it out
+        either. Asserting otherwise pinned the old suffix table, not the
+        behaviour (found by the full suite after PR #1259 merged).
+
+        These operands carry conventional suffixes *and* real content, so
+        either half of the predicate answers yes and this sweep does not
+        distinguish them -- deliberately: its subject is format coverage.
+        Which half answers is pinned in
+        `tests/test_action_release_operand_detection.py`, over
+        nonconventional names, and by the fallback test below.
+        """
+        assert _run_predicate(
+            f'_is_release_style_operand "{_real_package(tmp_path, suffix)}"'
+        )
+
+    def test_the_fallback_matches_an_extension_case_insensitively(
+        self, tmp_path
+    ) -> None:
+        """Lowercasing is a property of the *fallback* table, so this pins it
+        there. With the probe active the suffix is not consulted at all, and
+        an assertion through that path would pass without exercising the
+        `tr '[:upper:]' '[:lower:]'` it claims to test."""
         f = tmp_path / "libfoo.RPM"
-        f.write_text("", encoding="utf-8")
-        assert _run_predicate(f'_is_release_style_operand "{f}"')
+        f.write_bytes(b"")
+        assert _run_predicate(
+            f'_is_release_style_operand "{f}"', abicheck_available=False
+        )
 
     def test_missing_path_is_not_release_style(self) -> None:
         # A nonexistent path isn't a directory and doesn't match a package


### PR DESCRIPTION
## Summary

Follow-up fixes to the Phase 7n release-operand probe that #1259 landed: the probe now anchors a relative operand before its subshell changes directory, and it asks `run.sh`'s own `_is_path_already_qualified` rather than carrying a second, narrower regex for the same question.

## Motivation

`_is_release_style_operand` gates whether the Action forwards the package-only inputs (`devel-pkg1/2` → `--header`, `debug-info1/2`). Two defects made it withhold them from comparisons the CLI does fan out as a release:

1. The probe resolved `Path(sys.argv[1])` *after* `cd "$_PY_SAFE_DIR"`, so a relative `old-library`/`new-library` — the normal Action spelling — was stat'd under the safe directory and answered "not a package" (Codex review on #1259).
2. The anchoring fix for (1) carried its own "already qualified" regex instead of the shared predicate. The two disagreed on UNC (`\\server\share\pkg`), root-relative (`\pkg`) and drive-relative (`C:pkg`) paths, each then prefixed with `$PWD`; and being ungated on platform, it also read a POSIX file literally named `a:baseline.json` as a Windows path (Codex P2 and CodeRabbit, this PR).

## Changes

- `action/run.sh`: anchor a relative operand to `$PWD` before the probe subshell, and decide *which* spellings are already qualified by calling `_is_path_already_qualified` — one owner for that question, platform-gated as it already was.
- `tests/test_action_release_operand_detection.py`: the existing agreement tests now run with distinct working and safe directories and relative operands; a new class sweeps every branch of the predicate on both platform settings, observing the argv the probe actually passes.
- `tests/test_action_run_sh_helpers.py`: the release-style sweep builds real archives instead of empty files with package suffixes, since detection is content-based now.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `cli_surface.copied_option_table_went_stale` — a second, narrower copy of a predicate the script already owns, drifting from it silently. Same class as the suffix table this PR series replaced with a probe, one level down: here the copy is inside the probe itself.
- Publicly observable failure: an Action release comparison whose `old-library`/`new-library` is relative, UNC, root-relative or drive-relative silently ran without `--debug-info` and `--header`, lowering the evidence the comparison was made on — no error, just a weaker verdict.
- Regression test fails on base: yes, verified by mutation, not by assertion — restoring the regex in `action/run.sh` fails `TestTheProbeAnchorsExactlyWhatTheSharedPredicateSays::test_the_probe_anchors_iff_the_predicate_says_unqualified` on both platform parameters, naming `C:pkg`, `\pkg`, `\\server\share\pkg` and `a:baseline.json`; restoring the pre-#1261 `cd`-then-resolve order fails `TestTheProbeResolvesTheOperandNotTheSafeDirectory`.
- Negative control: `test_a_relative_non_package_still_answers_no` (anchoring must not make everything a package), `test_a_non_package_agrees_too`, and `test_a_directory_is_a_release_operand_either_way` (the one rule that deliberately stays in the shell must survive the probe being consulted).
- Public-surface test: the tests execute the real `_is_release_style_operand` parsed out of `action/run.sh` — no restated copy — through `bash`, which is the entry point the Action itself uses. `tests/test_action_run_sh_helpers.py` drives it over real archives.
- Axes covered: both platform settings (`_RUNNING_ON_WINDOWS` true and false, since the Windows branches are unreachable on a Linux runner otherwise); every package shape `is_package` recognises (rpm, deb, plain tar, gzip tar, wheel, conda v2), each under a non-conventional name; probe available and probe absent (the pre-install `validate-inputs.sh` position); absolute, relative, and dotted-relative operands.
- General invariant: the probe anchors a path **iff** `_is_path_already_qualified` says it is unqualified — stated over eleven spellings covering both sides of every branch the predicate has, with the predicate itself as the oracle (not a restated expectation list, which is the drift being fixed), plus `test_the_sweep_covers_both_answers_on_each_platform` as a vacuity guard so a predicate reduced to a constant cannot make the sweep pass. The observation is the argv the probe actually passes, deliberately not its verdict: "anchored to a nonexistent path" and "really not a package" collapse onto the same verdict, so a verdict-based test would have passed against this bug.
- Malicious fixture + side-effect absence: this diff touches `action/run.sh`. The probe is unchanged in what it *does* with the path — it runs in an isolated `PYTHONPATH=` subshell under `$_PY_SAFE_DIR`, reads the operand and exits with a status; the change is only which string it is handed. The tests execute the real shell function against attacker-shaped operand spellings (embedded backslashes, colons, spaces, `../`) rather than asserting the script's text, and assert the exact argv that reaches the subprocess, so a spelling that escaped into the anchoring would be visible as a wrong argv rather than inferred from the file.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — no `abicheck/**/*.py` change in the current commits; the fragment for the Phase 7n fixes landed with #1259
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9spAnL9CsBZw3sKBGxEYv