### PR TITLE
fix(tests): recover the autouse cache allocator when its temp tree vanishes

### DIFF
--- a/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
+++ b/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
@@ -13,3 +13,7 @@
   -- since these paths are predictable and sit on a temp root shared between
   users, so a `parents=True` recreate under the process umask would leave the
   hierarchy traversable and accept a path planted in the deletion window.
+  Those checks apply only within pytest's own `pytest-of-<user>` root: asserting
+  ownership or repairing modes on ancestors above it would error every test on a
+  runner that does not own the shared temp directory, and as root would strip that
+  directory's world-writable mode machine-wide.

--- a/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
+++ b/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `tests/conftest.py`'s autouse snapshot-cache fixture now recreates pytest's
+  basetemp before allocating, so a transient deletion anywhere in the temp tree
+  no longer fails every remaining test in the worker. The bucket's own
+  existence check covered the bucket disappearing but not its parent, so once a
+  worker's basetemp was gone every subsequent test errored with a
+  `FileNotFoundError` naming a different freshly-generated bucket — two Linux
+  unit lanes reported 20,867 and 29,164 such errors from one root cause. Bug
+  class: `test_infra.autouse_allocator_cannot_recover`.

--- a/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
+++ b/changelog.d/20260913_claude_autouse_cache_allocator_recovery.md
@@ -8,3 +8,8 @@
   `FileNotFoundError` naming a different freshly-generated bucket — two Linux
   unit lanes reported 20,867 and 29,164 such errors from one root cause. Bug
   class: `test_infra.autouse_allocator_cannot_recover`.
+  The recovery recreates each level with pytest's own guarantees -- mode `0o700`,
+  a refusal on a symlinked or foreign-owned level, and the same loose-mode fixup
+  -- since these paths are predictable and sit on a temp root shared between
+  users, so a `parents=True` recreate under the process umask would leave the
+  hierarchy traversable and accept a path planted in the deletion window.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -101,13 +102,65 @@ def _snapshot_cache_bucket(tmp_path_factory: pytest.TempPathFactory) -> Path:
     basetemp = tmp_path_factory.getbasetemp()
     bucket = _SNAPSHOT_CACHE_BUCKETS.get(basetemp)
     if bucket is None or not bucket.is_dir():
-        # `exist_ok` rather than a prior existence check: the point is to be
-        # correct whether or not the tree is there, and a check-then-create
-        # would reintroduce the same window this is fixing.
-        basetemp.mkdir(parents=True, exist_ok=True)
+        _recreate_private_tree(basetemp)
         bucket = Path(tempfile.mkdtemp(prefix="snapshot-caches-", dir=basetemp))
         _SNAPSHOT_CACHE_BUCKETS[basetemp] = bucket
     return bucket
+
+
+def _recreate_private_tree(path: Path) -> None:
+    """Recreate *path* and any missing ancestor, with pytest's own guarantees.
+
+    A plain ``mkdir(parents=True, exist_ok=True)`` is the wrong tool here, and
+    not for style reasons (Codex review). These paths are *predictable*
+    (``/tmp/pytest-of-<user>/pytest-N/popen-gwM``) and sit on a temp root that
+    is shared between users on Unix, and pytest deliberately creates every
+    level ``0o700``, refuses a level that is a symlink, refuses one owned by
+    somebody else, and tightens a level whose group/other bits are set. Raw
+    ``parents=True`` would recreate the hierarchy with the process umask
+    (commonly world-traversable ``0o755``) and, through ``exist_ok``, silently
+    accept a directory or symlink that someone else planted in the window
+    between the deletion and this recovery. So the recovery reproduces pytest's
+    checks rather than discarding them: re-creating the tree must not be a
+    weaker act than creating it was.
+
+    Each level is created individually (no ``parents=True``) so the mode
+    applies to every one, and ``chmod`` follows the ``mkdir`` because ``mkdir``
+    masks its mode with the umask while ``chmod`` does not. An ancestor that
+    already exists is validated, never adjusted into place -- except for the
+    one fixup pytest also performs, clearing group/other bits on a directory we
+    own.
+
+    The uid and symlink checks are skipped where the platform cannot express
+    them (no ``os.getuid`` on Windows), exactly as pytest skips them.
+    """
+    missing = [parent for parent in (path, *path.parents) if not parent.exists()]
+    for level in reversed(missing):
+        # `exist_ok` for the race where a sibling worker creates the same
+        # level first -- that is cooperation, not the planted-path case the
+        # validation below covers.
+        level.mkdir(mode=0o700, exist_ok=True)
+        _require_private_dir(level)
+    # Ancestors that already existed are validated too: the planted path this
+    # guards against is one that exists when recovery runs.
+    for parent in (path, *path.parents):
+        if parent == parent.parent:  # the filesystem root, nobody's to own
+            break
+        _require_private_dir(parent)
+
+
+def _require_private_dir(path: Path) -> None:
+    """Fail unless *path* is a real directory this user owns privately."""
+    follow = os.stat not in os.supports_follow_symlinks
+    info = path.stat(follow_symlinks=follow)
+    if stat.S_ISLNK(info.st_mode):
+        raise OSError(f"refusing to use {path}: it is a symbolic link")
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    if uid is not None and info.st_uid != uid:
+        raise OSError(f"refusing to use {path}: it is owned by another user")
+    if uid is not None and (info.st_mode & 0o077):
+        chmod_follow = os.chmod not in os.supports_follow_symlinks
+        path.chmod(info.st_mode & ~0o077, follow_symlinks=chmod_follow)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,21 +132,52 @@ def _recreate_private_tree(path: Path) -> None:
     own.
 
     The uid and symlink checks are skipped where the platform cannot express
