### PR TITLE
fix(tests): quote every path injected into the release-probe script

### DIFF
--- a/tests/test_action_release_operand_detection.py
+++ b/tests/test_action_release_operand_detection.py
@@ -33,6 +33,8 @@ the shell table did.
 
 from __future__ import annotations
 
+import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -68,6 +70,31 @@ def _function_source() -> str:
     )
 
 
+def _sh(value: Path | str) -> str:
+    """A path as a bash *word*: quoted, and separator-converted on Windows.
+
+    Every path this module injects into a generated script goes through
+    here. Interpolating one raw is what turned the windows-latest lane red
+    after PR #1259: `sys.executable` and the safe directory arrived as
+    `D:\\a\\...`, whose backslashes bash ate as escapes, so `$_PY_BIN`
+    named nothing, the probe never ran, and every shape that needs it
+    (tar, wheel, conda -- but not rpm/deb, which the magic check answers
+    without it) reported "not a package".
+
+    Two separate defects, so two separate fixes: `shlex.quote` for the
+    quoting, and `as_posix()` for the separator -- the latter only where
+    the separator actually differs, since a backslash is a legal filename
+    character on POSIX and rewriting one unconditionally would corrupt a
+    real path (`_workflow_exec.py` states the same rule at its own
+    `bash <script>` boundary, for the same reason).
+    """
+    return shlex.quote(
+        value.as_posix()
+        if isinstance(value, Path) and os.name == "nt"
+        else str(value)
+    )
+
+
 def _ask(
     path: Path | str,
     *,
@@ -84,7 +111,8 @@ def _ask(
     """
     require_bash()
     env_setup = (
-        f'_PY_BIN_HAS_ABICHECK=true\n_PY_BIN={sys.executable}\n_PY_SAFE_DIR={cwd}\n'
+        f"_PY_BIN_HAS_ABICHECK=true\n_PY_BIN={_sh(sys.executable)}\n"
+        f"_PY_SAFE_DIR={_sh(cwd)}\n"
         if abicheck_available
         else "_PY_BIN_HAS_ABICHECK=false\n"
     )
@@ -149,6 +177,77 @@ class TestAgreementWithTheRealPredicate:
         assert not is_package(d)
         assert _ask(d, abicheck_available=True, cwd=tmp_path)
         assert _ask(d, abicheck_available=False, cwd=tmp_path)
+
+
+class TestEveryInjectedPathSurvivesTheShell:
+    """A path interpolated into a generated script is a *bash word*.
+
+    This module builds its script by string interpolation, so every path it
+    injects is re-parsed by bash. Raw interpolation reddened windows-latest
+    after PR #1259 -- `D:\\a\\...` lost its backslashes to bash's escape
+    handling -- but the defect is not Windows-specific: a space, a quote or
+    a `$` in the path does the same thing on Linux, and no CI lane would
+    have caught it either, because every path in play happened to be tame.
+
+    So the contract is stated over the primitive (`_sh`), against an oracle
+    that is not `shlex` -- what bash itself reports receiving -- and swept
+    over names chosen to break naive interpolation, rather than pinned to
+    the one spelling that broke. The end-to-end case then proves the
+    primitive is actually *used* on the path that failed, since a correct
+    helper nothing calls fixes nothing.
+    """
+
+    AWKWARD = (
+        "plain",
+        "with space",
+        "with'single",
+        'with"double',
+        "with$dollar",
+        "with`backtick",
+        "with;semi",
+        "with*glob",
+        "with\\backslash",
+        "with\nnewline",
+        "with|pipe",
+        "-leading-dash",
+    )
+
+    @staticmethod
+    def _echo_through_bash(word: str) -> str:
+        """What bash actually receives for this word -- the oracle."""
+        require_bash()
+        completed = subprocess.run(  # noqa: S603
+            [bash_executable(), "-c", f"printf '%s' {word}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+        return completed.stdout
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="these names are legal on POSIX; NTFS rejects most of them",
+    )
+    @pytest.mark.parametrize("name", AWKWARD)
+    def test_a_path_round_trips_through_the_generated_script(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        target = tmp_path / name
+        assert self._echo_through_bash(_sh(target)) == str(target)
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX-legal name; NTFS rejects the backslash"
+    )
+    def test_the_probe_still_answers_from_an_awkwardly_named_safe_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """End to end, on the very path whose raw interpolation broke CI."""
+        safe_dir = tmp_path / "safe dir\\with odd $chars"
+        safe_dir.mkdir()
+        operand = _make_tar_mode(tmp_path / "operand", "w:gz")
+        assert is_package(operand)
+        assert _ask(operand, abicheck_available=True, cwd=safe_dir)
 
 
 class TestTheProbeResolvesTheOperandNotTheSafeDirectory:
@@ -254,9 +353,9 @@ class TestTheProbeAnchorsExactlyWhatTheSharedPredicateSays:
             (
                 f'_RUNNING_ON_WINDOWS={"true" if on_windows else "false"}',
                 "_PY_BIN_HAS_ABICHECK=true",
-                f'_PY_BIN="{stub}"',
-                f'_PY_SAFE_DIR="{workdir}"',
-                f'RECORD="{recorder}"; export RECORD',
+                f"_PY_BIN={_sh(stub)}",
+                f"_PY_SAFE_DIR={_sh(workdir)}",
+                f"RECORD={_sh(recorder)}; export RECORD",
                 _function_source(),
                 '_is_release_style_operand "$1"',
             )


### PR DESCRIPTION
## Summary

Fixes four tests that have been red on the `unit-tests (windows-latest, 3.13)` lane since #1259 and merged still-red with #1261. They are red on `main` right now.

## Motivation

`tests/test_action_release_operand_detection.py` builds its bash script by string interpolation, so every path it injects is re-parsed by bash — and it injected `sys.executable` and the safe directory **raw**. On windows-latest those arrive as `D:\a\...`; bash consumed the backslashes as escapes, `$_PY_BIN` named nothing, and the probe never ran. Every shape that depends on the probe (tar, wheel, conda) then reported "not a package", while rpm and deb passed because the magic check answers those without it — which is exactly the shape of the four failures:

```
FAILED TestAgreementWithTheRealPredicate::test_every_package_shape_agrees_under_a_nonconventional_name
  - AssertionError: {'rpm': (True, True), 'deb': (True, True), 'tar_gz': (True, False), 'tar_plain': (True, False), ...}
FAILED TestTheProbeResolvesTheOperandNotTheSafeDirectory::test_a_relative_operand_resolves_from_the_working_directory
FAILED TestTheProbeResolvesTheOperandNotTheSafeDirectory::test_a_dotted_relative_operand_resolves_too
FAILED TestThePreInstallFallback::test_the_fallback_is_what_the_probe_improves_on
```

The sibling module `test_action_run_sh_helpers.py` already quotes (`shlex.quote(py_bin or sys.executable)`); this one did not.

## Changes

- One documented `_sh()` helper that every injection site in the module now goes through, with the two halves deliberately separate: `shlex.quote` for the quoting, and `as_posix()` for the separator — the latter applied **only** where the separator actually differs, since a backslash is a legal POSIX filename character and rewriting one unconditionally would corrupt a real path (`_workflow_exec.py` states the same rule at its own `bash <script>` boundary).
- `TestEveryInjectedPathSurvivesTheShell`: the contract, stated over the primitive and end to end.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: a platform-shaped value interpolated into a generated shell script without quoting — the shell-boundary sibling of `cli_surface.name_independent_dispatch_undone_downstream`: the helper under test is correct, and the harness feeding it corrupts the input before it ever arrives, so the failure looks like a defect in the code under test.
- Publicly observable failure: four tests fail on `unit-tests (windows-latest, 3.13)` — a red required lane on `main`. No product behaviour is affected: the defect is in the test harness, and `action/run.sh` itself is unchanged by this PR.
- Regression test fails on base: yes, verified by mutation rather than asserted — reverting `_sh` to `return str(value)` fails ten of the new tests **on Linux**, the `with\backslash` case (the literal Windows failure mode) included. That is the point of the design: the original defect could only be observed on a Windows runner, and now it cannot reach CI unnoticed from any platform.
- Negative control: `plain` in the sweep (a name needing no quoting must round-trip unchanged, so the fix is not "mangle everything"), and the module's existing `test_a_non_package_agrees_too` / `test_a_relative_non_package_still_answers_no`, which still answer `False`.
- Public-surface test: `test_the_probe_still_answers_from_an_awkwardly_named_safe_dir` runs the real `_is_release_style_operand` parsed out of `action/run.sh`, through `bash`, with a real gzip tar operand and a safe directory containing a space, a backslash and a `$` — the path whose raw interpolation broke CI. A correct helper that nothing calls would fail here.
- Axes covered: POSIX (the sweep and the end-to-end case; both `os.name == "nt"`-skipped, since NTFS rejects most of these names) and the Windows separator branch by construction — `_sh` converts only when `os.name == "nt"`, and the POSIX branch is what every assertion here exercises. Probe available and probe absent both still covered by the pre-existing classes.
- General invariant: for any path, the bash word `_sh` produces is received by bash as exactly that path. Stated against an oracle that is **not** `shlex` — `printf '%s'` in a real bash, i.e. what the consumer actually reports receiving, deliberately not the same library the implementation calls — and swept over twelve names chosen to break naive interpolation (space, both quote characters, `$`, backtick, `;`, `*`, backslash, newline, `|`, leading dash) rather than pinned to the one spelling that broke.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — no `abicheck/**/*.py` change; this is a test-harness fix
- [x] Docs updated if user-visible behaviour changed — none; no user-visible behaviour changes
- [x] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9spAnL9CsBZw3sKBGxEYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9spAnL9CsBZw3sKBGxEYv)_