### PR TITLE
fix(report): align RenderOptions.show_recommendation with render_output

### DIFF
--- a/abicheck/report/envelope.py
+++ b/abicheck/report/envelope.py
@@ -105,7 +105,7 @@ class RenderOptions:
     show_impact: bool = False
     demangle: bool = False
     follow_deps: bool = False
-    show_recommendation: bool = False
+    show_recommendation: bool = True
     require_complete_analysis: bool = False
     contract_evaluation: bool = False
 

--- a/abicheck/service_render.py
+++ b/abicheck/service_render.py
@@ -306,10 +306,14 @@ def _project_review(envelope: ReportEnvelope) -> str:
 def _project_markdown(envelope: ReportEnvelope) -> str:
     """The full Markdown report (and its ``md`` alias).
 
-    ``show_recommendation`` stays this projection's own presentation option
-    with its pre-removal Tier-2 default of ``False`` (CLI cleanup phase two,
-    PR 1) -- ``cli._render_output`` passes ``True`` explicitly, which is why
-    the CLI's output is unconditional without this default changing.
+    ``show_recommendation`` stays this projection's own presentation option,
+    read off the envelope. It defaults to ``True`` in both
+    :class:`~abicheck.report.envelope.RenderOptions` and ``render_output``
+    above, so building an envelope directly and calling ``render_output``
+    with the option omitted produce byte-identical output -- the two used to
+    disagree (``False`` here, ``True`` there), which meant a direct Tier-2
+    envelope caller silently lost the Release Recommendation section that
+    every real consumer gets.
 
     Gap-C disposition for Markdown's own remaining facts: ``severity_groups``'
     headed-section grouping is **presentation** over already-classified

--- a/changelog.d/20260912_225403_noreply_hopeful_volta_h46a24.md
+++ b/changelog.d/20260912_225403_noreply_hopeful_volta_h46a24.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `RenderOptions.show_recommendation` now defaults to `True`, matching
+  `render_output`'s own default. The two disagreed, so building a
+  `ReportEnvelope` directly and projecting it silently dropped the Release
+  Recommendation section that every consumer going through `render_output`
+  gets.

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -136,7 +136,7 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `version` | `str` | `''` |
 | `pdb` | `Path \| None` | `None` |
 | `debug_roots` | `tuple[Path, ...]` | `()` |
-| `include_dependencies` | `bool` | `True` |
+| `include_dependencies` | `bool` | `False` |
 | `sources` | `Path \| None` | `None` |
 | `build_info` | `Path \| None` | `None` |
 | `build_targets` | `tuple[str, ...]` | `()` |
@@ -360,8 +360,7 @@ Render comparison result in the requested output format.
 | `severity_config` | `SeverityConfig \| None` | `None` |
 | `demangle` | `bool` | `False` |
 | `contract_evaluation` | `bool` | `False` |
-| `stat` | `bool` | `False` |
-| `show_recommendation` | `bool` | `False` |
+| `show_recommendation` | `bool` | `True` |
 | `require_complete_analysis` | `bool` | `False` |
 
 **Returns:** `str`
@@ -409,7 +408,7 @@ Auto-detect input type and return an ABI snapshot.
 | `notify` | `Callable[[str], None] \| None` | `None` |
 | `include_labels` | `dict[Path, str] \| None` | `None` |
 | `dump_manifest` | `DumpManifest \| None` | `None` |
-| `include_dependencies` | `bool` | `True` |
+| `include_dependencies` | `bool` | `False` |
 | `public_include_search_dirs` | `list[Path] \| None` | `None` |
 
 **Returns:** `AbiSnapshot`
@@ -457,7 +456,7 @@ Compare two ABI inputs and return the classified diff result.
 | `debuginfod_url` | `str \| None` | `None` |
 | `diagnostic_comparison` | `bool` | `False` |
 | `contract_evaluation` | `bool` | `False` |
-| `include_dependencies` | `bool` | `True` |
+| `include_dependencies` | `bool` | `False` |
 | `contract_mode` | `str \| None` | `None` |
 | `pack_policy_overrides` | `dict[Any, Any] \| None` | `None` |
 | `pack_internal_namespaces` | `tuple[str, ...] \| None` | `None` |
@@ -512,7 +511,7 @@ Extract an ABI snapshot from a native binary (ELF, PE, or Mach-O).
 | `include_labels` | `dict[Path, str] \| None` | `None` |
 | `dump_manifest` | `DumpManifest \| None` | `None` |
 | `public_include_search_dirs` | `list[Path] \| None` | `None` |
-| `include_dependencies` | `bool` | `True` |
+| `include_dependencies` | `bool` | `False` |
 
 **Returns:** `AbiSnapshot`
 
@@ -535,5 +534,33 @@ Read a small header chunk and return ``'json'``, ``'perl'``, ``'symvers'``, or `
 | Parameter | Type | Default |
 |---|---|---|
 | `path` | `Path` | *(required)* |
+
+**Returns:** `str`
+
+## `to_stat`
+
+One-line summary for CI gates.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `result` | `DiffResult` | *(required)* |
+| *(keyword-only below)* | | |
+| `severity_config` | `SeverityConfig \| None` | `None` |
+
+**Returns:** `str`
+
+## `to_stat_json`
+
+JSON output for --stat mode: summary only, no changes array.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `result` | `DiffResult` | *(required)* |
+| `indent` | `int` | `2` |
+| *(keyword-only below)* | | |
+| `severity_config` | `SeverityConfig \| None` | `None` |
+| `require_complete_analysis` | `bool` | `False` |
+| `show_only` | `str \| None` | `None` |
+| `contract_evaluation` | `bool` | `False` |
 
 **Returns:** `str`

--- a/tests/test_dump_write_after_resolve_time_embed.py
+++ b/tests/test_dump_write_after_resolve_time_embed.py
@@ -176,6 +176,17 @@ def test_write_snapshot_output_accepts_a_resolve_time_embedded_snapshot(
             sources=tmp_path,
             build_info=compile_db,
             compile=CompileContext(frontend="clang"),
+            # Deliberately the NON-default value. Every front end now
+            # defaults `include_dependencies` to False (PR #1258), so a
+            # request that omits it reaches `_write_snapshot_output` already
+            # `filtered` -- and then the "did `resolve_dependency_scope`
+            # run?" contrast below compares `filtered` with `filtered` and
+            # holds no matter what that step does, which is exactly the
+            # vacuous differential AGENTS.md's "a differential test must
+            # prove both of its configurations actually ran" warns about.
+            # Asking for the unfiltered surface here keeps the two states
+            # genuinely distinct, so the flip is still real evidence.
+            include_dependencies=True,
         ),
         depth="source",
     )
@@ -194,7 +205,9 @@ def test_write_snapshot_output_accepts_a_resolve_time_embedded_snapshot(
     # (that step is `_write_snapshot_output`'s own, dump-CLI-only concern —
     # see the module docstring) -- ground truth for the assertion below,
     # so a flip from "full" is genuine evidence that step ran on this
-    # already-embedded snapshot, not a value it already carried in.
+    # already-embedded snapshot, not a value it already carried in. This
+    # holds only because the request above asks for the unfiltered surface
+    # explicitly; see the comment there for why that matters.
     assert snap.dependency_scope == "full"
 
     import abicheck.cli_buildsource as cli_buildsource

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -193,13 +193,19 @@ class TestResolveInput:
             resolve_input(p, is_elf=True, include_dependencies=False)
         assert mock.call_args.kwargs["include_dependencies"] is False
 
-    def test_include_dependencies_defaults_true(self, tmp_path):
+    def test_include_dependencies_defaults_to_the_filtered_surface(self, tmp_path):
+        # PR #1258: every typed entry point agrees with the CLI's own
+        # dependency-scoping default, so an omitted option cannot yield a
+        # `full` snapshot here and a `filtered` one from `abicheck dump`
+        # (which is a ScopeMismatchError with no verdict at compare time).
+        # The cross-surface invariant lives in
+        # tests/test_front_end_default_parity.py; this pins the one call.
         p = tmp_path / "lib.so"
         p.write_bytes(b"\x7fELF" + b"\x00" * 100)
         snap = AbiSnapshot(library="test", version="1.0")
         with patch("abicheck.workflows.input_resolution.run_dump", return_value=snap) as mock:
             resolve_input(p, is_elf=True)
-        assert mock.call_args.kwargs["include_dependencies"] is True
+        assert mock.call_args.kwargs["include_dependencies"] is False
 
     def test_resolve_input_no_longer_accepts_header_graph_kwargs(self, tmp_path):
         # G29 Phase A: header_graph/header_graph_includes are no longer


### PR DESCRIPTION
## Summary

Follow-up to [#1258](https://github.com/abicheck/abicheck/pull/1258), which merged before these fixes were pushed. Three things that change landed without: `RenderOptions.show_recommendation` left at `False` while `render_output`'s own default moved to `True`, a `docs/reference/python-api-reference.md` not regenerated for the new `to_stat`/`to_stat_json` exports, and a dependency-scope differential test that the defaults flip quietly made vacuous.

## Motivation

#1258 flipped `render_output`'s `show_recommendation` default to `True` so the function's documented behaviour ("the release recommendation is included in every human-facing format") is true for its own audience — a direct Tier-2 caller. But `render_output` builds a `ReportEnvelope`, and `RenderOptions.show_recommendation` stayed `False`. So the two documented entry points into the same projection disagreed:

- `render_output(fmt, result, old, new)` → Markdown **with** the Release Recommendation section.
- `render_envelope(fmt, build_report_envelope(...))`, option omitted → Markdown **without** it.

That is the same class of defect #1258 was about — two surfaces disagreeing about what *omitting* an option means — reintroduced one layer down. An existing test caught it: `tests/unit/report/test_build_report_document.py::TestRendererOrderIndependence::test_envelope_projection_matches_render_output_byte_for_byte`, which exists precisely to stop these two drifting. 20 parametrizations failed.

## Changes

- `abicheck/report/envelope.py` — `RenderOptions.show_recommendation` now defaults to `True`.
- `abicheck/service_render.py` — `_project_markdown`'s docstring stated the old `False` default as deliberate; it now records the alignment and why the mismatch mattered.
- `docs/reference/python-api-reference.md` — regenerated (`python scripts/gen_python_api_reference.py`). `tests/test_python_api_reference.py` fails on current `main` without this: `to_stat`/`to_stat_json` are in `abicheck.service.__all__` but absent from the reference, which also still recorded `include_dependencies` as defaulting to `True`.
- `tests/test_service_unit.py` — `resolve_input`'s `include_dependencies` default test renamed and flipped to `False`, matching the surface alignment #1258 landed, pointing at `tests/test_front_end_default_parity.py` for the cross-surface invariant.
- `tests/test_dump_write_after_resolve_time_embed.py` — **a second, subtler consequence of the same flip.** `test_write_snapshot_output_accepts_a_resolve_time_embedded_snapshot` asserted `snap.dependency_scope == "full"` before calling `_write_snapshot_output`, and `payload["dependency_scope"] == "filtered"` after; the contrast *is* the test — it is how the test knows `resolve_dependency_scope` ran. Post-flip `execute_dump_request` already returns `filtered`, so both ends read `filtered` and the assertion held no matter what that step did. Changing the expected string would have left a green test proving nothing — the failure mode `AGENTS.md` describes under "a differential test must prove both of its configurations actually ran". The request now asks for the unfiltered surface explicitly, keeping the two states distinct, with the non-default value documented as load-bearing. **Confirmed non-vacuous by deleting the `resolve_dependency_scope` call:** the restored test fails, and passes again when restored; before the fix that same deletion passed.

## Bug-fix test contract

- Bug class: `config.front_end_default_divergence` (`tests/regressions/manifest.py`) — two front ends onto one operation disagreeing about what *omitting* an option means, so nothing is stated anywhere and every propagation test passes.
- Publicly observable failure: `render_envelope("markdown", build_report_envelope(...))` omits the `## Release Recommendation` section that `render_output("markdown", ...)` on the same comparison emits.
- Regression test fails on base: yes — `tests/unit/report/test_build_report_document.py::TestRendererOrderIndependence::test_envelope_projection_matches_render_output_byte_for_byte` fails in 20 parametrizations on the base commit and passes here. No new test was needed; the existing invariant already covered the class.
- Negative control: `show_recommendation=False` still suppresses the section through both entry points (asserted by the same file's existing per-option tests, which pass unchanged).
- Public-surface test: yes — the assertion compares the two public entry points' rendered output byte for byte, not an internal struct.
- Axes covered: all four `_CHANGE_COMBINATIONS` change sets × three option sets (`plain`, `show_only`, `impact`) × every format in `_FORMATS`.
- General invariant: `render_output` is exactly "build one envelope, project it" — asserted as byte equality across that whole product rather than for one option or format, so any future option that one entry point threads and the other ignores fails here too. The oracle is the *other* entry point's real output, not a re-derivation of either's formatting.

## Verification

| check | result |
|---|---|
| `tests/unit/report/`, `test_python_api_reference.py`, `test_service_unit.py`, `test_front_end_default_parity.py` | 515 passed |
| integration lane (`-m integration`, real castxml) | the one failure caused by this change fixed; see below |
| `mypy abicheck/` | clean, 798 files |
| `ruff check abicheck/ tests/` | clean |
| `python scripts/check_architecture.py` | 0 errors, no baseline raised |
| `python scripts/check_ai_readiness.py` | 0 errors |
| `scripts/check_bugfix_test_contract.py` (both halves, real body) | OK |

### CI state: every remaining failure is pre-existing

| lane | result |
|---|---|
| `unit-tests (macos-latest, 3.13)` | 11 failed, **45,329 passed** |
| `unit-tests (windows-latest, 3.13)` | 13 failed, **44,774 passed** |
| everything else in the run | success or skipped |

All 24 belong to the `action/run.sh` release-operand breakage introduced by `65473b26` (#1260), which made `_is_release_style_operand` consult the installed `abicheck.package.is_package()` first and treat a definite "no" as final — while the fixtures are zero-byte files that content-based detection correctly reports as non-packages. Diagnosis, a verified patch sketch, and the open semantics question are in the comments; I have not fixed it here, because it is another PR's CLI-surface migration and the "empty suffix-named file vs. content decides" call is its author's.

Two scope notes worth carrying: the Windows leg fails on **strictly more** than the Linux leg (13 vs 11 — two extra in `tests/test_action_release_operand_detection.py`, which pass on Linux), so a Linux-only fix will leave `windows-latest` red. And a `Baseline regression (PR vs base)` failure on an earlier sha was investigated and is a **measurement artifact**: head and base are timed sequentially on one runner, and local measurement reproduces CI's baselines to within 1–2% while showing head equal to base — details in the comments.

## Checklist

- [x] Tests added / updated for new behaviour — the existing invariant already covered the report class; two tests updated, one of them to restore a differential the flip had made vacuous
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — generated Python API reference
- [ ] `pre-commit run --all-files` passes locally — individual gates run directly, see table above
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BYuG83u8jFkGVn5JXwvMD