### PR TITLE
fix(tests): resolve three new bare-bash sites, and land #1255's last review round

### DIFF
--- a/tests/test_l2_real_profile_status.py
+++ b/tests/test_l2_real_profile_status.py
@@ -37,6 +37,7 @@ from _l2_real_profiles_support import (
     measurement_output,
     profiles,
 )
+from _workflow_exec import bash_executable, require_bash
 
 
 class TestReadinessIsNotAMeasurement:
@@ -288,6 +289,7 @@ class TestSideAcquisitionIsDeclared:
         string a text assertion would look for while passing for an empty
         directory.
         """
+        require_bash()
         script = profiles.prepare_script(profiles.SVS)
         guard = [
             line
@@ -296,7 +298,7 @@ class TestSideAcquisitionIsDeclared:
         ]
         assert guard, "no guard was generated for the supplied side"
         return subprocess.run(
-            ["bash", "-c", "set -u\n" + "\n".join(guard)],
+            [bash_executable(), "-c", "set -u\n" + "\n".join(guard)],
             cwd=tmp_path,
             capture_output=True,
             text=True,
@@ -1014,6 +1016,7 @@ class TestASuppliedDistributionMustProveItsIdentity:
         guard line failed to parse, and a text assertion would have reported the
         expected strings present throughout. Only running it caught that.
         """
+        require_bash()
         script = profiles.prepare_script(profiles.SVS)
         guard = "\n".join(
             line
@@ -1030,7 +1033,7 @@ class TestASuppliedDistributionMustProveItsIdentity:
                 f'#define SVS_RUNTIME_VERSION_STRING "{version}"\n'
             )
         result = subprocess.run(
-            ["bash", "-c", "set -u\n" + guard],
+            [bash_executable(), "-c", "set -u\n" + guard],
             cwd=tmp_path,
             capture_output=True,
             text=True,

--- a/tests/test_l2_real_profiles.py
+++ b/tests/test_l2_real_profiles.py
@@ -40,6 +40,7 @@ from _l2_real_profiles_support import (
     materialize_operands,
     profiles,
 )
+from _workflow_exec import bash_executable, require_bash
 
 
 class TestProfileDefinitions:
@@ -610,9 +611,14 @@ class TestPrepareScriptIsolatesEachCommand:
     def test_the_rendered_script_is_valid_shell(self, profile_id):
         # Parse-checked rather than eyeballed: a script nobody can run is not
         # reproduction instructions. `bash -n` needs no network and builds nothing.
+        require_bash()
         script = profiles.prepare_script(profiles.PROFILES[profile_id])
         proc = subprocess.run(
-            ["bash", "-n"], input=script, capture_output=True, text=True, check=False
+            [bash_executable(), "-n"],
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         assert proc.returncode == 0, proc.stderr
 

--- a/tests/test_subprocess_bash_is_resolved.py
+++ b/tests/test_subprocess_bash_is_resolved.py
@@ -53,7 +53,9 @@ call site, and only the *first* element of an argv list is the program.
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import _workflow_exec
 import pytest
@@ -63,6 +65,8 @@ TESTS_DIR = Path(__file__).resolve().parent
 
 #: The retired private clone. Banned as a name, not merely as a definition.
 _CLONE_NAME = "_bash_executable"
+
+T = TypeVar("T")
 
 
 #: Callables whose first positional argument is an argv sequence.
@@ -83,6 +87,31 @@ def _test_modules() -> list[Path]:
     module that defines them.
     """
     return sorted(TESTS_DIR.rglob("*.py"))
+
+
+def _scan(rule: Callable[[str], list[T]], path: Path) -> list[T]:
+    """Apply one scan to one file, naming the file if it will not parse.
+
+    `ast.parse` reports a `SyntaxError` against `"<unknown>"`, so a malformed
+    module added under `tests/` would fail all three rules at once without
+    saying which file it was (CodeRabbit review). Re-raised rather than
+    skipped: an unparseable module is a real problem, and one this scan is
+    well placed to notice.
+    """
+    try:
+        return rule(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        raise AssertionError(
+            f"{_display(path)} does not parse, so it cannot be scanned: {exc}"
+        ) from exc
+
+
+def _display(path: Path) -> str:
+    """`path` relative to `tests/` when it lives there, else in full."""
+    try:
+        return path.relative_to(TESTS_DIR).as_posix()
+    except ValueError:
+        return str(path)
 
 
 def _argv_program(node: ast.Call) -> ast.expr | None:
@@ -241,11 +270,20 @@ def _unguarded_resolutions(source: str) -> list[str]:
         hoist a guard it already has.
         """
         for stmt in getattr(fn, "body", []):
-            if (
-                isinstance(stmt, ast.Expr)
-                and isinstance(stmt.value, ast.Call)
-                and getattr(stmt.value.func, "id", None) == "require_bash"
-            ):
+            if not (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call)):
+                continue
+            # Both call forms, matching how `_names_called` reads a
+            # resolution: reading only `func.id` here while accepting
+            # `func.attr` there made the two halves disagree, so a function
+            # guarding with `_workflow_exec.require_bash()` was reported
+            # unguarded (CodeRabbit review).
+            func = stmt.value.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", None)
+            )
+            if name == "require_bash":
                 return stmt.lineno
         return None
 
