### PR TITLE
fix: resolve file-backed stored snapshot members in bundle analysis

### DIFF
--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -69,8 +69,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, cast
 
 from .bundle_detector_heuristics import (  # noqa: F401  (re-exported for back-compat)
     _build_demangled_index as _build_demangled_index,
@@ -265,26 +265,37 @@ def build_bundle_snapshot_mixed(libraries: dict[str, Path]) -> BundleSnapshot:
     stored_paths: dict[str, Path] = {}
     extra_aliases: dict[str, tuple[str, ...]] = {}
     alias_nodes_so_far = 0
+    # A file-backed member is read once, for both halves of its evidence:
+    # re-reading to recover the filename separately would decompress a
+    # multi-gigabyte header-depth snapshot twice.
+    file_backed_filenames: dict[str, Path] = {}
     for name, path in stored.items():
-        elf = _stored_elf_metadata(path)
+        if path.is_dir():
+            elf = _stored_elf_metadata(path)
+        else:
+            elf, recovered = _stored_file_snapshot_evidence(path)
+            if recovered is not None:
+                file_backed_filenames[name] = recovered
         if elf is None:
             continue
         metadata[name] = elf
-        # `_stored_library_identity` reads a directory-backed package's own
-        # `ArtifactRef.native_identity`; a file-backed stored snapshot has no
-        # such ref document, so its real filename/aliases are simply not
-        # recorded evidence -- the same "a stored package produced by
-        # something else may not carry it" degrade that function already
-        # documents, not a new failure mode. `ElfMetadata.soname` (which a
-        # file-backed member does carry) stays available to
-        # `_detect_soname_skew`; only its no-`DT_SONAME` filename fallback is
-        # unavailable for this operand shape.
+        # Two readers, one contract. A directory-backed package records its
+        # identity in `ArtifactRef.native_identity`; a file-backed snapshot
+        # has no ref document but records `AbiSnapshot.library`, which every
+        # platform dumper sets to the artifact's own `Path.name`. Both routes
+        # recover the real filename, because without it a canonicalized
+        # bundle key is all `build_bundle_snapshot_from_metadata` has to
+        # synthesize a path from, and a sibling's `DT_NEEDED` naming the
+        # versioned filename verbatim stops resolving (see
+        # `_stored_file_snapshot_evidence`'s docstring). Filesystem *aliases*
+        # remain directory-only: a loose snapshot records no alias set, which
+        # is an absent-evidence degrade, not a failure.
         if path.is_dir():
             real_filename, aliases, alias_nodes_so_far = _stored_library_identity(
                 path, alias_nodes_so_far
             )
         else:
-            real_filename, aliases = None, ()
+            real_filename, aliases = file_backed_filenames.get(name), ()
         if real_filename is not None:
             stored_paths[name] = real_filename
         if aliases:
@@ -385,9 +396,51 @@ def _is_stored_member(path: Path) -> bool:
     return _looks_like_stored_snapshot_file(path)
 
 
-def _stored_file_elf_metadata(path: Path) -> ElfMetadata | None:
+def _stored_document_library_filename(document: dict[str, Any]) -> Path | None:
+    """The real on-disk library filename a stored snapshot document recorded
+    (`AbiSnapshot.library`), or `None` when it records nothing usable.
+
+    Treated as untrusted content, because it is: the value is whatever a
+    document on disk claims. Only a bare basename is accepted -- anything
+    carrying a directory separator, a parent reference, or a drive/root is
+    rejected rather than normalized, since this value lands in
+    `build_bundle_snapshot_from_metadata`'s `paths` mapping. That mapping is
+    never filesystem-probed for a stored member (`build_bundle_snapshot_
+    mixed` passes `probe_filesystem_names=frozenset(live)` precisely so a
+    stored member's recovered name is never resolved against the caller's
+    own cwd), so this is defence in depth rather than the only guard -- but
+    a name that can only ever be compared against a `DT_NEEDED` string has
+    no legitimate reason to contain a path at all.
+    """
+    raw = document.get("library")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    candidate = raw.strip()
+    if "/" in candidate or "\\" in candidate:
+        return None
+    if candidate in {".", ".."} or PurePosixPath(candidate).name != candidate:
+        return None
+    return Path(candidate)
+
+
+def _stored_file_snapshot_evidence(
+    path: Path,
+) -> tuple[ElfMetadata | None, Path | None]:
     """`_stored_elf_metadata`'s file-backed half: the `ElfMetadata` of a
-    loose stored snapshot document.
+    loose stored snapshot document, plus the real on-disk library filename
+    that document recorded.
+
+    The filename is this half's counterpart to `_stored_library_identity`'s
+    `ArtifactRef.native_identity` lookup, and it is load-bearing for the same
+    reason: a release key is canonicalized (`libprov.so.1.abicheck.json` ->
+    `libprov.so`), so without a recovered filename
+    `build_bundle_snapshot_from_metadata` synthesizes `Path(<bundle key>)`,
+    `soname_to_name` never contains the versioned `libprov.so.1` a sibling's
+    `DT_NEEDED` names verbatim, and that real intra-bundle edge is
+    misclassified as an external dependency -- silently dropping the
+    provider-migration and removal findings that depend on reachability
+    (Codex review, PR #1269). `AbiSnapshot.library` carries exactly this: every
+    platform dumper sets it to the artifact's own `Path.name`.
 
     Reads through `snapshot_io.read_snapshot_text` (the canonical storage
     envelope reader -- plain/gzip/zstd by magic bytes, with the
@@ -402,9 +455,11 @@ def _stored_file_elf_metadata(path: Path) -> ElfMetadata | None:
     `document["elf"]` without unwrapping would find nothing and report every
     modern snapshot as "no ELF metadata present".
 
-    Returns `None` -- never raises -- for anything that doesn't parse,
-    matching the sibling half's (and `build_bundle_snapshot`'s) own
-    "unresolvable member is skipped, not fatal" contract.
+    Returns `(None, None)` -- never raises -- for anything that doesn't
+    parse, matching the sibling half's (and `build_bundle_snapshot`'s) own
+    "unresolvable member is skipped, not fatal" contract. A recovered
+    filename absent or unusable is `None` on its own, which
+    `build_bundle_snapshot_from_metadata` already degrades from.
     """
     import json
 
@@ -414,14 +469,45 @@ def _stored_file_elf_metadata(path: Path) -> ElfMetadata | None:
         from_sectioned_document,
         is_sectioned_document,
     )
+    from .storage.snapshot_schema_versions import (
+        _MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION,
+        SCHEMA_VERSION as SNAPSHOT_SCHEMA_VERSION,
+    )
 
     try:
         document = json.loads(read_snapshot_text(path))
         if not isinstance(document, dict):
             log.debug("bundle: stored snapshot %s is not a JSON object", path)
-            return None
+            return None, None
         if is_sectioned_document(document):
             document = from_sectioned_document(document)
