### PR TITLE
refactor: consolidate the three strict YAML manifest loaders

### DIFF
--- a/abicheck/compatibility_evaluation_packs.py
+++ b/abicheck/compatibility_evaluation_packs.py
@@ -70,12 +70,11 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
-import yaml
-
 from .change_registry_types import Verdict
 from .compatibility_evaluation_config import ImmutableIdentity
 from .errors import PackManifestError
 from .model.change_catalog.kinds import ChangeKind
+from .model.yaml_strict import load_strict_yaml
 from .policy_file import parse_severity_value
 
 
@@ -97,54 +96,6 @@ _VALID_CHANGE_KIND_SLUGS: frozenset[str] = frozenset(k.value for k in ChangeKind
 #: silently discarding the pack author's actual intent (Codex review).
 _TOP_LEVEL_MANIFEST_FIELDS: frozenset[str] = frozenset(
     {"id", "version", "kind", "assignments"}
-)
-
-
-class _StrictLoader(yaml.SafeLoader):
-    """A ``SafeLoader`` that rejects a duplicate key in the same mapping.
-
-    ``yaml.safe_load`` alone silently accepts ``{func_removed: break,
-    func_removed: ignore}`` with last-value-wins semantics (PyYAML's
-    ``SafeConstructor.construct_mapping`` never checks for a repeat) -- for a
-    hard-load-error manifest format, that would silently drop the earlier,
-    contradictory assignment instead of raising (Codex review). Mirrors
-    ``dump_manifest.py``'s own ``_StrictLoader``/``_construct_mapping`` for
-    the identical ADR-050 D3 gap; kept as a second, independent copy rather
-    than a shared import since that one is private to its own module and this
-    manifest format has no other coupling to ``dump_manifest.py``.
-    """
-
-
-def _construct_strict_mapping(
-    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
-) -> dict[Any, Any]:
-    seen: set[Any] = set()
-    mapping: dict[Any, Any] = {}
-    for key_node, value_node in node.value:
-        key = loader.construct_object(key_node, deep=True)
-        # A complex YAML key (e.g. `? [a, b] : value`) constructs to an
-        # unhashable list -- `key in seen`/`seen.add(key)` would otherwise
-        # raise a raw TypeError instead of the documented PackManifestError
-        # (Codex review).
-        try:
-            hash(key)
-        except TypeError as exc:
-            raise PackManifestError(
-                f"unhashable mapping key {key!r} "
-                f"(line {key_node.start_mark.line + 1}): {exc}"
-            ) from exc
-        if key in seen:
-            raise PackManifestError(
-                f"duplicate key {key!r} in the same mapping "
-                f"(line {key_node.start_mark.line + 1})"
-            )
-        seen.add(key)
-        mapping[key] = loader.construct_object(value_node, deep=True)
-    return mapping
-
-
-_StrictLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_strict_mapping
 )
 
 
@@ -610,26 +561,13 @@ def load_pack_manifest(path: str | Path) -> LoadedPack:
             f"{manifest_path}: pack manifest is not valid UTF-8 ({exc})"
         ) from exc
 