-    them (no ``os.getuid`` on Windows), exactly as pytest skips them.
+    them (no ``os.getuid`` on Windows), exactly as pytest skips them. They also
+    apply only within pytest's own root -- see `_pytest_owned_levels`.
     """
-    missing = [parent for parent in (path, *path.parents) if not parent.exists()]
-    for level in reversed(missing):
+    owned = _pytest_owned_levels(path)
+    # Anything ABOVE pytest's own root is the system's, not ours: create a
+    # missing level plainly and never validate or chmod it.
+    for level in reversed([p for p in path.parents if p not in owned]):
+        if not level.exists():
+            level.mkdir(exist_ok=True)
+    for level in owned:
         # `exist_ok` for the race where a sibling worker creates the same
         # level first -- that is cooperation, not the planted-path case the
-        # validation below covers.
+        # validation covers. An already-existing level is validated too: the
+        # planted path this guards against is one that exists when recovery
+        # runs.
         level.mkdir(mode=0o700, exist_ok=True)
         _require_private_dir(level)
-    # Ancestors that already existed are validated too: the planted path this
-    # guards against is one that exists when recovery runs.
-    for parent in (path, *path.parents):
-        if parent == parent.parent:  # the filesystem root, nobody's to own
-            break
-        _require_private_dir(parent)
+
+
+def _pytest_owned_levels(path: Path) -> list[Path]:
+    """*path* and the ancestors pytest itself owns, outermost first.
+
+    The boundary matters more than it looks, and getting it wrong is worse than
+    the bug this recovery fixes (Codex review). Validating *every* ancestor
+    walks into `/tmp` and `/`, which nobody running tests owns: on an ordinary
+    non-root runner the ownership check then raises on `/tmp` during the first
+    autouse allocation, so every test errors -- and running as root it is worse
+    than that, because the group/other fixup would strip `/tmp` down from its
+    usual `01777` and break the whole machine's shared temp directory.
+
+    pytest's own root is `<temproot>/pytest-of-<user>`; everything at or below
+    it is created, owned and privacy-checked by pytest, and that is exactly the
+    region this recovery may assert about. Found by name rather than by
+    comparing against `tempfile.gettempdir()`, because `PYTEST_DEBUG_TEMPROOT`,
+    a `TMPDIR` that changed mid-session, and a resolved symlink all move the
+    temp root without moving the marker.
+
+    With `--basetemp` there is no such marker: pytest creates exactly that one
+    directory (`mkdir(mode=0o700)`) and treats its parents as the caller's, so
+    the owned region is the path itself.
+    """
+    chain = [path, *path.parents]
+    for index, level in enumerate(chain):
+        if level.name.startswith("pytest-of-"):
+            return list(reversed(chain[: index + 1]))
+    return [path]
 
 
 def _require_private_dir(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,10 +83,28 @@ def _snapshot_cache_bucket(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
     Allocated once per process (each xdist worker has its own basetemp, so the
     key keeps a worker from ever reading another's entry).
+
+    **Self-healing, because this fixture is autouse.** The bucket's own
+    `is_dir()` check was not enough: if the worker's *basetemp* goes away, the
+    re-allocation below raises `FileNotFoundError` on the missing parent, and
+    since every test enters through this fixture, one transient deletion turns
+    into an error for every remaining test in that worker -- each reporting a
+    different freshly-generated bucket name, which is what made the real
+    failure so hard to read. That is not hypothetical: two Linux unit lanes
+    failed with 20,867 and 29,164 such errors (run 34729579282), and the same
+    signature appeared in a container where an unrelated process was pruning
+    `/tmp`. Recreating the parent makes the recovery independent of *what*
+    removed the tree, which is the only version of this fix that closes the
+    class: pytest's own retention policy, a tmp reaper, a sandbox cleanup and a
+    stray `rmtree` all present identically here.
     """
     basetemp = tmp_path_factory.getbasetemp()
     bucket = _SNAPSHOT_CACHE_BUCKETS.get(basetemp)
     if bucket is None or not bucket.is_dir():