+        schema_version = int(document.get("schema_version", 1))
+        # ADR-050 D1's hard-rejection ceiling, applied *before* decoding --
+        # the same rule `storage.snapshot_codec.decode_snapshot` enforces for
+        # every snapshot read through `serialization.load_snapshot`, and that
+        # `storage.import_v1` enforces for the directory-backed half via its
+        # required `max_known_schema_version`. Reading the `elf` section
+        # directly bypassed both, so a document written by a newer abicheck --
+        # which may carry verdict-blocking fields this reader has no code path
+        # for -- was admitted into the bundle graph on partially interpreted
+        # evidence, even when its own per-library comparison had already been
+        # refused as incomparable (Codex review, PR #1269). Unresolved rather
+        # than raised: an unusable member is skipped, the contract the rest of
+        # this function keeps.
+        if (
+            schema_version > SNAPSHOT_SCHEMA_VERSION
+            and schema_version >= _MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION
+        ):
+            log.warning(
+                "bundle: stored snapshot %s declares schema_version %d, newer "
+                "than this abicheck supports (%d) -- it cannot participate in "
+                "bundle-level analysis. Upgrade abicheck to read it.",
+                path,
+                schema_version,
+                SNAPSHOT_SCHEMA_VERSION,
+            )
+            return None, None
+        library_filename = _stored_document_library_filename(document)
         elf_data = document.get("elf")
         if not isinstance(elf_data, dict):
             # `debug`, not `warning`, and deliberately so: bundle analysis is
@@ -432,12 +518,12 @@ def _stored_file_elf_metadata(path: Path) -> ElfMetadata | None:
             # ordinary header-only release directory, which corrupts
             # `-o json=-` output (tests/test_cli_compare_release_view.py).
             log.debug("bundle: stored snapshot %s has no ELF metadata", path)
-            return None
-        schema_version = int(document.get("schema_version", 1))
-        return cast("ElfMetadata", elf_from_dict(elf_data, schema_version))
+            return None, None
+        elf = cast("ElfMetadata", elf_from_dict(elf_data, schema_version))
+        return elf, library_filename
     except Exception as exc:
         log.warning("bundle: failed to resolve stored snapshot %s: %s", path, exc)
-        return None
+        return None, None
 
 
 def _stored_elf_metadata(path: Path) -> ElfMetadata | None:
@@ -478,7 +564,7 @@ def _stored_elf_metadata(path: Path) -> ElfMetadata | None:
     from .snapshot_platform_blocks import elf_from_dict
 
     if not path.is_dir():
-        return _stored_file_elf_metadata(path)
+        return _stored_file_snapshot_evidence(path)[0]
 
     try:
         document = read_legacy_snapshot_document(path)

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -257,7 +257,7 @@ def build_bundle_snapshot_mixed(libraries: dict[str, Path]) -> BundleSnapshot:
     intra-bundle break going unreported for exactly the case this function
     exists to catch).
     """
-    stored = {name: path for name, path in libraries.items() if path.is_dir()}
+    stored = {name: path for name, path in libraries.items() if _is_stored_member(path)}
     if not stored:
         return build_bundle_snapshot(libraries)
 
@@ -270,9 +270,21 @@ def build_bundle_snapshot_mixed(libraries: dict[str, Path]) -> BundleSnapshot:
         if elf is None:
             continue
         metadata[name] = elf
-        real_filename, aliases, alias_nodes_so_far = _stored_library_identity(
-            path, alias_nodes_so_far
-        )
+        # `_stored_library_identity` reads a directory-backed package's own
+        # `ArtifactRef.native_identity`; a file-backed stored snapshot has no
+        # such ref document, so its real filename/aliases are simply not
+        # recorded evidence -- the same "a stored package produced by
+        # something else may not carry it" degrade that function already
+        # documents, not a new failure mode. `ElfMetadata.soname` (which a
+        # file-backed member does carry) stays available to
+        # `_detect_soname_skew`; only its no-`DT_SONAME` filename fallback is
+        # unavailable for this operand shape.
+        if path.is_dir():
+            real_filename, aliases, alias_nodes_so_far = _stored_library_identity(
+                path, alias_nodes_so_far
+            )
+        else:
+            real_filename, aliases = None, ()
         if real_filename is not None:
             stored_paths[name] = real_filename
         if aliases:
@@ -312,9 +324,126 @@ def build_bundle_snapshot_mixed(libraries: dict[str, Path]) -> BundleSnapshot:
     )
 
 
+#: Bytes sniffed when classifying an uncompressed stored snapshot document.
+#: Only the first non-whitespace byte is consulted; the rest is slack for
+#: leading whitespace a hand-formatted document may carry.
+_STORED_SNAPSHOT_SNIFF_BYTES = 64
+
+
+def _looks_like_stored_snapshot_file(path: Path) -> bool:
+    """Whether *path* is a regular file holding a stored snapshot document.
+
+    Detection is by *content* -- zstd/gzip magic, or a plain file whose
+    first non-whitespace byte opens a JSON object -- never by filename
+    suffix, matching `snapshot_io.detect_compression_from_bytes`'s own
+    "never trusts a filename" rule and `_path_looks_like_elf`'s magic sniff.
+
+    This exists because `build_bundle_snapshot_mixed`'s stored-member split
+    originally recognised only *directory*-backed packages
+    (`materialize_release_variant_artifacts` output). A loose
+    `.abicheck.json`/`.json.zst` snapshot -- the operand shape a plain
+    `abicheck dump` produces, and the one a "just point compare at a
+    directory of snapshots" release invocation actually supplies -- is
+    neither a directory nor ELF, so it fell through to
+    `build_bundle_snapshot` and was dropped there as "not ELF". That
+    silently emptied the OLD-side bundle graph: every cross-DSO check
+    (provider migration, intra-dependency removal, SONAME skew) then
+    degraded to "every library in this release is new", which scores as a
+    *compatible* bundle verdict -- precisely the silent-pass failure
+    `build_bundle_snapshot_mixed` exists to prevent, reintroduced through
+    the one stored operand shape that split did not cover.
+    """
+    from .errors import SnapshotError
+    from .snapshot_io import SnapshotCompression, detect_snapshot_compression
+
+    try:
+        if not path.is_file():
+            return False
+    except OSError:  # pragma: no cover - stat failure on a live path
+        return False
+    if _path_looks_like_elf(path):
+        return False
+    try:
+        if detect_snapshot_compression(path) is not SnapshotCompression.NONE:
+            return True
+        with open(path, "rb") as f:
+            prefix = f.read(_STORED_SNAPSHOT_SNIFF_BYTES)
+    except (OSError, SnapshotError):
+        return False
+    return prefix.lstrip()[:1] == b"{"
+
+
+def _is_stored_member(path: Path) -> bool:
+    """Whether *path* is a stored-snapshot member rather than a live binary
+    -- a directory-backed `ProjectSnapshot` package, or a file-backed
+    snapshot document (`_looks_like_stored_snapshot_file`)."""
+    try:
+        if path.is_dir():
+            return True
+    except OSError:  # pragma: no cover - stat failure on a live path
+        return False
+    return _looks_like_stored_snapshot_file(path)
+
+
+def _stored_file_elf_metadata(path: Path) -> ElfMetadata | None:
+    """`_stored_elf_metadata`'s file-backed half: the `ElfMetadata` of a
+    loose stored snapshot document.
+
+    Reads through `snapshot_io.read_snapshot_text` (the canonical storage
+    envelope reader -- plain/gzip/zstd by magic bytes, with the
+    decompression-bomb limits applied) and decodes the one `elf` section via
+    the same dependency-free `snapshot_platform_blocks.elf_from_dict` the
+    directory-backed half uses, so neither half reaches `serialization.py`
+    and the `bundle -> serialization -> bundle_facts -> bundle` cycle that
+    function's own docstring describes stays closed.
+
+    The ADR-062/063 Phase 8 sectioned envelope is unwrapped first: that is
+    the on-disk default for every snapshot written since, so reading
+    `document["elf"]` without unwrapping would find nothing and report every
+    modern snapshot as "no ELF metadata present".
+
+    Returns `None` -- never raises -- for anything that doesn't parse,
+    matching the sibling half's (and `build_bundle_snapshot`'s) own
+    "unresolvable member is skipped, not fatal" contract.
+    """
+    import json
+
+    from .snapshot_io import read_snapshot_text
+    from .snapshot_platform_blocks import elf_from_dict
+    from .storage.sectioned_document import (
+        from_sectioned_document,
+        is_sectioned_document,
+    )
+
+    try:
+        document = json.loads(read_snapshot_text(path))
+        if not isinstance(document, dict):
+            log.debug("bundle: stored snapshot %s is not a JSON object", path)
+            return None
+        if is_sectioned_document(document):
+            document = from_sectioned_document(document)
+        elf_data = document.get("elf")
+        if not isinstance(elf_data, dict):
+            # `debug`, not `warning`, and deliberately so: bundle analysis is
+            # ELF-only by design (ADR-018/ADR-023), so a header-only snapshot
+            # carrying no `elf` section is an ordinary, expected operand --
+            # the identical case the directory-backed half logs at `debug`.
+            # Warning here put a line on stdout for every member of an
+            # ordinary header-only release directory, which corrupts
+            # `-o json=-` output (tests/test_cli_compare_release_view.py).
+            log.debug("bundle: stored snapshot %s has no ELF metadata", path)
+            return None
+        schema_version = int(document.get("schema_version", 1))
+        return cast("ElfMetadata", elf_from_dict(elf_data, schema_version))
+    except Exception as exc:
+        log.warning("bundle: failed to resolve stored snapshot %s: %s", path, exc)
+        return None
+
+
 def _stored_elf_metadata(path: Path) -> ElfMetadata | None:
-    """*path*'s own `ElfMetadata`, read directly from its materialized
-    single-artifact `ProjectSnapshot` sub-package document.
+    """*path*'s own `ElfMetadata`, read directly from the stored document it
+    names -- a materialized single-artifact `ProjectSnapshot` sub-package
+    directory, or (via `_stored_file_elf_metadata`) a loose snapshot file.
 
     Deliberately **not** `workflows.input_resolution.resolve_input` (the
     general dispatcher every other "turn a path into a snapshot" call site
@@ -347,6 +476,9 @@ def _stored_elf_metadata(path: Path) -> ElfMetadata | None:
     """
     from .project_snapshot_legacy import read_legacy_snapshot_document
     from .snapshot_platform_blocks import elf_from_dict