-    try:
-        # `_StrictLoader` *is* a `yaml.SafeLoader` subclass (it only adds the
-        # duplicate-key check above); bandit's B506 flags any `Loader=` it
-        # cannot name-match against `SafeLoader`/`CSafeLoader`, subclasses
-        # included, so this is the safe-loader path, not an arbitrary-object one.
-        document: Any = yaml.load(raw_text, Loader=_StrictLoader)  # nosec B506
-    except PackManifestError as exc:
-        raise PackManifestError(f"{manifest_path}: {exc}") from exc
-    except yaml.YAMLError as exc:
-        raise PackManifestError(f"{manifest_path}: invalid YAML ({exc})") from exc
-    except ValueError as exc:
-        # PyYAML's implicit timestamp resolver constructs a real
-        # datetime.date/datetime for a timestamp-shaped scalar -- an
-        # out-of-range value (e.g. "2020-99-99") raises a raw ValueError
-        # from that stdlib constructor, not yaml.YAMLError, and would
-        # otherwise escape this loader's documented PackManifestError
-        # contract (Codex review, fresh evidence).
-        raise PackManifestError(
-            f"{manifest_path}: invalid YAML scalar ({exc})"
-        ) from exc
+    # Strict loading (duplicate key, unhashable key, invalid implicit
+    # scalar, syntax error -- all as PackManifestError) is
+    # `abicheck.model.yaml_strict`'s job, shared with every other hard-load-error
+    # manifest format here rather than kept as a second private copy.
+    document: Any = load_strict_yaml(
+        raw_text, error=lambda message: PackManifestError(f"{manifest_path}: {message}")
+    )
 
     if not isinstance(document, dict):
         raise PackManifestError(

--- a/abicheck/dump_manifest.py
+++ b/abicheck/dump_manifest.py
@@ -121,59 +121,20 @@ _SUPPORTED_FRONTEND_CONTEXTS = frozenset({"host", "device"})
 
 
 def _load_yaml_strict(text: str, *, source: str) -> Any:
-    """Parse *text* as YAML, raising :class:`ManifestValidationError` on a
-    duplicate mapping key anywhere in the document.
+    """Parse *text* as YAML, raising :class:`ManifestValidationError` on any
+    malformed document — a syntax error, a duplicate mapping key, an
+    unhashable (sequence/mapping) key, or an out-of-range implicit scalar.
 
-    ``yaml.safe_load`` alone silently accepts ``{a: 1, a: 2}`` with
-    last-value-wins semantics (PyYAML's ``SafeConstructor.construct_mapping``
-    never checks for a repeated key). A ``SafeLoader`` subclass overriding
-    ``construct_mapping`` to check for repeats is the standard, minimal way
-    to close this without hand-rolling a YAML parser.
+    The strict loader itself is :mod:`abicheck.model.yaml_strict`, shared with
+    every other hard-load-error manifest format here; this wrapper only
+    supplies the ``ManifestValidationError`` vocabulary and the *source*
+    prefix ``--dump-manifest``'s callers expect.
     """
-    try:
-        import yaml
-    except ImportError as exc:  # pragma: no cover - environment-dependent
-        raise ImportError(
-            "PyYAML is required for --dump-manifest support. "
-            "Install it with: pip install pyyaml"
-        ) from exc
+    from .model.yaml_strict import load_strict_yaml
 
-    class _StrictLoader(yaml.SafeLoader):
-        pass
-
-    def _construct_mapping(loader: Any, node: Any, deep: bool = False) -> dict[Any, Any]:
-        seen: set[Any] = set()
-        mapping: dict[Any, Any] = {}
-        for key_node, value_node in node.value:
-            key = loader.construct_object(key_node, deep=True)
-            if key in seen:
-                raise ManifestValidationError(
-                    f"{source}: duplicate key {key!r} in the same mapping "
-                    f"(line {key_node.start_mark.line + 1})"
-                )
-            seen.add(key)
-            mapping[key] = loader.construct_object(value_node, deep=True)
-        return mapping
-
-    _StrictLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+    return load_strict_yaml(
+        text, error=lambda message: ManifestValidationError(f"{source}: {message}")
     )
-
-    try:
-        # `_StrictLoader` subclasses `yaml.SafeLoader` and only replaces its
-        # mapping constructor with the duplicate-key check above; bandit's B506
-        # flags every `Loader=` it cannot name-match against
-        # `SafeLoader`/`CSafeLoader`, subclasses included.
-        return yaml.load(text, Loader=_StrictLoader)  # nosec B506
-    # `_construct_mapping`'s own duplicate-key error must reach the caller as
-    # itself, never re-wrapped as "invalid YAML" by the handler below. Today
-    # that is already true by inheritance (`AbicheckError`/`ValueError`, not
-    # `yaml.YAMLError`); this arm pins it so widening the handler below cannot
-    # silently reclassify a schema violation.
-    except ManifestValidationError:  # pylint: disable=try-except-raise
-        raise
-    except yaml.YAMLError as exc:
-        raise ManifestValidationError(f"{source}: invalid YAML: {exc}") from exc
 
 
 def _reject_unknown_fields(

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -68,8 +68,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
-
 from ..buildsource.graph_facts import (
     CONF_HIGH,
     CONF_UNKNOWN,
@@ -79,6 +77,7 @@ from ..buildsource.graph_facts import (
     GraphNode,
 )
 from ..errors import UseCaseManifestError
+from ..model.yaml_strict import load_strict_yaml
 
 if TYPE_CHECKING:
     from ..model.source_graph import SourceGraphSummary
@@ -93,61 +92,6 @@ if TYPE_CHECKING:
 #: replay, or consumer (ADR-057 slice 1) one in the ADR-046 D2 merge
 #: (``GraphFact.producer``).
 USE_CASE_PROVENANCE = "declared_use_case"
-
-
-class _DuplicateKeyCheckingLoader(yaml.SafeLoader):
-    """``yaml.SafeLoader`` with one behavior change: a mapping that repeats a
-    key is a load error instead of the PyYAML default of silently keeping
-    only the last value.
-
-    A manifest author who accidentally repeats a field (two ``entrypoints:``
-    lines in one use-case entry, most plausibly from a copy-paste) would
-    otherwise have part of their declared coverage silently dropped with no
-    signal at all — exactly the "coverage quietly disappears" failure mode
-    :func:`load_use_case_manifest`'s docstring already promises this module
-    never allows. Scoped to this loader class alone (not a process-wide
-    ``yaml`` monkeypatch), so it affects nothing outside this module.
-    """
-
-
-def _construct_mapping_rejecting_duplicates(
-    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
-) -> dict[Any, Any]:
-    """PyYAML's own ``SafeConstructor.construct_mapping`` already rejects an
-    unhashable key (e.g. ``- {[a, b]: x}``, a YAML sequence used as a
-    mapping key) with a ``ConstructorError`` — a check this override must
-    keep, not just the duplicate-key check it adds, or a syntactically
-    valid-but-unhashable-keyed document raises a bare ``TypeError`` that
-    escapes ``load_use_case_manifest``'s ``except yaml.YAMLError`` and the
-    documented :class:`~abicheck.errors.UseCaseManifestError` contract
-    entirely (Codex review, fresh evidence)."""
-    mapping: dict[Any, Any] = {}
-    for key_node, value_node in node.value:
-        key = loader.construct_object(key_node, deep=deep)
-        try:
-            hash(key)
-        except TypeError as exc:
-            raise yaml.constructor.ConstructorError(
-                "while constructing a mapping",
-                node.start_mark,
-                f"found unhashable key: {key!r}",
-                key_node.start_mark,
-            ) from exc
-        if key in mapping:
-            raise yaml.constructor.ConstructorError(
-                "while constructing a mapping",
-                node.start_mark,
-                f"found duplicate key: {key!r}",
-                key_node.start_mark,
-            )
-        mapping[key] = loader.construct_object(value_node, deep=deep)
-    return mapping
-
-
-_DuplicateKeyCheckingLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    _construct_mapping_rejecting_duplicates,
-)
 
 
 def use_case_node_id(name: str) -> str:
@@ -271,8 +215,8 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
     Raises :class:`~abicheck.errors.UseCaseManifestError` for a structurally
     malformed document (not a list, a non-mapping entry, a missing/blank
     ``use_case`` name), a syntactically invalid one, one that repeats a
-    mapping key (:class:`_DuplicateKeyCheckingLoader`), or one that isn't
-    valid UTF-8 — the same hard-load-error discipline
+    mapping key or uses an unhashable one
+    (:mod:`abicheck.model.yaml_strict`), or one that isn't valid UTF-8 — the same hard-load-error discipline
     ``policy_file.py``/``suppression.py`` already use for user-supplied
     YAML, since silently skipping or overwriting a malformed entry could
     make a use case's declared coverage quietly disappear.
@@ -286,35 +230,29 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
     raised a bare ``UnicodeDecodeError`` instead of the documented
     exception type).
 
-    Also wraps a bare ``ValueError`` from PyYAML's own implicit-resolver
-    scalar constructors (Codex review, fresh evidence): a value that looks
-    like a YAML timestamp but has an invalid component (``2023-99-99`` —
-    no such month) is resolved to the timestamp tag by PyYAML's *resolver*
-    before construction even reaches this loader's own overrides, and its
-    built-in timestamp constructor raises a plain ``ValueError`` (not a
-    ``yaml.YAMLError`` subclass) for an out-of-range date/time part — a
-    document shape neither the syntax nor the UTF-8 guard above catches.
+    An out-of-range implicit scalar (``2023-99-99`` — timestamp-shaped, no
+    such month) is wrapped too: PyYAML's *resolver* tags it before
+    construction, and its built-in timestamp constructor raises a plain
+    ``ValueError``, not a ``yaml.YAMLError``. That translation now lives in
+    :func:`~abicheck.model.yaml_strict.load_strict_yaml`, alongside the identical
+    one every other manifest format needed.
     """
     try:
         text = Path(path).read_text(encoding="utf-8")
-        # `_DuplicateKeyCheckingLoader` subclasses `yaml.SafeLoader` and only
-        # replaces its mapping constructor with the duplicate-key check;
-        # bandit's B506 flags every `Loader=` it cannot name-match against
-        # `SafeLoader`/`CSafeLoader`, subclasses included (same annotation as
-        # `dump_manifest._load_strict_yaml`).
-        raw = yaml.load(text, Loader=_DuplicateKeyCheckingLoader)  # nosec B506
     except UnicodeError as exc:
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: {path}: not valid UTF-8: {exc}"
         ) from exc