+        # `exist_ok` rather than a prior existence check: the point is to be
+        # correct whether or not the tree is there, and a check-then-create
+        # would reintroduce the same window this is fixing.
+        basetemp.mkdir(parents=True, exist_ok=True)
         bucket = Path(tempfile.mkdtemp(prefix="snapshot-caches-", dir=basetemp))
         _SNAPSHOT_CACHE_BUCKETS[basetemp] = bucket
     return bucket

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -341,7 +341,12 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             "paths are predictable and sit on a temp root shared between "
             "users, so every level it recreates carries the same private mode, "
             "symlink refusal and ownership check the framework applied when it "
-            "created them, or the recovery is itself the vulnerability."
+            "created them, or the recovery is itself the vulnerability -- and no "
+            "level ABOVE the framework's own root, because asserting ownership "
+            "or repairing modes up to the filesystem root is strictly worse "
+            "than the original bug: it errors every test on a runner that does "
+            "not own the shared temp directory, and as root it would strip that "
+            "directory's world-writable mode for the whole machine."
         ),
         # Runs 34729579282: `unit-tests (ubuntu-latest, 3.12)` reported 2
         # failed + 20,867 errors and 3.14 reported 29,164, every one of them
@@ -365,6 +370,7 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             "recovery": ("fresh_directory", "empty", "reused_when_intact"),
             "privacy": ("mode_0700", "symlink_refused", "foreign_uid_refused"),
             "hostile_environment": ("permissive_umask", "loose_existing_mode"),
+            "boundary": ("inside_pytest_root", "system_ancestor", "explicit_basetemp"),
             "oracle": ("unfixed_allocator_reproduction",),
         },
         known_gaps=(

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -320,4 +320,62 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
         ),
     ),
+    BugClass(
+        id="test_infra.autouse_allocator_cannot_recover",
+        invariant=(
+            "A fixture every test enters must not convert a transient "
+            "failure of its own environment into a failure of the whole "
+            "session. Concretely, for an autouse allocator that creates a "
+            "directory under pytest's temp tree: the allocation must succeed "
+            "again after ANY part of the tree above it is removed -- the "
+            "allocated directory, its parent basetemp, or an ancestor -- "
+            "because the allocator cannot know, and must not depend on, what "
+            "removed it. The hazard is specific to being autouse: the first "
+            "deletion is transient, but with nothing recreating the tree "
+            "every subsequent test enters through the same failing path, so "
+            "one lost directory reads as tens of thousands of unrelated "
+            "errors. Recovery must also stay idempotent -- a version that "
+            "heals by allocating a fresh directory on every call silently "
+            "discards the per-process reuse the allocator exists for."
+        ),
+        # Runs 34729579282: `unit-tests (ubuntu-latest, 3.12)` reported 2
+        # failed + 20,867 errors and 3.14 reported 29,164, every one of them
+        # `FileNotFoundError: .../popen-gwN/snapshot-caches-XXXXXXXX` out of
+        # the autouse `_isolate_snapshot_cache`. The bucket's own `is_dir()`
+        # check handled the bucket disappearing but not its PARENT, so once a
+        # worker's basetemp was gone `mkdtemp(dir=basetemp)` failed for the
+        # rest of the run -- each test reporting a different freshly-generated
+        # bucket name, which is what disguised one root cause as a flood of
+        # unrelated ones. The same signature appeared in a dev container where
+        # an unrelated process was pruning `/tmp`; that second environment is
+        # why the invariant is written about the tree vanishing rather than
+        # about any particular deleter.
+        fixed_by=(1270,),
+        seed_tests=("tests/test_conftest_cache_isolation.py",),
+        # The seed test inspects a pytest fixture's own allocator directly, so
+        # per this field's rule it claims no public surface.
+        public_surfaces=(),
+        axes={
+            "removed_level": ("bucket", "basetemp", "ancestor"),
+            "recovery": ("fresh_directory", "empty", "reused_when_intact"),
+            "oracle": ("unfixed_allocator_reproduction",),
+        },
+        known_gaps=(
+            KnownGap(
+                description=(
+                    "Only this one allocator is repaired and pinned. Nothing "
+                    "sweeps conftest for other autouse fixtures that would "
+                    "fail the same way -- `_isolate_ast_memo` and the "
+                    "hypothesis profile hooks touch no filesystem today, so "
+                    "there is no second instance to fix, but a future autouse "
+                    "fixture that creates a directory would not be caught by "
+                    "any gate. The shape is also not mechanically detectable "
+                    "from a fixture's text: creating a directory under "
+                    "basetemp is not by itself a defect, only doing so without "
+                    "recovery is."
+                ),
+                reference="docs/contribute/plans/bug-class-regression-testing.md",
+            ),
+        ),
+    ),
 )