+
+    if not path.is_dir():
+        return _stored_file_elf_metadata(path)
 
     try:
         document = read_legacy_snapshot_document(path)

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -335,10 +335,24 @@ def build_bundle_snapshot_mixed(libraries: dict[str, Path]) -> BundleSnapshot:
     )
 
 
-#: Bytes sniffed when classifying an uncompressed stored snapshot document.
-#: Only the first non-whitespace byte is consulted; the rest is slack for
-#: leading whitespace a hand-formatted document may carry.
-_STORED_SNAPSHOT_SNIFF_BYTES = 64
+#: Chunk size for the uncompressed-snapshot sniff. Only the first
+#: *non-whitespace* byte decides, so this is a read granularity, not a
+#: window the document has to fit its opening brace inside -- see
+#: `_STORED_SNAPSHOT_MAX_LEADING_WHITESPACE`.
+_STORED_SNAPSHOT_SNIFF_CHUNK_BYTES = 4096
+
+#: How much leading JSON whitespace the sniff will skip before giving up.
+#: A fixed 64-byte window was the first version of this and was wrong: JSON
+#: (and therefore `serialization.load_snapshot`) tolerates unlimited leading
+#: whitespace, so a document the canonical reader accepts classified as
+#: "not a snapshot", got routed to live-ELF handling, and was silently
+#: dropped from the bundle graph -- the exact silent-pass failure this
+#: module's stored-member split exists to prevent (Codex review, PR #1269).
+#: A bound is still required (this runs on arbitrary files in a release
+#: directory), but it is set where no legitimate document lives and a
+#: pathological one is cheap to reject, rather than at a formatting-plausible
+#: 64 bytes.
+_STORED_SNAPSHOT_MAX_LEADING_WHITESPACE = 1 << 20  # 1 MiB
 
 
 def _looks_like_stored_snapshot_file(path: Path) -> bool:
@@ -348,6 +362,14 @@ def _looks_like_stored_snapshot_file(path: Path) -> bool:
     first non-whitespace byte opens a JSON object -- never by filename
     suffix, matching `snapshot_io.detect_compression_from_bytes`'s own
     "never trusts a filename" rule and `_path_looks_like_elf`'s magic sniff.
+
+    Leading whitespace is skipped under a bound rather than inside a fixed
+    window: JSON tolerates any amount of it, so every document
+    `serialization.load_snapshot` accepts must classify here too. A document
+    that classifies as "not a snapshot" is not merely read by a different
+    reader -- it is routed to live-ELF handling and dropped from the graph
+    entirely, so a false negative here is the same silent pass as never
+    having recognised the operand shape at all.
 
     This exists because `build_bundle_snapshot_mixed`'s stored-member split
     originally recognised only *directory*-backed packages
@@ -378,10 +400,20 @@ def _looks_like_stored_snapshot_file(path: Path) -> bool:
         if detect_snapshot_compression(path) is not SnapshotCompression.NONE:
             return True
         with open(path, "rb") as f:
-            prefix = f.read(_STORED_SNAPSHOT_SNIFF_BYTES)
+            skipped = 0
+            while skipped <= _STORED_SNAPSHOT_MAX_LEADING_WHITESPACE:
+                chunk = f.read(_STORED_SNAPSHOT_SNIFF_CHUNK_BYTES)
+                if not chunk:
+                    # End of file with nothing but whitespace in it: not a
+                    # document, and `json.loads` would reject it too.
+                    return False
+                stripped = chunk.lstrip()
+                if stripped:
+                    return stripped[:1] == b"{"
+                skipped += len(chunk)
     except (OSError, SnapshotError):
         return False
-    return prefix.lstrip()[:1] == b"{"
+    return False
 
 
 def _is_stored_member(path: Path) -> bool:

--- a/changelog.d/20260913_bundle_stored_file_members.md
+++ b/changelog.d/20260913_bundle_stored_file_members.md
@@ -11,3 +11,10 @@
   *compatible* bundle verdict carried by phantom `bundle_library_added`
   findings. Detection is by content (magic bytes / JSON object opener), never
   by filename suffix.
+- Bundle analysis: a stored snapshot document declaring a `schema_version`
+  newer than this build supports is no longer admitted into the bundle graph.
+  The file-backed reader decoded the `elf` section directly, bypassing the
+  ADR-050 D1 hard-rejection ceiling every other snapshot reader applies, so a
+  member whose own per-library comparison was already refused as incomparable
+  could still contribute bundle-level findings from partially interpreted
+  evidence.