-    except yaml.YAMLError as exc:
-        raise UseCaseManifestError(
-            f"impact-use-cases.yaml: {path}: invalid YAML syntax: {exc}"
-        ) from exc
-    except ValueError as exc:
-        raise UseCaseManifestError(
-            f"impact-use-cases.yaml: {path}: invalid scalar value: {exc}"
-        ) from exc
+    # Strict loading (duplicate key, unhashable key, invalid implicit
+    # scalar, syntax error) is `abicheck.model.yaml_strict`'s job -- shared with
+    # every other hard-load-error manifest format here; only the
+    # `UseCaseManifestError` vocabulary is this module's.
+    raw = load_strict_yaml(
+        text,
+        error=lambda message: UseCaseManifestError(
+            f"impact-use-cases.yaml: {path}: {message}"
+        ),
+    )
     return parse_use_case_manifest(raw)
 
 

--- a/abicheck/model/AGENTS.md
+++ b/abicheck/model/AGENTS.md
@@ -81,6 +81,7 @@ types, so `from abicheck.elf_metadata import ElfMetadata` still resolves.
 | A canonical, backend-independent IR field or canonicalization rule (ADR-063 Phase 6) | `semantic_ir.py` |
 | A read-only query/lookup over an already-built `SemanticIR` (entity/occurrence/kind lookups; ADR-063 Phase 6B) | `semantic_ir_index.py` |
 | A `BundleFacts` field or construction invariant (ADR-061 gap E) | `bundle_facts.py` |