--- a/tests/regressions/manifest_guards.py
+++ b/tests/regressions/manifest_guards.py
@@ -336,7 +336,12 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
             "one lost directory reads as tens of thousands of unrelated "
             "errors. Recovery must also stay idempotent -- a version that "
             "heals by allocating a fresh directory on every call silently "
-            "discards the per-process reuse the allocator exists for."
+            "discards the per-process reuse the allocator exists for -- and it "
+            "must not be a WEAKER act than the original creation was: these "
+            "paths are predictable and sit on a temp root shared between "
+            "users, so every level it recreates carries the same private mode, "
+            "symlink refusal and ownership check the framework applied when it "
+            "created them, or the recovery is itself the vulnerability."
         ),
         # Runs 34729579282: `unit-tests (ubuntu-latest, 3.12)` reported 2
         # failed + 20,867 errors and 3.14 reported 29,164, every one of them
@@ -358,6 +363,8 @@ GUARD_BUG_CLASSES: tuple[BugClass, ...] = (
         axes={
             "removed_level": ("bucket", "basetemp", "ancestor"),
             "recovery": ("fresh_directory", "empty", "reused_when_intact"),
+            "privacy": ("mode_0700", "symlink_refused", "foreign_uid_refused"),
+            "hostile_environment": ("permissive_umask", "loose_existing_mode"),
             "oracle": ("unfixed_allocator_reproduction",),
         },
         known_gaps=(

--- a/tests/test_conftest_cache_isolation.py
+++ b/tests/test_conftest_cache_isolation.py
@@ -124,9 +124,121 @@ def test_cache_directories_do_not_accumulate_in_pytest_basetemp(
 
     # And basetemp itself carries no per-test cache entry at all, however many
     # tests have run before this one.
-    assert [p.name for p in basetemp.iterdir() if p.name.startswith("snapshot_cache-")] == []
+    assert [
+        p.name for p in basetemp.iterdir() if p.name.startswith("snapshot_cache-")
+    ] == []
 
     # The bucket is shared, the directories in it are not: this occurrence's
     # directory is distinct from every earlier one even though they are
     # siblings now.
     assert cache_dir not in _SEEN
+
+
+class TestTheAllocatorSurvivesItsDirectoryTreeVanishing:
+    """The allocator recovers whatever was removed under it, not just the bucket.
+
+    The failure this closes was suite-wide and badly disguised. `_isolate_snapshot_cache`
+    is autouse, so a single transient deletion under pytest's temp tree made
+    *every remaining test in that worker* error with a `FileNotFoundError`
+    naming a different freshly-generated bucket each time -- 20,867 errors on
+    one Linux lane and 29,164 on another (run 34729579282), plus the same
+    signature in a container where an unrelated process was pruning `/tmp`.
+    The bucket's own `is_dir()` check handled the bucket going away and not its
+    parent, so re-allocation failed on the missing parent forever after.
+
+    The invariant is stated over *which part of the tree was removed* rather
+    than against the one observed deletion, because the deleter is not the
+    bug: pytest's retention policy, a tmp reaper, a sandbox cleanup and a stray
+    `rmtree` all arrive here identically, and a test pinned to one of them
+    would leave the others open.
+    """
+
+    @staticmethod
+    def _allocate(basetemp: Path) -> Path:
+        """One allocation through the real allocator, with a real factory."""
+        import conftest
+
+        return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
+
+    @pytest.mark.parametrize(
+        "remove",
+        ["the bucket only", "the basetemp", "the whole tree above it"],
+        ids=["bucket", "basetemp", "ancestor"],
+    )
+    def test_allocation_recovers_after_a_deletion(
+        self, tmp_path: Path, remove: str
+    ) -> None:
+        import shutil
+
+        root = tmp_path / "root"
+        basetemp = root / "pytest-0" / "popen-gw0"
+        basetemp.mkdir(parents=True)
+
+        first = self._allocate(basetemp)
+        assert first.is_dir()
+
+        target = {
+            "the bucket only": first,
+            "the basetemp": basetemp,
+            "the whole tree above it": root,
+        }[remove]
+        shutil.rmtree(target)
+
+        second = self._allocate(basetemp)
+        assert second.is_dir(), f"no recovery after removing {remove}"
+        assert second != first, "a recovered bucket must be a fresh directory"
+        assert not any(second.iterdir()), "a recovered bucket must be empty"
+
+    def test_the_deletion_really_breaks_the_unfixed_allocator(
+        self, tmp_path: Path
+    ) -> None:
+        """Vacuity guard: the `basetemp` case must be unrecoverable without the fix.
+
+        Without it the test above could pass because the deletion was harmless
+        rather than because the allocator heals. This reproduces the pre-fix
+        allocator verbatim and requires it to fail.
+        """
+        import shutil
+        import tempfile
+
+        basetemp = tmp_path / "pytest-0" / "popen-gw0"
+        basetemp.mkdir(parents=True)
+
+        def unfixed() -> Path:
+            # The allocator as it was: no parent recreation.
+            return Path(tempfile.mkdtemp(prefix="snapshot-caches-", dir=basetemp))
+
+        unfixed()
+        shutil.rmtree(basetemp)
+        with pytest.raises(FileNotFoundError):
+            unfixed()
+
+    def test_repeated_allocation_without_deletion_reuses_one_bucket(
+        self, tmp_path: Path
+    ) -> None:
+        """And the fix must not turn every call into a new bucket.
+
+        The per-process bucket is the whole point of the allocator (it keeps
+        pytest's numbered allocator off a directory with thousands of siblings),
+        so a `mkdir`-always version that forgot the cache would be a silent
+        performance regression rather than a visible failure.
+        """
+        basetemp = tmp_path / "pytest-0" / "popen-gw0"
+        basetemp.mkdir(parents=True)
+        assert self._allocate(basetemp) == self._allocate(basetemp)
+
+
+class _FactoryStub:
+    """The one method `_snapshot_cache_bucket` uses off `pytest.TempPathFactory`.
+
+    A stub rather than a real factory because the test needs to *choose* the
+    basetemp in order to delete it, and deleting the session's real basetemp
+    would take the rest of the run with it -- which is the very failure under
+    test.
+    """
+
+    def __init__(self, basetemp: Path) -> None:
+        self._basetemp = basetemp
+
+    def getbasetemp(self) -> Path:
+        return self._basetemp

--- a/tests/test_conftest_cache_isolation.py
+++ b/tests/test_conftest_cache_isolation.py
@@ -35,8 +35,17 @@ session-wide cache directory -- the obvious way to make this "even faster"
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
+# The *same* module object pytest itself loaded, not a second copy: `tests/` has
+# no `__init__.py`, so pytest's prepend import mode puts this file's directory on
+# `sys.path` and loads the conftest as the top-level module `conftest` -- verified
+# by identity, which matters because the allocator caches its bucket in a
+# module-level dict. Imported here rather than inside each test so the tests read
+# as ordinary calls.
+import conftest  # noqa: E402
 import pytest
 
 from abicheck import dumper_cache, snapshot_cache
@@ -157,7 +166,6 @@ class TestTheAllocatorSurvivesItsDirectoryTreeVanishing:
     @staticmethod
     def _allocate(basetemp: Path) -> Path:
         """One allocation through the real allocator, with a real factory."""
-        import conftest
 
         return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
 
@@ -169,7 +177,6 @@ class TestTheAllocatorSurvivesItsDirectoryTreeVanishing:
     def test_allocation_recovers_after_a_deletion(
         self, tmp_path: Path, remove: str
     ) -> None:
-        import shutil
 
         root = tmp_path / "root"
         basetemp = root / "pytest-0" / "popen-gw0"
@@ -199,8 +206,6 @@ class TestTheAllocatorSurvivesItsDirectoryTreeVanishing:
         rather than because the allocator heals. This reproduces the pre-fix
         allocator verbatim and requires it to fail.
         """
-        import shutil
-        import tempfile
 
         basetemp = tmp_path / "pytest-0" / "popen-gw0"
         basetemp.mkdir(parents=True)
@@ -244,7 +249,6 @@ class TestRecoveryKeepsPytestsPrivacyGuarantees:
 
     @staticmethod
     def _allocate(basetemp: Path) -> Path:
-        import conftest
 
         return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
 
@@ -320,7 +324,6 @@ class TestValidationStopsAtPytestsOwnRoot:
 
     @staticmethod
     def _allocate(basetemp: Path) -> Path:
-        import conftest
 
         return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
 
@@ -379,10 +382,6 @@ class TestValidationStopsAtPytestsOwnRoot:
         outside `/tmp` -- it failed the moment the same test ran under pytest's
         default temp root, which is how the false premise surfaced.
         """
-        import shutil
-        import tempfile
-
-        import conftest
 
         root = Path(tempfile.mkdtemp(prefix="marker-free-"))
         try:
@@ -401,7 +400,6 @@ class TestValidationStopsAtPytestsOwnRoot:
 
     def test_the_owned_region_is_the_marker_and_everything_under_it(self) -> None:
         """The boundary as a pure function, independent of any filesystem."""
-        import conftest
 
         leaf = Path("/tmp/pytest-of-someone/pytest-3/popen-gw2")
         assert conftest._pytest_owned_levels(leaf) == [

--- a/tests/test_conftest_cache_isolation.py
+++ b/tests/test_conftest_cache_isolation.py
@@ -303,6 +303,116 @@ class TestRecoveryKeepsPytestsPrivacyGuarantees:
             os.umask(previous)
 
 
+class TestValidationStopsAtPytestsOwnRoot:
+    """Nothing above `pytest-of-<user>` is ours to check or to repair.
+
+    Validating every ancestor reaches `/tmp` and `/`, and that is worse than the
+    bug the recovery fixes (Codex review). On an ordinary non-root runner the
+    ownership check raises on root-owned `/tmp` during the very first autouse
+    allocation, so every test in the session errors. Running as root it is worse
+    still: the group/other fixup would strip `/tmp` from its usual `01777` and
+    break the machine's shared temp directory for everyone.
+
+    So the boundary is asserted directly, with a stand-in for `/tmp` whose mode
+    and ownership are deliberately *wrong* by the rules that apply inside
+    pytest's root.
+    """
+
+    @staticmethod
+    def _allocate(basetemp: Path) -> Path:
+        import conftest
+
+        return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
+
+    @staticmethod
+    def _tree(tmp_path: Path) -> tuple[Path, Path]:
+        """A `/tmp`-like ancestor holding a pytest root, returned as (system, leaf)."""
+        system = tmp_path / "tmp-like"
+        system.mkdir(mode=0o755)
+        return system, system / "pytest-of-someone" / "pytest-0" / "popen-gw0"
+
+    def test_a_system_ancestors_mode_is_left_alone(self, tmp_path: Path) -> None:
+        """The destructive half: `/tmp` must keep its world-writable mode."""
+        system, leaf = self._tree(tmp_path)
+        before = system.stat().st_mode
+        self._allocate(leaf)
+        assert system.stat().st_mode == before
+
+    def test_a_sticky_world_writable_ancestor_keeps_its_sticky_bit(
+        self, tmp_path: Path
+    ) -> None:
+        """Stated as the real `/tmp` shape, 01777, since that is what would break."""
+        system = tmp_path / "tmp-like-sticky"
+        system.mkdir()
+        system.chmod(0o1777)
+        self._allocate(system / "pytest-of-someone" / "pytest-0" / "popen-gw0")
+        assert system.stat().st_mode & 0o7777 == 0o1777
+
+    @pytest.mark.skipif(
+        not hasattr(os, "getuid") or os.getuid() != 0,
+        reason="needs root to create a directory owned by another user",
+    )
+    def test_a_foreign_owned_system_ancestor_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """The every-test-errors half: `/tmp` is root's, and a test run is not."""
+        system, leaf = self._tree(tmp_path)
+        os.chown(system, 1, 1)
+        assert self._allocate(leaf).is_dir()
+
+    def test_the_pytest_root_itself_is_still_validated(self, tmp_path: Path) -> None:
+        """The boundary is inclusive: the marker directory is pytest's, so ours."""
+        system, leaf = self._tree(tmp_path)
+        root = system / "pytest-of-someone"
+        root.mkdir(mode=0o755)
+        self._allocate(leaf)
+        assert root.stat().st_mode & 0o077 == 0
+
+    def test_with_an_explicit_basetemp_only_that_directory_is_owned(self) -> None:
+        """`--basetemp` has no marker; pytest creates just that one directory.
+
+        Deliberately NOT built under `tmp_path`: by default `tmp_path` lives
+        inside `/tmp/pytest-of-<user>/pytest-N/...`, so a path under it always
+        has a marker ancestor and this case would silently become the
+        marker-found one. The first version of this test did exactly that and
+        passed only because the suite was being run with `--basetemp` pointed
+        outside `/tmp` -- it failed the moment the same test ran under pytest's
+        default temp root, which is how the false premise surfaced.
+        """
+        import shutil
+        import tempfile
+
+        import conftest
+
+        root = Path(tempfile.mkdtemp(prefix="marker-free-"))
+        try:
+            assert not any(
+                level.name.startswith("pytest-of-") for level in (root, *root.parents)
+            ), f"{root} is not marker-free, so this case would not be exercised"
+            parent = root / "chosen-by-the-caller"
+            parent.mkdir(mode=0o755)
+            basetemp = parent / "basetemp"
+            assert conftest._pytest_owned_levels(basetemp) == [basetemp]
+            self._allocate(basetemp)
+            assert parent.stat().st_mode & 0o777 == 0o755
+            assert basetemp.stat().st_mode & 0o077 == 0
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_the_owned_region_is_the_marker_and_everything_under_it(self) -> None:
+        """The boundary as a pure function, independent of any filesystem."""
+        import conftest
+
+        leaf = Path("/tmp/pytest-of-someone/pytest-3/popen-gw2")
+        assert conftest._pytest_owned_levels(leaf) == [
+            Path("/tmp/pytest-of-someone"),
+            Path("/tmp/pytest-of-someone/pytest-3"),
+            leaf,
+        ]
+        assert Path("/tmp") not in conftest._pytest_owned_levels(leaf)
+        assert Path("/") not in conftest._pytest_owned_levels(leaf)
+
+
 class _FactoryStub:
     """The one method `_snapshot_cache_bucket` uses off `pytest.TempPathFactory`.
 

--- a/tests/test_conftest_cache_isolation.py
+++ b/tests/test_conftest_cache_isolation.py
@@ -34,6 +34,7 @@ session-wide cache directory -- the obvious way to make this "even faster"
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -226,6 +227,80 @@ class TestTheAllocatorSurvivesItsDirectoryTreeVanishing:
         basetemp = tmp_path / "pytest-0" / "popen-gw0"
         basetemp.mkdir(parents=True)
         assert self._allocate(basetemp) == self._allocate(basetemp)
+
+
+class TestRecoveryKeepsPytestsPrivacyGuarantees:
+    """Recreating the tree must not be a weaker act than creating it was.
+
+    These paths are predictable (`/tmp/pytest-of-<user>/pytest-N/popen-gwM`) on a
+    temp root shared between users, and pytest creates every level `0o700`,
+    refuses a symlinked or foreign-owned level, and tightens loose modes. A
+    `mkdir(parents=True, exist_ok=True)` recovery would have recreated the
+    hierarchy with the process umask (commonly world-traversable `0o755`) and
+    accepted a path planted in the window between the deletion and the recovery
+    (Codex review). Each property is asserted separately, because a single
+    "recovery works" test passes while any one of them is absent.
+    """
+
+    @staticmethod
+    def _allocate(basetemp: Path) -> Path:
+        import conftest
+
+        return conftest._snapshot_cache_bucket(_FactoryStub(basetemp))
+
+    def test_every_recreated_level_is_private(self, tmp_path: Path) -> None:
+        """Not just the leaf: an open ancestor makes the leaf reachable."""
+        root = tmp_path / "pytest-of-someone"
+        basetemp = root / "pytest-0" / "popen-gw0"
+        self._allocate(basetemp)
+        for level in (root, root / "pytest-0", basetemp):
+            mode = level.stat().st_mode & 0o777
+            assert mode & 0o077 == 0, f"{level} is group/other-accessible ({mode:#o})"
+
+    def test_a_symlinked_level_is_refused(self, tmp_path: Path) -> None:
+        """The planted-path case: a symlink where a directory is expected."""
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        root = tmp_path / "pytest-of-someone"
+        root.symlink_to(elsewhere, target_is_directory=True)
+        with pytest.raises(OSError, match="symbolic link"):
+            self._allocate(root / "pytest-0" / "popen-gw0")
+
+    @pytest.mark.skipif(
+        not hasattr(os, "getuid") or os.getuid() != 0,
+        reason="needs root to create a directory owned by another user",
+    )
+    def test_a_foreign_owned_level_is_refused(self, tmp_path: Path) -> None:
+        """Ownership, not just mode: a 0700 directory someone else owns is theirs."""
+        root = tmp_path / "pytest-of-someone"
+        root.mkdir(mode=0o700)
+        os.chown(root, 1, 1)
+        with pytest.raises(OSError, match="owned by another user"):
+            self._allocate(root / "pytest-0" / "popen-gw0")
+
+    def test_a_loose_mode_on_an_existing_level_is_tightened(
+        self, tmp_path: Path
+    ) -> None:
+        """pytest performs this same fixup rather than failing, so recovery does too."""
+        root = tmp_path / "pytest-of-someone"
+        root.mkdir(mode=0o755)
+        self._allocate(root / "pytest-0" / "popen-gw0")
+        assert root.stat().st_mode & 0o077 == 0
+
+    def test_the_umask_cannot_loosen_a_recreated_level(self, tmp_path: Path) -> None:
+        """`mkdir`'s mode is umask-masked, so the chmod after it is load-bearing.
+
+        Under a permissive umask a mode-only `mkdir` still yields a private
+        directory, so this sets the hostile case explicitly: umask 0 is what
+        distinguishes `mkdir(mode=0o700)` alone from `mkdir` plus `chmod`.
+        """
+        previous = os.umask(0)
+        try:
+            basetemp = tmp_path / "pytest-of-someone" / "pytest-0" / "popen-gw0"
+            self._allocate(basetemp)
+            assert basetemp.stat().st_mode & 0o077 == 0
+        finally:
+            os.umask(previous)
 
 
 class _FactoryStub:


### PR DESCRIPTION
## Summary

`main`'s two Linux unit lanes are failing with tens of thousands of errors from a single root cause in `tests/conftest.py`. This fixes it.

## Motivation

On run [34729579282](https://github.com/abicheck/abicheck/actions/runs/34729579282): `unit-tests (ubuntu-latest, 3.12)` reported **2 failed, 20,867 errors** and 3.14 reported **29,164**, every one of them

```
FileNotFoundError: .../pytest-of-runner/pytest-0/popen-gwN/snapshot-caches-XXXXXXXX
```

out of the autouse `_isolate_snapshot_cache` fixture.

`_snapshot_cache_bucket` guards against its *bucket* disappearing, but not against the bucket's **parent**. Once a worker's basetemp was gone, `mkdtemp(dir=basetemp)` raised, nothing recreated the tree, and because the fixture is autouse every remaining test in that worker failed on entry — each reporting a *different* freshly-generated bucket name, which is what disguised one root cause as a flood of unrelated ones and explains why the error count equals "all remaining tests".

I found this while watching #1267's CI and [wrote up the diagnosis there](https://github.com/abicheck/abicheck/pull/1267#issuecomment-5650081083) rather than widening that perf PR with it. Worth recording honestly: I had previously hit the same signature locally, attributed it solely to an unrelated process pruning `/tmp` in my container, and said so — the deletion there was real, but calling it only external interference was wrong, since a GitHub runner has no such process and fails identically.

## Changes

- `_snapshot_cache_bucket` recreates the parent (`mkdir(parents=True, exist_ok=True)`) before allocating. That makes recovery independent of **what** removed the tree — pytest's own retention policy, a tmp reaper, a sandbox cleanup and a stray `rmtree` all arrive here identically, so keying the fix to any one deleter would leave the rest open. `exist_ok` rather than a prior existence check, since check-then-create reintroduces the window being closed.
- `TestTheAllocatorSurvivesItsDirectoryTreeVanishing` in `tests/test_conftest_cache_isolation.py`.
- New bug class `test_infra.autouse_allocator_cannot_recover` in `tests/regressions/manifest_guards.py` — a distinct root cause from the neighbouring shared-state class, which is about a differential test being served its own cached result.

## Bug-fix test contract

- Bug class: `test_infra.autouse_allocator_cannot_recover` — a fixture every test enters converts a transient failure of its own environment into a failure of the whole session.
- Publicly observable failure: tens of thousands of `FileNotFoundError` errors across a full unit lane, one per remaining test, each naming a different directory, from one lost directory.
- Regression test fails on base: `TestTheAllocatorSurvivesItsDirectoryTreeVanishing::test_allocation_recovers_after_a_deletion[basetemp]` and `[ancestor]` — verified by stashing the `conftest.py` change and re-running: exactly those two fail, 33 pass.
- Negative control: `test_repeated_allocation_without_deletion_reuses_one_bucket` — a heal-by-always-allocating version would pass the recovery cases while silently discarding the per-process bucket reuse the allocator exists for (the reason it was introduced: keeping pytest's numbered allocator off a directory with thousands of siblings).
- Public-surface test: none, and the registry entry claims none — the seed test inspects a pytest fixture's own allocator directly.
- Axes covered: which level of the tree was removed (the bucket, the basetemp, an ancestor above it); recovery properties (fresh directory, empty, reused when intact).
- General invariant: *allocation must succeed again after any part of the tree above it is removed, and must still reuse one bucket when the tree is intact.* Exercised across the three removal levels rather than the one observed deletion, with an oracle that is not the implementation: `test_the_deletion_really_breaks_the_unfixed_allocator` reproduces the pre-fix allocator verbatim and requires it to raise, so the recovery cases cannot pass because a deletion happened to be harmless.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [ ] Docs updated if user-visible behaviour changed — not applicable, test infrastructure only
- [x] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

### Local verification

**2,212 tests pass in the exact lanes CI failed** (`tests/unit/storage`, `tests/test_action_report_query.py`, `tests/test_action_report_destinations.py`), plus 35 in the isolation and regression-manifest suites. `check_ai_readiness.py` and `check_architecture.py` both 0 errors; `ruff check tests/ scripts/` clean. The fix was verified in both directions — the two new cases fail without the `conftest.py` change and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vee2ztjM4Utc7E3fVNjsEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vee2ztjM4Utc7E3fVNjsEN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience of test runs when temporary directories are unexpectedly removed.
  - Automatically restores missing temporary-directory levels while preserving privacy, ownership, symlink, and permission safeguards.
  - Prevents unrelated system directories from being modified during recovery.
  - Reuses the existing temporary allocation after recovery instead of creating unnecessary replacements.

- **Tests**
  - Added coverage for recovery after removing the cache directory, its parent, or the surrounding temporary tree.
  - Added validation for permissions, ownership, symlink handling, and restrictive umask scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->