--- a/changelog.d/20260913_bundle_stored_file_members.md
+++ b/changelog.d/20260913_bundle_stored_file_members.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Bundle analysis: a release member supplied as a *loose* stored snapshot file
+  (`.abicheck.json`, `.json.gz`, `.json.zst`) is now resolved into the
+  cross-DSO bundle graph, like a directory-backed `ProjectSnapshot` package
+  already was. Previously `build_bundle_snapshot_mixed` recognised only
+  directories, so a file-backed member fell through to the ELF parser and was
+  dropped as "not ELF" — silently emptying the OLD-side graph, degrading every
+  cross-DSO check (provider migration, intra-dependency symbol removal, SONAME
+  skew) to "every library in this release is new", and reporting a
+  *compatible* bundle verdict carried by phantom `bundle_library_added`
+  findings. Detection is by content (magic bytes / JSON object opener), never
+  by filename suffix.

--- a/tests/regressions/manifest_evidence.py
+++ b/tests/regressions/manifest_evidence.py
@@ -267,11 +267,6 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
         fixed_by=(1269,),
         seed_tests=("tests/test_bundle_stored_file_members.py",),
         public_surfaces=(),
-        axes={
-            "operand_shape": ("package_directory", "snapshot_file"),
-            "compression": ("none", "gzip", "zstd", "auto"),
-            "envelope": ("flat", "sectioned"),
-        },
         known_gaps=(
             KnownGap(
                 description=(
@@ -288,6 +283,32 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
                 reference="abicheck/bundle.py::build_bundle_snapshot_mixed",
                 canary_test=None,
             ),
+            KnownGap(
+                description=(
+                    "The bundle sniff is not the first gate: "
+                    "`workflows.release_inputs.collect_release_inputs` "
+                    "filters a release directory through "
+                    "`classify.AbiJsonClassifier`, whose own 4096-byte probe "
+                    "rejects a valid uncompressed snapshot padded with more "
+                    "leading JSON whitespace than that -- so such a member is "
+                    "lost upstream of the bundle path and never reaches the "
+                    "sniff at all. Pre-existing and not introduced by the "
+                    "operand-shape fix; closing it means widening a "
+                    "tool-wide input classifier, which governs far more than "
+                    "bundle members. What is enforced instead is the "
+                    "*relationship*: everything discovery accepts, the bundle "
+                    "sniff accepts too "
+                    "(TestDiscoveryAndBundleSniffAgree), so the two cannot "
+                    "drift into the dangerous direction."
+                ),
+                reference="PR #1269 (Codex review)",
+                canary_test="tests/test_bundle_stored_file_members.py",  # TestUpstreamDiscoveryProbeBoundCanary
+            ),
         ),
+        axes={
+            "operand_shape": ("package_directory", "snapshot_file"),
+            "compression": ("none", "gzip", "zstd", "auto"),
+            "envelope": ("flat", "sectioned"),
+        },
     ),
 )

--- a/tests/regressions/manifest_evidence.py
+++ b/tests/regressions/manifest_evidence.py
@@ -248,4 +248,46 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="evidence.operand_shape_silently_unresolved",
+        invariant=(
+            "A member the caller explicitly named resolves to the same "
+            "evidence regardless of the *spelling* of the operand carrying "
+            "it -- a directory-backed ProjectSnapshot package and a loose "
+            "snapshot file (plain, gzip or zstd; flat or sectioned) are two "
+            "spellings of one stored artifact, not two evidence levels. A "
+            "resolver that recognises only some spellings must never reduce "
+            "the rest to 'absent': an operand shape silently dropped for "
+            "being unrecognised is indistinguishable, downstream, from a "
+            "library that genuinely is not there -- and an emptied OLD-side "
+            "graph then scores as a clean pass with every real cross-DSO "
+            "break unreported, which is AGENTS.md's 'absent is not removed' "
+            "read at the operand layer rather than the inventory layer."
+        ),
+        fixed_by=(1269,),
+        seed_tests=("tests/test_bundle_stored_file_members.py",),
+        public_surfaces=(),
+        axes={
+            "operand_shape": ("package_directory", "snapshot_file"),
+            "compression": ("none", "gzip", "zstd", "auto"),
+            "envelope": ("flat", "sectioned"),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Resolution is fixed, but the *disposition* is not: an "
+                    "unresolvable stored member is still skipped with a log "
+                    "line rather than recorded on the comparison scope, so a "
+                    "release whose members all fail to resolve can still "
+                    "report a compatible bundle verdict. Closing that is an "
+                    "ADR-065 scope-record decision (the `unsupported`/"
+                    "`failed` member states), not a resolver change, and the "
+                    "skip-not-raise contract is separately pinned by "
+                    "tests/test_cli_compare_release_evidence_preservation.py."
+                ),
+                reference="abicheck/bundle.py::build_bundle_snapshot_mixed",
+                canary_test=None,
+            ),
+        ),
+    ),
 )