+| A duplicate-key/unhashable-key rule for a hard-load-error YAML manifest format | `yaml_strict.py` (the one strict loader every manifest format shares; suppression files deliberately stay on plain `SafeLoader` -- see that module's docstring) |
 
 `__init__.py` is the supported import surface and stays a re-export list
 with `__all__` — no logic, no new names that are not owned by a submodule.

--- a/abicheck/model/yaml_strict.py
+++ b/abicheck/model/yaml_strict.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The one strict-YAML mapping loader every abicheck *manifest* format uses.
+
+``yaml.safe_load`` alone silently accepts ``{a: 1, a: 2}`` with
+last-value-wins semantics (PyYAML's ``SafeConstructor.construct_mapping``
+never checks for a repeated key), so a manifest author who accidentally
+repeats a field has part of their declared intent dropped with no signal at
+all. Every hard-load-error manifest format in this repository closes that
+gap the same standard way — a ``yaml.SafeLoader`` subclass overriding
+``construct_mapping`` — and three independent copies of that override had
+accumulated (``dump_manifest.py``, ``compatibility_evaluation_packs.py``,
+``impact/use_cases.py``). They had already *diverged*: only two of the three
+checked key hashability, so a sequence-keyed mapping (``? [a, b]\\n: 1``)
+raised a raw ``TypeError`` out of one of them instead of that module's
+documented error type, and each translated PyYAML's own implicit-resolver
+``ValueError`` (an invalid timestamp-shaped scalar such as ``2023-99-99``)
+differently or not at all.
+
+This module owns the override once. :func:`load_strict_yaml` is the whole
+supported surface: it normalizes *every* malformed-document failure —
+syntax, duplicate key, unhashable key, out-of-range implicit scalar — into
+the caller's own documented exception type, built by the ``error`` callback,
+so each manifest format keeps its own error vocabulary without keeping its
+own parser.
+
+**Deliberately not used by** :mod:`abicheck.suppression_yaml`: a suppression
+document's duplicate key is *not* an error there. That format resolves YAML
+merge keys (``<<:``) and mirrors ``yaml.safe_load``'s own last-value-wins
+mapping semantics on purpose, because its raw-node pass has to agree,
+index for index, with the mapping ``safe_load`` actually built. Rejecting a
+repeat there would change the format's accepted input, not just its
+diagnostics — so it stays on the plain ``SafeLoader`` and is out of scope
+for this consolidation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import yaml
+
+
+class StrictMappingError(Exception):
+    """A mapping this loader refuses: a duplicate or unhashable key.
+
+    Raised from inside PyYAML's construction pass and caught by
+    :func:`load_strict_yaml`, which re-raises it as the caller's own
+    exception type. Deliberately *not* a ``yaml.YAMLError``: these are
+    schema violations with a precise, one-line message of our own, and
+    routing them through PyYAML's error vocabulary would bury that message
+    in a multi-line ``ConstructorError`` context/mark dump.
+    """
+
+
+def _construct_strict_mapping(
+    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    """``SafeConstructor.construct_mapping`` plus two rejections.
+
+    A **duplicate** key is the gap this loader exists to close. An
+    **unhashable** key (a sequence or mapping used as a key, which PyYAML's
+    own ``SafeConstructor`` already rejects) must be re-checked here rather
+    than inherited, because this override replaces that constructor
+    outright: without the check, ``key in mapping`` raises a bare
+    ``TypeError`` that escapes every caller's documented error contract --
+    which is exactly how the three copies of this override diverged.
+    """
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=True)
+        line = key_node.start_mark.line + 1
+        try:
+            hash(key)
+        except TypeError as exc:
+            raise StrictMappingError(
+                f"unhashable mapping key {key!r} (line {line}): {exc}"
+            ) from exc
+        if key in mapping:
+            raise StrictMappingError(
+                f"duplicate key {key!r} in the same mapping (line {line})"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=True)
+    return mapping
+
+
+class StrictYamlLoader(yaml.SafeLoader):
+    """``yaml.SafeLoader`` with :func:`_construct_strict_mapping` installed.
+
+    A real ``SafeLoader`` subclass that only replaces the mapping
+    constructor — it adds no tag, so it resolves and constructs exactly the
+    safe scalar/sequence/mapping vocabulary ``yaml.safe_load`` does.
+    """
+
+
+StrictYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_strict_mapping
+)
+
+
+def load_strict_yaml(text: str, *, error: Callable[[str], Exception]) -> Any:
+    """Parse *text* as YAML under :class:`StrictYamlLoader`.
+
+    Every malformed-document failure is raised as ``error(message)``:
+
+    * a syntax error (``yaml.YAMLError``);
+    * a duplicate mapping key, or an unhashable one (both
+      :class:`StrictMappingError`, whose one-line message is passed through
+      verbatim);
+    * a bare ``ValueError`` from PyYAML's own implicit-resolver scalar
+      constructors — a timestamp-shaped scalar with an out-of-range
+      component (``2023-99-99``) is resolved to the timestamp tag by the
+      *resolver*, before construction reaches this loader's override at all,
+      and its built-in constructor raises a plain ``ValueError`` that is not
+      a ``yaml.YAMLError``.
+
+    A ``RecursionError`` from a pathologically nested document is
+    deliberately **not** translated: it is a resource limit rather than a
+    schema violation, and the one caller that surfaces it to a user
+    (``workflows.bundle_facts_library_overrides``) needs its own message for
+    it.
+    """
+    try:
+        # `StrictYamlLoader` subclasses `yaml.SafeLoader` and only replaces
+        # its mapping constructor; bandit's B506 flags every `Loader=` it
+        # cannot name-match against `SafeLoader`/`CSafeLoader`, subclasses
+        # included.
+        return yaml.load(text, Loader=StrictYamlLoader)  # nosec B506
+    except StrictMappingError as exc:
+        raise error(str(exc)) from exc
+    except yaml.YAMLError as exc:
+        raise error(f"invalid YAML: {exc}") from exc
+    except ValueError as exc:
+        raise error(f"invalid YAML scalar: {exc}") from exc

--- a/abicheck/suppression_yaml.py
+++ b/abicheck/suppression_yaml.py
@@ -15,6 +15,18 @@
 """Raw-scalar YAML helpers for ``suppression.py``, split out to stay under
 the file-size cap (CLAUDE.md). No dependency on ``suppression.py`` itself,
 so the import direction stays one-way.
+
+**Deliberately does not use** :mod:`abicheck.model.yaml_strict`, the strict
+loader every hard-load-error *manifest* format here shares. A suppression
+document's duplicate key is not an error: this format resolves YAML merge
+keys (``<<:``) and follows ``yaml.safe_load``'s own last-value-wins mapping
+semantics on purpose, because the raw-node pass below has to agree, index
+for index and value for value, with the mapping ``safe_load`` actually
+built (see :func:`_raw_node_lookup`'s direct-over-merged precedence rules).
+Swapping in the strict loader would change which suppression files load at
+all -- a change to the accepted input of a user-facing format, not a
+diagnostics cleanup -- so it stays on the plain ``SafeLoader`` and is out of
+scope for that consolidation.
 """
 
 from __future__ import annotations

--- a/abicheck/workflows/bundle_facts_library_overrides.py
+++ b/abicheck/workflows/bundle_facts_library_overrides.py
@@ -71,6 +71,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..compile_context import CompileContext
+from ..model.yaml_strict import load_strict_yaml
 
 #: Recognized keys inside one library's own mapping. The compile-context
 #: fields mirror `CompileContext`'s own field names exactly (rather than the
@@ -345,12 +346,10 @@ def load_bundle_facts_library_overrides(
 
     The file-reading counterpart of :func:`parse_bundle_facts_library_overrides`
     above, kept in this ``workflows``-classified module rather than the
-    ``frontends``-layer CLI dispatch code that calls it (Codex review):
-    ``dump_manifest`` (the ``_load_yaml_strict`` duplicate-key-checking YAML
-    loader below, shared with ``--dump-manifest``) is classified ``extract``,
-    and ``frontends`` may not import ``extract`` directly
-    (``architecture/modules.yaml``'s ``may_import: [model, workflows,
-    report]``) -- only ``workflows`` may. Threads the manifest's own resolved
+    ``frontends``-layer CLI dispatch code that calls it (Codex review).
+    Strict parsing itself is :mod:`abicheck.model.yaml_strict`, the one
+    duplicate-key-checking loader ``--dump-manifest`` and every other
+    hard-load-error manifest format here share. Threads the manifest's own resolved
     parent directory through as *base_dir*, so a relative ``headers``/
     ``includes``/``sysroot`` path inside the manifest anchors to the manifest
     file itself rather than the calling process's current working directory.
