### PR TITLE
refactor: subtractive cleanup batch 2 — one owner per duplicated helper

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .appcompat_consumer_impact import (
+    _change_covers_symbol,
     attach_consumer_impact,
     consumer_impact_explanations,
     enrich_covered_changes,
@@ -584,20 +585,6 @@ def _is_relevant_to_app(change: Change, app: AppRequirements) -> bool:
             return True
 
     return False
-
-
-def _change_covers_symbol(change: Change, symbol: str) -> bool:
-    """Does *change* already account for *symbol* (exact, demangled, or via
-    ``affected_symbols``)? Mirrors :func:`_is_relevant_to_app`'s matching in
-    reverse -- symbol-name lookup, not app-requirements lookup."""
-    if change.symbol == symbol:
-        return True
-    from .demangle import demangle as _demangle_symbol
-
-    plain = _demangle_symbol(change.symbol)
-    if plain and plain == symbol:
-        return True
-    return bool(change.affected_symbols and symbol in change.affected_symbols)
 
 
 def uncovered_missing_symbols(

--- a/abicheck/buildsource/baseline_publish.py
+++ b/abicheck/buildsource/baseline_publish.py
@@ -46,30 +46,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .build_output import BuildOutput, BuildOutputTarget
+from .build_output import BuildOutput, BuildOutputTarget, _resolve_under_root
 
 #: Default ``key_prefix`` (ADR-047 section 10) when a baseline channel's
 #: ``.abicheck.yml`` entry doesn't set one -- matches the ADR's own example
 #: (``key_prefix: "abicheck-baseline-main"``).
 DEFAULT_ACCEPTED_MAIN_KEY_PREFIX = "abicheck-baseline-main"
-
-
-def _resolve_under_root(root: Path, rel: str) -> Path | None:
-    """Resolve *rel* under *root*, refusing an absolute path or an escape.
-
-    A local copy of :func:`~.build_output._resolve_under_root`'s identical
-    guard -- mirrors :mod:`~.baseline_set`'s own precedent of keeping this
-    small safety check duplicated per-module (see
-    ``_resolve_under_baseline_dir``'s docstring there) rather than importing
-    a leading-underscore helper across a module boundary.
-    """
-    if Path(rel).is_absolute():
-        return None
-    candidate = (root / rel).resolve()
-    root_resolved = root.resolve()
-    if candidate != root_resolved and not candidate.is_relative_to(root_resolved):
-        return None
-    return root / rel
 
 
 @dataclass

--- a/abicheck/buildsource/call_graph.py
+++ b/abicheck/buildsource/call_graph.py
@@ -55,6 +55,7 @@ from ..model.graph_facts import (
     GraphEdge,
     GraphNode,
 )
+from ..model.mangled_name import strip_macho_itanium_decoration
 from ..model.source_graph import function_decl_identity
 from .adapters.base import source_from_argv
 from .clang_ast_run import run_clang_ast_dump
@@ -177,46 +178,9 @@ class CallEdge:
 def _identity(node: dict[str, Any]) -> str:
     """Stable callee/caller identity: the mangled name when clang emits one
     (encodes the full signature, keeps overloads distinct), else the name."""
-    return _normalize_mangled(str(node.get("mangledName") or node.get("name") or ""))
-
-
-def _normalize_mangled(mangled: str) -> str:
-    """Strip a spurious macOS Mach-O ABI leading underscore from an Itanium
-    mangled name clang reports (``__ZN...`` -> ``_ZN...``).
-
-    On Darwin, clang's own AST dump reports a C++ decl's ``mangledName`` with
-    the platform's extra linker-symbol-table underscore still attached (the
-    same decoration ``macho_metadata.py`` strips when parsing the *binary*
-    export table) -- but the ``Function``/``Variable`` objects this identity
-    must join against (``header_graph._decl_identity``, seeded from the flat
-    ``AbiSnapshot``) carry the already-stripped, one-underscore form, since
-    that normalization already happened upstream in ``macho_metadata.py``/
-    ``dumper._dump_macho``. Left unstripped, a header-only graph's
-    call/type-graph node for a public *function* (as opposed to a type --
-    types don't get this decoration) never joins its ``SOURCE_DECLARES``-
-    seeded, provenance-tagged counterpart, so it can never be recognized as
-    a public graph entry (``is_public_dependency_node``) -- silently
-    dropping every ``PUBLIC_API_INTERNAL_DEPENDENCY_ADDED`` finding rooted
-    at a function on macOS. ``__Z`` is an unambiguous, platform-independent
-    marker (a real Itanium mangled name always starts with ``_Z``; a literal
-    C++ identifier starting with two underscores is reserved and never
-    emitted here), so this is a no-op on Linux/Windows, where clang's
-    ``mangledName`` is already the bare ``_Z...`` form.
-
-    **Known gap, not fixed here** (self-review round, fresh evidence): the
-    "no-op on Linux/Windows" claim above does not hold for an explicit GNU
-    ``asm("__Zfake")`` label -- clang reports that literal spelling
-    verbatim on *any* platform, confirmed empirically. Called
-    unconditionally (unlike :mod:`template_graph`'s own
-    ``_normalize_mangled``, whose join now tries the exact spelling first
-    and only falls back to this strip -- see that module's
-    ``_resolve_emitted_symbol``), this corrupts such a decl's identity here
-    too, silently failing (or mis-joining) the same way. Porting the same
-    guarded-fallback fix to this module's own join
-    (:func:`augment_graph_with_calls`) needs its own scoped change, not a
-    drive-by extension of this docstring.
-    """
-    return mangled[1:] if mangled.startswith("__Z") else mangled
+    return strip_macho_itanium_decoration(
+        str(node.get("mangledName") or node.get("name") or "")
+    )
 
 
 def _function_identity(node: dict[str, Any], scope: list[str]) -> str:
@@ -240,7 +204,7 @@ def _function_identity(node: dict[str, Any], scope: list[str]) -> str:
     type_obj = node.get("type")
     type_qual = str(type_obj.get("qualType", "")) if isinstance(type_obj, dict) else ""
     return function_decl_identity(
-        _normalize_mangled(str(node.get("mangledName") or "")),
+        strip_macho_itanium_decoration(str(node.get("mangledName") or "")),
         name,
         qualified_name,
         type_qual,

--- a/abicheck/buildsource/macro_graph.py
+++ b/abicheck/buildsource/macro_graph.py
@@ -203,6 +203,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .. import deadline
+from ..model.mangled_name import strip_macho_itanium_decoration
 from .clang_ast_run import run_clang_ast_dump
 from .graph_facts import CONF_HIGH, CONF_REDUCED, GraphEdge
 from .preprocessor_facts import _DEFINE_RE
@@ -301,14 +302,6 @@ class _LocationCursor:
         return (self.file, self.line)
 
 
-def _normalize_mangled(mangled: str) -> str:
-    """Strip a spurious macOS Mach-O leading underscore, mirroring
-    ``call_graph._normalize_mangled``/``type_graph._normalize_mangled`` (same
-    bug, same fix, kept as a local copy per those modules' own documented
-    reasoning: this module doesn't otherwise depend on either)."""
-    return mangled[1:] if mangled.startswith("__Z") else mangled
-
-
 def _var_decl_identity(node: dict[str, Any], scope: list[str], name: str) -> str:
     """A namespace/class-scope variable's identity, mirroring
     ``type_graph._emit_var_decl_edge``'s identity computation (that function
@@ -316,7 +309,7 @@ def _var_decl_identity(node: dict[str, Any], scope: list[str], name: str) -> str
     from ..model.source_graph import function_decl_identity
 
     return function_decl_identity(
-        _normalize_mangled(str(node.get("mangledName") or "")),
+        strip_macho_itanium_decoration(str(node.get("mangledName") or "")),
         name,
         "::".join([*scope, name]) if scope else name,
         "",

--- a/abicheck/buildsource/override_graph.py
+++ b/abicheck/buildsource/override_graph.py
@@ -134,9 +134,10 @@ from ..model.graph_facts import (
     GraphNode,
     _decl_node_id,
 )
+from ..model.mangled_name import strip_macho_itanium_decoration
 from ..model.source_graph import function_decl_identity
 from .clang_ast_run import run_clang_ast_dump
-from .type_graph import EDGE_TYPE_INHERITS, _normalize_mangled, parse_clang_ast_types
+from .type_graph import EDGE_TYPE_INHERITS, parse_clang_ast_types
 
 if TYPE_CHECKING:
     from ..model.source_graph import SourceGraphSummary
@@ -238,14 +239,13 @@ def _method_info(node: dict[str, Any], scope: list[str]) -> _MethodInfo | None:
     name = str(node.get("name") or "")
     if not name:
         return None
-    # _normalize_mangled strips a spurious macOS Mach-O leading underscore
-    # (Codex review, fresh evidence, verified against real
+    # Codex review, fresh evidence, verified against real
     # `clang++ --target=x86_64-apple-darwin` output: mangledName reports
-    # "__ZN1D1fEv", not the standard "_ZN1D1fEv") -- left unstripped, an
+    # "__ZN1D1fEv", not the standard "_ZN1D1fEv". Left unstripped, an
     # override edge's decl:// node never joins the call/type graph's own
-    # node for the SAME method (both already normalize via this exact
-    # helper), leaving it a disconnected duplicate on Darwin.
-    mangled = _normalize_mangled(str(node.get("mangledName") or ""))
+    # node for the SAME method (all of them now normalize through the one
+    # model-owned helper), leaving it a disconnected duplicate on Darwin.
+    mangled = strip_macho_itanium_decoration(str(node.get("mangledName") or ""))
     type_obj = node.get("type")
     type_qual = str(type_obj.get("qualType", "")) if isinstance(type_obj, dict) else ""
     qualified_name = "::".join([*scope, name]) if scope else name

--- a/abicheck/buildsource/type_graph.py
+++ b/abicheck/buildsource/type_graph.py
@@ -71,6 +71,7 @@ from typing import TYPE_CHECKING, Any
 
 from .. import deadline
 from ..model.graph_facts import CONF_HIGH, CONF_REDUCED, GraphEdge, GraphNode
+from ..model.mangled_name import strip_macho_itanium_decoration
 from ..model.source_graph import function_decl_identity
 from .clang_ast_run import run_clang_ast_dump
 from .graph_facts import register_fact
@@ -504,47 +505,9 @@ def _decl_return_type_name(node: dict[str, Any]) -> str:
 
 def _decl_identity(node: dict[str, Any]) -> str:
     """Stable identity for a decl node: mangled name when clang emits one."""
-    return _normalize_mangled(str(node.get("mangledName") or node.get("name") or ""))
-
-
-def _normalize_mangled(mangled: str) -> str:
-    """Strip a spurious macOS Mach-O ABI leading underscore from an Itanium
-    mangled name clang reports (``__ZN...`` -> ``_ZN...``).
-
-    Mirrors ``call_graph._normalize_mangled`` (same bug, same fix, kept as a
-    local copy rather than a cross-import since neither module currently
-    imports the other and both sit near the AI-readiness line-count cap).
-    On Darwin, clang's own AST dump reports a C++ decl's ``mangledName`` with
-    the platform's extra linker-symbol-table underscore still attached, but
-    the ``Function``/``Variable`` objects this identity must join against
-    (``header_graph._decl_identity``, seeded from the flat ``AbiSnapshot``)
-    carry the already-stripped, one-underscore form (normalized upstream in
-    ``macho_metadata.py``/``dumper._dump_macho``). Left unstripped, a
-    header-only graph's ``DECL_HAS_TYPE``/``TYPE_INHERITS`` edge rooted at a
-    public *function* (as opposed to a type -- types don't get this
-    decoration) never joins its ``SOURCE_DECLARES``-seeded counterpart, so
-    it can never be recognized as a public graph entry
-    (``is_public_dependency_node``) -- silently dropping every
-    ``PUBLIC_API_INTERNAL_DEPENDENCY_ADDED`` finding rooted at a function on
-    macOS. ``__Z`` is an unambiguous, platform-independent marker (a real
-    Itanium mangled name always starts with ``_Z``; a literal C++ identifier
-    starting with two underscores is reserved and never emitted here), so
-    this is a no-op on Linux/Windows, where clang's ``mangledName`` is
-    already the bare ``_Z...`` form.
-
-    **Known gap, not fixed here** (self-review round, fresh evidence): the
-    "no-op on Linux/Windows" claim above does not hold for an explicit GNU
-    ``asm("__Zfake")`` label -- clang reports that literal spelling
-    verbatim on *any* platform, confirmed empirically. Called
-    unconditionally (unlike :mod:`template_graph`'s own
-    ``_normalize_mangled``, whose join now tries the exact spelling first
-    and only falls back to this strip), this corrupts such a decl's
-    identity here too. Porting the same guarded-fallback fix to this
-    module's own join needs its own scoped change, not a drive-by
-    extension of this docstring; see ``call_graph._normalize_mangled``'s
-    identical note.
-    """
-    return mangled[1:] if mangled.startswith("__Z") else mangled
+    return strip_macho_itanium_decoration(
+        str(node.get("mangledName") or node.get("name") or "")
+    )
 
 
 def _node_file(node: dict[str, Any]) -> str:
@@ -1293,7 +1256,7 @@ def _var_decl_ident(node: Any, scope: list[str], name: str) -> str:
     function's docstring for why the qualified-name fallback is load-bearing.
     """
     return function_decl_identity(
-        _normalize_mangled(str(node.get("mangledName") or "")),
+        strip_macho_itanium_decoration(str(node.get("mangledName") or "")),
         name,
         "::".join([*scope, name]) if scope else name,
         "",
@@ -1374,7 +1337,7 @@ def _function_decl_ident(node: Any, scope: list[str], name: str) -> str:
         return ""
     type_obj = node.get("type")
     return function_decl_identity(
-        _normalize_mangled(str(node.get("mangledName") or "")),
+        strip_macho_itanium_decoration(str(node.get("mangledName") or "")),
         name,
         "::".join([*scope, name]) if scope else name,
         str(type_obj.get("qualType", "")) if isinstance(type_obj, dict) else "",

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -66,6 +66,7 @@ from .cli_buildsource_helpers import (  # noqa: F401  (re-exported for API stabi
     purge_external_outputs as purge_external_outputs,
 )
 from .errors import SnapshotError, ValidationError
+from .evidence_depth import layer_payload_empty
 
 if TYPE_CHECKING:
     from .model import AbiSnapshot
@@ -226,26 +227,6 @@ def dump_source_only(
 # ---------------------------------------------------------------------------
 
 
-def _layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
-    """True when *key*'s embedded payload carries no facts.
-
-    A coverage row can read ``PARTIAL``/``PRESENT`` while the payload is empty —
-    e.g. ``_run_inline_source_abi`` returns an empty ``SourceAbiSurface()`` when
-    clang is unavailable after L3 was found. The status alone then hides the
-    miss, so we inspect the actual payload (Codex review, PR #422).
-    """
-    if key == "L3":
-        be = pack.build_evidence
-        return be is None or (not be.targets and not be.compile_units)
-    if key == "L4":
-        sa = pack.source_abi
-        return sa is None or not any(sa.reachable_buckets().values())
-    if key == "L5":
-        sg = pack.source_graph
-        return sg is None or not sg.nodes
-    return False
-
-
 def _missing_requested_evidence_layers(
     pack: BuildSourcePack | None, collect_mode: str
 ) -> list[str]:
@@ -278,7 +259,7 @@ def _missing_requested_evidence_layers(
         if (
             cov is None
             or cov.status == CoverageStatus.NOT_COLLECTED
-            or _layer_payload_empty(pack, key)
+            or layer_payload_empty(pack, key)
         ):
             missing.append(layer.value)
     return missing

--- a/abicheck/contract_evaluation.py
+++ b/abicheck/contract_evaluation.py
@@ -62,6 +62,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .checker_types import Change
+from .compare.surface_graph import _type_identifiers
 from .contract_relevance_types import (
     CONTRACT_REASON_CODES,
     NON_ENTITY_RELEVANCE,
@@ -92,7 +93,6 @@ from .surface import (
     SurfaceUnions,
     _hidden_friend_owner_effective_origin,
     _one_sided_key_origin,
-    _type_identifiers,
     classify_change_surface,
     surface_unions,
 )

--- a/abicheck/contract_evidence.py
+++ b/abicheck/contract_evidence.py
@@ -83,7 +83,10 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TypeVar
 
-from .compatibility_evaluation_config import CompatibilityEvaluationConfig
+from .compatibility_evaluation_config import (
+    CompatibilityEvaluationConfig,
+    _frozen_tuple,
+)
 from .contract_relevance_types import (
     CONTRACT_EVIDENCE_SCHEMA_VERSION,
     DECISION_RECEIPT_SCHEMA_VERSION,
@@ -96,30 +99,6 @@ from .contract_relevance_types import (
 )
 
 _T = TypeVar("_T")
-
-
-def _frozen_tuple(s: Sequence[_T], *, element_type: type[_T]) -> tuple[_T, ...]:
-    """Freeze *s* into an order-preserving tuple, validating element types.
-
-    Rejects a bare ``str``/``bytes`` (iterating one yields characters, not
-    the intended single element) and materializes before validating so a
-    one-shot iterable isn't silently consumed by the check alone -- mirrors
-    ``compatibility_evaluation_config._frozen_tuple``.
-    """
-    if isinstance(s, (str, bytes)):
-        raise TypeError(
-            f"Expected a sequence of items, not a bare {type(s).__name__} "
-            f"{s!r} -- iterating a string/bytes value yields individual "
-            "characters, not the intended elements; wrap a single value in "
-            "a list/tuple explicitly."
-        )
-    materialized = tuple(s)
-    invalid = [item for item in materialized if not isinstance(item, element_type)]
-    if invalid:
-        raise TypeError(
-            f"Every element must be a {element_type.__name__}, not: {invalid!r}"
-        )
-    return materialized
 
 
 def _frozen_mapping(m: Mapping[str, object]) -> MappingProxyType[str, object]:

--- a/abicheck/diff_cpp_patterns.py
+++ b/abicheck/diff_cpp_patterns.py
@@ -712,8 +712,10 @@ def _stable_leading_template_args(old_args: str, new_args: str) -> bool:
     >>> _stable_leading_template_args("A", "B")  # 1-arg degenerate case
     True
     """
-    old_list = [p.strip() for p in _split_top_level_commas_local(old_args)]
-    new_list = [p.strip() for p in _split_top_level_commas_local(new_args)]
+    from .internal_leak import _split_top_level_commas  # local import: cycle-free
+
+    old_list = [p.strip() for p in _split_top_level_commas(old_args)]
+    new_list = [p.strip() for p in _split_top_level_commas(new_args)]
     if not old_list or not new_list:
         return False
     # Degenerate single-arg template: nothing leading to compare.
@@ -727,31 +729,6 @@ def _stable_leading_template_args(old_args: str, new_args: str) -> bool:
         len(old_list),
     )
     return 1 <= diff_idx < len(old_list)
-
-
-def _split_top_level_commas_local(s: str) -> list[str]:
-    """Split *s* on commas not nested inside ``<...>``. Lightweight local
-    copy of the helper in ``internal_leak`` to avoid a cross-module
-    dependency for a small parser.
-    """
-    parts: list[str] = []
-    depth = 0
-    buf: list[str] = []
-    for ch in s:
-        if ch == "<":
-            depth += 1
-            buf.append(ch)
-        elif ch == ">":
-            depth -= 1
-            buf.append(ch)
-        elif ch == "," and depth == 0:
-            parts.append("".join(buf))
-            buf = []
-        else:
-            buf.append(ch)
-    if buf:
-        parts.append("".join(buf))
-    return parts
 
 
 def _extract_template_args(demangled: str) -> str | None:

--- a/abicheck/diff_stdlib_impl.py
+++ b/abicheck/diff_stdlib_impl.py
@@ -146,8 +146,8 @@ def _public_by_value_type_closure(snap: AbiSnapshot) -> set[str]:
     it. There is no pairwise comparison here for
     :func:`~abicheck.compare.fact_comparison.compare_facts` to gate.
     """
+    from .compare.surface_graph import _type_identifiers
     from .model import RecordType, resolved_fact_value
-    from .surface import _type_identifiers
 
     record_by_name: dict[str, RecordType] = {rec.name: rec for rec in snap.types}
     for rec in snap.types:

--- a/abicheck/frontends/cli/runtime.py
+++ b/abicheck/frontends/cli/runtime.py
@@ -309,23 +309,6 @@ def _resolve_debug_artifact(
     )
 
 
-def _validate_show_only(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: str | None,
-) -> str | None:
-    """Eagerly validate --show-only tokens so invalid ones surface early."""
-    if value is None:
-        return None
-    from ...reporter import ShowOnlyFilter
-
-    try:
-        ShowOnlyFilter.parse(value)
-    except ValueError as exc:
-        raise click.BadParameter(str(exc)) from exc
-    return value
-
-
 def _validate_view(
     ctx: click.Context,
     param: click.Parameter,

--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -1145,38 +1145,6 @@ def _typedef_target_is_indirect(
     )
 
 
-def _typenode_is_indirection_wrapper(name: str) -> bool:
-    """Return True if a *type node* on a leak path is itself a pointer/reference
-    or a smart-pointer wrapper type.
-
-    Stricter than :func:`_field_is_indirect`: it must NOT fire on a regular
-    record/function name that merely *contains* a wrapper-ish substring. A
-    public type named ``PimplHandle`` that embeds an internal type **by value**
-    is a real layout leak, not an indirection (Codex review) — so the loose
-    ``pimpl``/``unique_ptr`` substring match used for *field declared types* is
-    not applied to path labels. Only a raw ``*``/``&`` or a qualified
-    ``std::``/libstdc++ smart-pointer spelling counts.
-    """
-    # Top-level only (collapse template args): a wrapper node like
-    # ``std::__uniq_ptr_impl<...>`` is indirection, but ``std::array<int*, 4>``
-    # (a pointer in an unrelated arg) is not (Codex review).
-    no_targs = _strip_template_args(name)
-    if "*" in no_targs or "&" in no_targs:
-        return True
-    outer = _strip_decorators(no_targs)
-    return any(
-        marker in outer
-        for marker in (
-            "std::unique_ptr",
-            "std::shared_ptr",
-            "std::weak_ptr",
-            "__uniq_ptr",
-            "__shared_ptr",
-            "__weak_ptr",
-        )
-    )
-
-
 def _record_field_is_value_embedded(rec: RecordType, field_name: str) -> bool | None:
     """Check whether *field_name* in *rec* is embedded by value.
 

--- a/abicheck/model/mangled_name.py
+++ b/abicheck/model/mangled_name.py
@@ -135,6 +135,18 @@ def strip_macho_itanium_decoration(mangled: str) -> str:
     resolve that narrower case themselves; see
     ``extract.headers.clang.context.strip_darwin_itanium_decoration``).
 
+    **Known gap, carried here from the two `buildsource` graph copies this
+    replaced** (their own self-review round, fresh evidence): the "always
+    safe" claim above holds for a *compiler-produced* mangled name, not for
+    an explicit GNU ``asm("__Zfake")`` label -- clang reports that literal
+    spelling verbatim on any platform, confirmed empirically, and stripping
+    it corrupts that decl's identity. A caller that joins against a symbol
+    table should try the exact spelling first and fall back to this strip
+    (``buildsource.template_graph._resolve_emitted_symbol`` does);
+    ``call_graph``/``type_graph``'s own joins still call this
+    unconditionally, which is a real, separately-scoped gap in those joins
+    rather than in this function.
+
     Returns *mangled* unchanged for every other shape. The single canonical
     home for this specific structural check -- previously duplicated,
     independently, by :func:`_itanium_strip_prefix` below,

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -78,20 +78,6 @@ class PipelineStep(Protocol):
 # ---------------------------------------------------------------------------
 
 
-def _safe_index(snap: AbiSnapshot) -> bool:
-    """Index ``snap`` for lookups, tolerating partial snapshots.
-
-    Returns ``True`` when the snapshot indexed cleanly and is safe to read
-    from, ``False`` otherwise. Keeping the swallowed exception out of a
-    ``try/except/continue`` loop body avoids a silently-ignored-error pattern.
-    """
-    try:
-        snap.index()
-    except Exception:  # noqa: BLE001 — defensive; snapshots may be partial
-        return False
-    return True
-
-
 def _matches_suppression_key(symbol: str, key: str) -> bool:
     """Return ``True`` iff *symbol* is suppressed by *key*.
 

--- a/abicheck/report/render_markdown.py
+++ b/abicheck/report/render_markdown.py
@@ -497,20 +497,6 @@ class SeveritySectionsData:
     groups: tuple[ChangeGroup, ...]
 
 
-def render_severity_sections(data: SeveritySectionsData) -> list[str]:
-    lines: list[str] = []
-    for group in data.groups:
-        lines += [group.heading, ""]
-        if group.note_lines:
-            lines += list(group.note_lines)
-            lines.append("")
-        fmt = _format_change_md_oneline if group.oneline else _format_change_md
-        for c in group.changes:
-            lines.append(fmt(c))
-        lines.append("")
-    return lines
-
-
 # ---------------------------------------------------------------------------
 # Environment & toolchain drift section
 # ---------------------------------------------------------------------------

--- a/abicheck/storage/dto.py
+++ b/abicheck/storage/dto.py
@@ -64,7 +64,7 @@ from .sparse_section_codec import (
     LayoutSection,
     ProvenanceSection,
 )
-from .types_section_codec import TypesSection
+from .types_section_codec import TypesSection, _freeze
 
 __all__ = [
     "BASELINE_SET_SECTION_KIND",
@@ -234,30 +234,6 @@ _MIGRATIONS: Mapping[
     **{kind: {} for kind in SECTION_SCHEMA_VERSIONS},
     BUNDLE_COMPOSITION_SECTION_KIND: {1: _bundle_composition_v1_to_v2},
 }
-
-
-def _freeze(value: Any) -> Any:
-    """*value* — already `canonical_form`'s output, so a tree of only
-    `dict`/`list`/`str`/`int`/`float`/`bool`/`None` — rebuilt so nothing
-    reachable from a `SectionDTO` after construction is mutable: every
-    mapping becomes a `MappingProxyType` over a `dict` of already-frozen
-    values, every list becomes a `tuple` of already-frozen values.
-
-    `canonical_form` already rebuilds every container, so `__post_init__`'s
-    stored `payload` never aliases the caller's own object — but the
-    rebuilt containers were still ordinary, mutable `dict`/`list`, reachable
-    both through `dto.payload` directly and through a *nested* value inside
-    an earlier `to_dict()` call's return, either of which could then mutate
-    this frozen DTO's own stored content after construction already
-    validated it (Codex review, a second finding on the same field after
-    the copy-on-construction fix: a shallow copy stops the *caller's*
-    mapping from aliasing this DTO's storage, but does nothing once the
-    values inside that storage are themselves mutable)."""
-    if isinstance(value, Mapping):
-        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
-    if isinstance(value, list):
-        return tuple(_freeze(item) for item in value)
-    return value
 
 
 def _unfreeze(value: Any) -> Any:

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -65,6 +65,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .compare.surface_graph import _type_identifiers
 from .demangle import demangle
 from .model import ScopeOrigin
 from .model.mangled_name import (
@@ -310,26 +311,6 @@ _TYPE_NOISE: frozenset[str] = frozenset(
 )
 
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_:]*")
-
-
-def _type_identifiers(type_str: str | None) -> set[str]:
-    """Extract candidate record/enum/typedef names from a type string.
-
-    Handles pointers, references, ``const``/``volatile``, arrays, and
-    template arguments (``A<B, C>`` yields ``A``, ``B``, ``C``). Built-in
-    keywords are dropped. Both the fully-qualified name and its trailing
-    ``::`` segment are returned so callers can match either encoding.
-    """
-    if not type_str:
-        return set()
-    out: set[str] = set()
-    for tok in _IDENT_RE.findall(type_str):
-        if tok in _TYPE_NOISE:
-            continue
-        out.add(tok)
-        if "::" in tok:
-            out.add(tok.rsplit("::", 1)[1])
-    return out
 
 
 # ``PublicSurface`` itself now lives in ``policy/public_surface.py`` --

--- a/abicheck/surface_graph.py
+++ b/abicheck/surface_graph.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .checker_policy import EvidenceTier
+from .compare.surface_graph import _type_identifiers
 from .model import (
     AbiSnapshot,
     Function,
@@ -45,7 +46,6 @@ from .model import (
 )
 from .model.dwarf_facts import debug_info_present
 from .model.surface_facts import in_public_surface, is_binary_exported
-from .surface import _type_identifiers
 
 if TYPE_CHECKING:
     from .model.identity import EntityId

--- a/changelog.d/1789003000_claude_dedup-shared-helpers.md
+++ b/changelog.d/1789003000_claude_dedup-shared-helpers.md
@@ -1,0 +1,21 @@
+### Removed
+
+- Deleted four functions nothing in the package referenced:
+  `internal_leak._typenode_is_indirection_wrapper`,
+  `frontends.cli.runtime._validate_show_only`,
+  `report.render_markdown.render_severity_sections`, and
+  `post_processing._safe_index` — the last was never called in its own
+  module and had one test as its only consumer, now pointed at the live
+  `diff_filtering` implementation it duplicated.
+
+### Changed
+
+- Seven byte-identical helper implementations now have one owner each, with
+  every caller importing it: the Mach-O Itanium underscore strip (five
+  copies across `buildsource/{call,type,macro,override}_graph.py`, folded
+  onto `model.mangled_name.strip_macho_itanium_decoration`, which already
+  declared itself their canonical home), plus `layer_payload_empty`,
+  `_change_covers_symbol`, `_freeze`, `_type_identifiers`,
+  `_split_top_level_commas`, `_resolve_under_root` and `_frozen_tuple`.
+  Each owner is the module the other already depended on, so no new import
+  edge or cycle was introduced.

--- a/docs/reference/header-backend-capabilities.md
+++ b/docs/reference/header-backend-capabilities.md
@@ -110,7 +110,7 @@ Across the 149 fields of the 6 declaration types the two header-AST backends bui
 | `is_pure_virtual` | ✅ Yes | ✅ Yes | ✅ Yes | — |
 | `is_deleted` | ✅ Yes | ✅ Yes | ✅ Yes | — |
 | `deleted_from_dwarf` | — n/a | — n/a | — n/a | Set from DWARF's `DW_AT_deleted` (`dwarf_snapshot.py`). |
-| `is_inline` | ✅ Yes | ✅ Yes | ✅ Yes | — |
+| `is_inline` | ✅ Yes | ✅ Yes | ✅ Yes | Inline linkage, explicit or implicit. castxml's frontend resolves implicit inline before emitting; clang's JSON emits its `inline` key only for the written keyword, so the clang backend reconstructs the implicit forms (`extract/headers/clang/inline_semantics.py`). This row read _FULL/_FULL while the two actually disagreed on every constexpr/in-class declaration. |
 | `access` | ✅ Yes | ✅ Yes | ✅ Yes | — |
 | `return_pointer_depth` | ✅ Yes | ✅ Yes | ✅ Yes | — |
 | `elf_visibility` | — n/a | — n/a | — n/a | Read from the binary's own symbol table (`dumper_elf_symbols.py`). |

--- a/tests/test_cov95_diff_cpp_patterns.py
+++ b/tests/test_cov95_diff_cpp_patterns.py
@@ -15,7 +15,7 @@ existing ``test_cpp_pattern_detectors.py`` suite does not reach:
 * ``_parent_namespace`` with no ``::``
 * ``_stable_leading_template_args`` degenerate / mismatch branches
 * ``_extract_template_args`` no-match path
-* ``_split_top_level_commas_local`` nesting
+* ``_split_top_level_commas`` nesting
 * tag-rename candidate rejection paths
 * inline-body pimpl helper branches
 * bundle-SONAME directory scanning and best-effort SONAME readers
@@ -39,7 +39,6 @@ from abicheck.diff_cpp_patterns import (
     _parent_namespace,
     _read_elf_soname,
     _read_soname_best_effort,
-    _split_top_level_commas_local,
     _stable_leading_template_args,
     _symbols_embedding_leaf,
     _unqualified_function_name,
@@ -49,6 +48,7 @@ from abicheck.diff_cpp_patterns import (
     detect_inline_body_renamed_member,
     detect_tag_type_renamed,
 )
+from abicheck.internal_leak import _split_top_level_commas
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -169,20 +169,20 @@ class TestStableLeadingTemplateArgs:
 
 
 # ---------------------------------------------------------------------------
-# _split_top_level_commas_local
+# _split_top_level_commas
 # ---------------------------------------------------------------------------
 
 
 class TestSplitTopLevelCommas:
     def test_simple(self) -> None:
-        assert _split_top_level_commas_local("a, b, c") == ["a", " b", " c"]
+        assert _split_top_level_commas("a, b, c") == ["a", " b", " c"]
 
     def test_nested_angle_brackets_not_split(self) -> None:
         # The comma inside ``<...>`` must not split.
-        assert _split_top_level_commas_local("a, X<b, c>") == ["a", " X<b, c>"]
+        assert _split_top_level_commas("a, X<b, c>") == ["a", " X<b, c>"]
 
     def test_empty(self) -> None:
-        assert _split_top_level_commas_local("") == []
+        assert _split_top_level_commas("") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cov95_reporting.py
+++ b/tests/test_cov95_reporting.py
@@ -492,7 +492,7 @@ class TestReporterConfidenceSection:
 class TestPostProcessingHelpers:
     def test_safe_index_success_and_failure(self) -> None:
         # Lines 98-102: index OK True, exception → False.
-        from abicheck.post_processing import _safe_index
+        from abicheck.diff_filtering import _safe_index
 
         assert _safe_index(_snap()) is True
 


### PR DESCRIPTION
## Summary

Follow-on to #1279. That batch removed the delegation-only *facades*; this removes duplicated *implementations* underneath them. **−282 net lines of package implementation**, of which −116 is executable structure and the rest is five copies of one Mach-O explanation collapsing into one.

## Motivation

Batch 1's survey left a question open: after the facades went, was there a pool of genuinely dead or duplicated code left? I answered it mechanically rather than by guessing — hashing every function body under `abicheck/` and every module-level definition's reference count across the whole repo.

The answer is that the dead-code well is nearly dry (four real finds), but **duplicated implementations are not**: 16 groups of byte-identical bodies. Per this repo's own rule that "a duplicate test body is a review queue, not a deletion list", I read all 16 rather than deleting on the hash — which is what caught the three that must not be merged.

## Changes

**Seven helpers deduplicated onto one owner**, every caller importing it.

The largest had five copies: the Mach-O Itanium leading-underscore strip in `buildsource/call_graph.py`, `type_graph.py`, `macro_graph.py` (with `override_graph.py` importing one of them). `model/mangled_name.py` already declared itself *"the single canonical home for this specific structural check — previously duplicated, independently, by … so a Mach-O-target identity fix made in one no longer needs to be separately rediscovered and reapplied in the other two."* The consolidation was declared but never finished. The copies' stated reason — *"kept as a local copy … both sit near the AI-readiness line-count cap"* — was void: importing the owner makes both files smaller, not larger.

Their real knowledge is preserved, not deleted with the fifth copy: the `asm("__Zfake")` gap (clang reports that literal spelling on any platform, so the strip corrupts a hand-labelled symbol's identity) is carried into the canonical docstring, where it now applies to every caller instead of two of five.

The other six: `layer_payload_empty`, `_change_covers_symbol`, `_freeze`, `_type_identifiers`, `_split_top_level_commas`, `_resolve_under_root`, `_frozen_tuple`.

**Four functions deleted as unreferenced:** `internal_leak._typenode_is_indirection_wrapper`, `frontends.cli.runtime._validate_show_only`, `report.render_markdown.render_severity_sections`, and `post_processing._safe_index`. The last was found by the dedup, not the dead-code scan — it was never called in its own module and had a single test as its only consumer, which now exercises the live `diff_filtering` implementation it duplicated.

## What was deliberately *not* deduplicated

This is the part that needed reading rather than hashing:

- **`_deadline_bound_worker`** — identical bodies, **different type signatures** (one typed for `SourceAbiTu`, one for type-graph results). Deduping needs a `TypeVar`, which adds structure rather than removing it. I applied it, mypy caught it, I reverted it.
- **`policy/selectors._strip_template_args`** — its copy documents a real reason: importing `internal_leak` would pull `checker_types`/`buildsource` in transitively.
- **`_is_intel_sycl_driver` / `_is_dpcpp_family_binary`** — same body, different names, and the docstring already says they are deliberately two functions over one name set for two distinct call sites.
- **`_node_file`** — would create a brand-new cross-package edge for 14 lines.
- **`_linker_identity` / `_canonical_decl_key`** — a one-line body (`return mangled or name`) whose two docstrings explain different call-site concerns. A one-liner cannot meaningfully drift.

Where a pair was mutually dependent (`appcompat` ↔ `appcompat_consumer_impact`, `storage/dto` ↔ `types_section_codec`), ownership went to the module the other already imports. My first attempt picked the wrong direction in both cases and created import cycles; both were caught by the test suite and reversed, so **no new import edge or cycle is introduced**.

## Line accounting

| Area | + | − | Net |
|---|---:|---:|---:|
| Package implementation (`abicheck/**/*.py`) | 49 | 331 | **−282** |
| Tests | 6 | 6 | 0 |
| Changelog fragment | 20 | 0 | +20 |
| **Total** | **75** | **337** | **−262** |

Of the −282: **−116 is executable structure**; the remainder is comment and docstring text that existed only because the same explanation was written five times. Three oversized files shrank (`appcompat.py` 1714→1701, `internal_leak.py` 1652→1620, `type_graph.py` 1995→1958 — the last within 5 lines of the hard cap).

## Validation

Against recorded base `b0be72f3`.

- `verify.py --profile pr --only lint,fmt-check,typecheck,ai-readiness,architecture,docs-contract,repo-facts,schema-sync` — **8 passed, 0 failed**.
- `mypy abicheck/` — Success, 792 files, baseline 0 held. (This is what caught the `_deadline_bound_worker` signature mismatch.)
- `check_architecture.py` — 0 errors, including no new cycle after both direction reversals.
- Full unit lane: **47,523 passed, 46 failed**. 43 reproduce on the recorded base; two are the `test_action_report_destinations` / `test_action_run_sh_compare_pr_json_write` modules that fail only under `-n 4`, with a different parametrization each run (established in #1279, pass serially); one was mine (`_safe_index`) and is fixed in this branch.
- Real compiled C fixture re-run — unchanged pair exit 0, breaking pair exit 4 on the same three change kinds. The Mach-O dedup touches mangled-name normalization, so this is behavioural coverage and not just a type check.

## Remaining candidates

Unchanged from #1279's list, minus the strict-YAML item (now known blocked), plus one new:

- **Export convergence (`expand_export_kwargs`)** — `secondary_writes` spans 9 files including the refusal/error output paths, where a missing secondary artifact is a correctness bug. Needs its own slice with export-on-refusal tests.
- **`checker_policy`/`contract_gating`/`reclassify`** — blocked on `model`-owned `DiffResult` reaching policy. Note most of what `checker_types` imports through them are *enums* (shapes, arguably `model`'s), but `apply_policy_file_overrides`/`policy_kind_sets` are real policy, so moving the enums alone does not unblock it.
- **Storage convergence** — assessed again this batch and still not started. `storage/import_v1.py` is on the live write path, not dead; replacing it means a direct `AbiSnapshot`→sections encoder plus regenerated baselines, with persisted user artifacts at stake. Not a one-session change.
- **Schema mirror** (`abicheck/schemas/` ↔ `docs/reference/schemas/v1/`) — all 5 files byte-identical, 4,353 tracked duplicate lines. Removable by generating the docs copy at build time, but that is docs-workflow surgery on the publish path, and #1279 already showed this repo has CI jobs whose constraints are invisible locally. Wants its own PR. Hygiene, not runtime code.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated (n/a — no user-visible surface changed)
- [x] Lint / format / mypy / architecture / ai-readiness all clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTGETYEXyHHGnEep1CrUqg


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTGETYEXyHHGnEep1CrUqg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared helper logic to improve consistency across analysis, build, reporting, and storage workflows.
  * Removed several unused internal helpers without changing supported public interfaces.
  * Centralized symbol normalization and type-identity handling for more consistent results across build analysis.
* **Documentation**
  * Clarified limitations around Mach-O symbol normalization.
* **Tests**
  * Updated tests to use the consolidated helper implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->