@@ -313,7 +351,7 @@ class TestNoModuleSpellsBashItself:
     def test_no_test_module_passes_a_bare_bash_program(self) -> None:
         offenders = {}
         for path in _test_modules():
-            hits = _bare_bash_call_sites(path.read_text(encoding="utf-8"))
+            hits = _scan(_bare_bash_call_sites, path)
             if hits:
                 offenders[path.relative_to(TESTS_DIR).as_posix()] = hits
         assert offenders == {}, (
@@ -326,7 +364,7 @@ class TestNoModuleSpellsBashItself:
     def test_no_test_module_clones_the_resolver(self) -> None:
         offenders = {}
         for path in _test_modules():
-            hits = _private_clone_lines(path.read_text(encoding="utf-8"))
+            hits = _scan(_private_clone_lines, path)
             if hits:
                 offenders[path.relative_to(TESTS_DIR).as_posix()] = hits
         assert offenders == {}, (
@@ -360,6 +398,13 @@ class TestNoModuleSpellsBashItself:
         modules in this very migration (Codex review, P1).
         """
         assert _private_clone_lines(reference) == [1]
+
+    def test_an_unparseable_module_names_itself(self, tmp_path: Path) -> None:
+        """A `SyntaxError` from `ast.parse` blames `"<unknown>"` otherwise."""
+        broken = tmp_path / "broken_module.py"
+        broken.write_text("def f(\n", encoding="utf-8")
+        with pytest.raises(AssertionError, match="does not parse"):
+            _scan(_bare_bash_call_sites, broken)
 
     def test_prose_about_the_retired_clones_is_not_a_mention(self) -> None:
         """Otherwise this module, whose subject is that name, bans itself."""
@@ -453,7 +498,7 @@ class TestEveryResolvedCallSiteGuardsFirst:
     def test_every_function_that_resolves_also_guards(self) -> None:
         offenders = {}
         for path in _test_modules():
-            hits = _unguarded_resolutions(path.read_text(encoding="utf-8"))
+            hits = _scan(_unguarded_resolutions, path)
             if hits:
                 offenders[path.relative_to(TESTS_DIR).as_posix()] = hits
         assert offenders == {}, (
@@ -471,9 +516,14 @@ class TestEveryResolvedCallSiteGuardsFirst:
         indirect = (
             "def f():\n    cmd = [bash_executable(), p]\n    subprocess.run(cmd)\n"
         )
+        qualified = (
+            "def f():\n    _workflow_exec.require_bash()\n"
+            "    subprocess.run([_workflow_exec.bash_executable(), p])\n"
+        )
         assert _unguarded_resolutions(unguarded) == ["f"]
         assert _unguarded_resolutions(indirect) == ["f"]
         assert _unguarded_resolutions(guarded) == []
+        assert _unguarded_resolutions(qualified) == []
 
     @pytest.mark.parametrize(
         "source",

--- a/tests/test_subprocess_bash_is_resolved.py
+++ b/tests/test_subprocess_bash_is_resolved.py
@@ -68,6 +68,10 @@ _CLONE_NAME = "_bash_executable"
 
 T = TypeVar("T")
 
+#: The availability guard, and the module a qualified call must name.
+_GUARD_NAME = "require_bash"
+_RESOLVER_MODULE_NAME = "_workflow_exec"
+
 
 #: Callables whose first positional argument is an argv sequence.
 _SUBPROCESS_ENTRY_POINTS = frozenset(
@@ -208,6 +212,24 @@ def _bare_bash_call_sites(source: str) -> list[int]:
     return hits
 
 
+def _is_guard_call(call: ast.Call) -> bool:
+    """Is *call* the real `require_bash()`, bare or qualified by its module?
+
+    A bare name is trusted: the module-level import is what binds it, and no
+    rule here can see past a deliberately shadowed import without a full
+    symbol table. A qualified call must name `_workflow_exec`, so an
+    unrelated object's same-named method cannot pose as the guard.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id == _GUARD_NAME
+    if isinstance(func, ast.Attribute) and func.attr == _GUARD_NAME:
+        return (
+            isinstance(func.value, ast.Name) and func.value.id == _RESOLVER_MODULE_NAME
+        )
+    return False
+
+
 def _unguarded_resolutions(source: str) -> list[str]:
     """Names of functions that resolve bash, shell out, and never guard.
 
@@ -277,13 +299,14 @@ def _unguarded_resolutions(source: str) -> list[str]:
             # `func.attr` there made the two halves disagree, so a function
             # guarding with `_workflow_exec.require_bash()` was reported
             # unguarded (CodeRabbit review).
-            func = stmt.value.func
-            name = (
-                func.attr
-                if isinstance(func, ast.Attribute)
-                else getattr(func, "id", None)
-            )
-            if name == "require_bash":
+            #
+            # The receiver is checked, unlike on the resolution side, because
+            # the two directions fail differently: a stricter resolution rule
+            # only asks for a guard that is already there, while a looser
+            # guard rule lets an unrelated `helper.require_bash()` stand in
+            # for the real one and silently permits the subprocess (Codex
+            # review). So a qualified guard must name `_workflow_exec`.
+            if _is_guard_call(stmt.value):
                 return stmt.lineno
         return None
 
@@ -524,6 +547,13 @@ class TestEveryResolvedCallSiteGuardsFirst:
         assert _unguarded_resolutions(indirect) == ["f"]
         assert _unguarded_resolutions(guarded) == []
         assert _unguarded_resolutions(qualified) == []
+        # A same-named method on some other object is not the guard: unlike
+        # the resolution side, a false negative here permits the subprocess.
+        wrong_receiver = (
+            "def f():\n    helper.require_bash()\n"
+            "    subprocess.run([_workflow_exec.bash_executable(), p])\n"
+        )
+        assert _unguarded_resolutions(wrong_receiver) == ["f"]
 
     @pytest.mark.parametrize(
         "source",

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -347,8 +347,14 @@ class TestBashResolutionNeverFallsBackToWhatItRejected:
     def test_the_two_public_functions_agree_on_this_machine(self) -> None:
         """The invariant the defect broke, on whatever platform runs this:
         `have_bash()` is true exactly when what `bash_executable()` returns is
-        a real bash. Their disagreement was the whole finding."""
-        require_bash()
+        a real bash. Their disagreement was the whole finding.
+
+        Deliberately unguarded, unlike every migrated call site: this test
+        never shells out, so there is no stub to run -- and a bash-less or
+        stub-only machine is precisely the state where the two functions
+        disagreed, so skipping there would retire the assertion exactly where
+        it earns its keep (CodeRabbit review). An over-eager guard inserted
+        here by the migration sweep, not a call site."""
         assert have_bash() is (not is_wsl_launcher_stub(bash_executable()))
 
 

--- a/tests/test_workflow_exec_harness.py
+++ b/tests/test_workflow_exec_harness.py
@@ -38,6 +38,7 @@ only that one 50 KB step now runs.
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 import _workflow_exec
@@ -345,17 +346,38 @@ class TestBashResolutionNeverFallsBackToWhatItRejected:
         assert select_real_bash(candidates, system_root=root) == candidates[0]
 
     def test_the_two_public_functions_agree_on_this_machine(self) -> None:
-        """The invariant the defect broke, on whatever platform runs this:
-        `have_bash()` is true exactly when what `bash_executable()` returns is
-        a real bash. Their disagreement was the whole finding.
+        """The invariant the defect broke, on whatever platform runs this.
 
         Deliberately unguarded, unlike every migrated call site: this test
         never shells out, so there is no stub to run -- and a bash-less or
         stub-only machine is precisely the state where the two functions
         disagreed, so skipping there would retire the assertion exactly where
-        it earns its keep (CodeRabbit review). An over-eager guard inserted
-        here by the migration sweep, not a call site."""
-        assert have_bash() is (not is_wsl_launcher_stub(bash_executable()))
+        it earns its keep (CodeRabbit review; the guard was inserted here by
+        the migration sweep, not by anyone reading the test).
+
+        Stated over three states rather than two, which is the correction the
+        de-guarding forced (Codex review). `have_bash() is not
+        is_wsl_launcher_stub(bash_executable())` reads as the invariant but is
+        only true on two of the three: on a genuinely bash-less host
+        `have_bash()` is False while `bash_executable()` returns its
+        documented `"bash"` fallback, which is not a stub, so the shorthand
+        claims disagreement where there is none -- it would have turned the
+        skip into a *failure* on exactly the host the paragraph above says
+        this test is for. What the two functions actually promise is: when
+        one reports a bash, the other hands back a real, runnable one; when
+        it does not, the other hands back the fallback and claims nothing."""
+        resolved = bash_executable()
+        if have_bash():
+            assert not is_wsl_launcher_stub(resolved)
+            assert shutil.which(resolved) or Path(resolved).is_file(), (
+                f"have_bash() is True but {resolved!r} is not a runnable bash"
+            )
+        else:
+            assert resolved == "bash", (
+                "with no real bash the resolver must return its documented "
+                f"fallback rather than {resolved!r}, which would read as a "
+                "claim that this machine has one"
+            )
 
 
 class TestRequireBashSkipsRatherThanRunsTheStub:


### PR DESCRIPTION
## Summary

`tests/test_subprocess_bash_is_resolved.py` is failing on `main`, on every unit lane. Two separate causes, both fixed here.

## The gate is working

Three bare `["bash", …]` argv sites landed after #1255 merged, and the gate named them:

- `tests/test_l2_real_profile_status.py:298, 1032`
- `tests/test_l2_real_profiles.py:614`

This is the class #1255 exists to close — new modules written without the convention — caught mechanically instead of by a red Windows lane nobody attributes correctly. Resolved through `bash_executable()` and guarded with `require_bash()` in the established shape.

## #1255's final review round never reached main

Worth stating plainly, since I reported otherwise: **#1255 merged at `4963307f7`, two minutes before `58ba691f2` was pushed.** That last commit — the three CodeRabbit fixes — stayed on the branch. It is cherry-picked here:

- **`_dominating_guard_line` read only `func.id`** while `_names_called` accepted `func.attr`, so a function guarding with `_workflow_exec.require_bash()` and resolving with `_workflow_exec.bash_executable()` was reported unguarded.
- **An over-eager guard** in `test_the_two_public_functions_agree_on_this_machine`, inserted by the migration sweep into a test that never shells out.
- **Unnamed parse failures**: a malformed module raised `SyntaxError` against `"<unknown>"`, failing all three rules without saying which file.

## Two further findings from review of this PR

- **The de-guarded assertion was itself wrong.** Removing the guard (correct as far as it went) exposed that `have_bash() is not is_wsl_launcher_stub(bash_executable())` holds on only two of three states: on a genuinely bash-less host `have_bash()` is `False` while the resolver returns its documented `"bash"` fallback, which is not a stub. De-guarding would have turned a skip into a *failure* on exactly the host the de-guarding was for. Restated over all three states.
- **The guard's receiver was unchecked**, so an unrelated `helper.require_bash()` could stand in for the real one.

## Not addressed here

`test_backend_capability_matrix`'s two failures on the same lanes are a stale generated file from an unrelated change — `python scripts/gen_backend_capability_matrix.py` regenerates it.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: `guard.platform_convention_without_a_gate` (registered in `tests/regressions/manifest_guards.py` by #1255) — a platform-portability rule enforced by a shared helper other modules must remember to import, rather than by a scan for the banned shape. This PR is the class's first live instance: new violations appeared within hours of the gate landing, and the gate named them.
- Publicly observable failure: `unit-tests` red on every lane (Linux, macOS, Windows), with `test_no_test_module_passes_a_bare_bash_program` naming three modules. Before the gate existed the same defect surfaced only as an unattributed red `windows-latest` lane, where a bare `"bash"` resolves to the WSL launcher stub and the whole calling module fails at once with no bash-level diagnostic.
- Regression test fails on base: yes, and that is how this PR was found rather than a claim made afterwards — `test_no_test_module_passes_a_bare_bash_program` fails on `b0be72f3e` (main's tip), naming `test_l2_real_profile_status.py` [298, 1032] and `test_l2_real_profiles.py` [614]. The two review findings are pinned the same way: `wrong_receiver` returns `[]` under the old `func.attr`-only check, and the old two-state assertion evaluates `False is True` when `_real_bash()` is stubbed to `None` (verified by simulating that state, not by reasoning about it).
- Negative control: the non-firing half of each rule, asserted alongside the firing one — `shutil.which("bash")`, prose and comments naming the banned identifier, `"bash"` in a non-program argv position, `args=[exe, "bash"]`, `cmd = [exe, "bash"]` traced but not the program, a name bound from a parameter or call (genuinely untraceable), a nested helper carrying its own guard, and a correctly guarded function. Without these, each rule could "pass" by rejecting everything — for the guard rule that would mean demanding a guard in every test that merely mentions the resolver, which is exactly the over-eager insertion this PR removes.
- Public-surface test: none, deliberately. This is test-suite infrastructure reaching no shipped CLI, typed-API or report surface, which is why the registered bug class carries `public_surfaces=()`. The equivalent rigor here is that all three rules run against the real `tests/` tree rather than fixtures alone, and that whole-suite collection (48598 tests, zero errors) is the check matching a change to a module's exported surface — the check whose absence let #1255 ship two modules dead at collection.
- Axes covered: host (`posix`, `nt`, and the third state — no real bash at all); argv shape (inline literal, `args=` keyword, name traced from `ast.Assign`, name traced from `ast.AnnAssign`, untraceable name); guard shape (bare call, qualified by `_workflow_exec`, wrong receiver, placed after the call, inside `if`/`try`/loop, in a nested closure); scope (module body, function, nested function). Not covered: a real `windows-latest` runner, which no environment available here can provide — CI on this PR is the only source of that.
- General invariant: three rules over every module under `tests/`, each exercised with generated shapes rather than the reported inputs — (1) no bare `"bash"` reaches a subprocess program position, by any argv spelling; (2) the retired `_bash_executable` name appears nowhere, as definition, import, call or attribute; (3) a function that resolves *and* shells out is dominated by a real `require_bash()`. Plus the resolver's own three-state contract: `have_bash()` true ⇒ `bash_executable()` returns a real, runnable, non-stub program; false ⇒ it returns the documented fallback and claims nothing. The oracle is independent of the implementation in each case — the scans are AST walks written against Python's grammar, not against the resolver, and the three-state assertion checks `shutil.which`/`Path.is_file` rather than re-deriving `_real_bash`'s own answer.

## Verification

Gate at 35 tests, `test_l2_real_profile_status.py` 116 passed, `test_workflow_exec_harness.py` and the workflow-exec consumers green. Pinned-`ruff` clean. Whole-suite collection: **48598 tests, zero collection errors**.

As with #1255, the Windows lane itself can only be verified by CI here.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment — n/a, no `abicheck/**/*.py` change
- [x] Docs updated — n/a
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173q5kUcC63nkVmJao2AGjV