@@ -360,16 +359,11 @@ def load_bundle_facts_library_overrides(
     document, or any schema violation :func:`parse_bundle_facts_library_overrides`
     itself raises.
     """
-    from ..dump_manifest import _load_yaml_strict
-    from ..errors import ManifestValidationError
-
     try:
-        raw = _load_yaml_strict(
-            manifest_path.read_text(encoding="utf-8"), source=str(manifest_path)
-        )
+        text = manifest_path.read_text(encoding="utf-8")
     except UnicodeDecodeError as exc:
         # Codex review, fresh evidence: a manifest file containing invalid
-        # UTF-8 raises here, before _load_yaml_strict ever runs -- and
+        # UTF-8 raises here, before parsing ever runs -- and
         # UnicodeDecodeError is a ValueError subclass, so without this it
         # was still caught, but by dispatch()'s generic ``except
         # (SnapshotError, ValueError, OSError)`` clause, exiting 1 instead
@@ -378,29 +372,27 @@ def load_bundle_facts_library_overrides(
         raise BundleFactsLibraryOverridesError(
             f"--bundle-facts-library-manifest {manifest_path}: cannot decode as UTF-8: {exc}"
         ) from exc
-    except ManifestValidationError as exc:
-        raise BundleFactsLibraryOverridesError(
-            f"--bundle-facts-library-manifest {manifest_path}: {exc}"
-        ) from exc
-    except TypeError as exc:
-        # Codex review, fresh evidence: a syntactically valid YAML mapping
-        # can use a non-scalar (list/dict) node as a *key* -- e.g.
-        # `? [a, b]\n: 1`. `_load_yaml_strict`'s own duplicate-key set
-        # (`seen: set[Any] = set(); key in seen; seen.add(key)`) raises a
-        # raw, untranslated `TypeError: unhashable type` for that, before
-        # parse_bundle_facts_library_overrides() ever runs its own
-        # non-string-key check below -- and dispatch()'s CLI boundary
-        # catches ValueError, not TypeError, so this previously leaked a
-        # traceback instead of the clean exit-64 usage error every other
-        # malformed manifest input here produces.
-        raise BundleFactsLibraryOverridesError(
-            f"--bundle-facts-library-manifest {manifest_path}: invalid YAML: {exc}"
-        ) from exc
+
+    # A duplicate mapping key, an unhashable (sequence/mapping) key -- e.g.
+    # `? [a, b]\n: 1`, which an earlier hand-rolled duplicate-key set turned
+    # into a raw `TypeError` -- an out-of-range implicit scalar, and a
+    # syntax error all arrive as BundleFactsLibraryOverridesError:
+    # `load_strict_yaml` normalizes every malformed-document failure into
+    # the caller's own error type, so none of them can reach dispatch()'s
+    # CLI boundary (which catches ValueError, not TypeError) as a raw
+    # traceback.
+    try:
+        raw = load_strict_yaml(
+            text,
+            error=lambda message: BundleFactsLibraryOverridesError(
+                f"--bundle-facts-library-manifest {manifest_path}: {message}"
+            ),
+        )
     except RecursionError as exc:
         # Codex review, fresh evidence: a well-formed but sufficiently
         # deeply nested manifest (~1,500 nested sequences reproduces it)
         # exhausts Python's own recursion limit inside PyYAML's/
-        # _load_yaml_strict's recursive-descent parsing, before this
+        # `load_strict_yaml`'s recursive-descent parsing, before this
         # function's own translation layer or parse_bundle_facts_library_
         # overrides() ever run -- and dispatch()'s CLI boundary catches
         # ValueError, not RecursionError, so this previously leaked a raw

--- a/changelog.d/1789000000_claude_strict-yaml-loader-consolidation.md
+++ b/changelog.d/1789000000_claude_strict-yaml-loader-consolidation.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **One strict YAML manifest loader.** The three independent
+  duplicate-key-checking `yaml.SafeLoader` subclasses in `dump_manifest.py`,
+  `compatibility_evaluation_packs.py`, and `impact/use_cases.py` are replaced
+  by a single shared primitive, `abicheck.model.yaml_strict.load_strict_yaml`.
+  The copies had already diverged, so two malformed-manifest cases now report
+  correctly where they previously did not: a sequence/mapping used as a
+  mapping key (`? [a, b]` / `--bundle-facts-library-manifest`, `--dump-manifest`)
+  raised a raw `TypeError` instead of the command's own manifest error, and
+  an out-of-range implicit scalar (`2023-99-99`) escaped `--dump-manifest`'s
+  error contract as a bare `ValueError`. Every malformed document — syntax
+  error, duplicate key, unhashable key, invalid implicit scalar — now reaches
+  the user as that manifest format's documented error type. Suppression files
+  are deliberately unaffected: their format resolves YAML merge keys and keeps
+  `safe_load`'s last-value-wins semantics on purpose.

--- a/tests/test_bundle_facts_library_overrides.py
+++ b/tests/test_bundle_facts_library_overrides.py
@@ -365,7 +365,9 @@ class TestLoadBundleFactsLibraryOverrides:
         manifest = tmp_path / "manifest.yaml"
         manifest.write_text("libreal.so:\n  ? [a, b]\n  : 1\n")
 
-        with pytest.raises(BundleFactsLibraryOverridesError, match="invalid YAML"):
+        with pytest.raises(
+            BundleFactsLibraryOverridesError, match="unhashable mapping key"
+        ):
             load_bundle_facts_library_overrides(manifest)
 
     def test_invalid_utf8_manifest_is_a_clean_error(self, tmp_path: Path) -> None:

--- a/tests/test_cli_compare_bundle_facts_manifest.py
+++ b/tests/test_cli_compare_bundle_facts_manifest.py
@@ -330,10 +330,14 @@ class TestBundleFactsLibraryManifest:
     def test_unhashable_yaml_key_is_a_clean_usage_error(self, tmp_path: Path) -> None:
         """Codex review, fresh evidence: a syntactically valid YAML mapping
         can use a non-scalar (list) node as a key (``? [a, b]\\n: 1``),
-        which raises a raw, untranslated ``TypeError`` inside the
+        which raised a raw, untranslated ``TypeError`` inside the
         duplicate-key-checking loader -- confirm it now surfaces as the
         same clean exit-64 usage error every other malformed manifest here
-        produces, all the way through the real CLI."""
+        produces, all the way through the real CLI.
+
+        The shared strict loader (:mod:`abicheck.model.yaml_strict`) names
+        the offending key rather than reporting a generic "invalid YAML",
+        so the message assertion below is on that wording."""
         old_dir = tmp_path / "old"
         new_dir = tmp_path / "new"
         old_dir.mkdir()
@@ -359,7 +363,7 @@ class TestBundleFactsLibraryManifest:
         )
 
         assert code == 64, out