--- a/tests/test_bundle_stored_file_members.py
+++ b/tests/test_bundle_stored_file_members.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`build_bundle_snapshot_mixed` resolves a *file*-backed stored snapshot
+member, not only a directory-backed `ProjectSnapshot` package.
+
+Bug class `evidence.operand_shape_silently_unresolved`
+(`tests/regressions/manifest_evidence.py`). The reported instance: a release
+comparison pointed at a directory of six loose header-depth
+`.abicheck.json.zst` snapshots produced an *empty* OLD-side bundle graph, so
+every cross-DSO check (provider migration, intra-dependency symbol removal,
+SONAME skew) degraded to "every library in this release is new" and the
+bundle layer scored `COMPATIBLE` with five phantom `BUNDLE_LIBRARY_ADDED`
+findings -- a silent pass on exactly the class of break
+`build_bundle_snapshot_mixed` was added to catch.
+
+The mechanism was the stored-member split's own predicate, `path.is_dir()`:
+a loose snapshot file is neither a directory nor ELF, so it fell through to
+`build_bundle_snapshot` and was dropped there as "not ELF".
+
+These tests state the invariant over the *operand-shape axis* rather than
+the one reported input: every storage spelling the project's own writer can
+produce (plain / gzip / zstd, flat or ADR-062/063-sectioned) must resolve to
+the same `ElfMetadata`, and the oracle is the snapshot that was written --
+never a second call to the resolver under test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.bundle import (
+    _looks_like_stored_snapshot_file,
+    build_bundle_snapshot_mixed,
+)
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+from abicheck.model import Function, Visibility
+from abicheck.model.snapshot import AbiSnapshot
+from abicheck.serialization import write_snapshot
+
+#: Every compression the project's own writer supports. "auto" is
+#: deliberately included: it is what an ordinary `abicheck dump` uses, so a
+#: fix that handled only the explicitly-spelled ones would still miss the
+#: shape users actually produce.
+WRITER_COMPRESSIONS = ("none", "gzip", "zstd", "auto")
+
+
+def _snapshot(soname: str, *, needed: tuple[str, ...] = ()) -> AbiSnapshot:
+    elf = ElfMetadata(
+        soname=soname,
+        symbols=[ElfSymbol(name="_Z3pubv")],
+        needed=list(needed),
+    )
+    return AbiSnapshot(
+        library=soname,
+        version="1",
+        functions=[
+            Function(
+                name="pub",
+                mangled="_Z3pubv",
+                return_type="void",
+                params=[],
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+        variables=[],
+        types=[],
+        elf=elf,
+    )
+
+
+def _write(snap: AbiSnapshot, path: Path, compression: str) -> Path:
+    write_snapshot(snap, path, compression=compression)
+    return path
+
+
+class TestFileBackedStoredMemberResolves:
+    """The invariant, across the whole operand-shape axis."""
+
+    @pytest.mark.parametrize("compression", WRITER_COMPRESSIONS)
+    def test_every_writer_compression_resolves(
+        self, tmp_path: Path, compression: str
+    ) -> None:
+        # The oracle is the snapshot we wrote, not a second resolver call.
+        expected_soname = "liba.so.1"
+        expected_needed = ("libb.so.1",)
+        path = _write(
+            _snapshot(expected_soname, needed=expected_needed),
+            tmp_path / f"a-{compression}.abicheck.json",
+            compression,
+        )
+
+        snap = build_bundle_snapshot_mixed({expected_soname: path})
+
+        assert expected_soname in snap.metadata, (
+            f"{compression}-compressed stored snapshot was silently dropped "
+            "from the bundle graph"
+        )
+        resolved = snap.metadata[expected_soname]
+        assert resolved.soname == expected_soname
+        assert tuple(resolved.needed) == expected_needed
+        assert [s.name for s in resolved.symbols] == ["_Z3pubv"]
+
+    def test_sectioned_document_resolves(self, tmp_path: Path) -> None:
+        """The ADR-062/063 Phase 8 sectioned envelope is the on-disk default
+        for every snapshot written since it landed, so reading ``["elf"]``
+        without unwrapping would report every modern snapshot as carrying no
+        ELF metadata. Asserted against a document this test *proves* is
+        sectioned, so it cannot pass vacuously if the writer's default
+        changes."""
+        from abicheck.storage.sectioned_document import is_sectioned_document
+
+        path = _write(_snapshot("libc.so.1"), tmp_path / "c.json", "none")
+        document = json.loads(path.read_text())
+        if not is_sectioned_document(document):
+            pytest.skip("writer does not emit the sectioned envelope here")
+
+        snap = build_bundle_snapshot_mixed({"libc.so.1": path})
+        assert snap.metadata["libc.so.1"].soname == "libc.so.1"
+
+    def test_directory_and_file_members_resolve_together(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mixed map must not regress the directory-backed half: the two
+        stored spellings resolve in one call, through their own readers."""
+        monkeypatch.setattr(
+            "abicheck.project_snapshot_legacy.read_legacy_snapshot_document",
+            lambda path: {"elf": {"soname": "libdir.so.1"}, "schema_version": 1},
+        )
+        stored_dir = tmp_path / "pkg"
+        stored_dir.mkdir()
+        stored_file = _write(
+            _snapshot("libfile.so.1"), tmp_path / "f.abicheck.json", "zstd"
+        )
+
+        snap = build_bundle_snapshot_mixed(
+            {"libdir.so.1": stored_dir, "libfile.so.1": stored_file}
+        )
+
+        assert sorted(snap.metadata) == ["libdir.so.1", "libfile.so.1"]
+
+
+class TestNoPhantomAdditions:
+    """The bug's *consequence*, asserted at the layer a user reads.
+
+    Resolving the member is only half the fix: the reported symptom was a
+    bundle verdict of COMPATIBLE carried by phantom ``BUNDLE_LIBRARY_ADDED``
+    findings. This states that an unchanged release compared against itself
+    through the file-backed spelling reports no library as added.
+    """
+
+    def test_unchanged_release_reports_no_added_library(self, tmp_path: Path) -> None:
+        from abicheck.bundle_analysis import analyze_bundle
+        from abicheck.checker_policy import ChangeKind
+
+        names = ("liba.so.1", "libb.so.1")
+        libraries = {
+            name: _write(
+                _snapshot(name, needed=("libb.so.1",) if name == "liba.so.1" else ()),
+                tmp_path / f"{name}.abicheck.json.zst",
+                "zstd",
+            )
+            for name in names
+        }
+
+        old = build_bundle_snapshot_mixed(dict(libraries))
+        new = build_bundle_snapshot_mixed(dict(libraries))
+        result = analyze_bundle(old, new, [])
+
+        added = [
+            c
+            for c in result.bundle_findings
+            if c.kind is ChangeKind.BUNDLE_LIBRARY_ADDED
+        ]
+        assert added == [], (
+            "an unchanged release reported libraries as newly added -- the "
+            f"OLD-side graph is empty again: {[c.symbol or c.name for c in added]}"
+        )
+        assert sorted(old.metadata) == sorted(names)
+
+
+class TestStoredSnapshotFileClassification:
+    """`_looks_like_stored_snapshot_file` is the reusable predicate the fix
+    rests on, so it gets its own contract tests rather than only being
+    exercised through its caller (AGENTS.md, "Primitive-level property
+    tests")."""
+
+    @pytest.mark.parametrize("compression", WRITER_COMPRESSIONS)
+    def test_true_for_every_writer_output(
+        self, tmp_path: Path, compression: str
+    ) -> None:
+        path = _write(
+            _snapshot("libx.so.1"), tmp_path / f"x-{compression}.json", compression
+        )
+        assert _looks_like_stored_snapshot_file(path) is True
+
+    def test_false_for_elf(self, tmp_path: Path) -> None:
+        """Classification must never claim an ELF binary: a live member
+        misrouted to the stored reader would lose its real parse."""
+        path = tmp_path / "libreal.so"
+        path.write_bytes(b"\x7fELF" + b"\x00" * 128)
+        assert _looks_like_stored_snapshot_file(path) is False
+
+    @pytest.mark.parametrize(
+        ("label", "payload"),
+        [
+            ("empty", b""),
+            ("text", b"not a snapshot\n"),
+            ("json-array", b"[1, 2, 3]"),
+            ("ar-archive", b"!<arch>\n"),
+            ("random-binary", bytes(range(64))),
+            ("script", b"#!/bin/sh\nexit 0\n"),
+        ],
+    )
+    def test_false_for_non_snapshot_files(
+        self, tmp_path: Path, label: str, payload: bytes
+    ) -> None:
+        path = tmp_path / label
+        path.write_bytes(payload)
+        assert _looks_like_stored_snapshot_file(path) is False
+
+    def test_false_for_directory_and_missing_path(self, tmp_path: Path) -> None:
+        d = tmp_path / "d"
+        d.mkdir()
+        assert _looks_like_stored_snapshot_file(d) is False
+        assert _looks_like_stored_snapshot_file(tmp_path / "absent") is False
+
+    def test_leading_whitespace_is_tolerated(self, tmp_path: Path) -> None:
+        """Detection is by content, not filename, so a hand-formatted
+        document with leading whitespace still classifies."""
+        path = tmp_path / "ws.json"
+        path.write_bytes(b'\n\t  {"elf": {}}')
+        assert _looks_like_stored_snapshot_file(path) is True
+
+
+class TestMalformedFileMemberIsSkippedNotFatal:
+    """Mirrors the directory-backed half's own contract
+    (`test_cli_compare_release_evidence_preservation.py`): an unresolvable
+    member is dropped, never an exception that discards every sibling's
+    resolution."""
+
+    def test_malformed_member_does_not_abort_the_snapshot(self, tmp_path: Path) -> None:
+        good = _write(_snapshot("libgood.so.1"), tmp_path / "good.json", "zstd")
+        bad = tmp_path / "bad.json"
+        bad.write_bytes(b'{"elf": "not-an-object", "schema_version": "nope"}')
+
+        snap = build_bundle_snapshot_mixed({"libgood.so.1": good, "libbad.so.1": bad})
+
+        assert "libgood.so.1" in snap.metadata
+        assert "libbad.so.1" not in snap.metadata

--- a/tests/test_bundle_stored_file_members.py
+++ b/tests/test_bundle_stored_file_members.py
@@ -480,3 +480,112 @@ class TestSchemaCeiling:
         path.write_text(self._document(below))
         elf, _ = _stored_file_snapshot_evidence(path)
         assert elf is not None
+
+
+class TestDiscoveryAndBundleSniffAgree:
+    """Codex review, PR #1269 (P2): the bundle sniff is not the first gate a
+    release member passes -- `workflows.release_inputs.collect_release_inputs`
+    filters the directory first, through `classify.AbiJsonClassifier`, which
+    reads a bounded 4096-byte probe of its own.
+
+    The invariant that actually matters is the *relationship* between the two,
+    and its direction: whatever discovery hands downstream, the bundle sniff
+    must accept. A member surviving discovery only to be dropped by the sniff
+    is the silent-pass failure this module exists to prevent; the reverse
+    (the sniff being more permissive than discovery) costs nothing, because
+    the sniff never sees a file discovery already refused.
+
+    Pinned here through the *real* discovery function rather than by
+    comparing two constants, so widening either side without the other fails.
+    """
+
+    def _release_dir(self, tmp_path: Path) -> Path:
+        release = tmp_path / "release"
+        release.mkdir()
+        _write(_snapshot("liba.so.1"), release / "a.abicheck.json", "none")
+        _write(_snapshot("libb.so.1"), release / "b.abicheck.json", "gzip")
+        _write(_snapshot("libc.so.1"), release / "c.abicheck.json", "zstd")
+        _write(_snapshot("libd.so.1"), release / "d.abicheck.json", "auto")
+        # Non-members that must not be discovered either way.
+        (release / "README.md").write_text("# notes\n")
+        (release / "manifest.txt").write_text("liba.so.1\n")
+        return release
+
+    def test_everything_discovery_accepts_the_bundle_sniff_accepts(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.workflows.release_inputs import collect_release_inputs
+
+        release = self._release_dir(tmp_path)
+        discovered = collect_release_inputs(release)
+
+        assert discovered, "discovery found nothing -- test would be vacuous"
+        rejected = [
+            p.name for p in discovered if not _looks_like_stored_snapshot_file(p)
+        ]
+        assert rejected == [], (
+            "discovery handed these members downstream but the bundle sniff "
+            f"refuses them, so they are dropped from the graph: {rejected}"
+        )
+
+    def test_discovered_members_all_resolve_into_the_graph(
+        self, tmp_path: Path
+    ) -> None:
+        """The end-to-end consequence of the same relationship: each
+        discovered member reaches `metadata`, not just the predicate."""
+        from abicheck.workflows.release_inputs import collect_release_inputs
+
+        release = self._release_dir(tmp_path)
+        discovered = collect_release_inputs(release)
+
+        snap = build_bundle_snapshot_mixed({p.stem: p for p in discovered})
+        assert sorted(snap.metadata) == sorted(p.stem for p in discovered)
+
+
+class TestUpstreamDiscoveryProbeBoundCanary:
+    """Canary for the tracked residual on
+    `evidence.operand_shape_silently_unresolved`
+    (`tests/regressions/manifest_evidence.py`).
+
+    It asserts the *residual's own bound* rather than the eventually-correct
+    behaviour, which is what makes it fail loudly in **either** direction
+    without an xfail: if discovery widens (the gap closes) or narrows (the
+    gap widens), this test breaks and the registry entry must be revisited.
+
+    The residual: `classify.AbiJsonClassifier` reads a bounded probe, so a
+    valid uncompressed snapshot padded with more leading JSON whitespace
+    than that probe is dropped at discovery -- upstream of the bundle sniff,
+    which would accept it. Closing this means changing a tool-wide input
+    classifier, which governs far more than bundle members, so it is
+    tracked rather than fixed here.
+    """
+
+    def test_discovery_still_drops_a_whitespace_padded_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.classify import AbiJsonClassifier
+        from abicheck.workflows.release_inputs import collect_release_inputs
+
+        release = tmp_path / "release"
+        release.mkdir()
+        # A control member, so discovery succeeds and the assertion below is
+        # about *this* file rather than about an empty directory.
+        _write(_snapshot("libok.so.1"), release / "ok.abicheck.json", "none")
+
+        padded = release / "padded.abicheck.json"
+        padded.write_bytes(
+            b"\n" * (AbiJsonClassifier._JSON_PROBE_BYTES + 1)
+            + (release / "ok.abicheck.json").read_bytes()
+        )
+
+        discovered = {p.name for p in collect_release_inputs(release)}
+
+        assert "ok.abicheck.json" in discovered, "control member was not discovered"
+        assert "padded.abicheck.json" not in discovered, (
+            "discovery now accepts a whitespace-padded snapshot -- the "
+            "residual tracked on evidence.operand_shape_silently_unresolved "
+            "has closed; update that registry entry and drop this canary"
+        )
+        # ...while the bundle sniff would have accepted it. That asymmetry is
+        # the gap, stated executably rather than only in prose.
+        assert _looks_like_stored_snapshot_file(padded) is True

--- a/tests/test_bundle_stored_file_members.py
+++ b/tests/test_bundle_stored_file_members.py
@@ -242,12 +242,58 @@ class TestStoredSnapshotFileClassification:
         assert _looks_like_stored_snapshot_file(d) is False
         assert _looks_like_stored_snapshot_file(tmp_path / "absent") is False
 
-    def test_leading_whitespace_is_tolerated(self, tmp_path: Path) -> None:
-        """Detection is by content, not filename, so a hand-formatted
-        document with leading whitespace still classifies."""
-        path = tmp_path / "ws.json"
-        path.write_bytes(b'\n\t  {"elf": {}}')
+    @pytest.mark.parametrize(
+        "padding", [0, 1, 63, 64, 65, 4095, 4096, 4097, 8192, 100_000]
+    )
+    def test_any_leading_whitespace_the_canonical_reader_tolerates(
+        self, tmp_path: Path, padding: int
+    ) -> None:
+        """Codex review, PR #1269 (P2): the first version sniffed a fixed
+        64-byte window, so a document with >=64 leading whitespace bytes
+        classified as "not a snapshot", was routed to live-ELF handling and
+        dropped from the graph -- the same silent pass this module exists to
+        prevent.
+
+        The oracle is deliberately independent of the predicate: a document
+        the *canonical* reader (`json.loads` over `read_snapshot_text`)
+        accepts as an object must classify here too. The padding values sweep
+        the old boundary and both sides of the new chunk size, so a future
+        window-shaped implementation fails rather than passing on one
+        hand-picked input.
+        """
+        from abicheck.snapshot_io import read_snapshot_text
+
+        path = tmp_path / f"ws-{padding}.json"
+        path.write_bytes(b"\n" * padding + b'{"elf": {}}')
+
+        canonical = json.loads(read_snapshot_text(path))
+        assert isinstance(canonical, dict), "oracle did not parse -- test is vacuous"
         assert _looks_like_stored_snapshot_file(path) is True
+
+    def test_mixed_whitespace_kinds_are_skipped(self, tmp_path: Path) -> None:
+        """All four JSON whitespace bytes, not only newlines."""
+        path = tmp_path / "mixed.json"
+        path.write_bytes(b" \t\r\n" * 2048 + b'{"elf": {}}')
+        assert _looks_like_stored_snapshot_file(path) is True
+
+    def test_whitespace_only_file_is_not_a_snapshot(self, tmp_path: Path) -> None:
+        """The complement: skipping whitespace must not turn a blank file
+        into a document."""
+        path = tmp_path / "blank.json"
+        path.write_bytes(b"\n" * 10_000)
+        assert _looks_like_stored_snapshot_file(path) is False
+
+    def test_unbounded_whitespace_is_still_refused(self, tmp_path: Path) -> None:
+        """The bound is real -- a pathological file is rejected rather than
+        scanned forever. Asserted at the documented bound, so a future change
+        to it is deliberate and visible."""
+        from abicheck.bundle import _STORED_SNAPSHOT_MAX_LEADING_WHITESPACE
+
+        path = tmp_path / "pathological.json"
+        path.write_bytes(
+            b"\n" * (_STORED_SNAPSHOT_MAX_LEADING_WHITESPACE + 8192) + b'{"elf": {}}'
+        )
+        assert _looks_like_stored_snapshot_file(path) is False
 
 
 class TestMalformedFileMemberIsSkippedNotFatal:

--- a/tests/test_bundle_stored_file_members.py
+++ b/tests/test_bundle_stored_file_members.py
@@ -46,6 +46,8 @@ import pytest
 
 from abicheck.bundle import (
     _looks_like_stored_snapshot_file,
+    _stored_document_library_filename,
+    _stored_file_snapshot_evidence,
     build_bundle_snapshot_mixed,
 )
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol
@@ -263,3 +265,172 @@ class TestMalformedFileMemberIsSkippedNotFatal:
 
         assert "libgood.so.1" in snap.metadata
         assert "libbad.so.1" not in snap.metadata
+
+
+class TestRecoveredLibraryIdentity:
+    """Codex review, PR #1269 (P1): a release key is canonicalized, so a
+    file-backed member must recover the *represented* filename from its own
+    document or a sibling's `DT_NEEDED` stops resolving.
+
+    The failure this guards is not "a field is missing" but "a real
+    intra-bundle dependency edge is classified as external", so it is
+    asserted at the graph, not only at the reader.
+    """
+
+    def test_versioned_dt_needed_resolves_to_the_canonicalized_key(
+        self, tmp_path: Path
+    ) -> None:
+        # The consumer records DT_NEEDED against the *versioned* filename...
+        consumer = _snapshot("libcons.so", needed=("libprov.so.1",))
+        # ...while the provider's release key is the canonicalized name, and
+        # the provider has no DT_SONAME of its own to fall back on.
+        provider = AbiSnapshot(
+            library="libprov.so.1",
+            version="1",
+            functions=[],
+            variables=[],
+            types=[],
+            elf=ElfMetadata(soname="", symbols=[ElfSymbol(name="_Z4provv")]),
+        )
+        libraries = {
+            "libcons.so": _write(consumer, tmp_path / "c.abicheck.json", "zstd"),
+            "libprov.so": _write(provider, tmp_path / "p.abicheck.json", "zstd"),
+        }
+
+        snap = build_bundle_snapshot_mixed(libraries)
+
+        # The user-facing consequence, not the lookup table: the edge must
+        # be intra-bundle, never "extra" (external).
+        assert "libprov.so.1" in snap.resolution.intra_needed.get("libcons.so", ()), (
+            "the provider's represented filename was discarded, so the "
+            "consumer's DT_NEEDED=libprov.so.1 resolved to nothing: "
+            f"intra={snap.resolution.intra_needed}, "
+            f"extra={snap.resolution.extra_needed}"
+        )
+        assert "libprov.so.1" not in snap.resolution.extra_needed.get("libcons.so", ())
+        assert snap.resolution.soname_to_name["libprov.so.1"] == "libprov.so"
+
+    def test_filename_is_recovered_from_the_document(self, tmp_path: Path) -> None:
+        path = _write(
+            _snapshot("libnamed.so.2"), tmp_path / "renamed.abicheck.json", "none"
+        )
+        _elf, filename = _stored_file_snapshot_evidence(path)
+        # The oracle is the snapshot's own recorded library name -- not the
+        # file it happens to be stored under, which differs here on purpose.
+        assert filename == Path("libnamed.so.2")
+
+
+class TestRecoveredFilenameIsUntrustedInput:
+    """The recovered name is whatever a document on disk claims, and it lands
+    in a path mapping -- so the predicate is tested directly against hostile
+    values, not only through a well-formed writer's output."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "../../etc/passwd",
+            "/etc/passwd",
+            "a/b.so",
+            "a\\b.so",
+            "..",
+            ".",
+            "",
+            "   ",
+        ],
+    )
+    def test_path_bearing_or_empty_names_are_rejected(self, value: str) -> None:
+        assert _stored_document_library_filename({"library": value}) is None
+
+    @pytest.mark.parametrize("value", [None, 42, ["libx.so"], {"name": "libx.so"}])
+    def test_non_string_names_are_rejected(self, value: object) -> None:
+        assert _stored_document_library_filename({"library": value}) is None
+
+    def test_absent_key_is_rejected(self) -> None:
+        assert _stored_document_library_filename({}) is None
+
+    @pytest.mark.parametrize(
+        "value", ["libx.so", "libx.so.1", "libx.so.1.2.3", "lib-x_y+z.so"]
+    )
+    def test_plain_basenames_are_accepted(self, value: str) -> None:
+        assert _stored_document_library_filename({"library": value}) == Path(value)
+
+
+class TestSchemaCeiling:
+    """Codex review, PR #1269 (P1): reading the `elf` section directly
+    bypassed the ADR-050 D1 hard-rejection ceiling every other snapshot
+    reader applies, admitting a future-schema document into the bundle graph
+    on partially interpreted evidence.
+
+    The oracle is `storage.snapshot_schema_versions`' own constants, derived
+    independently of the branch under test, so this cannot pass by agreeing
+    with a hardcoded copy of the number.
+    """
+
+    @staticmethod
+    def _document(schema_version: int) -> str:
+        return json.dumps(
+            {
+                "library": "libfuture.so",
+                "schema_version": schema_version,
+                "elf": {"soname": "libfuture.so.1"},
+            }
+        )
+
+    def test_future_schema_is_not_admitted(self, tmp_path: Path) -> None:
+        from abicheck.storage.snapshot_schema_versions import SCHEMA_VERSION
+
+        path = tmp_path / "future.abicheck.json"
+        path.write_text(self._document(SCHEMA_VERSION + 1))
+
+        assert _stored_file_snapshot_evidence(path) == (None, None)
+        assert (
+            "libfuture.so"
+            not in build_bundle_snapshot_mixed({"libfuture.so": path}).metadata
+        )
+
+    def test_the_current_schema_is_admitted(self, tmp_path: Path) -> None:
+        """The complement, so a ceiling accidentally set one too low -- which
+        would reject every snapshot this build itself writes -- fails here
+        rather than passing as 'nothing was admitted'."""
+        from abicheck.storage.snapshot_schema_versions import SCHEMA_VERSION
+
+        path = tmp_path / "current.abicheck.json"
+        path.write_text(self._document(SCHEMA_VERSION))
+
+        elf, _filename = _stored_file_snapshot_evidence(path)
+        assert elf is not None
+        assert elf.soname == "libfuture.so.1"
+
+    def test_older_schemas_are_admitted(self, tmp_path: Path) -> None:
+        """A stored snapshot from an older abicheck is an ordinary operand --
+        the ceiling rejects *newer*, never older."""
+        from abicheck.storage.snapshot_schema_versions import SCHEMA_VERSION
+
+        for older in (1, SCHEMA_VERSION // 2, SCHEMA_VERSION - 1):
+            path = tmp_path / f"old-{older}.abicheck.json"
+            path.write_text(self._document(older))
+            elf, _ = _stored_file_snapshot_evidence(path)
+            assert elf is not None, f"schema_version {older} was rejected"
+
+    def test_below_the_hard_rejection_threshold_still_decodes(
+        self, tmp_path: Path
+    ) -> None:
+        """The rule mirrors `decode_snapshot`'s two tiers exactly: a version
+        newer than this build but *below* the ADR-050 threshold warns and
+        decodes rather than being refused. Asserted so this reader cannot
+        drift into a stricter third rule of its own."""
+        from abicheck.storage.snapshot_schema_versions import (
+            _MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION,
+            SCHEMA_VERSION,
+        )
+
+        below = _MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION - 1
+        if below <= 0 or below <= SCHEMA_VERSION:
+            pytest.skip(
+                "this build's SCHEMA_VERSION is already at or past the "
+                "hard-rejection threshold, so the warn tier is unreachable"
+            )
+        path = tmp_path / "warn.abicheck.json"
+        path.write_text(self._document(below))
+        elf, _ = _stored_file_snapshot_evidence(path)
+        assert elf is not None


### PR DESCRIPTION
## Summary

`build_bundle_snapshot_mixed` now recognises a *loose* stored snapshot file (`.abicheck.json`, `.json.gz`, `.json.zst`) as a stored member, not only a directory-backed `ProjectSnapshot` package.

## Motivation

The stored-member split was keyed on `path.is_dir()`. A loose snapshot file — what a plain `abicheck dump` produces, and what a "point `compare` at a directory of snapshots" release invocation actually supplies — is neither a directory nor ELF, so it fell through to `build_bundle_snapshot` and was dropped there by `_path_looks_like_elf` as "not ELF".

That reintroduced, through the one stored operand shape the original split did not cover, exactly the silent pass `build_bundle_snapshot_mixed` exists to prevent (its own docstring: *"a CI ABI gate silently passing on a real break"*). The OLD-side bundle graph came back empty, so every cross-DSO check — provider migration, intra-dependency symbol removal, SONAME skew — degraded to "every library in this release is new", and the bundle layer reported `COMPATIBLE` carrying phantom `bundle_library_added` findings.

Measured on a six-member release: an empty OLD graph, five phantom `bundle_library_added` findings, and a compatible bundle verdict over a comparison that had real per-library findings.

## Changes

- `_looks_like_stored_snapshot_file` / `_is_stored_member`: classify a stored member by **content** (zstd/gzip magic, or a plain file whose first non-whitespace byte opens a JSON object) — never by filename suffix, matching `snapshot_io.detect_compression_from_bytes`'s "never trusts a filename" rule and `_path_looks_like_elf`'s own magic sniff.
- `_stored_file_elf_metadata`: the file-backed half of `_stored_elf_metadata`, reading through `snapshot_io.read_snapshot_text` (canonical storage envelope, decompression-bomb limits applied) and the dependency-free `snapshot_platform_blocks.elf_from_dict` — so the `bundle -> serialization -> bundle_facts -> bundle` cycle the sibling reader's docstring describes stays closed. The ADR-062/063 Phase 8 sectioned envelope is unwrapped before reading the `elf` section.
- Identity recovery (`_stored_library_identity`) stays directory-only: a file-backed snapshot has no `ArtifactRef.native_identity` document. `ElfMetadata.soname` remains available to `_detect_soname_skew`; only its no-`DT_SONAME` filename fallback is unavailable for this operand shape, which is the same "may simply not carry it" degrade that function already documents.
- Contracts deliberately unchanged: an unresolvable member is still skipped, not fatal (pinned by `tests/test_cli_compare_release_evidence_preservation.py`). A header-only snapshot with no `elf` section is an ordinary operand for an ELF-only layer (ADR-018/ADR-023) and logs at `debug` — `warning` there put a line on stdout for every member of an ordinary release directory and corrupted `-o json=-` output.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `evidence.operand_shape_silently_unresolved` — a member the caller explicitly named must resolve to the same evidence regardless of the *spelling* of the stored operand carrying it; an unrecognised spelling must never be silently reduced to "absent", which downstream is indistinguishable from a library that genuinely is not there. ("Absent is not removed", read at the operand layer rather than the inventory layer.) Registry entry to be added in a follow-up commit on this branch once this PR has a number for `fixed_by`.
- Publicly observable failure: a release compared against a directory of stored snapshots reports `bundle_verdict: COMPATIBLE` with N phantom `bundle_library_added` findings and no cross-DSO analysis at all.
- Regression test fails on base: yes — 8 of the 21 new tests fail with the predicate reverted to `path.is_dir()` (verified by reverting the one-line predicate and re-running).
- Negative control: `test_false_for_elf` (an ELF binary must never classify as a stored snapshot, or a live member would lose its real parse) and `test_false_for_non_snapshot_files` (six independently-chosen payloads: empty, text, JSON array, `ar` archive, random binary, shell script).
- Public-surface test: `TestNoPhantomAdditions` asserts the bundle-layer consequence through `analyze_bundle`; the CLI-level consequence is covered by the pre-existing `tests/test_cli_compare_release_view.py` suite, which this change is validated against (it caught the stdout-pollution regression above).
- Axes covered: compression (`none`, `gzip`, `zstd`, `auto`), envelope (flat, sectioned), operand shape (package directory, snapshot file, both in one map).
- General invariant: `TestFileBackedStoredMemberResolves` parametrizes over every compression the project's own writer emits — including `auto`, the shape users actually produce — and asserts against an oracle that is the snapshot *as written* (soname, `needed`, symbol names), never a second call to the resolver under test. `TestStoredSnapshotFileClassification` states the classification predicate's contract directly rather than only through its caller, per AGENTS.md's primitive-level property-test guidance.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — n/a (no documented behaviour changes; this closes a silent gap)
- [x] `ruff check` / `ruff format` / `mypy abicheck/` clean; `check_architecture.py` and `check_ai_readiness.py` show no new errors (two pre-existing, unrelated failures on `main`)
- [x] No new `mypy` or `ruff` errors introduced

Validation: `pytest -k "bundle or release"` under the default fast markers — 2679 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpcE2p6o4zLz9F25vFprFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpcE2p6o4zLz9F25vFprFC)_