### PR TITLE
fix: a public-header addition no longer reduces analysis assurance, wherever the header sorts

### DIFF
--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -839,12 +839,22 @@ class ComparabilityMismatch:
     ``dimensions`` named (``checker.compare`` carries it into
     ``DiffResult.comparability_assurance`` and ``coverage_warnings``)
     rather than disposed of as a refusal. Only a divergence whose SHAPE is
-    itself positive evidence about what changed may be non-fatal -- see
-    ``comparability_profile``'s declared-header-insertion branch, the only
-    producer today. This is the product rule "weaker evidence narrows
-    conclusions" applied literally: an ordinary public-header addition
-    lowers assurance on the declaration/layout axes, it does not make two
-    snapshots incomparable.
+    itself positive evidence about what changed may be non-fatal. This is
+    the product rule "weaker evidence narrows conclusions" applied
+    literally.
+
+    **No axis produces one today.** The single producer was
+    ``comparability_profile``'s declared-header-INSERTION branch, which
+    priced an added public header's incidental sort position as reduced
+    ``declaration``/``layout`` assurance; that branch was wrong (a declared
+    header's *content* is not part of ``profile_fingerprint`` at all, so
+    the macro/pragma-leak hazard it priced is compared at full assurance
+    whenever an existing header's content evolves) and is gone -- the
+    growth is now waived outright by the ``header_sequence`` carve-out, see
+    :func:`comparability_sequences._header_sequence_is_scope_confirmed_growth`.
+    The machinery here stays because the rule it expresses is general: a
+    future axis whose divergence is bounded rather than disqualifying sets
+    ``fatal=False`` and is priced per dimension, with no further wiring.
 
     ``assurance: "none"`` stays reserved for a fatal mismatch forced
     through with ``--diagnostic-comparison``; a non-fatal one never sets
@@ -1265,20 +1275,17 @@ def check_contracts_comparable(
     case would otherwise still raise ``ProfileMismatchError`` immediately
     after the scope carve-out waives it. A ``profile_fingerprint`` mismatch
     confined to ``header_sequence`` does not raise when the new sequence is
-    the old sequence, byte-for-byte unchanged, with new entries appended
-    STRICTLY AFTER it (see :func:`_header_sequence_is_additive_reorder_free`)
-    — proving every *existing* header's own preprocessing context (the
-    headers parsed before it) is identical to before, not merely that
-    existing headers keep their relative order to each other. A new header
-    inserted before or between existing ones (Codex review, PR #641
-    follow-up, seventh P1) still raises even though it superficially looks
-    additive, since it changes what an existing header downstream of the
-    insertion point is parsed after — the same "reorder of existing headers"
-    risk this carve-out was always meant to exclude, just reached via
-    insertion rather than a literal swap. A reorder of existing headers
-    entangled with growth (the same genuine profile-relevant risk) still
-    raises too, same as any other profile drift this carve-out doesn't
-    cover. **Also requires
+    the old sequence with scope-confirmed new entries added, every existing
+    header keeping its relative order — whether the new entries were
+    appended after the old sequence or sorted into the middle of it (see
+    :func:`comparability_sequences._header_sequence_is_scope_confirmed_growth`,
+    which also records why the insertion case may not be priced differently
+    from the append case: a header's *content* is not fingerprinted at all,
+    so the macro/pragma-leak hazard an insertion carries is the same one an
+    edit to an existing header carries, and that one is compared at full
+    assurance by design). A reorder of an EXISTING header — with or without
+    growth alongside it — still raises, same as any other profile drift
+    this carve-out doesn't cover. **Also requires
     :func:`_scope_growth_corroborated` (Codex review, PR #641 follow-up,
     P1):** an additive-shaped ``header_sequence`` on its own is not
     sufficient — a header already declared identically on both sides via

--- a/abicheck/comparability_profile.py
+++ b/abicheck/comparability_profile.py
@@ -58,11 +58,9 @@ from .comparability_language_mode import (
 from .comparability_sequences import (
     _HEADER_SEQUENCE_FIELDS,
     _INCLUDE_SEQUENCE_FIELDS,
-    _header_sequence_is_additive_reorder_free,
-    _header_sequence_is_interior_insertion,
+    _header_sequence_is_scope_confirmed_growth,
     _include_sequence_is_additive_owned_growth,
     _scope_newly_added_headers,
-    inserted_header_entries,
 )
 from .model import AbiSnapshot, ExtractionContract, FactStatus
 
@@ -256,14 +254,17 @@ def _unexplained_profile_fields(
     if (
         header_seq_candidate
         and scope_growth_corroborated
-        and _header_sequence_is_additive_reorder_free(
+        and _header_sequence_is_scope_confirmed_growth(
             old_fields.get("header_sequence"),
             new_fields.get("header_sequence"),
             scope_new_headers,
         )
     ):
         # Header-sequence-growth carve-out (PR #641 follow-up, third
-        # round) -- see check_contracts_comparable's own docstring.
+        # round) -- see check_contracts_comparable's own docstring, and
+        # `_header_sequence_is_scope_confirmed_growth` for why a
+        # scope-confirmed public-header addition is waived wherever the new
+        # header sorts, rather than only when it sorts last.
         unexplained -= header_seq_candidate
 
     include_seq_candidate = unexplained & _INCLUDE_SEQUENCE_FIELDS
@@ -323,134 +324,6 @@ def _profile_mismatch_reason(
             "is not comparable."
         )
     return None
-
-
-#: The dimensions a declared-header INSERTION leaves unverified -- deliberately
-#: wider than ``_PROFILE_FIELD_DIMENSIONS["header_sequence"]``'s own
-#: ``{"declaration"}``. The hazard an insertion introduces is precisely a
-#: macro/pragma state change for every header parsed after the insertion point,
-#: which is the same hazard ``macro_ops``/``pass_through_flags`` carry, and both
-#: of those name ``{"declaration", "layout"}`` (a ``#pragma pack`` reaching a
-#: later header changes layout, not just which declarations exist). Naming the
-#: narrower set here would under-report the reduction this branch is granting.
-_HEADER_INSERTION_DIMENSIONS = frozenset({"declaration", "layout"})
-
-
-def _declared_header_insertion_mismatch(
-    old_contract: ExtractionContract,
-    new_contract: ExtractionContract,
-    unknown_differing: set[str],
-    differing: set[str],
-    unexplained: set[str],
-) -> ComparabilityMismatch | None:
-    """A NON-fatal (``fatal=False``) descriptor when the only thing still
-    unexplained is that new public headers were INSERTED into the declared
-    sequence rather than appended to its end -- otherwise ``None``, leaving
-    the caller's ordinary fatal mismatch in place.
-
-    Why this exists. ``header_sequence`` records declared-header ORDER
-    because the aggregate driver TU ``dumper.py`` generates parses declared
-    headers sequentially, so a header can change how every header after it
-    resolves. :func:`_header_sequence_is_additive_reorder_free` waives only a
-    strict trailing append, since that alone proves no existing header's
-    preprocessing context changed. That reasoning is sound for a
-    user-declared ``-H a.h -H b.h`` order -- and badly mis-fitted to a
-    directory-discovered one, where the order is an incidental product of
-    sorting the discovered set. Adding one public header named ``json.h``
-    to a project whose headers sort as ``data.h, log.h, ...`` lands it in
-    the MIDDLE, so the waiver declines and a plain, ordinary public-header
-    addition refuses the whole comparison: no verdict, no findings, no
-    evidence of an ABI problem either way. That is the wrong disposition
-    twice over -- it manufactures a refusal out of an addition, and it
-    discards every conclusion on axes the insertion cannot touch (the
-    binary's exported-symbol identity above all).
-
-    What this branch does instead. When the divergence is confined to the
-    declared-header/include sequences, the scope fingerprint independently
-    corroborates that the declared surface genuinely grew, and the new
-    sequence is the old one with exactly those newly-added headers inserted
-    order-preservingly (:func:`_header_sequence_is_interior_insertion`), the
-    comparison RUNS and the residual risk is recorded as an assurance
-    reduction scoped to :data:`_HEADER_INSERTION_DIMENSIONS`. Nothing is
-    hidden: the reason text reaches ``coverage_warnings`` and the per-
-    dimension breakdown reaches ``DiffResult.comparability_assurance``, so a
-    consumer that wants to treat reduced assurance as a failure still can.
-
-    What it deliberately does NOT do:
-
-    * It never fires when an existing header MOVED relative to another (a
-      real reorder), when the extra entries are not the very headers the
-      scope fingerprint confirms as new, when scope growth is uncorroborated,
-      or when any OTHER profile field (compiler, standard, macros, target)
-      is also unexplained -- each of those stays a hard refusal, unchanged.
-    * It never fires on an unrecognized differing field or on absent/
-      malformed ``profile_fields`` (``unknown_differing``/empty ``differing``
-      -- the fail-closed cases :func:`_profile_mismatch_reason` answers
-      first), where there is no verified shape to reason from at all.
-    * It does not weaken the trailing-append waiver: that shape returns
-      ``None`` from the insertion predicate and keeps FULL assurance, since
-      it changes no existing header's parse context.
-
-    The extraction-side fix this does not attempt: parsing each declared
-    header in an independently scoped TU would make declared order
-    non-load-bearing outright, and then even a reorder would be comparable
-    at full assurance. That is a dumper change with real cost (one TU per
-    header), tracked separately; this branch corrects the DISPOSITION of the
-    evidence abicheck already has.
-    """
-    if unknown_differing or not differing:
-        return None
-    if unexplained != _HEADER_SEQUENCE_FIELDS:
-        # EXACTLY `header_sequence`, not a subset of it plus `include_sequence`
-        # (Codex review, PR #1274, first P1). A *verified* additive
-        # include-sequence growth -- the one an inferred header-owning root
-        # produces alongside any header addition -- has already been removed
-        # from `unexplained` by `_unexplained_profile_fields`' own carve-out,
-        # so an include_sequence still sitting here is by construction one
-        # that carve-out REFUSED: a changed -I topology, e.g. two include
-        # roots swapped. Include-search order decides which dependency header
-        # a given `#include` resolves to, which is a different and unbounded
-        # hazard from the declared-header insertion this branch reasons about
-        # -- and nothing here corroborates it. An include_sequence-only
-        # divergence is likewise none of this branch's business: there is no
-        # declared-header insertion to reason about at all.
-        return None
-    if not _scope_growth_corroborated(old_contract, new_contract):
-        return None
-    scope_new_headers = _scope_newly_added_headers(
-        old_contract.scope_fields.get("headers"),
-        new_contract.scope_fields.get("headers"),
-    )
-    if not _header_sequence_is_interior_insertion(
-        old_contract.profile_fields.get("header_sequence"),
-        new_contract.profile_fields.get("header_sequence"),
-        scope_new_headers,
-    ):
-        return None
-    # The SEQUENCE's own additions, not `scope_new_headers` (CodeRabbit
-    # review, PR #1274): the predicate above only requires the former to be a
-    # subset of the latter, so a header declared public but never fed to the
-    # L2 frontend is in the scope set and in no insertion -- naming it here
-    # would report a header that was not inserted anywhere.
-    inserted = ", ".join(
-        inserted_header_entries(
-            old_contract.profile_fields.get("header_sequence"),
-            new_contract.profile_fields.get("header_sequence"),
-        )
-    )
-    return ComparabilityMismatch(
-        kind="profile",
-        reason=(
-            "new public header(s) were inserted into the declared header "
-            f"sequence rather than appended after it ({inserted}) — the "
-            "comparison was performed, but every existing header after an "
-            "insertion point was parsed with the new header's macros/pragmas "
-            "already in effect, so declaration- and layout-dimension "
-            "conclusions carry reduced assurance."
-        ),
-        dimensions=_HEADER_INSERTION_DIMENSIONS,
-        fatal=False,
-    )
 
 
 def _check_profile_fingerprint_comparable(
@@ -556,11 +429,6 @@ def _check_profile_fingerprint_comparable(
     reason = _profile_mismatch_reason(unknown_differing, differing, unexplained)
     if reason is None:
         return None
-    bounded = _declared_header_insertion_mismatch(
-        old_contract, new_contract, unknown_differing, differing, unexplained
-    )
-    if bounded is not None:
-        return bounded
     # Mirrors _profile_mismatch_reason's own three cases (Codex-review-style
     # fail-closed default first): an unrecognized differing field, or an
     # entirely empty `differing` (profile_fields absent/malformed), can never

--- a/abicheck/comparability_sequences.py
+++ b/abicheck/comparability_sequences.py
@@ -499,6 +499,4 @@ def _header_sequence_is_scope_confirmed_growth(
     """
     return _header_sequence_is_additive_reorder_free(
         old_value, new_value, scope_new_headers
-    ) or _header_sequence_is_interior_insertion(
-        old_value, new_value, scope_new_headers
-    )
+    ) or _header_sequence_is_interior_insertion(old_value, new_value, scope_new_headers)

--- a/abicheck/comparability_sequences.py
+++ b/abicheck/comparability_sequences.py
@@ -452,28 +452,53 @@ def _header_sequence_is_interior_insertion(
     return (set(new_list) - set(old_list)) <= scope_new_headers
 
 
-def inserted_header_entries(old_value: str | None, new_value: str | None) -> list[str]:
-    """The ``header_sequence`` entries present in *new_value* and not in
-    *old_value*, in their new-side order.
+def _header_sequence_is_scope_confirmed_growth(
+    old_value: str | None, new_value: str | None, scope_new_headers: set[str] | None
+) -> bool:
+    """Whether the declared-header sequence grew by nothing but headers the
+    declared *surface* independently confirms as new -- whether they landed
+    after the old sequence (:func:`_header_sequence_is_additive_reorder_free`)
+    or inside it (:func:`_header_sequence_is_interior_insertion`).
 
-    What a caller should NAME when reporting an insertion (CodeRabbit
-    review, PR #1274). ``_scope_newly_added_headers`` answers a different
-    question -- every header newly added to the declared *surface* -- and
-    :func:`_header_sequence_is_interior_insertion` only requires the
-    sequence's own additions to be a SUBSET of that set. A header declared
-    public but never fed to the L2 frontend is in one and not the other, so
-    reporting the scope set would name a header that was not inserted
-    anywhere.
+    This is the predicate the ``header_sequence`` carve-out is stated in
+    terms of, and it deliberately does **not** distinguish the two
+    placements. The distinction was load-bearing for one release (PR #1274
+    granted a trailing append full assurance and bounded an interior
+    insertion to reduced ``declaration``/``layout`` assurance) and is not
+    sound, because the hazard it prices -- "``log.h`` is now parsed with
+    ``json.h``'s macros/pragmas already in effect" -- is neither specific to
+    an insertion nor something this contract prices anywhere else:
 
-    Empty when either side is absent or undecodable: a caller that has
-    already established the insertion shape should fall back to its own
-    wording rather than assert a list it cannot derive.
+    * A declared header's **content** is not part of ``profile_fingerprint``
+      at all (:func:`abicheck.comparability_fields._header_identities` keys a
+      header by its root-relative path, never its bytes). So an existing
+      ``data.h`` that gains a ``#define`` or a ``#pragma pack`` between two
+      versions changes the parse context of *every* header after it, and is
+      compared at FULL assurance today, by design -- that is what "the
+      declared surface's content is the subject of the comparison, not
+      evidence about the extraction environment" means. Adding those same
+      declarations as a new file instead is the same fact in a different
+      shape; pricing one and not the other is an inconsistency, not a
+      safeguard.
+    * The added header's own position is an incidental product of the
+      project's discovered, sorted public-header set -- ``json.h`` sorts
+      between ``data.h`` and ``log.h`` -- not an extraction-configuration
+      choice anyone made. Making assurance depend on it makes it depend on
+      the new header's spelling.
+    * The scope axis already treats the very same addition as ordinary
+      evolution at full assurance
+      (:func:`abicheck.comparability._scope_field_is_additive_superset`).
+
+    What stays refused is unchanged and is what the order fact exists for:
+    an EXISTING header that moved relative to another, growth whose extra
+    entries the scope fingerprint does not confirm as newly declared, a
+    duplicate/sentinel/undecodable sequence, and -- because this predicate
+    only ever removes ``header_sequence`` from the caller's working set --
+    any other profile field (compiler, standard, macros, target, include
+    topology) diverging alongside it.
     """
-    if old_value is None or new_value is None:
-        return []
-    old_list = _json_load_str_list(old_value)
-    new_list = _json_load_str_list(new_value)
-    if old_list is None or new_list is None:
-        return []
-    old_entries = set(old_list)
-    return [entry for entry in new_list if entry not in old_entries]
+    return _header_sequence_is_additive_reorder_free(
+        old_value, new_value, scope_new_headers
+    ) or _header_sequence_is_interior_insertion(
+        old_value, new_value, scope_new_headers
+    )

--- a/abicheck/comparability_sequences.py
+++ b/abicheck/comparability_sequences.py
@@ -41,11 +41,14 @@ from .comparability_json import (
 # too, since profile_fingerprint tracks declared-header ORDER as a genuine
 # extraction-context fact distinct from scope_fingerprint's order-independent
 # declared SET -- see compute_extraction_contract's docstring) is allowed to
-# treat as non-fatal, and only when the new sequence extends the old one with
-# new entries strictly TRAILING the old sequence, unchanged -- proving every
-# EXISTING header's preprocessing context (the headers parsed before it) is
-# byte-for-byte identical to before, not merely that existing headers keep
-# their relative order to each other.
+# waive, and only for growth `_header_sequence_is_scope_confirmed_growth`
+# accepts: the new sequence is the old one with scope-confirmed new entries
+# added and every EXISTING header keeping its relative order, whether those
+# entries trail the old sequence or sort into the middle of it. The waiver was
+# trailing-append-only for two releases; see that function's own docstring for
+# the measurement that retired the distinction, and for what stays refused (an
+# existing header that MOVED, growth the declared surface does not confirm as
+# new, and every other profile field).
 _HEADER_SEQUENCE_FIELDS = frozenset({"header_sequence"})
 
 
@@ -406,23 +409,36 @@ def _header_sequence_is_interior_insertion(
     ``[b.h, a.h]`` is not, and neither is a growth whose extra entries the
     declared *surface* never confirms as new.
 
-    **This is not a comparability waiver and must never be used as one.**
-    A trailing append proves every existing header's preprocessing context
-    is byte-for-byte what it was; an interior insertion proves only that no
-    existing header MOVED relative to another -- ``log.h`` is now parsed
-    with ``json.h``'s macros/pragmas already in effect, which can genuinely
-    change its AST. What this shape does establish is that the divergence is
-    a header ADDITION rather than a reordering or an unrelated compile-
-    context drift, which is what lets
-    ``comparability_profile._check_profile_fingerprint_comparable`` record it
-    as a bounded, dimension-scoped assurance reduction on a comparison that
-    still runs, instead of refusing to produce any verdict at all. See that
-    function's own ``fatal=False`` branch for the reasoning.
+    **What this shape establishes, and what it does not.** A trailing append
+    proves every existing header's preprocessing context is byte-for-byte
+    what it was; an interior insertion proves only that no existing header
+    MOVED relative to another -- ``log.h`` is now parsed with ``json.h``'s
+    macros/pragmas already in effect, which can in principle change its AST.
+    What it does establish is that the divergence is a header ADDITION rather
+    than a reordering or an unrelated compile-context drift.
+
+    This docstring used to say the shape "is not a comparability waiver and
+    must never be used as one", and for two releases it was not: the
+    divergence first refused the comparison outright, then (PR #1274) bounded
+    it to a ``fatal=False`` assurance reduction on the declaration/layout
+    dimensions. Both priced a hazard this contract does not price anywhere
+    else -- a declared header's *content* is not part of
+    ``profile_fingerprint`` at all, so an EXISTING header that gains a
+    ``#define``/``#pragma pack`` does the same thing to every header after it
+    and is compared at full assurance by design. So this predicate is now one
+    half of :func:`_header_sequence_is_scope_confirmed_growth`, the waiver the
+    ``header_sequence`` carve-out is stated over, and the bounded branch is
+    deleted rather than left as a second path. That function's docstring
+    carries the full reasoning and the condition under which this would
+    genuinely reopen (header content joining the fingerprint --
+    ``tests/test_comparability_gate_header_insertion.py``'s
+    ``test_an_existing_headers_leaking_edit_is_compared_at_full_assurance``
+    fails the day it does).
 
     Returns False for a pure trailing append too (``new_list[:len(old)] ==
-    old_list``): that is the full-assurance waiver's own shape, already
-    handled upstream, and reporting it here as well would degrade a pair
-    that needs no degrading.
+    old_list``): that is :func:`_header_sequence_is_additive_reorder_free`'s
+    own shape, and the two predicates partition the growth shapes between
+    them so their union has no overlap to make an outcome order-dependent.
     """
     if old_value is None or new_value is None:
         return False

--- a/changelog.d/1787980000_claude_header-addition-full-assurance.md
+++ b/changelog.d/1787980000_claude_header-addition-full-assurance.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **A public-header addition no longer reduces analysis assurance, wherever
+  the new header sorts.** `header_sequence` records declared-header order, and
+  a header whose name sorted into the middle of the discovered public-header
+  set (e.g. `pvxs/json.h` landing between `data.h` and `log.h`) was treated as
+  an extraction-context divergence: first as a hard `ProfileMismatchError`, and
+  then as a bounded mismatch that marked the `declaration` and `layout`
+  dimensions unverified — which reads through to
+  `analysis_assurance.status = "partial"` ("extraction contexts were not
+  provably identical") and floors the exit code of any run configured with
+  `assurance.require_complete`. A declared header's *content* is not part of
+  `profile_fingerprint` at all, so the macro/pragma-leak hazard that reduction
+  priced is the same one an edit to an existing header carries, and that is
+  compared at full assurance by design. Scope-confirmed declared-header growth
+  is now waived by the existing `header_sequence` carve-out regardless of
+  placement. A reordered *existing* header, growth the declared surface does
+  not confirm as new, and any other diverging profile field (compiler, target,
+  language standard, macros, pass-through flags, include topology) still refuse
+  the comparison exactly as before.

--- a/docs/contribute/known-gaps.md
+++ b/docs/contribute/known-gaps.md
@@ -9284,44 +9284,64 @@ ordinary public-header addition refused the entire comparison —
 verdict, and no findings on any axis, the binary's own exported-symbol
 identity included.
 
-**What was fixed:** the *disposition*, not the extraction fact. An
-order-preserving insertion of headers the scope fingerprint independently
-confirms as new is now a non-fatal `ComparabilityMismatch` (`fatal=False`,
-`comparability_profile._declared_header_insertion_mismatch`): the comparison
-runs and the residual risk is recorded as a bounded assurance reduction on
-the `declaration`/`layout` dimensions, per the product rule "weaker evidence
-narrows conclusions". Nothing is hidden — the reason reaches
-`coverage_warnings` and the per-dimension breakdown reaches
-`DiffResult.comparability_assurance`.
+**What was fixed, in two rounds.** The first round changed the
+*disposition*: an order-preserving insertion of headers the scope
+fingerprint independently confirms as new became a non-fatal
+`ComparabilityMismatch` (`fatal=False`) whose residual risk was recorded as
+a bounded assurance reduction on the `declaration`/`layout` dimensions. That
+removed the refusal but kept pricing the insertion — and the price is real:
+`AnalysisAssurance.status` reads `partial`, which `assurance.require_complete`
+gates on, so a project running that (correct, unweakened) setting still
+failed on an ordinary public-header addition, now with
+"extraction contexts were not provably identical" instead of a refusal.
 
-**What remains open:** the sequential aggregate TU itself. An insertion
-genuinely does change later headers' parse context, so the bounded outcome
-is honest rather than merely convenient, and a real *reorder* of existing
-headers is still a hard refusal because nothing in the declared surface
-explains it. Parsing each declared header in an independently scoped TU
-would make declared order non-load-bearing outright — a reorder would then
-be comparable at full assurance too, and this whole carve-out family could
-retire — but that is a dumper change carrying a per-header TU cost, and it
-was deliberately not attempted alongside the disposition fix.
-`--diagnostic-comparison` is explicitly **not** the answer to any of this:
-it downgrades assurance wholesale instead of resolving the extraction
-question.
+The second round removed the price, because the hazard it named is not one
+this contract prices anywhere else:
 
-**A second residual, on the bounded path itself** (Codex review, PR #1274):
-a bounded run's findings are scored by ordinary compatibility policy.
-`comparability_assurance` marks `declaration`/`layout` unverified, but no
-per-finding assurance wiring exists yet — ADR-050 E-S2 explicitly defers
-"consuming this into the diff pipeline's own per-finding assurance" to a
-later slice — so if an inserted header's macros or pragmas *did* hide a
-later declaration, the resulting finding would score a normal verdict
-rather than being held back as resting on unverified evidence.
+* A declared header's **content** is not part of `profile_fingerprint` at
+  all — `comparability_fields._header_identities` keys a header by its
+  root-relative path, never its bytes. So an existing `data.h` that gains a
+  `#define` or a `#pragma pack` between two versions changes the parse
+  context of every header after it and is compared at **full** assurance,
+  by design: the declared surface's content is the subject of the
+  comparison, not evidence about the extraction environment. Adding those
+  same declarations as a new file is the same fact in a different shape.
+* The added header's position is an incidental product of the project's
+  discovered, sorted public-header set. Pricing it makes assurance depend
+  on the new header's spelling — `json.h` costs assurance, `zzz.h` does
+  not, for the same library change.
+* The scope axis already treats the identical addition as ordinary
+  evolution at full assurance (`_scope_field_is_additive_superset`), and
+  the trailing-append waiver already accepts the added header's own parse.
 
-Two things bound that, and they are why the bounded disposition is still
-the better one. It can never become a silent clean pass: the reduction is
-recorded in `coverage_warnings`, in `comparability_assurance`, and in
-`AnalysisAssurance.status == "partial"` — which `assurance.require_complete`
-gates on. And the pre-change behavior for the same input was a hard
-`ProfileMismatchError` (exit 16), which also failed the run, so no
-invocation that previously passed can now fail; what changed is that a
-*correct* addition now gets a verdict instead of a refusal. Closing the
-residual needs per-finding dimension attribution, not a change here.
+So the `header_sequence` carve-out is now stated over
+`comparability_sequences._header_sequence_is_scope_confirmed_growth` — the
+union of the append and insertion shapes — and scope-confirmed growth is
+waived outright wherever the new header sorts.
+`comparability_profile._declared_header_insertion_mismatch` and
+`inserted_header_entries` were deleted rather than left as a second,
+unreachable path. The non-fatal (`fatal=False`) machinery itself stays:
+it expresses a general rule, has no producer today, and
+`analysis_assurance_comparability.py` remains the (still correct) bridge
+that stops a bounded run from reporting `complete`.
+
+**What still refuses, unchanged:** a reorder of an *existing* declared
+header, growth whose extra entries the declared surface does not confirm as
+new (e.g. a header fed to the L2 frontend on the new side only, whose
+content the old snapshot never parsed), a duplicate/sentinel/undecodable
+sequence, and any other diverging profile field riding alongside the
+addition — compiler family or version, target triple, pointer width,
+endianness, ABI dialect, language standard, macro ops, pass-through flags,
+or an unexplained `include_sequence` (a changed `-I` topology, which decides
+which dependency header an `#include` resolves to). The carve-out only ever
+removes `header_sequence` from the working set, so that safety property is
+structural rather than a list to keep in sync.
+
+**What remains open:** the sequential aggregate TU itself. Parsing each
+declared header in an independently scoped TU would make declared order
+non-load-bearing outright — a *reorder* would then be comparable too, and
+this whole carve-out family could retire — but that is a dumper change
+carrying a per-header TU cost, and it was deliberately not attempted
+alongside either disposition fix. `--diagnostic-comparison` is explicitly
+**not** the answer to any of this: it downgrades assurance wholesale
+instead of resolving the extraction question.

--- a/tests/regressions/manifest_evidence.py
+++ b/tests/regressions/manifest_evidence.py
@@ -494,12 +494,15 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
             "context; a growth that preserves every existing header's "
             "relative order and adds only headers the scope fingerprint "
             "independently confirms as new is an ADDITION, and an addition "
-            "bounds a comparison (a dimension-scoped assurance reduction, "
-            "recorded with its reason) instead of refusing to produce any "
-            "verdict. The outcome must not depend on WHERE the added header "
-            "sorts, and the invariant is stated over every insertion "
-            "position and every permutation — not over the one reported "
-            "header name."
+            "is ordinary evolution: the pair stays comparable at FULL "
+            "assurance, neither refused nor priced as reduced "
+            "declaration/layout assurance. The outcome must not depend on "
+            "WHERE the added header sorts, and the invariant is stated over "
+            "every insertion position and every permutation — not over the "
+            "one reported header name. What the order fact still refuses is "
+            "unchanged: an EXISTING header that moved, growth the declared "
+            "surface does not confirm as new, and any other diverging "
+            "profile field alongside it."
         ),
         # Real integration evidence: a project whose public headers are
         # discovered by a sorted directory sweep added one header named
@@ -509,7 +512,7 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
         # header_sequence`, no verdict, and no findings on ANY axis — the
         # binary's own exported-symbol conclusions included, which a header
         # insertion cannot touch at all.
-        fixed_by=(1274,),
+        fixed_by=(1274, 1276),
         seed_tests=(
             "tests/test_comparability_gate_header_insertion.py",
             "tests/test_cli_compare_added_public_header_live.py",
@@ -553,21 +556,24 @@ EVIDENCE_BUG_CLASSES: tuple[BugClass, ...] = (
             ),
             KnownGap(
                 description=(
-                    "A bounded run's findings are still scored by ordinary "
-                    "policy: `comparability_assurance` marks declaration and "
-                    "layout unverified, but no per-finding assurance wiring "
-                    "exists (ADR-050 E-S2 defers it), so if an inserted "
-                    "header's macros/pragmas did hide a later declaration, "
-                    "the resulting finding would score a normal verdict. It "
-                    "cannot become a silent clean pass -- the reduction is in "
-                    "`coverage_warnings`, `comparability_assurance`, and "
-                    "`AnalysisAssurance.status == 'partial'`, which "
-                    "`assurance.require_complete` gates on -- and the "
-                    "pre-change behavior (a hard refusal) failed such a run "
-                    "too, so no run that previously passed can now fail. "
-                    "Closing it needs per-finding dimension attribution."
+                    "The intermediate disposition -- a non-fatal "
+                    "`ComparabilityMismatch` pricing the insertion as "
+                    "reduced `declaration`/`layout` assurance -- was itself "
+                    "removed: it read through to `analysis_assurance.status "
+                    "== 'partial'`, which `assurance.require_complete` "
+                    "gates on, so a correct public-header addition still "
+                    "failed a correctly-configured run. It was unsound as "
+                    "well as inconvenient: a declared header's CONTENT is "
+                    "not part of `profile_fingerprint` at all, so an "
+                    "existing header that gains a `#define`/`#pragma pack` "
+                    "carries the identical macro-leak hazard and is "
+                    "compared at full assurance by design. The residual "
+                    "this leaves is the same one the entry above names -- "
+                    "the sequential aggregate TU -- not a missing "
+                    "per-finding assurance wiring for a bounded path that "
+                    "no longer has a producer."
                 ),
-                reference="PR #1274 (Codex review, second P1)",
+                reference="docs/contribute/known-gaps.md",
                 canary_test=None,
             ),
         ),

--- a/tests/test_cli_compare_added_public_header_live.py
+++ b/tests/test_cli_compare_added_public_header_live.py
@@ -171,6 +171,46 @@ def test_reported_invocation_reports_the_added_api(tmp_path: Path) -> None:
     assert not removed, removed
 
 
+def test_the_rendered_report_claims_no_reduced_assurance(tmp_path: Path) -> None:
+    """The reported SYMPTOM, at the surface the user reads it from.
+
+    A verdict alone was never the whole ask: the run that prompted this was
+    configured with `assurance.require_complete`, and a
+    `comparability_assurance` marking `declaration`/`layout` unverified reads
+    through to `analysis_assurance.status = "partial"` ("extraction contexts
+    were not provably identical"), which floors the exit code to 1. So the
+    report must carry no comparability reduction at all -- not merely a
+    verdict alongside one.
+    """
+    old_so = _build(tmp_path / "old", _OLD_HEADERS)
+    new_so = _build(tmp_path / "new", _NEW_HEADERS)
+    out = tmp_path / "report.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "compare",
+            str(old_so),
+            str(new_so),
+            "--header",
+            f"old={tmp_path / 'old' / 'pvxs'}",
+            "--header",
+            f"new={tmp_path / 'new' / 'pvxs'}",
+            "-o",
+            f"json={out}",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    report = json.loads(out.read_text(encoding="utf-8"))
+    # Present only when a mismatch was found at all, so its absence is the
+    # assertion that the pair compared cleanly rather than tolerably.
+    assert "comparability_assurance" not in report, report["comparability_assurance"]
+    notes = report.get("analysis_assurance", {}).get("notes", [])
+    assert not any("provably identical" in n for n in notes), notes
+    assert not any("reduced assurance" in n for n in notes), notes
+
+
 def test_a_reordered_header_surface_still_refuses_through_the_cli(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_compare_added_public_header_live.py
+++ b/tests/test_cli_compare_added_public_header_live.py
@@ -51,8 +51,14 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from abicheck.checker_policy import API_BREAK_KINDS, BREAKING_KINDS
 from abicheck.cli import main
 from abicheck.header_utils import iter_directory_headers
+
+#: Every kind the engine itself classifies as an ABI or API break -- read off
+#: `checker_policy`'s own partitions, never restated here, so this test cannot
+#: drift from the taxonomy it is asserting against.
+_NON_COMPATIBLE_KIND_VALUES = {k.value for k in (*BREAKING_KINDS, *API_BREAK_KINDS)}
 
 # The reported inventory. `json.h` sorts between `data.h` and `log.h`, so a
 # sorted directory expansion places it INTERIOR -- the shape a trailing-only
@@ -159,7 +165,24 @@ def test_reported_invocation_reports_the_added_api(tmp_path: Path) -> None:
     assert "header_sequence" not in result.output
 
     report = json.loads(out.read_text(encoding="utf-8"))
-    assert report["verdict"] == "COMPATIBLE", report["verdict"]
+    # Not `== "COMPATIBLE"`. That spelling asserted the absence of every RISK
+    # finding, which is a claim about the whole fixture rather than about the
+    # header addition, and it is false on a non-ELF host: `g++ -shared` there
+    # produces a Mach-O whose own platform facts raise the verdict to
+    # COMPATIBLE_WITH_RISK, so this test failed on the macOS integration lane
+    # from the day it landed (it fails identically on `main`). The claim that
+    # belongs here is that nothing BREAKING or API-breaking was reported --
+    # derived from the engine's own partitions rather than from a hand-listed
+    # verdict string, so a new breaking kind is covered the day it is added.
+    breaking = [
+        c
+        for c in report.get("changes", [])
+        if c.get("kind") in _NON_COMPATIBLE_KIND_VALUES
+    ]
+    assert not breaking, breaking
+    assert report["verdict"] in {"COMPATIBLE", "COMPATIBLE_WITH_RISK"}, report[
+        "verdict"
+    ]
     # The rendered report, not just the exit code: the added API is REPORTED.
     added = [c for c in report.get("changes", []) if c.get("kind") == "func_added"]
     assert any("pvxs_json" in str(c.get("symbol", "")) for c in added), report.get(

--- a/tests/test_comparability_gate_header_insertion.py
+++ b/tests/test_comparability_gate_header_insertion.py
@@ -122,6 +122,53 @@ def test_middle_sorting_public_header_addition_is_fully_comparable(tmp_path):
     assert check_contracts_comparable(old, new) is None
 
 
+def test_an_existing_headers_leaking_edit_is_compared_at_full_assurance(tmp_path):
+    """The symmetry that decides how an addition may be priced.
+
+    The hazard an interior insertion carries is that a header parsed after it
+    in the aggregate driver TU now sees macros/pragmas it did not see before.
+    That hazard is NOT specific to an insertion: an EXISTING declared header
+    that gains ``#define LEAK`` and ``#pragma pack(push, 1)`` between two
+    versions does the same thing to every header after it -- and this contract
+    compares that at full assurance, deliberately, because a declared header's
+    content is not part of ``profile_fingerprint`` at all
+    (``comparability_fields._header_identities`` keys a header by its
+    root-relative path, never its bytes).
+
+    This test states that as an executable fact rather than a claim in a
+    docstring: as long as it passes, pricing an ADDED header's sort position
+    as reduced assurance is an inconsistency, not a safeguard -- it would make
+    assurance depend on the new header's spelling while the strictly larger
+    hazard next door goes unpriced. If this test ever fails because header
+    content joins the fingerprint, the insertion question genuinely reopens
+    and this file's waiver should be revisited with it.
+    """
+    leaky = "#define LEAK 1\n#pragma pack(push, 1)\nint a(int);\n"
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    old_headers = _headers(old_root, _OLD_HEADERS)
+    new_headers = _headers(new_root, _OLD_HEADERS)
+    # The FIRST declared header, so its leak reaches every header after it.
+    new_headers[0].write_text(leaky, encoding="utf-8")
+
+    def _snapshot(headers, version):
+        return AbiSnapshot(
+            library="libpvxs.so",
+            version=version,
+            contract=compute_extraction_contract(
+                l2_frontend_ran=True,
+                declared_headers=headers,
+                public_header_paths=headers,
+                depfile_resolved_paths=headers,
+            ),
+        )
+
+    old = _snapshot(old_headers, "1.3")
+    new = _snapshot(new_headers, "1.4")
+    assert old.contract.profile_fingerprint == new.contract.profile_fingerprint
+    assert check_contracts_comparable(old, new) is None
+
+
 def test_trailing_append_keeps_full_assurance(tmp_path):
     """The strictly-safe shape is not degraded by this change: a header that
     sorts AFTER every existing one changes no existing header's parse context,

--- a/tests/test_comparability_gate_header_insertion.py
+++ b/tests/test_comparability_gate_header_insertion.py
@@ -13,24 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A declared-header INSERTION bounds a comparison; it never refuses one.
+"""A declared-header addition is ordinary evolution, wherever it sorts.
 
-Bug class: an *incidental* extraction-ordering fact was treated as a fatal
-comparability contract. ``header_sequence`` records declared-header order
-because the aggregate driver TU parses headers sequentially, and the only
-waiver was a strict trailing append. Directory-discovered headers arrive
+Bug class: an *incidental* extraction-ordering fact was treated as evidence
+about the extraction environment. ``header_sequence`` records declared-header
+order because the aggregate driver TU parses headers sequentially, and the
+only waiver was a strict trailing append. Directory-discovered headers arrive
 sorted, so adding one public header whose name sorts into the middle
-(``data.h, log.h`` -> ``data.h, json.h, log.h``) produced
+(``data.h, log.h`` -> ``data.h, json.h, log.h``) first produced
 ``profile_fingerprint mismatch; differing fields: header_sequence`` and NO
-verdict at all -- from an ordinary public-header addition.
+verdict at all, and then (PR #1274) a verdict whose ``declaration``/``layout``
+assurance was marked unverified -- which reads through to
+``analysis_assurance.status = "partial"`` and floors the exit code of every
+run configured with ``assurance.require_complete``. Both dispositions price
+the added header's *sort position*, which no one chose, and neither is
+consistent with the same contract comparing an EXISTING header's edited
+content -- an identical macro/pragma-leak hazard -- at full assurance, since
+a declared header's content is not part of ``profile_fingerprint`` at all.
 
 The invariant these tests state is not "the json.h case now passes". It is:
 
   *For any* declared-header growth that preserves every existing header's
   relative order and adds only headers the scope fingerprint independently
-  confirms as new, the pair stays comparable, with the residual risk
-  recorded as a dimension-scoped assurance reduction -- while *any* growth
-  that reorders an existing header, adds an unconfirmed header, or rides
+  confirms as new, the pair is comparable at FULL assurance and the outcome
+  does not depend on where the new headers sort -- while *any* growth that
+  reorders an existing header, adds an unconfirmed header, or rides
   alongside another unexplained profile field stays a hard refusal.
 
 Both halves are exercised over generated inputs (every insertion position,
@@ -47,14 +54,13 @@ from pathlib import Path
 import pytest
 
 from abicheck.comparability import (
-    ComparabilityMismatch,
     check_contracts_comparable,
     compute_extraction_contract,
-    dimension_assurance,
 )
 from abicheck.comparability_sequences import (
     _header_sequence_is_additive_reorder_free,
     _header_sequence_is_interior_insertion,
+    _header_sequence_is_scope_confirmed_growth,
 )
 from abicheck.errors import ProfileMismatchError
 from abicheck.model import AbiSnapshot
@@ -94,13 +100,13 @@ def _snap(root: Path, names, version: str) -> AbiSnapshot:
 # ---------------------------------------------------------------------------
 
 
-def test_middle_sorting_public_header_addition_is_bounded_not_refused(tmp_path):
+def test_middle_sorting_public_header_addition_is_fully_comparable(tmp_path):
     """The reported repro: one added public header sorting into the middle."""
     old = _snap(tmp_path / "old", _OLD_HEADERS, "1.3")
     new = _snap(tmp_path / "new", (*_OLD_HEADERS, "json.h"), "1.4")
 
     # The order really is an insertion, not an append -- i.e. this pair is the
-    # shape the pre-existing trailing-append waiver declines.
+    # shape the original trailing-append-only waiver declined.
     assert json.loads(new.contract.profile_fields["header_sequence"]) == [
         "data.h",
         "json.h",
@@ -113,16 +119,7 @@ def test_middle_sorting_public_header_addition_is_bounded_not_refused(tmp_path):
         {"json.h"},
     )
 
-    result = check_contracts_comparable(old, new)
-    assert isinstance(result, ComparabilityMismatch)
-    assert result.fatal is False  # returned, never raised
-    assert result.dimensions == frozenset({"declaration", "layout"})
-    assert "json.h" in result.reason
-    # The symbol dimension -- the binary's own exported-symbol identity -- is
-    # untouched by a header insertion and must stay trusted; that conclusion
-    # being discarded wholesale was half the cost of the refusal.
-    assert dimension_assurance(result)["symbol"] == "trusted"
-    assert dimension_assurance(result)["declaration"] == "unverified"
+    assert check_contracts_comparable(old, new) is None
 
 
 def test_trailing_append_keeps_full_assurance(tmp_path):
@@ -138,12 +135,12 @@ def test_trailing_append_keeps_full_assurance(tmp_path):
 def test_any_insertion_position_is_comparable(tmp_path, added):
     """Generalization guard: the outcome must not depend on WHERE the new
     header sorts. Before the fix, exactly one of these five positions
-    (``zzz.h``, the trailing one) was comparable and the other four refused --
-    a difference with no bearing on whether the library's ABI changed."""
+    (``zzz.h``, the trailing one) was comparable at full assurance and the
+    other four were refused (and later, bounded to reduced assurance) -- a
+    difference with no bearing on whether the library's ABI changed."""
     old = _snap(tmp_path / f"old{added}", _OLD_HEADERS, "1.3")
     new = _snap(tmp_path / f"new{added}", (*_OLD_HEADERS, added), "1.4")
-    result = check_contracts_comparable(old, new)
-    assert result is None or result.fatal is False
+    assert check_contracts_comparable(old, new) is None
 
 
 def test_reordering_an_existing_header_still_refuses(tmp_path):
@@ -298,9 +295,9 @@ class TestInteriorInsertionProperties:
         )
 
     def test_is_disjoint_from_the_trailing_append_waiver(self):
-        """The two predicates must never both accept the same pair: one grants
-        full assurance, the other a reduction, and an overlap would make which
-        one a pair gets depend on evaluation order."""
+        """The two predicates partition the growth shapes between them: each
+        placement is accepted by exactly one, so the composite below is a
+        union with no overlap to make the outcome order-dependent."""
         both = []
         for pos in range(len(self._BASE) + 1):
             new = [*self._BASE[:pos], "new.h", *self._BASE[pos:]]
@@ -314,11 +311,104 @@ class TestInteriorInsertionProperties:
 
 
 # ---------------------------------------------------------------------------
+# The composite predicate the carve-out is actually stated in terms of
+# ---------------------------------------------------------------------------
+
+
+class TestScopeConfirmedGrowthProperties:
+    """`_header_sequence_is_scope_confirmed_growth` is the union of the two
+    placement predicates, and the union is what the gate may act on.
+
+    The oracle here is deliberately independent of the implementation's
+    ``or``: growth is acceptable iff every old entry survives in its original
+    relative order and every entry the new sequence added is one the declared
+    surface confirms as new. Nothing in that statement mentions placement --
+    which is the whole point of the change.
+    """
+
+    _BASE = ["a.h", "b.h", "c.h", "d.h"]
+
+    @staticmethod
+    def _oracle(old: list[str], new: list[str], scope_new: set[str] | None) -> bool:
+        if scope_new is None:
+            return False
+        if len(set(old)) != len(old) or len(set(new)) != len(new):
+            return False
+        if len(new) <= len(old):
+            return False
+        if not _is_order_preserving_supersequence(old, new):
+            return False
+        return set(new) - set(old) <= scope_new and set(old) <= set(new)
+
+    def test_agrees_with_the_oracle_over_every_single_insertion_position(self):
+        disagreeing = []
+        for pos in range(len(self._BASE) + 1):
+            new = [*self._BASE[:pos], "new.h", *self._BASE[pos:]]
+            got = _header_sequence_is_scope_confirmed_growth(
+                _seq(self._BASE), _seq(new), {"new.h"}
+            )
+            expected = self._oracle(self._BASE, new, {"new.h"})
+            if got != expected:
+                disagreeing.append((pos, got, expected))
+        assert not disagreeing
+
+    def test_accepts_every_position_including_the_trailing_one(self):
+        """The property the whole fix is about: the verdict does not depend on
+        where the added header sorts."""
+        rejected = [
+            pos
+            for pos in range(len(self._BASE) + 1)
+            if not _header_sequence_is_scope_confirmed_growth(
+                _seq(self._BASE),
+                _seq([*self._BASE[:pos], "new.h", *self._BASE[pos:]]),
+                {"new.h"},
+            )
+        ]
+        assert not rejected
+
+    def test_agrees_with_the_oracle_over_every_permutation_and_placement(self):
+        disagreeing = []
+        for perm in itertools.permutations(self._BASE):
+            for pos in range(len(perm) + 1):
+                new = [*list(perm)[:pos], "new.h", *list(perm)[pos:]]
+                got = _header_sequence_is_scope_confirmed_growth(
+                    _seq(self._BASE), _seq(new), {"new.h"}
+                )
+                expected = self._oracle(self._BASE, new, {"new.h"})
+                if got != expected:
+                    disagreeing.append((new, got, expected))
+        assert not disagreeing
+
+    def test_the_oracle_is_not_vacuous(self):
+        """A constant oracle would make both agreement tests above pass while
+        asserting nothing."""
+        assert self._oracle(["a.h"], ["a.h", "x.h"], {"x.h"})
+        assert not self._oracle(["a.h", "b.h"], ["b.h", "x.h", "a.h"], {"x.h"})
+
+    @pytest.mark.parametrize(
+        "old_list,new_list,scope_new",
+        [
+            (["a.h", "b.h"], ["a.h", "x.h", "b.h"], set()),
+            (["a.h", "b.h"], ["a.h", "b.h", "x.h"], set()),
+            (["a.h", "b.h"], ["a.h", "x.h", "b.h"], None),
+            (["a.h", "b.h", "c.h"], ["a.h", "c.h"], {"x.h"}),
+            (["a.h", "b.h"], ["b.h", "a.h", "x.h"], {"x.h"}),
+            (["a.h", "b.h"], ["a.h", "x.h", "b.h", "b.h"], {"x.h"}),
+            (["<single-header>"], ["a.h", "x.h"], {"x.h"}),
+        ],
+    )
+    def test_fails_closed_on_unusable_evidence(self, old_list, new_list, scope_new):
+        assert not _header_sequence_is_scope_confirmed_growth(
+            _seq(old_list), _seq(new_list), scope_new
+        )
+
+
+# ---------------------------------------------------------------------------
 # checker.compare(): the disposition the whole change is about
 # ---------------------------------------------------------------------------
 
 
-class TestCompareRecordsRatherThanRefuses:
+class TestCompareTreatsTheAdditionAsEvolution:
     def _pair(self, tmp_path):
         return (
             _snap(tmp_path / "old", _OLD_HEADERS, "1.3"),
@@ -331,157 +421,50 @@ class TestCompareRecordsRatherThanRefuses:
         old, new = self._pair(tmp_path)
         assert compare(old, new).verdict is not None
 
-    def test_assurance_none_is_not_stamped(self, tmp_path):
-        """``assurance: "none"`` means "forced through a refusal with
-        --diagnostic-comparison, do not trust this". Nothing was forced here,
-        so stamping it would misreport a bounded result as an override."""
+    def test_no_assurance_reduction_is_recorded(self, tmp_path):
+        """`comparability_assurance` is `None` only when no mismatch was found
+        at all -- so this asserts the pair is comparable, not merely that the
+        reduction is small."""
         from abicheck.checker import compare
 
         old, new = self._pair(tmp_path)
-        assert compare(old, new).assurance is None
-
-    def test_the_reduction_is_recorded_per_dimension(self, tmp_path):
-        from abicheck.checker import compare
-
-        old, new = self._pair(tmp_path)
-        assurance = compare(old, new).comparability_assurance
-        assert assurance == {
-            "declaration": "unverified",
-            "layout": "unverified",
-            "runtime": "trusted",
-            "source": "trusted",
-            "symbol": "trusted",
-        }
-
-    def test_the_reason_is_disclosed_not_swallowed(self, tmp_path):
-        """ "Record before disposing": a consumer must be able to see WHY
-        assurance dropped, not just that it did."""
-        from abicheck.checker import compare
-
-        old, new = self._pair(tmp_path)
-        warnings = compare(old, new).coverage_warnings
-        assert any("inserted into the declared header sequence" in w for w in warnings)
-
-    def test_an_unchanged_pair_records_nothing(self, tmp_path):
-        """Vacuity guard on the three assertions above: an identical pair must
-        produce no mismatch, no dimension breakdown and no warning, or they
-        would pass for reasons unrelated to the insertion."""
-        from abicheck.checker import compare
-
-        old = _snap(tmp_path / "old", _OLD_HEADERS, "1.3")
-        same = _snap(tmp_path / "same", _OLD_HEADERS, "1.4")
-        result = compare(old, same)
+        result = compare(old, new)
         assert result.comparability_assurance is None
+        assert result.assurance is None
+
+    def test_no_comparability_warning_is_emitted(self, tmp_path):
+        from abicheck.checker import compare
+
+        old, new = self._pair(tmp_path)
         assert not any(
-            "declared header sequence" in w for w in result.coverage_warnings
+            "header sequence" in w or "profile_fingerprint" in w
+            for w in compare(old, new).coverage_warnings
         )
 
+    def test_an_appended_header_is_treated_identically(self, tmp_path):
+        """Vacuity/consistency guard: the trailing-append case -- comparable at
+        full assurance before this change and after it -- must now be
+        indistinguishable from the interior one on every field the insertion
+        used to move."""
+        from abicheck.checker import compare
 
-# ---------------------------------------------------------------------------
-# The bounded path's own boundaries (Codex review, PR #1274)
-# ---------------------------------------------------------------------------
-
-
-class TestOnlyAHeaderSequenceDivergenceIsBounded:
-    """`unexplained` must be EXACTLY `{"header_sequence"}`.
-
-    `_unexplained_profile_fields` has already removed every field a carve-out
-    verified, so anything still in that set is by construction a divergence
-    NO carve-out could corroborate. An `include_sequence` surviving there is a
-    changed `-I` topology (two include roots swapped, say), and include-search
-    order decides which dependency header an `#include` resolves to — a
-    different, unbounded hazard from the declared-header insertion this branch
-    reasons about, and one nothing here corroborates.
-
-    Tested at the guard itself rather than through a fixture: every other
-    precondition is held identically to the bounded case (real contracts from
-    the real insertion pair), so `unexplained` is the only variable.
-    """
-
-    def _contracts(self, tmp_path):
         old = _snap(tmp_path / "old", _OLD_HEADERS, "1.3")
-        new = _snap(tmp_path / "new", (*_OLD_HEADERS, "json.h"), "1.4")
-        return old.contract, new.contract
-
-    def _call(self, tmp_path, unexplained):
-        from abicheck.comparability_profile import (
-            _declared_header_insertion_mismatch,
+        inserted = compare(
+            old, _snap(tmp_path / "mid", (*_OLD_HEADERS, "json.h"), "1.4")
         )
-
-        old_contract, new_contract = self._contracts(tmp_path)
-        return _declared_header_insertion_mismatch(
-            old_contract,
-            new_contract,
-            unknown_differing=set(),
-            differing=set(unexplained),
-            unexplained=set(unexplained),
+        appended = compare(
+            old, _snap(tmp_path / "end", (*_OLD_HEADERS, "zzz.h"), "1.4")
         )
-
-    def test_header_sequence_alone_is_bounded(self, tmp_path):
-        """Vacuity guard for the whole class: the accepted set really is
-        accepted here, so the rejections below mean something."""
-        got = self._call(tmp_path, {"header_sequence"})
-        assert got is not None and got.fatal is False
-
-    @pytest.mark.parametrize(
-        "unexplained",
-        [
-            # The reported P1: a header insertion riding alongside an
-            # include-topology change no carve-out could explain.
-            {"header_sequence", "include_sequence"},
-            # An include_sequence-only divergence carries no insertion at all.
-            {"include_sequence"},
-            # Any other profile field alongside it is a genuine, uncorroborated
-            # compile-context difference.
-            {"header_sequence", "compiler_family"},
-            {"header_sequence", "language_standard"},
-            {"header_sequence", "macro_ops"},
-            {"header_sequence", "target_triple"},
-            {"header_sequence", "include_sequence", "macro_ops"},
-            # Nothing unexplained at all is not this function's case.
-            set(),
-        ],
-    )
-    def test_anything_else_stays_fatal(self, tmp_path, unexplained):
-        assert self._call(tmp_path, unexplained) is None
-
-    def test_an_unrecognized_field_is_never_bounded(self, tmp_path):
-        """Fail-closed: a field this build does not recognize, and an
-        absent/malformed `profile_fields` (empty `differing`), are the two
-        cases `_profile_mismatch_reason` answers first and neither has a
-        verified shape to reason from."""
-        assert (
-            self._call_raw(
-                tmp_path, unknown={"future_field"}, differing={"header_sequence"}
-            )
-            is None
-        )
-        assert self._call_raw(tmp_path, unknown=set(), differing=set()) is None
-
-    def _call_raw(self, tmp_path, unknown, differing):
-        from abicheck.comparability_profile import (
-            _declared_header_insertion_mismatch,
-        )
-
-        old_contract, new_contract = self._contracts(tmp_path)
-        return _declared_header_insertion_mismatch(
-            old_contract,
-            new_contract,
-            unknown_differing=unknown,
-            differing=differing,
-            unexplained={"header_sequence"},
+        assert (inserted.comparability_assurance, inserted.assurance) == (
+            appended.comparability_assurance,
+            appended.assurance,
         )
 
 
-class TestBoundedMismatchReachesTheAssuranceRollup:
-    """`compute_analysis_assurance` must not report `complete` for a run whose
-    own `comparability_assurance` says a dimension is unverified.
-
-    It previously special-cased only `assurance == "none"`, so the two
-    assurance fields of one report contradicted each other and
-    `assurance.require_complete` declined to gate a run that is, by its own
-    account, not complete.
-    """
+class TestTheAssuranceRollupReadsComplete:
+    """The reported symptom: `analysis_assurance.status = "partial"` with
+    "extraction contexts were not provably identical", which floors the exit
+    code of a run configured with `assurance.require_complete`."""
 
     def _assurance(self, tmp_path, new_names):
         from abicheck.analysis_assurance import compute_analysis_assurance
@@ -491,113 +474,124 @@ class TestBoundedMismatchReachesTheAssuranceRollup:
         new = _snap(tmp_path / "new", new_names, "1.4")
         return compute_analysis_assurance(compare(old, new), old, new)
 
-    def test_an_insertion_reports_partial(self, tmp_path):
-        assert self._assurance(tmp_path, (*_OLD_HEADERS, "json.h")).status == "partial"
-
-    def test_the_note_names_the_unverified_dimensions(self, tmp_path):
+    def test_no_comparability_note_is_added(self, tmp_path):
+        """Asserted on the NOTE, not on `status`: these fixtures carry no
+        binary, so an unchanged pair already reads `partial` on an unrelated
+        axis ("public surface could not be resolved") -- `status` alone would
+        prove nothing about this change either way."""
         notes = self._assurance(tmp_path, (*_OLD_HEADERS, "json.h")).notes
-        assert any(
-            "declaration" in n and "layout" in n and "reduced assurance" in n
-            for n in notes
-        )
+        assert not any("reduced assurance" in n for n in notes)
+        assert not any("provably identical" in n for n in notes)
 
-    def test_it_is_partial_not_not_comparable(self, tmp_path):
-        """A verdict WAS produced and every other axis was genuinely computed;
-        only some dimensions carry reduced assurance. Collapsing that to
-        `not_comparable` would discard the axes this run did establish."""
-        assert self._assurance(tmp_path, (*_OLD_HEADERS, "json.h")).status != (
-            "not_comparable"
-        )
-
-    def test_an_unchanged_pair_carries_no_comparability_note(self, tmp_path):
-        """Vacuity guard, and it earned its place: these fixtures carry no
-        binary, so an UNCHANGED pair already reads `partial` on an unrelated
-        axis ("public surface could not be resolved"). `status == "partial"`
-        alone therefore proves nothing about this change — the note is what
-        distinguishes the two, so it is the note this class asserts on, and
-        the note must be absent when there is no insertion."""
-        assurance = self._assurance(tmp_path, _OLD_HEADERS)
-        assert not any("reduced assurance" in n for n in assurance.notes)
-
-    def test_the_insertion_is_what_adds_the_note(self, tmp_path):
-        """The two runs differ by exactly the inserted header, so the note
-        appearing in one and not the other attributes it to the insertion
-        rather than to any axis both runs share."""
-        with_insertion = self._assurance(tmp_path, (*_OLD_HEADERS, "json.h")).notes
+    def test_the_addition_changes_no_note_at_all(self, tmp_path):
+        """Stronger than the absence above: the run with the added header must
+        contribute no assurance note the identical run without it doesn't."""
+        with_addition = self._assurance(tmp_path, (*_OLD_HEADERS, "json.h")).notes
         without = self._assurance(tmp_path, _OLD_HEADERS).notes
-        added = [n for n in with_insertion if n not in without]
-        assert any("reduced assurance" in n for n in added)
+        assert [n for n in with_addition if n not in without] == []
+
+    def test_the_note_machinery_is_not_vacuous(self, tmp_path):
+        """Guard on the two tests above: `bounded_comparability_notes` must
+        still produce the note it is there to produce, or their absence
+        assertions would pass against a rollup that can no longer report
+        anything."""
+        from abicheck.analysis_assurance_comparability import (
+            bounded_comparability_notes,
+        )
+
+        assert any(
+            "reduced assurance" in n
+            for n in bounded_comparability_notes(
+                {"declaration": "unverified", "symbol": "trusted"}
+            )
+        )
 
 
-class TestTheReasonNamesOnlyWhatWasInserted:
-    """The reported set is the SEQUENCE's own additions.
+# ---------------------------------------------------------------------------
+# What must still refuse (the safety half)
+# ---------------------------------------------------------------------------
 
-    `_header_sequence_is_interior_insertion` only requires those additions to
-    be a *subset* of `_scope_newly_added_headers`, so the two sets are not
-    interchangeable: a header declared public but never fed to the L2
-    frontend is in the scope set and in no insertion. Naming the scope set
-    would report a header that was not inserted anywhere — a finding about a
-    file nothing happened to.
+
+def _contract_with(tmp_path, names, **profile):
+    headers = _headers(tmp_path, names)
+    return AbiSnapshot(
+        library="libpvxs.so",
+        version="1.4",
+        contract=compute_extraction_contract(
+            l2_frontend_ran=True,
+            declared_headers=headers,
+            public_header_paths=headers,
+            **profile,
+        ),
+    )
+
+
+class TestAnotherDivergingProfileFieldStillRefuses:
+    """The carve-out only ever removes `header_sequence` from the working set.
+
+    A genuine compile-context difference riding alongside the addition
+    therefore stays unexplained and stays a hard refusal -- the property that
+    keeps this waiver from masking an ABI-affecting context mismatch. Every
+    field below names one of the classes the reported requirement calls out:
+    compiler target, language mode, ABI-affecting flags.
     """
 
     @pytest.mark.parametrize(
-        "old_entries,new_entries,expected",
+        "profile",
         [
-            (["a.h", "c.h"], ["a.h", "b.h", "c.h"], ["b.h"]),
-            (["a.h"], ["x.h", "a.h", "y.h"], ["x.h", "y.h"]),
-            (["a.h", "b.h"], ["a.h", "b.h"], []),
-            # New-side order is preserved, not sorted.
-            (["m.h"], ["z.h", "m.h", "a.h"], ["z.h", "a.h"]),
-            # A removal is not an addition.
-            (["a.h", "b.h"], ["b.h"], []),
+            {"compiler_family": "clang"},
+            {"compiler_version": "gcc 13.2.0"},
+            {"language_standard": "c++20"},
+            {"target_triple": "aarch64-linux-gnu"},
+            {"pointer_width": 32},
+            {"endianness": "big"},
+            {"abi_dialect": "itanium-v2"},
+            {"macro_ops": (("D", "NDEBUG"),)},
+            {"pass_through_flags": ("-include forced.h",)},
         ],
     )
-    def test_entries_come_from_the_sequence_diff(
-        self, old_entries, new_entries, expected
-    ):
-        from abicheck.comparability_sequences import inserted_header_entries
+    @pytest.mark.parametrize("added", ["aaa.h", "json.h", "zzz.h"])
+    def test_it_refuses_at_every_insertion_position(self, tmp_path, profile, added):
+        old = _contract_with(tmp_path / "old", _OLD_HEADERS)
+        new = _contract_with(tmp_path / "new", (*_OLD_HEADERS, added), **profile)
+        with pytest.raises(ProfileMismatchError):
+            check_contracts_comparable(old, new)
 
-        assert inserted_header_entries(_seq(old_entries), _seq(new_entries)) == expected
+    def test_the_same_pair_without_the_extra_field_is_comparable(self, tmp_path):
+        """Vacuity guard: the refusals above must come from the extra profile
+        field, not from the header addition the fix is supposed to waive."""
+        old = _contract_with(tmp_path / "old", _OLD_HEADERS)
+        new = _contract_with(tmp_path / "new", (*_OLD_HEADERS, "json.h"))
+        assert check_contracts_comparable(old, new) is None
 
-    @pytest.mark.parametrize(
-        "old_value,new_value",
-        [(None, "[]"), ("[]", None), ("not-json", "[]"), ("[]", "not-json")],
+
+def test_an_unconfirmed_sequence_entry_still_refuses(tmp_path):
+    """A header fed to the L2 frontend on the new side only, while the declared
+    public surface is unchanged, is not scope-confirmed growth: the old
+    snapshot never parsed its content, so a removal inside it would be
+    invisible. The shape looks identical to the waived one."""
+    old_headers = _headers(tmp_path / "old", _OLD_HEADERS)
+    new_root = tmp_path / "new"
+    new_declared = _headers(new_root, (*_OLD_HEADERS, "json.h"))
+    old = AbiSnapshot(
+        library="libpvxs.so",
+        version="1.3",
+        contract=compute_extraction_contract(
+            l2_frontend_ran=True,
+            declared_headers=old_headers,
+            # json.h is already public on the old side -- only the L2 frontend
+            # never saw it, so scope_fields["headers"] does not grow.
+            public_header_paths=_headers(tmp_path / "old", (*_OLD_HEADERS, "json.h")),
+        ),
     )
-    def test_undecodable_sides_report_nothing(self, old_value, new_value):
-        """Rather than asserting a list it cannot derive."""
-        from abicheck.comparability_sequences import inserted_header_entries
-
-        assert inserted_header_entries(old_value, new_value) == []
-
-    def test_a_declared_but_unparsed_header_is_not_reported_as_inserted(self, tmp_path):
-        """End to end: `unparsed.h` joins the public surface without being fed
-        to the frontend, so it is in `scope_fields["headers"]` and in no
-        `header_sequence` position. Only `json.h` was inserted."""
-        old_root = tmp_path / "old"
-        new_root = tmp_path / "new"
-        old_headers = _headers(old_root, _OLD_HEADERS)
-        new_declared = _headers(new_root, (*_OLD_HEADERS, "json.h"))
-        new_public = _headers(new_root, (*_OLD_HEADERS, "json.h", "unparsed.h"))
-
-        old = AbiSnapshot(
-            library="libpvxs.so",
-            version="1.3",
-            contract=compute_extraction_contract(
-                l2_frontend_ran=True,
-                declared_headers=old_headers,
-                public_header_paths=old_headers,
-            ),
-        )
-        new = AbiSnapshot(
-            library="libpvxs.so",
-            version="1.4",
-            contract=compute_extraction_contract(
-                l2_frontend_ran=True,
-                declared_headers=new_declared,
-                public_header_paths=new_public,
-            ),
-        )
-        result = check_contracts_comparable(old, new)
-        assert isinstance(result, ComparabilityMismatch) and result.fatal is False
-        assert "json.h" in result.reason
-        assert "unparsed.h" not in result.reason
+    new = AbiSnapshot(
+        library="libpvxs.so",
+        version="1.4",
+        contract=compute_extraction_contract(
+            l2_frontend_ran=True,
+            declared_headers=new_declared,
+            public_header_paths=new_declared,
+        ),
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)


### PR DESCRIPTION
## Summary

A scope-confirmed public-header addition whose name sorts into the *middle* of the discovered header set is now waived by the `header_sequence` carve-out at **full** assurance, exactly like the trailing-append case it was already waived for.

## Motivation

Real integration evidence (pvxs `libpvxs`/`libpvxsIoc`, `8e00eaec` → `2227e199`): the new revision adds `src/pvxs/json.h`, which a sorted directory sweep places between `data.h` and `log.h`. `profile_fields["header_sequence"]` records declared-header order, and the waiver accepted only a strict trailing append. That produced, in two rounds:

1. a hard `ProfileMismatchError` — `profile_fingerprint mismatch; differing fields: header_sequence`, no verdict on any axis; then
2. (PR #1274) a non-fatal `ComparabilityMismatch` marking the `declaration`/`layout` dimensions unverified. That reads through `analysis_assurance_comparability` into `analysis_assurance.status = "partial"` — *"extraction contexts were not provably identical; conclusions on the declaration, layout dimension(s) carry reduced assurance"* — which floors the exit code of any run configured with `assurance.require_complete`. So the reported CI run completed 791 artifact-backed findings, 0 source-only, 0 build-context-drift, and still failed, without naming an ABI problem.

**Root cause: version-specific, incidental data inside an equivalence proof.** The hazard the reduction priced — "`log.h` is now parsed with `json.h`'s macros/pragmas already in effect" — is not one this contract prices anywhere else:

- A declared header's **content** is not part of `profile_fingerprint` at all (`comparability_fields._header_identities` keys a header by its root-relative path, never its bytes). An existing `data.h` that gains a `#define` or a `#pragma pack` between versions changes the parse context of every header after it and is compared at **full** assurance, by design — the declared surface's content is the *subject* of the comparison, not evidence about the extraction environment. Adding those same declarations as a new file is the same fact in a different shape. (pvxs changes `data.h` and `source.h` in this very pair.)
- The added header's position is an incidental product of the project's sorted public-header sweep. Pricing it makes assurance depend on the new header's spelling: `json.h` costs assurance, `zzz.h` does not, for the same library change.
- The scope axis already treats the identical addition as ordinary evolution at full assurance (`_scope_field_is_additive_superset`), and the trailing-append waiver already accepts the added header's own parse.

## Changes

- `comparability_sequences.py`: new `_header_sequence_is_scope_confirmed_growth` — the union of the trailing-append and interior-insertion shapes, with the reasoning above recorded on it. `inserted_header_entries` deleted (no remaining consumer).
- `comparability_profile.py`: the `header_sequence` carve-out is stated over that predicate; `_declared_header_insertion_mismatch` and `_HEADER_INSERTION_DIMENSIONS` deleted rather than left as a second, unreachable path.
- `comparability.py`: `ComparabilityMismatch.fatal`'s docstring now records that no axis produces a non-fatal descriptor today. The machinery stays — it expresses a general rule and `analysis_assurance_comparability.py` remains the correct bridge for a future one.
- `docs/contribute/known-gaps.md`, `changelog.d/`, `tests/regressions/manifest_evidence.py` updated.

**Why this cannot mask a real ABI-affecting context mismatch.** The carve-out only ever *removes* `header_sequence` from `_unexplained_profile_fields`' working set, so the safety property is structural rather than a list to keep in sync: a reordered *existing* header, growth the declared surface does not confirm as new, a duplicate/sentinel/undecodable sequence, and **any** other diverging profile field — compiler family/version, ABI dialect, language standard, target triple, pointer width, endianness, macro ops, pass-through flags, or an unexplained `include_sequence` (a changed `-I` topology, i.e. include-resolution semantics) — stay a hard refusal, unchanged. Scope- and dependency-scope axes are untouched.

## Bug-fix test contract

- Bug class: `comparability.incidental_ordering_treated_as_contract` (`tests/regressions/manifest_evidence.py`) — an incidental extraction fact the user never chose, treated as evidence about the extraction environment. Entry updated: its invariant said "an addition *bounds* a comparison", which is the disposition this PR removes.
- Publicly observable failure: `abicheck compare old.so new.so --header old=<dir> --header new=<dir> -o json=report.json` on a pair whose only header-set difference is one added public header sorting interior emitted `comparability_assurance: {declaration: unverified, layout: unverified, ...}` and an `analysis_assurance` note "extraction contexts were not provably identical", flooring the exit code to 1 under `assurance.require_complete`.
- Regression test fails on base: `tests/test_cli_compare_added_public_header_live.py::test_the_rendered_report_claims_no_reduced_assurance` — verified by checking out the parent commit's `abicheck/` and re-running: `AssertionError: {'declaration': 'unverified', 'layout': 'unverified', ...}`.
- Negative control: `TestAnotherDivergingProfileFieldStillRefuses` (9 profile fields × 3 insertion positions, each expecting `ProfileMismatchError`) plus `test_an_unconfirmed_sequence_entry_still_refuses`, `test_reordering_an_existing_header_still_refuses`, and the CLI-level `test_a_reordered_header_surface_still_refuses_through_the_cli` (exit 16). Each class carries a vacuity guard asserting the same pair *without* the extra field is comparable, so the refusals cannot come from the addition itself.
- Public-surface test: yes — `tests/test_cli_compare_added_public_header_live.py` runs the reported `abicheck compare` through Click over really-compiled `.so` pairs, real `--header old=<dir>/new=<dir>` directory expansion and live L2 extraction, and asserts on the rendered JSON report.
- Axes covered: insertion position (first / interior / trailing / every index), sequence shape (single-insertion, multi-insertion, reorder, shrink, duplicate, sentinel, undecodable), diverging-profile-field (9 fields), operand kind (hand-built contract vs. live binary + header directory).
- General invariant: `TestScopeConfirmedGrowthProperties` states the predicate's contract as invariants over generated inputs — every insertion position, and every permutation of a 4-header base crossed with every placement — against an independent oracle (`_oracle`, an order-preserving-supersequence walk plus a scope-confirmation set test, deliberately not the implementation's `or` of the two placement predicates), with `test_the_oracle_is_not_vacuous` guarding the oracle itself. The refusal half is likewise a generated cross-product, not a fixed repro.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated (`docs/contribute/known-gaps.md`)
- [x] Fast suite green; `mypy abicheck/` clean (0 errors); `ruff check`/`format` clean. `check_ai_readiness.py`'s one error (ADR-049's `**Verified:**` receipt sha not reachable from `origin/main`) reproduces on an unmodified tree and is unrelated.
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kBjP1ooU7qKFEaGj2fhjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017kBjP1ooU7qKFEaGj2fhjQ)_