-        assert "invalid YAML" in out
+        assert "unhashable mapping key" in out
 
     def test_per_library_headers_reach_compare_release_against_bundle_facts(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -215,7 +215,7 @@ def test_load_use_case_manifest_wraps_a_yaml_syntax_error(tmp_path: Path) -> Non
     exception type for any invalid manifest."""
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("- use_case: [unterminated flow sequence\n")
-    with pytest.raises(UseCaseManifestError, match="invalid YAML syntax"):
+    with pytest.raises(UseCaseManifestError, match="invalid YAML"):
         load_use_case_manifest(manifest)
 
 
@@ -237,10 +237,12 @@ def test_load_use_case_manifest_wraps_an_invalid_timestamp_scalar(
     with an invalid component (no such month) makes PyYAML's own
     timestamp constructor raise a bare ValueError, not a yaml.YAMLError --
     a document shape neither the syntax nor the UTF-8 guard catches
-    (Codex review, fresh evidence)."""
+    (Codex review, fresh evidence). Translated by the shared
+    ``yaml_strict`` loader since the three copies of that translation were
+    consolidated."""
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("- use_case: 2023-99-99\n")
-    with pytest.raises(UseCaseManifestError, match="invalid scalar value"):
+    with pytest.raises(UseCaseManifestError, match="invalid YAML scalar"):
         load_use_case_manifest(manifest)
 
 
@@ -275,7 +277,7 @@ def test_load_use_case_manifest_wraps_an_unhashable_key(tmp_path: Path) -> None:
     constructor already performs."""
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("- {[a, b]: x}\n")
-    with pytest.raises(UseCaseManifestError, match="unhashable key"):
+    with pytest.raises(UseCaseManifestError, match="unhashable mapping key"):
         load_use_case_manifest(manifest)
 
 

--- a/tests/test_yaml_strict.py
+++ b/tests/test_yaml_strict.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for :mod:`abicheck.model.yaml_strict`, the one strict
+manifest loader ``dump_manifest``/``compatibility_evaluation_packs``/
+``impact.use_cases``/``bundle_facts_library_overrides`` share.
+
+Written as *invariants over generated documents* rather than a handful of
+fixed strings, per AGENTS.md's "Primitive-level property tests" rule: this
+is a reusable, general-purpose parsing primitive, and the three private
+copies it replaced diverged precisely in cases nobody had written a fixed
+example for (an unhashable key raised a raw ``TypeError`` out of one of
+them; an out-of-range implicit scalar escaped another's documented error
+type). The oracle for acceptance is ``yaml.safe_load`` — a genuinely
+independent second implementation, not the function under test — and the
+oracle for rejection is a *constructed* duplicate/unhashable key, not a
+re-derivation of the loader's own check.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from hypothesis import given, settings, strategies as st
+
+from abicheck.model.yaml_strict import StrictMappingError, load_strict_yaml
+
+
+class _Boom(Exception):
+    """The domain error type a caller supplies via ``error=``."""
+
+
+def _load(text: str) -> object:
+    return load_strict_yaml(text, error=_Boom)
+
+
+# --- Acceptance: identical to yaml.safe_load for any duplicate-free document
+
+
+_SCALARS = st.one_of(
+    st.integers(),
+    st.booleans(),
+    st.text(alphabet="abcxyz-_ ", min_size=0, max_size=8),
+    st.none(),
+)
+
+_KEYS = st.text(alphabet="abcdefgh", min_size=1, max_size=4)
+
+_DOCS = st.recursive(
+    _SCALARS,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.dictionaries(_KEYS, children, max_size=4),
+    ),
+    max_leaves=12,
+)
+
+
+@settings(max_examples=200, deadline=None)
+@given(document=_DOCS)
+def test_accepts_and_decodes_every_duplicate_free_document_like_safe_load(
+    document: object,
+) -> None:
+    """The strict loader narrows *which documents are accepted* only by the
+    duplicate/unhashable-key rule. For everything else it must be
+    ``yaml.safe_load`` — same acceptance, same decoded value.
+
+    ``yaml.safe_dump`` never emits a repeated key, so every document this
+    generates is in the accepted set by construction; the oracle is PyYAML
+    itself rather than a second call into the code under test.
+    """
+    text = yaml.safe_dump(document, default_flow_style=False, sort_keys=False)
+    assert _load(text) == yaml.safe_load(text)
+
+
+# --- Rejection: a duplicate key anywhere, at any nesting depth
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    depth=st.integers(min_value=0, max_value=4),
+    key=_KEYS,
+)
+def test_rejects_a_duplicate_key_at_any_nesting_depth(depth: int, key: str) -> None:
+    """A repeat is an error wherever it appears — not only at the top level,
+    which is the one place a fixed-example test would have pinned.
+
+    The document is built by nesting the offending mapping under *depth*
+    enclosing mappings, and the control assertion below proves the same
+    document without the repeat parses fine, so the failure can only be
+    attributable to the duplicate key itself.
+    """
+    prefix = "".join(f"{'  ' * i}k{i}:\n" for i in range(depth))
+    pad = "  " * depth
+    duplicated = f"{prefix}{pad}{key}: 1\n{pad}{key}: 2\n"
+    clean = f"{prefix}{pad}{key}: 1\n{pad}{key}2: 2\n"
+
+    assert _load(clean) is not None  # control: the shape itself is accepted
+    with pytest.raises(_Boom, match="duplicate key"):
+        _load(duplicated)
+    # yaml.safe_load is the thing being *improved on*: it accepts it silently.
+    assert yaml.safe_load(duplicated) is not None
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    key=_KEYS,
+    values=st.lists(st.integers(), min_size=2, max_size=5, unique=True),
+)
+def test_rejects_a_repeat_regardless_of_how_many_times_or_which_values(
+    key: str, values: list[int]
+) -> None:
+    """Repetition count and value spelling never make a repeat acceptable —
+    an invariant the "two identical lines" example cannot state."""
+    text = "".join(f"{key}: {value}\n" for value in values)
+    with pytest.raises(_Boom, match="duplicate key"):
+        _load(text)
+
+
+def test_a_repeat_across_two_sibling_mappings_is_not_a_duplicate() -> None:
+    """The rule is *within one mapping*, not document-wide: the same key
+    under two different parents is ordinary, valid YAML. Without this the
+    invariant above could be satisfied by a loader that rejects far too
+    much."""
+    assert _load("a:\n  k: 1\nb:\n  k: 2\n") == {"a": {"k": 1}, "b": {"k": 2}}
+
+
+# --- Rejection: an unhashable key, the divergence between the old copies
+
+
+@pytest.mark.parametrize(
+    "key_text",
+    ["[a, b]", "{a: 1}", "[[a]]", "[]", "{}"],
+    ids=["sequence", "mapping", "nested-sequence", "empty-sequence", "empty-mapping"],
+)
+def test_rejects_every_shape_of_unhashable_key(key_text: str) -> None:
+    """A non-scalar mapping key is a schema violation reported through the
+    caller's error type — never a raw ``TypeError``, which is what one of
+    the three replaced copies leaked (``key in seen`` on a list).
+
+    Enumerated over the whole small domain of unhashable YAML node shapes
+    rather than the one ``? [a, b]`` case that was originally reported.
+    """
+    with pytest.raises(_Boom, match="unhashable mapping key"):
+        _load(f"? {key_text}\n: 1\n")
+
+
+# --- Every malformed-document failure reaches the caller as *their* type
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a: [1, 2\n",  # syntax error
+        "\ta: 1\n",  # tab indentation
+        "a: 1\na: 2\n",  # duplicate key
+        "? [a, b]\n: 1\n",  # unhashable key
+        "a: 2023-99-99\n",  # implicit timestamp, out of range (bare ValueError)
+        "a: 2023-01-01T99:99:99\n",  # implicit timestamp, out-of-range time
+        "a: !!python/object:os.system {}\n",  # unsafe tag: SafeLoader rejects
+        "*missing\n",  # undefined alias
+    ],
+    ids=[
+        "syntax",
+        "tab-indent",
+        "duplicate-key",
+        "unhashable-key",
+        "bad-date",
+        "bad-time",
+        "unsafe-tag",
+        "undefined-alias",
+    ],
+)
+def test_no_malformed_document_escapes_as_a_foreign_exception_type(text: str) -> None:
+    """The single promise every caller relies on: one error type out, for
+    every class of malformed input — including the two that are *not*
+    ``yaml.YAMLError`` subclasses (a duplicate/unhashable key and PyYAML's
+    own implicit-resolver ``ValueError``), which is exactly where the three
+    private copies disagreed with each other."""
+    with pytest.raises(_Boom):
+        _load(text)
+
+
+def test_the_error_factory_receives_a_message_and_its_result_is_raised() -> None:
+    """``error`` is a factory, not an exception class: the loader must call
+    it with a human-readable message and raise what it returns, so a caller
+    can prefix the message with its own source/path context."""
+    seen: list[str] = []
+
+    def factory(message: str) -> Exception:
+        seen.append(message)
+        return _Boom(f"prefix: {message}")
+
+    with pytest.raises(_Boom, match=r"prefix: duplicate key 'a' in the same mapping"):
+        load_strict_yaml("a: 1\na: 2\n", error=factory)
+    assert len(seen) == 1
+
+
+def test_duplicate_and_unhashable_messages_name_the_offending_line() -> None:
+    """The line number is what makes the message actionable in a 200-line
+    manifest; assert it against a document whose offending line is
+    deliberately not line 1."""
+    with pytest.raises(_Boom, match=r"\(line 3\)"):
+        _load("head: 0\na: 1\na: 2\n")
+    with pytest.raises(_Boom, match=r"\(line 2\)"):
+        _load("head: 0\n? [a]\n: 1\n")
+
+
+def test_strict_mapping_error_is_not_a_yaml_error() -> None:
+    """A vacuity guard on the translation layer itself: if
+    ``StrictMappingError`` were a ``yaml.YAMLError`` subclass, the
+    ``except StrictMappingError`` arm's precise one-line message would be
+    indistinguishable from the generic "invalid YAML: ..." arm, and this
+    module's message tests would pass for the wrong reason."""
+    assert not issubclass(StrictMappingError, yaml.YAMLError)
+
+
+def test_a_recursion_error_is_deliberately_not_translated() -> None:
+    """A pathologically nested document exhausts Python's recursion limit
+    inside PyYAML's recursive-descent parser. That is a resource limit, not
+    a schema violation, and the caller that surfaces it to a user needs its
+    own message — so it must pass through untranslated."""
+    with pytest.raises(RecursionError):
+        _load("[" * 3000 + "]" * 3000)


### PR DESCRIPTION
## Summary

One strict, duplicate-key-checking YAML loader (`abicheck/model/yaml_strict.py`) replaces the three private `yaml.SafeLoader` subclasses that had accumulated in `dump_manifest.py`, `compatibility_evaluation_packs.py` and `impact/use_cases.py`.

## Motivation

The three copies had already **diverged**, and the divergences were real defects rather than style:

- Only two of the three checked key hashability, so a sequence/mapping used as a mapping key (`? [a, b]`) raised a raw `TypeError` out of `dump_manifest._load_yaml_strict` instead of `ManifestValidationError` — which `workflows/bundle_facts_library_overrides.py` then had to catch and translate by hand at its own call site.
- `--dump-manifest` never translated PyYAML's implicit-resolver `ValueError` (an out-of-range timestamp-shaped scalar such as `2023-99-99`), so that escaped its documented error contract too.
- The pack loader's own docstring recorded that it was copied from `dump_manifest.py` purely because that one was private.

The cleanup deletes the duplicated *implementation* while keeping the *protection* — plain `yaml.safe_load` silently accepts a repeated key with last-value-wins semantics, which is exactly what these formats must not do.

## Changes

- **New `abicheck/model/yaml_strict.py`** — `load_strict_yaml(text, error=...)` normalizes every malformed-document failure (syntax error, duplicate key, unhashable key, invalid implicit scalar) into the caller's own exception type, so each manifest format keeps its error vocabulary without keeping its parser. `StrictMappingError` carries a precise one-line message (`duplicate key 'a' in the same mapping (line 3)`) rather than PyYAML's multi-line `ConstructorError` dump. A `RecursionError` is deliberately left untranslated: it is a resource limit, and the one caller that surfaces it to a user has its own message for it. Placed in `model/` because it is a dependency-free leaf that `extract`, `policy`, `workflows` and `impact` all need.
- `dump_manifest.py`, `compatibility_evaluation_packs.py`, `impact/use_cases.py` now supply only their own error vocabulary (net −238 / +84 production lines).
- `workflows/bundle_facts_library_overrides.py` calls the shared loader directly instead of importing `dump_manifest`'s private `_load_yaml_strict` across a layer boundary, and its hand-rolled `TypeError` arm (and the docstring paragraph justifying the cross-layer reach) are gone.
- `suppression_yaml.py` is deliberately **unchanged**, with a docstring note saying why: a suppression document's duplicate key is not an error there. That format resolves YAML merge keys (`<<:`) and follows `safe_load`'s last-value-wins semantics on purpose, because its raw-node pass must agree index for index with the mapping `safe_load` actually built. Switching loaders would change which suppression files load at all — a change to a user-facing format's accepted input, not a diagnostics cleanup.
- `tests/test_yaml_strict.py`, `abicheck/model/AGENTS.md` routing row, changelog fragment.

Remaining copies, deliberately out of scope and named in the commit message: `scripts/pipeline_status_ledger.py` (dependency-free by design, and needs two distinct error types) and the identical pair in `scripts/catalog_subjects.py` / `catalog_classification.py`.

## Behavioral deltas (user-visible)

| Input | Before | After |
|---|---|---|
| Sequence/mapping used as a mapping key, `--dump-manifest` / `--bundle-facts-library-manifest` | raw `TypeError` (translated by hand in one caller only) | that manifest's own error, `unhashable mapping key [...] (line N)` |
| `2023-99-99`-style implicit scalar, `--dump-manifest` | bare `ValueError` | `ManifestValidationError: ... invalid YAML scalar: month must be in 1..12` |
| Same input, `impact-use-cases.yaml` | `invalid scalar value: ...` / `invalid YAML syntax: ...` | one shared wording: `invalid YAML scalar: ...` / `invalid YAML: ...` |

Acceptance is unchanged everywhere: no document that loaded before is rejected now, and none that was rejected now loads.

## Testing

`tests/test_yaml_strict.py` states the primitive's contract as invariants over generated documents rather than fixed strings, per AGENTS.md's "Primitive-level property tests" rule:

- **Acceptance**: 200 Hypothesis-generated documents round-tripped through `yaml.safe_dump`, asserted equal to `yaml.safe_load` — an independent oracle, not a second call into the code under test.
- **Rejection**: duplicates constructed at every nesting depth 0–4 with a paired clean-document control; repetition count and value spelling varied; the whole small domain of unhashable key shapes enumerated; a sibling-mapping repeat asserted *accepted*, so the invariant cannot be satisfied by a loader that rejects too much.
- **Translation**: eight malformed classes each asserted to arrive as the caller's own type, plus a vacuity guard that `StrictMappingError` is not a `yaml.YAMLError` (otherwise the precise-message tests would pass for the wrong reason).
- Two mutations were run against the suite and both fail it: removing the hashability check (7 failures) and disabling the duplicate check (11 failures).

Also run: `ruff check abicheck/ tests/` clean, `mypy abicheck/` clean (799 files), `scripts/check_architecture.py` and `scripts/check_ai_readiness.py` show only the three pre-existing `debt-no-growth` entries and the pre-existing ADR-049 `Verified:` receipt error (all present on `main` — verified by stashing). Targeted suites (dump-manifest, packs, use-cases, bundle-facts overrides, suppression, project-validate, pack application, every `-k yaml` test) pass; the full fast unit lane was still running at push time and the result will be reported on this PR.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py`
- [x] Docs updated if user-visible behaviour changed (`abicheck/model/AGENTS.md`; error-message deltas are in the changelog fragment)
- [ ] `pre-commit run --all-files` passes locally — ran the equivalent gates individually (see Testing); the repo is not currently `ruff format`-clean on files this PR does not touch
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJBQQfk7zXgj9X7Uk4o9B8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJBQQfk7zXgj9X7Uk4o9B8)_